### PR TITLE
LPS-111617 URLPathPatternMatchers only

### DIFF
--- a/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/path/pattern/matcher/DynamicURLPathPatternMatcher.java
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/path/pattern/matcher/DynamicURLPathPatternMatcher.java
@@ -14,6 +14,9 @@
 
 package com.liferay.portal.remote.cors.internal.path.pattern.matcher;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author Arthur Chan
  * @author Carlos Sierra Andrés
@@ -22,13 +25,263 @@ public class DynamicURLPathPatternMatcher<T>
 	implements URLPathPatternMatcher<T> {
 
 	public DynamicURLPathPatternMatcher() {
+		_trieNodeArrayList = new TrieNodeArrayList<>();
+
+		_extensionTrieNode = _trieNodeArrayList.nextNode();
+		_wildCardTrieNode = _trieNodeArrayList.nextNode();
 	}
 
 	@Override
 	public T getValue(String urlPath) {
+		T value = getWildcardValue(urlPath);
+
+		if (value != null) {
+			return value;
+		}
+
+		return getExtensionValue(urlPath);
 	}
 
 	public void putValue(String urlPathPattern, T value)
+		throws IllegalArgumentException {
+
+		if (value == null) {
+			throw new IllegalArgumentException("Value can not be null");
+		}
+
+		if (URLPathPatternMatcher.isValidWildCardPattern(urlPathPattern)) {
+			putValue(urlPathPattern, value, _wildCardTrieNode, true);
+
+			return;
+		}
+
+		if (URLPathPatternMatcher.isValidExtensionPattern(urlPathPattern)) {
+			putValue(urlPathPattern, value, _extensionTrieNode, false);
+
+			return;
+		}
+
+		putValue(urlPathPattern, value, _wildCardTrieNode, true);
+	}
+
+	protected T getExtensionValue(String urlPath) {
+		TrieNode<T> currentTrieNode = null;
+		TrieNode<T> previousTrieNode = _extensionTrieNode;
+
+		for (int i = 0; i < urlPath.length(); ++i) {
+			int index = urlPath.length() - 1 - i;
+
+			char character = urlPath.charAt(index);
+
+			if (character == '/') {
+				break;
+			}
+
+			currentTrieNode = previousTrieNode.next(character);
+
+			if (currentTrieNode == null) {
+				break;
+			}
+
+			if (urlPath.charAt(index) == '.') {
+				TrieNode<T> nextTrieNode = currentTrieNode.next('*');
+
+				if ((nextTrieNode != null) && nextTrieNode.isEnd()) {
+					return nextTrieNode.getValue();
+				}
+			}
+
+			previousTrieNode = currentTrieNode;
+		}
+
+		return null;
+	}
+
+	protected T getWildcardValue(String urlPath) {
+		boolean onlyExact = false;
+		boolean onlyWildcard = false;
+
+		if (urlPath.charAt(0) != '/') {
+			onlyExact = true;
+		}
+		else if ((urlPath.length() > 1) &&
+				 (urlPath.charAt(urlPath.length() - 2) == '/') &&
+				 (urlPath.charAt(urlPath.length() - 1) == '*')) {
+
+			onlyWildcard = true;
+		}
+
+		T value = null;
+
+		TrieNode<T> currentTrieNode = null;
+		TrieNode<T> previousTrieNode = _wildCardTrieNode;
+
+		for (int i = 0; i < urlPath.length(); ++i) {
+			currentTrieNode = previousTrieNode.next(urlPath.charAt(i));
+
+			if (currentTrieNode == null) {
+				break;
+			}
+
+			if (!onlyExact && (urlPath.charAt(i) == '/')) {
+				TrieNode<T> nextTrieNode = currentTrieNode.next('*');
+
+				if ((nextTrieNode != null) && nextTrieNode.isEnd()) {
+					value = nextTrieNode.getValue();
+				}
+			}
+
+			previousTrieNode = currentTrieNode;
+		}
+
+		if (currentTrieNode != null) {
+			if (onlyExact) {
+				if (!currentTrieNode.isEnd()) {
+					return null;
+				}
+
+				return currentTrieNode.getValue();
+			}
+
+			if (!onlyWildcard && currentTrieNode.isEnd()) {
+				return currentTrieNode.getValue();
+			}
+
+			currentTrieNode = currentTrieNode.next('/');
+
+			if (currentTrieNode != null) {
+				currentTrieNode = currentTrieNode.next('*');
+
+				if ((currentTrieNode != null) && currentTrieNode.isEnd()) {
+					value = currentTrieNode.getValue();
+				}
+			}
+		}
+
+		return value;
+	}
+
+	protected void putValue(
+		String urlPathPattern, T value, TrieNode<T> previousTrieNode,
+		boolean forward) {
+
+		TrieNode<T> currentTrieNode = null;
+
+		for (int i = 0; i < urlPathPattern.length(); ++i) {
+			int index = i;
+
+			if (!forward) {
+				index = urlPathPattern.length() - 1 - i;
+			}
+
+			currentTrieNode = previousTrieNode.next(
+				urlPathPattern.charAt(index));
+
+			if (currentTrieNode == null) {
+				currentTrieNode = previousTrieNode.setNext(
+					urlPathPattern.charAt(index), _trieNodeArrayList);
+			}
+
+			previousTrieNode = currentTrieNode;
+		}
+
+		if (currentTrieNode != null) {
+			currentTrieNode.setValue(value);
+		}
+	}
+
+	private final TrieNode<T> _extensionTrieNode;
+	private final TrieNodeArrayList<T> _trieNodeArrayList;
+	private final TrieNode<T> _wildCardTrieNode;
+
+	private static class TrieNode<T> {
+
+		public TrieNode() {
+			_trieNodes = new ArrayList<>(ASCII_CHARACTER_RANGE);
+
+			for (int i = 0; i < ASCII_CHARACTER_RANGE; ++i) {
+				_trieNodes.add(null);
+			}
+		}
+
+		public T getValue() {
+			return _value;
+		}
+
+		public boolean isEnd() {
+			if (_value != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public TrieNode<T> next(char character) {
+			int index = character - ASCII_PRINTABLE_OFFSET;
+
+			if ((index < 0) ||
+				(index >= (ASCII_CHARACTER_RANGE + ASCII_PRINTABLE_OFFSET))) {
+
+				throw new IllegalArgumentException();
+			}
+
+			return _trieNodes.get(index);
+		}
+
+		public TrieNode<T> setNext(
+			char character, TrieNodeArrayList<T> trieNodeArrayList) {
+
+			TrieNode<T> trieNode = trieNodeArrayList.nextNode();
+
+			int index = character - ASCII_PRINTABLE_OFFSET;
+
+			if ((index < 0) ||
+				(index >= (ASCII_CHARACTER_RANGE + ASCII_PRINTABLE_OFFSET))) {
+
+				throw new IllegalArgumentException();
+			}
+
+			_trieNodes.set(index, trieNode);
+
+			return trieNode;
+		}
+
+		public void setValue(T value) {
+			_value = value;
+		}
+
+		private final List<TrieNode<T>> _trieNodes;
+		private T _value;
+
+	}
+
+	private static class TrieNodeArrayList<T> {
+
+		public TrieNodeArrayList() {
+			_trieNodes = new ArrayList<>(_INIT_SIZE);
+
+			for (int i = 0; i < _INIT_SIZE; ++i) {
+				_trieNodes.add(new TrieNode<>());
+			}
+		}
+
+		public TrieNode<T> nextNode() {
+			if (_index >= _trieNodes.size()) {
+				_trieNodes.ensureCapacity(_trieNodes.size() + _INIT_SIZE);
+
+				for (int i = 0; i < _INIT_SIZE; ++i) {
+					_trieNodes.add(new TrieNode<>());
+				}
+			}
+
+			return _trieNodes.get(_index++);
+		}
+
+		private static final int _INIT_SIZE = 1024;
+
+		private int _index;
+		private ArrayList<TrieNode<T>> _trieNodes;
+
 	}
 
 }

--- a/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/path/pattern/matcher/DynamicURLPathPatternMatcher.java
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/path/pattern/matcher/DynamicURLPathPatternMatcher.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.remote.cors.internal.path.pattern.matcher;
+
+/**
+ * @author Arthur Chan
+ * @author Carlos Sierra Andrés
+ */
+public class DynamicURLPathPatternMatcher<T>
+	implements URLPathPatternMatcher<T> {
+
+	public DynamicURLPathPatternMatcher() {
+	}
+
+	@Override
+	public T getValue(String urlPath) {
+	}
+
+	public void putValue(String urlPathPattern, T value)
+	}
+
+}

--- a/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/path/pattern/matcher/StaticURLPathPatternMatcher.java
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/path/pattern/matcher/StaticURLPathPatternMatcher.java
@@ -14,6 +14,9 @@
 
 package com.liferay.portal.remote.cors.internal.path.pattern.matcher;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author Arthur Chan
  * @author Carlos Sierra Andrés
@@ -22,12 +25,337 @@ public class StaticURLPathPatternMatcher<T>
 	implements URLPathPatternMatcher<T> {
 
 	public StaticURLPathPatternMatcher(int longesturlPathPatternSize) {
+		if (longesturlPathPatternSize < 1) {
+			longesturlPathPatternSize = 64;
+		}
+
+		_extensionStaticTrieArrayMatcher =
+			new ExtensionStaticTrieArrayMatcher<>(longesturlPathPatternSize);
+		_wildcardStaticTrieArrayMatcher = new WildcardStaticTrieArrayMatcher<>(
+			longesturlPathPatternSize);
 	}
 
 	public T getValue(String urlPath) {
+		T value = _wildcardStaticTrieArrayMatcher.getValue(urlPath);
+
+		if (value != null) {
+			return value;
+		}
+
+		return _extensionStaticTrieArrayMatcher.getValue(urlPath);
 	}
 
 	public void putValue(String urlPathPattern, T value)
+		throws IllegalArgumentException {
+
+		if (URLPathPatternMatcher.isValidExtensionPattern(urlPathPattern)) {
+			_extensionStaticTrieArrayMatcher.putValue(
+				urlPathPattern, value, false);
+		}
+		else {
+			_wildcardStaticTrieArrayMatcher.putValue(
+				urlPathPattern, value, true);
+		}
+	}
+
+	protected static int getFirstSetBitIndex(long bitMask) {
+		int firstSetBitIndex = -1;
+
+		if (bitMask == 0) {
+			return firstSetBitIndex;
+		}
+
+		firstSetBitIndex = 63;
+
+		long currentBitMask = bitMask << 32;
+
+		if (currentBitMask != 0) {
+			firstSetBitIndex -= 32;
+			bitMask = currentBitMask;
+		}
+
+		currentBitMask = bitMask << 16;
+
+		if (currentBitMask != 0) {
+			firstSetBitIndex -= 16;
+			bitMask = currentBitMask;
+		}
+
+		currentBitMask = bitMask << 8;
+
+		if (currentBitMask != 0) {
+			firstSetBitIndex -= 8;
+			bitMask = currentBitMask;
+		}
+
+		currentBitMask = bitMask << 4;
+
+		if (currentBitMask != 0) {
+			firstSetBitIndex -= 4;
+			bitMask = currentBitMask;
+		}
+
+		currentBitMask = bitMask << 2;
+
+		if (currentBitMask != 0) {
+			firstSetBitIndex -= 2;
+			bitMask = currentBitMask;
+		}
+
+		currentBitMask = bitMask << 1;
+
+		if (currentBitMask != 0) {
+			firstSetBitIndex -= 1;
+		}
+
+		return firstSetBitIndex;
+	}
+
+	private static final long _ALL_BITS_SET = ~0;
+
+	private static final int _SLASH_INDEX = '/' - ASCII_PRINTABLE_OFFSET;
+
+	private static final int _STAR_INDEX = '*' - ASCII_PRINTABLE_OFFSET;
+
+	private final ExtensionStaticTrieArrayMatcher<T>
+		_extensionStaticTrieArrayMatcher;
+	private final WildcardStaticTrieArrayMatcher<T>
+		_wildcardStaticTrieArrayMatcher;
+
+	private abstract static class BaseStaticTrieArrayMatcher<T> {
+
+		public BaseStaticTrieArrayMatcher(int maxUrlPathPatternLength) {
+			this.maxUrlPathPatternLength = maxUrlPathPatternLength;
+
+			trieArray =
+				new long[2][maxUrlPathPatternLength][ASCII_CHARACTER_RANGE];
+		}
+
+		protected int getExactIndex(String urlPath) {
+			int row = 0;
+			long bitMask = _ALL_BITS_SET;
+			int column = 0;
+
+			for (; row < urlPath.length(); ++row) {
+				if (row > (maxUrlPathPatternLength - 1)) {
+					bitMask = 0;
+
+					break;
+				}
+
+				char character = urlPath.charAt(row);
+
+				column = character - ASCII_PRINTABLE_OFFSET;
+
+				bitMask &= trieArray[0][row][column];
+
+				if (bitMask == 0) {
+					break;
+				}
+			}
+
+			if (bitMask != 0) {
+				bitMask &= trieArray[1][row - 1][column];
+
+				if (bitMask != 0) {
+					return getFirstSetBitIndex(bitMask);
+				}
+			}
+
+			return -1;
+		}
+
+		protected void putValue(
+			String urlPathPattern, T value, boolean forward) {
+
+			if (_count > 63) {
+				throw new IllegalArgumentException(
+					"Exceeding maximum number of allowed URL patterns");
+			}
+
+			int index = getExactIndex(urlPathPattern);
+
+			if (index > -1) {
+				values.add(index, value);
+
+				return;
+			}
+
+			index = _count++;
+
+			int row = 0;
+			int column = 0;
+			long bitMask = 1 << index;
+
+			for (; row < urlPathPattern.length(); ++row) {
+				char character = urlPathPattern.charAt(row);
+
+				if (!forward) {
+					character = urlPathPattern.charAt(
+						urlPathPattern.length() - 1 - row);
+				}
+
+				column = character - ASCII_PRINTABLE_OFFSET;
+
+				trieArray[0][row][column] |= bitMask;
+			}
+
+			trieArray[1][row - 1][column] |= bitMask;
+
+			values.add(index, value);
+		}
+
+		protected int maxUrlPathPatternLength;
+		protected final long[][][] trieArray;
+		protected List<T> values = new ArrayList<>(Long.SIZE);
+
+		private int _count;
+
+	}
+
+	private static class ExtensionStaticTrieArrayMatcher<T>
+		extends BaseStaticTrieArrayMatcher<T> {
+
+		public ExtensionStaticTrieArrayMatcher(int maxUrlPathPatternLength) {
+			super(maxUrlPathPatternLength);
+		}
+
+		public T getValue(String urlPath) {
+			int urlPathLength = urlPath.length();
+			long currentBitMask = _ALL_BITS_SET;
+
+			for (int row = 0; row < urlPathLength; ++row) {
+				if (row > (maxUrlPathPatternLength - 1)) {
+					break;
+				}
+
+				char character = urlPath.charAt(urlPathLength - 1 - row);
+
+				if (character == '/') {
+					break;
+				}
+
+				int column = character - ASCII_PRINTABLE_OFFSET;
+
+				currentBitMask &= trieArray[0][row][column];
+
+				if (currentBitMask == 0) {
+					break;
+				}
+
+				if ((character == '.') &&
+					((row + 1) < maxUrlPathPatternLength)) {
+
+					long bitMask =
+						currentBitMask & trieArray[1][row + 1][_STAR_INDEX];
+
+					if (bitMask != 0) {
+						return values.get(getFirstSetBitIndex(bitMask));
+					}
+
+					break;
+				}
+			}
+
+			return null;
+		}
+
+	}
+
+	private static class WildcardStaticTrieArrayMatcher<T>
+		extends BaseStaticTrieArrayMatcher<T> {
+
+		public WildcardStaticTrieArrayMatcher(int maxUrlPathPatternLength) {
+			super(maxUrlPathPatternLength);
+		}
+
+		public T getValue(String urlPath) {
+			boolean onlyExact = false;
+			boolean onlyWildcard = false;
+
+			if (urlPath.charAt(0) != '/') {
+				onlyExact = true;
+			}
+			else if ((urlPath.length() > 1) &&
+					 (urlPath.charAt(urlPath.length() - 2) == '/') &&
+					 (urlPath.charAt(urlPath.length() - 1) == '*')) {
+
+				onlyWildcard = true;
+			}
+
+			int row = 0;
+			int col = 0;
+			long currentBitMask = _ALL_BITS_SET;
+			long bestMatchBitMask = 0;
+
+			for (; row < urlPath.length(); ++row) {
+				if (row > (maxUrlPathPatternLength - 1)) {
+					currentBitMask = 0;
+
+					break;
+				}
+
+				char character = urlPath.charAt(row);
+
+				col = character - ASCII_PRINTABLE_OFFSET;
+
+				currentBitMask &= trieArray[0][row][col];
+
+				if (currentBitMask == 0) {
+					break;
+				}
+
+				if (!onlyExact && (character == '/') &&
+					((row + 1) < maxUrlPathPatternLength)) {
+
+					long bitMask =
+						currentBitMask & trieArray[1][row + 1][_STAR_INDEX];
+
+					if (bitMask != 0) {
+						bestMatchBitMask = bitMask;
+					}
+				}
+			}
+
+			if (currentBitMask == 0) {
+				if (bestMatchBitMask == 0) {
+					return null;
+				}
+
+				return values.get(getFirstSetBitIndex(bestMatchBitMask));
+			}
+
+			if (onlyExact) {
+				long bitMask = currentBitMask & trieArray[1][row - 1][col];
+
+				if (bitMask != 0) {
+					return values.get(getFirstSetBitIndex(bitMask));
+				}
+
+				return null;
+			}
+
+			if (!onlyWildcard) {
+				long bitMask = currentBitMask & trieArray[1][row - 1][col];
+
+				if (bitMask != 0) {
+					return values.get(getFirstSetBitIndex(bitMask));
+				}
+			}
+
+			long extraBitMask =
+				currentBitMask & trieArray[0][row][_SLASH_INDEX];
+
+			extraBitMask &= trieArray[0][row + 1][_STAR_INDEX];
+			extraBitMask &= trieArray[1][row + 1][_STAR_INDEX];
+
+			if (extraBitMask != 0) {
+				return values.get(getFirstSetBitIndex(extraBitMask));
+			}
+
+			return values.get(getFirstSetBitIndex(bestMatchBitMask));
+		}
+
 	}
 
 }

--- a/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/path/pattern/matcher/StaticURLPathPatternMatcher.java
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/path/pattern/matcher/StaticURLPathPatternMatcher.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.remote.cors.internal.path.pattern.matcher;
+
+/**
+ * @author Arthur Chan
+ * @author Carlos Sierra Andrés
+ */
+public class StaticURLPathPatternMatcher<T>
+	implements URLPathPatternMatcher<T> {
+
+	public StaticURLPathPatternMatcher(int longesturlPathPatternSize) {
+	}
+
+	public T getValue(String urlPath) {
+	}
+
+	public void putValue(String urlPathPattern, T value)
+	}
+
+}

--- a/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/path/pattern/matcher/URLPathPatternMatcher.java
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/path/pattern/matcher/URLPathPatternMatcher.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.remote.cors.internal.path.pattern.matcher;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+/**
+ * @author Arthur Chan
+ * @author Carlos Sierra Andrés
+ */
+public interface URLPathPatternMatcher<T> {
+
+	public static final byte ASCII_CHARACTER_RANGE = 96;
+
+	public static final byte ASCII_PRINTABLE_OFFSET = 32;
+
+	/**
+	 *  https://download.oracle.com/otndocs/jcp/servlet-4-final-eval-spec/index.html#12.1.3
+	 *  https://download.oracle.com/otndocs/jcp/servlet-4-final-eval-spec/index.html#12.2
+	 *
+	 * @param urlPathPattern the given urlPathPattern
+	 * @return a boolean value indicating if the urlPathPattern a valid extensionPattern
+	 */
+	public static boolean isValidExtensionPattern(String urlPathPattern) {
+		if ((urlPathPattern.length() < 3) ||
+			(urlPathPattern.charAt(0) != '*') ||
+			(urlPathPattern.charAt(1) != '.')) {
+
+			return false;
+		}
+
+		for (int i = 2; i < urlPathPattern.length(); ++i) {
+			if (urlPathPattern.charAt(i) == '/') {
+				return false;
+			}
+
+			if (urlPathPattern.charAt(i) == '.') {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 *  https://tools.ietf.org/html/rfc3986#section-3.3
+	 *  https://download.oracle.com/otndocs/jcp/servlet-4-final-eval-spec/index.html#12.2
+	 *
+	 * @param urlPathPattern the given urlPathPattern
+	 * @return a boolean value indicating if the urlPathPattern a valid wildCardPattern
+	 */
+	public static boolean isValidWildCardPattern(String urlPathPattern) {
+		if ((urlPathPattern.length() < 2) ||
+			(urlPathPattern.charAt(0) != '/') ||
+			(urlPathPattern.charAt(urlPathPattern.length() - 1) != '*') ||
+			(urlPathPattern.charAt(urlPathPattern.length() - 2) != '/')) {
+
+			return false;
+		}
+
+		try {
+			String urlPath = urlPathPattern.substring(
+				0, urlPathPattern.length() - 1);
+
+			URI uri = new URI("https://test" + urlPath);
+
+			if (!urlPath.contentEquals(uri.getPath())) {
+				return false;
+			}
+		}
+		catch (URISyntaxException uriSyntaxException) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * https://download.oracle.com/otndocs/jcp/servlet-4-final-eval-spec/index.html#12.1
+	 *
+	 * @param urlPath a legal urlPath from a URL
+	 * @return the matched pattern
+	 */
+	public T getValue(String urlPath);
+
+	/**
+	 * https://download.oracle.com/otndocs/jcp/servlet-4-final-eval-spec/index.html#12.2
+	 *
+	 * @param urlPathPattern the pattern of urlPath, used for pattern matching
+	 * @param value an non null object associated with urlPathPattern
+	 */
+	public void putValue(String urlPathPattern, T value)
+		throws IllegalArgumentException;
+
+}

--- a/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/path/pattern/matcher/URLPathPatternMatcherFactory.java
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/path/pattern/matcher/URLPathPatternMatcherFactory.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.remote.cors.internal.path.pattern.matcher;
+
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Carlos Sierra Andrés
+ */
+@Component(service = URLPathPatternMatcherFactory.class)
+public class URLPathPatternMatcherFactory {
+
+	public <T> URLPathPatternMatcher<T> createPatternMatcher(
+		Map<String, T> urlPathPatternsMap) {
+
+		URLPathPatternMatcher<T> urlPathPatternMatcher;
+
+		if (urlPathPatternsMap.size() > 64) {
+			urlPathPatternMatcher = new DynamicURLPathPatternMatcher<>();
+		}
+		else {
+			Set<String> urlPathPatterns = urlPathPatternsMap.keySet();
+
+			Stream<String> stream = urlPathPatterns.stream();
+
+			urlPathPatternMatcher = new StaticURLPathPatternMatcher<>(
+				stream.map(
+					String::length
+				).max(
+					Comparator.naturalOrder()
+				).orElse(
+					0
+				));
+		}
+
+		for (Map.Entry<String, T> entry : urlPathPatternsMap.entrySet()) {
+			urlPathPatternMatcher.putValue(entry.getKey(), entry.getValue());
+		}
+
+		return urlPathPatternMatcher;
+	}
+
+}


### PR DESCRIPTION
hi Brian, 
this pull comes after your comment [here](https://github.com/brianchandotcom/liferay-portal/pull/91977#issuecomment-666146571).

I did not fully understand what you meant by "just the classes that are passed around and without even an implementation" so I sent the classes and the implementations are in separate commits. Hopefully this is useful. 

So here comes the common interface, the factory that chosses between the two implementations and the two (empty) implementations and the _bodies_ in different commits.

Carlos.