### PR TITLE
LPS-118204 BuildLang

### DIFF
--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algorithm Key Size
 algorithm-key-size-description=Set the size of the algorithm key.
-button-remove-configured-timebased-otp=Remove configured time-based one-time password.
+button-remove-configured-timebased-otp=Remove configured time-based one-time password
 clock-skew=Clock Skew
 clock-skew-description=Set the time in milliseconds that the clocks can differ before a code will be rejected. This means the checker could perform a validation against the current time and then two further validations (+ clock skew time / - clock skew time).
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Time-Based One-Time Password

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_ar.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_ar.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=حجم مفتاح الخوارزمية
 algorithm-key-size-description=تعيين حجم خوارزمية المفاتيح.
-button-remove-configured-timebased-otp=إزالة كلمة مرور ذات مرة واحدة تستند إلى الوقت. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=انحراف الساعة
 clock-skew-description=تعيين الوقت بالمللي ثانية الذي يمكن أن تختلف الساعات فيه قبل رفض التعليمة البرمجية. هذا يعني أنه يمكن لأداة الفحص تنفيذ التحقق من الصحة مقابل الوقت الحالي ثم إجراء عمليتي تحقق أخرتين (+ وقت انخراف الساعة / - وقت انحراف الساعة).
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=كلمة مرور لمرة واحدة تعتمد على الوقت

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_bg.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_bg.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Размер на ключа за алгоритъм (Automatic Translation)
 algorithm-key-size-description=Задаване на размера на алгоритъма за ключ. (Automatic Translation)
-button-remove-configured-timebased-otp=Премахване на конфигурирана еднократна парола, базирана на времето. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Часовник изкрив (Automatic Translation)
 clock-skew-description=Задайте времето в милисекунди, които могат да се различават преди код ще бъде отхвърлен. Това означава, че проверяващата може да извърши проверка срещу текущото време и след това две допълнителни валидирания (+ часовник изкривяване време / - време на изкривяване на часовника). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Еднократната парола, базирана на времето (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_ca.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_ca.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Mida de la clau de l'algoritme
 algorithm-key-size-description=Establiu la mida de la clau de l'algoritme.
-button-remove-configured-timebased-otp=Traieu la contrasenya d'un sol temps configurada per temps configurat. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Biaix del rellotge
 clock-skew-description=Estableix el temps en mil·lisegons que els rellotges poden variar abans de rebutjar un codi. Això vol dir que el verificador podria executar una validació en relació a l'hora actual i després dues validacions més (+ biaix del rellotge / - biaix del rellotge).
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Contrasenya d'un sol ús basada en l'hora

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_cs.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_cs.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Velikost klíče algoritmu (Automatic Translation)
 algorithm-key-size-description=Nastavte velikost algoritmu klíče. (Automatic Translation)
-button-remove-configured-timebased-otp=Odeberte nakonfigurované jednorázové heslo založené na čase. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Zkosení hodin (Automatic Translation)
 clock-skew-description=Nastavte čas v milisekundách, že hodiny se mohou lišit před kód bude odmítnut. To znamená, že kontrola může provést ověření proti aktuálnímu času a pak dvě další ověření (+ čas zkosení hodin / - čas zkosení hodin). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Jednorázové jednorázové heslo založené na čase (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_da.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_da.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algorithm Key Size (Automatic Copy)
 algorithm-key-size-description=Set the size of the algorithm key. (Automatic Copy)
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Clock Skew (Automatic Copy)
 clock-skew-description=Set the time in milliseconds that the clocks can differ before a code will be rejected. This means the checker could perform a validation against the current time and then two further validations (+ clock skew time / - clock skew time). (Automatic Copy)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Time-Based One-Time Password (Automatic Copy)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_de.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_de.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Größe des Schlüsselalgorithmus
 algorithm-key-size-description=Legen Sie die Größe des Schlüsselalgorithmus fest.
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Zeitabweichung
 clock-skew-description=Legen Sie die Zeit in Millisekunden fest, die die Uhren voneinander abweichen können, bevor ein Code abgelehnt wird. Dies bedeutet, dass der Prüfer eine Validierung anhand der aktuellen Zeit und anschließend zwei weitere Validierungen durchführen kann (+ Taktversatzzeit / - Taktversatzzeit).
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Zeitbasiertes Einmalpasswort

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_el.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_el.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Μέγεθος κλειδιού αλγορίθμου (Automatic Translation)
 algorithm-key-size-description=Ορίστε το μέγεθος του αλγόριθμου κλειδιού. (Automatic Translation)
-button-remove-configured-timebased-otp=Καταργήστε τον ρυθμισμένο κωδικό πρόσβασης που βασίζεται στο χρόνο. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Κλίση ρολογιού (Automatic Translation)
 clock-skew-description=Ορίστε το χρόνο σε χιλιοστά του δευτερολέπτου που μπορεί να διαφέρουν τα ρολόγια πριν από την απόρριψη ενός κώδικα. Αυτό σημαίνει ότι ο ελεγκτής θα μπορούσε να εκτελέσει μια επικύρωση σε σχέση με την τρέχουσα ώρα και στη συνέχεια δύο περαιτέρω επικυρώσεις (+ ρολόι κλίση του χρόνου / - ρολόι κλίση του χρόνου). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Εφάπαξ κωδικός πρόσβασης βάσει χρόνου (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_en.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_en.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algorithm Key Size
 algorithm-key-size-description=Set the size of the algorithm key.
-button-remove-configured-timebased-otp=Remove configured time-based one-time password.
+button-remove-configured-timebased-otp=Remove configured time-based one-time password
 clock-skew=Clock Skew
 clock-skew-description=Set the time in milliseconds that the clocks can differ before a code will be rejected. This means the checker could perform a validation against the current time and then two further validations (+ clock skew time / - clock skew time).
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Time-Based One-Time Password

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_en_AU.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_en_AU.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algorithm Key Size (Automatic Copy)
 algorithm-key-size-description=Set the size of the algorithm key. (Automatic Copy)
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Clock Skew (Automatic Copy)
 clock-skew-description=Set the time in milliseconds that the clocks can differ before a code will be rejected. This means the checker could perform a validation against the current time and then two further validations (+ clock skew time / - clock skew time). (Automatic Copy)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Time-Based One-Time Password (Automatic Copy)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_en_GB.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_en_GB.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algorithm Key Size (Automatic Copy)
 algorithm-key-size-description=Set the size of the algorithm key. (Automatic Copy)
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Clock Skew (Automatic Copy)
 clock-skew-description=Set the time in milliseconds that the clocks can differ before a code will be rejected. This means the checker could perform a validation against the current time and then two further validations (+ clock skew time / - clock skew time). (Automatic Copy)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Time-Based One-Time Password (Automatic Copy)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_es.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_es.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Tamaño de la clave del algoritmo
 algorithm-key-size-description=Establece el tamaño de la clave del algoritmo.
-button-remove-configured-timebased-otp=Elimine la contraseña de un solo uso basada en el tiempo configurada. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Desfase de reloj
 clock-skew-description=Establece el tiempo (en milisegundos) en que los relojes pueden ser distintos antes de que se rechace un código. Esto quiere decir que el comprobador debe realizar una validación de la hora actual y, después, dos validaciones adicionales (+ hora de desfase de reloj/ - hora de desfase de reloj).
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Contraseña de un solo uso de duración definida

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_et.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_et.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algoritmi võtme suurus (Automatic Translation)
 algorithm-key-size-description=Määrake võtmealgoritmi suurus. (Automatic Translation)
-button-remove-configured-timebased-otp=Eemaldage konfigureeritud ajapõhine ühekordne parool. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Kell viltu (Automatic Translation)
 clock-skew-description=Määrake aeg millisekundites, et kellad võivad erineda enne koodi tagasilükkamist. See tähendab, et kontrollija võiks teha valideerimise võrreldes praeguse ajaga ja seejärel veel kaks valideerimist (+ kell viltu aeg / - kell viltu aeg). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Ajapõhine ühekordne parool (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_eu.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_eu.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algorithm Key Size (Automatic Copy)
 algorithm-key-size-description=Set the size of the algorithm key. (Automatic Copy)
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Clock Skew (Automatic Copy)
 clock-skew-description=Set the time in milliseconds that the clocks can differ before a code will be rejected. This means the checker could perform a validation against the current time and then two further validations (+ clock skew time / - clock skew time). (Automatic Copy)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Time-Based One-Time Password (Automatic Copy)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_fa.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_fa.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=اندازه کلید الگوریتم (Automatic Translation)
 algorithm-key-size-description=اندازه الگوریتم کلید را تنظیم کنید. (Automatic Translation)
-button-remove-configured-timebased-otp=حذف پیکربندی شده زمان مبتنی بر یک کلمه عبور یک بار. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=انحراف ساعت (Automatic Translation)
 clock-skew-description=تنظیم زمان در میلی ثانیه که ساعت می تواند متفاوت باشد قبل از کد رد خواهد شد. این به این معنی است که checker می تواند یک اعتبار را در برابر زمان فعلی انجام دهد و سپس دو اعتبار سنجی بیشتر (زمان انحراف ساعت/ساعت انحراف). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=رمز عبور یک بار بر اساس زمان (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_fi.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_fi.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algoritmin Avaimen Koko
 algorithm-key-size-description=Aseta avainalgoritmin koko.
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Kellopoikkeama
 clock-skew-description=Aseta millisekunteina aika, jonka kellot voivat erota ennen kuin koodi hylätään. Tämä tarkoittaa sitä, että tarkistaja voi tehdä validoinnin tämänhetkistä aikaa vasten ja kaksi muuta validointia (+kellopoikeama-aika/-kellopoikkeama-aika).
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Aikapohjainen Kertakäyttöinen Salasana

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_fr.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_fr.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Taille de la clé de l'algorithme
 algorithm-key-size-description=Définissez la taille de la clé de l'algorithme.
-button-remove-configured-timebased-otp=Supprimez le mot de passe unique configuré basé sur le temps. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Correction d'horloge
 clock-skew-description=Définissez le temps en millisecondes que les horloges peuvent différer avant qu'un code soit refusé. Cela signifie que le vérificateur peut effectuer une validation contre l'heure actuelle, puis deux autres validations (+ heure de correction de l'horloge ( - heure de correction de l'horloge).
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Mot de passe unique à durée

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_fr_CA.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algorithm Key Size (Automatic Copy)
 algorithm-key-size-description=Set the size of the algorithm key. (Automatic Copy)
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Clock Skew (Automatic Copy)
 clock-skew-description=Set the time in milliseconds that the clocks can differ before a code will be rejected. This means the checker could perform a validation against the current time and then two further validations (+ clock skew time / - clock skew time). (Automatic Copy)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Time-Based One-Time Password (Automatic Copy)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_gl.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_gl.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algorithm Key Size (Automatic Copy)
 algorithm-key-size-description=Set the size of the algorithm key. (Automatic Copy)
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Clock Skew (Automatic Copy)
 clock-skew-description=Set the time in milliseconds that the clocks can differ before a code will be rejected. This means the checker could perform a validation against the current time and then two further validations (+ clock skew time / - clock skew time). (Automatic Copy)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Time-Based One-Time Password (Automatic Copy)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_hi_IN.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=एल्गोरिदम कुंजी आकार (Automatic Translation)
 algorithm-key-size-description=कुंजी एल्गोरिदम का आकार निर्धारित करें। (Automatic Translation)
-button-remove-configured-timebased-otp=कॉन्फ़िगर किए गए समय-आधारित वन-टाइम पासवर्ड निकालें। (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=घड़ी तिरछा (Automatic Translation)
 clock-skew-description=मिलीसेकंड में समय निर्धारित करें कि कोड अस्वीकार किए जाने से पहले घड़ियां अलग-अलग हो सकती हैं। इसका मतलब यह है कि चेकर वर्तमान समय के खिलाफ एक सत्यापन प्रदर्शन कर सकता है और फिर दो और सत्यापन (+ घड़ी तिरछा समय/-घड़ी तिरछा समय) । (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=टाइम-बेस्ड वन-टाइम पासवर्ड (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_hr.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_hr.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algorithm Key Size (Automatic Copy)
 algorithm-key-size-description=Set the size of the algorithm key. (Automatic Copy)
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Clock Skew (Automatic Copy)
 clock-skew-description=Set the time in milliseconds that the clocks can differ before a code will be rejected. This means the checker could perform a validation against the current time and then two further validations (+ clock skew time / - clock skew time). (Automatic Copy)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Time-Based One-Time Password (Automatic Copy)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_hu.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_hu.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algoritmus kulcsmérete
 algorithm-key-size-description=Állítsa be a kulcsalgoritmus méretét.
-button-remove-configured-timebased-otp=Távolítsa el a konfigurált időalapú, egyszeri jelszót.
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Időcsúszás
 clock-skew-description=Állítsa be az órák közötti különbséget ezredmásodpercekben, amely felett a kód elutasításra kerül. Ez azt jelenti, hogy az ellenőrző hitelesítést végezhet, amely ellenőrzi az aktuális időt, és két további ellenőrzést végez (+ időcsúszás / - időcsúszás).
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Időalapú egyszeri jelszó

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_in.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_in.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Ukuran kunci algoritma (Automatic Translation)
 algorithm-key-size-description=Mengatur ukuran algoritma kunci. (Automatic Translation)
-button-remove-configured-timebased-otp=Hapus sandi satu kali berdasarkan waktu yang dikonfigurasi. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Jam Skew (Automatic Translation)
 clock-skew-description=Mengatur waktu dalam milidetik bahwa jam dapat berbeda sebelum kode akan ditolak. Ini berarti Checker dapat melakukan validasi terhadap waktu saat ini dan kemudian dua validasi lebih lanjut (+ jam condong waktu/jam condong waktu). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Sandi satu kali berdasarkan waktu (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_it.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_it.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Dimensione chiave algoritmo (Automatic Translation)
 algorithm-key-size-description=Impostare le dimensioni dell'algoritmo a chiave. (Automatic Translation)
-button-remove-configured-timebased-otp=Rimuovere la password monooraria configurata. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Inclinazione dell'orologio (Automatic Translation)
 clock-skew-description=Impostare il tempo in millisecondi che gli orologi possono differire prima che un codice venga rifiutato. Ciò significa che il correttore potrebbe eseguire una convalida rispetto all'ora corrente e quindi a due ulteriori convalide (ora di inclinazione dell'orologio / - ora di inclinazione dell'orologio). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Password monodata basata sul tempo (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_iw.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_iw.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=גודל מפתח האלגוריתם (Automatic Translation)
 algorithm-key-size-description=קבע את גודל אלגוריתם המפתח. (Automatic Translation)
-button-remove-configured-timebased-otp=הסר סיסמה מבוססת-זמן המבוססת על זמן אחד. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=שעון הטיה (Automatic Translation)
 clock-skew-description=הגדר את השעה באלפיות שניה שהשעונים יכולים להיות שונים לפני שהקוד ידחה. משמעות הדבר היא שבודק יכול לבצע אימות נגד הזמן הנוכחי ולאחר מכן שני אימותים נוספים (+ זמן הטיה לשעון). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=סיסמה חד פעמי מבוססת זמן (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_ja.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_ja.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=アルゴリズムの鍵サイズ
 algorithm-key-size-description=アルゴリズムの鍵サイズを設定します。
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=許容時刻誤差(クロックスキュー)
 clock-skew-description=コードが却下される時刻のずれをミリ秒単位で設定します。このチェッカーは現在時刻を検証した後、さらに2つの検証（+ clock skew time / - clock skew time）を行う場合があります。
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=タイムベースワンタイムパスワード

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_kk.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_kk.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algorithm Key Size (Automatic Copy)
 algorithm-key-size-description=Set the size of the algorithm key. (Automatic Copy)
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Clock Skew (Automatic Copy)
 clock-skew-description=Set the time in milliseconds that the clocks can differ before a code will be rejected. This means the checker could perform a validation against the current time and then two further validations (+ clock skew time / - clock skew time). (Automatic Copy)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Time-Based One-Time Password (Automatic Copy)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_ko.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_ko.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=알고리즘 키 크기 (Automatic Translation)
 algorithm-key-size-description=키 알고리즘의 크기를 설정합니다. (Automatic Translation)
-button-remove-configured-timebased-otp=구성된 시간 기반 일회성 암호를 제거합니다. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=시계 기울이기 (Automatic Translation)
 clock-skew-description=코드가 거부되기 전에 시계가 다를 수 있는 시간을 밀리초 단위로 설정합니다. 즉, 체커는 현재 시간에 대한 유효성 검사를 수행한 다음 두 번의 추가 유효성 검사(+ 클럭 왜곡 시간/- 클럭 왜곡 시간)를 수행할 수 있습니다. (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=시간 기반 일회성 암호 (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_lo.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_lo.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algorithm Key Size (Automatic Copy)
 algorithm-key-size-description=Set the size of the algorithm key. (Automatic Copy)
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Clock Skew (Automatic Copy)
 clock-skew-description=Set the time in milliseconds that the clocks can differ before a code will be rejected. This means the checker could perform a validation against the current time and then two further validations (+ clock skew time / - clock skew time). (Automatic Copy)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Time-Based One-Time Password (Automatic Copy)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_lt.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_lt.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algoritmo rakto dydis (Automatic Translation)
 algorithm-key-size-description=Nustatykite rakto algoritmo dydį. (Automatic Translation)
-button-remove-configured-timebased-otp=Pašalinkite sukonfigūruotą laiko slaptažodį. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Laikrodis nerijos (Automatic Translation)
 clock-skew-description=Nustatykite laiką milisekundėmis, kad laikrodžiai gali skirtis prieš atmesdami kodą. Tai reiškia, kad tikrintuvas gali atlikti patvirtinimą pagal dabartinį laiką ir tada dar du patvirtinimus (+ laikrodžio nerijos laikas / - laikrodžio nerijos laikas). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Vienkartinis slaptažodis pagal laiką (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_nb.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_nb.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algoritme Nøkkel Størrelse (Automatic Translation)
 algorithm-key-size-description=Angi størrelsen på nøkkelalgoritmen. (Automatic Translation)
-button-remove-configured-timebased-otp=Fjern konfigurert tidsbasert engangspassord. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Klokke Skew (Automatic Translation)
 clock-skew-description=Angi tiden i millisekunder som klokkene kan variere før en kode blir avvist. Dette betyr at kontrollør kan utføre en validering mot gjeldende tid og deretter to ytterligere valideringer (+ klokke skjev tid / - klokke skjev tid). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Tidsbasert engangspassord (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_nl.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_nl.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Grootte algoritmesleutel
 algorithm-key-size-description=Stel de grootte van de algoritmesleutel in.
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Tijdverschil klok
 clock-skew-description=Stel de tijd in milliseconden in waarna een code wordt geweigerd. Dit houdt in dat bij de controle de huidige tijd wordt gevalideerd, waarna nog twee validaties volgen (tijdverschil klok + / tijdverschil klok -).
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Tijdgebaseerd eenmalig wachtwoord

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_nl_BE.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algorithm Key Size (Automatic Copy)
 algorithm-key-size-description=Set the size of the algorithm key. (Automatic Copy)
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Clock Skew (Automatic Copy)
 clock-skew-description=Set the time in milliseconds that the clocks can differ before a code will be rejected. This means the checker could perform a validation against the current time and then two further validations (+ clock skew time / - clock skew time). (Automatic Copy)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Time-Based One-Time Password (Automatic Copy)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_pl.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_pl.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Rozmiar klucza algorytmu (Automatic Translation)
 algorithm-key-size-description=Ustaw rozmiar algorytmu klucza. (Automatic Translation)
-button-remove-configured-timebased-otp=Usuń skonfigurowane hasło jednorazowe oparte na czasie. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Pochylenie zegara (Automatic Translation)
 clock-skew-description=Ustaw czas w milisekundach, że zegary mogą się różnić, zanim kod zostanie odrzucony. Oznacza to, że kontroler może wykonać sprawdzanie poprawności względem bieżącego czasu, a następnie dwie kolejne weryfikacje (+ czas pochylenia zegara / - czas pochylenia zegara). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Hasło jednorazowe oparte na czasie (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_pt_BR.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Tamanho da chave de algoritmo
 algorithm-key-size-description=Definir o tamanho do algoritmo da chave.
-button-remove-configured-timebased-otp=Remova a senha dinâmica baseada em tempo configurada.
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Defasagem horária
 clock-skew-description=Definir o tempo em milissegundos em que os relógios podem diferir antes que um código seja rejeitado. Isto significa que o verificador pode executar uma validação em relação à hora atual e, em seguida, mais duas validações (+ tempo de defasagem horária / - tempo de defasagem horária).
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Senha única baseada em tempo

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_pt_PT.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algorithm Key Size (Automatic Copy)
 algorithm-key-size-description=Set the size of the algorithm key. (Automatic Copy)
-button-remove-configured-timebased-otp=Remova a senha única configurada do tempo. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Clock Skew (Automatic Copy)
 clock-skew-description=Set the time in milliseconds that the clocks can differ before a code will be rejected. This means the checker could perform a validation against the current time and then two further validations (+ clock skew time / - clock skew time). (Automatic Copy)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Time-Based One-Time Password (Automatic Copy)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_ro.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_ro.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Dimensiune cheie algoritm (Automatic Translation)
 algorithm-key-size-description=Setați dimensiunea algoritmului cheie. (Automatic Translation)
-button-remove-configured-timebased-otp=Eliminați parola unică configurată pe bază de timp. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Înclinare ceas (Automatic Translation)
 clock-skew-description=Setați ora în milisecunde în care ceasurile pot diferi înainte ca un cod să fie respins. Acest lucru înseamnă că verificatorul ar putea efectua o validare împotriva orei curente și apoi două validări suplimentare (+ timp de înclinare a ceasului / - timp de înclinare a ceasului). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Parolă unică bazată pe timp (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_ru.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_ru.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Алгоритм Ключевой размер (Automatic Translation)
 algorithm-key-size-description=Установите размер ключевого алгоритма. (Automatic Translation)
-button-remove-configured-timebased-otp=Удалите настроенный одноразовый пароль на основе времени. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Часы Skew (Automatic Translation)
 clock-skew-description=Установите время в миллисекундах, что часы могут отличаться, прежде чем код будет отклонен. Это означает, что проверка может выполнять проверку по отношению к текущему времени, а затем еще две проверки (время перекоса часов / - время перекоса часов). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Одноразовый пароль на основе времени (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_sk.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_sk.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Veľkosť kľúča algoritmu (Automatic Translation)
 algorithm-key-size-description=Nastavte veľkosť algoritmu kľúča. (Automatic Translation)
-button-remove-configured-timebased-otp=Odstráňte nakonfigurované časové heslo. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Hodiny skosenie (Automatic Translation)
 clock-skew-description=Pred odmietnutím kódu nastavte čas v milisekundách, počas ktorého sa hodiny môžu líšiť. To znamená, že kontrola môže vykonať overenie oproti aktuálnemu času a potom dve ďalšie overenia (+ hodiny skew čas / - hodiny skosenie čas). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Jednorazové heslo založené na čase (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_sl.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_sl.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Velikost ključa algoritma (Automatic Translation)
 algorithm-key-size-description=Nastavite velikost algoritma ključa. (Automatic Translation)
-button-remove-configured-timebased-otp=Odstranite konfigurirano časovno geslo. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Ura skew (Automatic Translation)
 clock-skew-description=Nastavite čas v milisekundah, da se ure lahko razlikujejo, preden bo koda zavrnjena. To sredstvo skladiščnik strjena lava izvršiti nalogo a proglasitev pravnomočnosti ali pravne veljavnosti zoper tok čas ter torej dva naknaden proglasitev pravnomočnosti ali pravne veljavnosti (+ ura skew čas/-ura skew čas). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Časovno-osnova nedoločni zaimek-čas parola (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_sr_RS.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algorithm Key Size (Automatic Copy)
 algorithm-key-size-description=Set the size of the algorithm key. (Automatic Copy)
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Clock Skew (Automatic Copy)
 clock-skew-description=Set the time in milliseconds that the clocks can differ before a code will be rejected. This means the checker could perform a validation against the current time and then two further validations (+ clock skew time / - clock skew time). (Automatic Copy)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Time-Based One-Time Password (Automatic Copy)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algorithm Key Size (Automatic Copy)
 algorithm-key-size-description=Set the size of the algorithm key. (Automatic Copy)
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Clock Skew (Automatic Copy)
 clock-skew-description=Set the time in milliseconds that the clocks can differ before a code will be rejected. This means the checker could perform a validation against the current time and then two further validations (+ clock skew time / - clock skew time). (Automatic Copy)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Time-Based One-Time Password (Automatic Copy)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_sv.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_sv.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Storlek på nyckelalgoritm
 algorithm-key-size-description=Ange storlek på nyckelalgoritm.
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Klockavvikelser
 clock-skew-description=Ställ in tid i millisekunder som klockorna kan skilja sig innan en kod avvisas. Det innebär att kontrolleraren kan göra en validering mot den nuvarande tiden och sedan ytterligare två valideringar (+tid för klockavvikelser/- tid för klockavvikelser).
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Tidsbaserat engångslösenord

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_ta_IN.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algorithm Key Size (Automatic Copy)
 algorithm-key-size-description=Set the size of the algorithm key. (Automatic Copy)
-button-remove-configured-timebased-otp=Remove configured time-based one-time password. (Automatic Copy)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Clock Skew (Automatic Copy)
 clock-skew-description=Set the time in milliseconds that the clocks can differ before a code will be rejected. This means the checker could perform a validation against the current time and then two further validations (+ clock skew time / - clock skew time). (Automatic Copy)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Time-Based One-Time Password (Automatic Copy)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_th.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_th.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=ขนาดคีย์อัลกอริทึม (Automatic Translation)
 algorithm-key-size-description=ตั้งค่าขนาดของอัลกอริทึมคีย์ (Automatic Translation)
-button-remove-configured-timebased-otp=เอารหัสผ่านแบบใช้ครั้งเดียวตามการกําหนดค่า (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=นาฬิกาเอียง (Automatic Translation)
 clock-skew-description=ตั้งค่าเวลาเป็นมิลลิวินาทีที่นาฬิกาอาจแตกต่างก่อนที่รหัสจะถูกปฏิเสธ ซึ่งหมายความว่าตัวตรวจสอบสามารถดําเนินการตรวจสอบกับเวลาปัจจุบันและจากนั้นสองการตรวจสอบเพิ่มเติม (+ เวลาลาดนาฬิกา / - เวลาลาดนาฬิกา) (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=รหัสผ่านแบบใช้ครั้งเดียวตามเวลา (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_tr.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_tr.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Algoritma Anahtar Boyutu (Automatic Translation)
 algorithm-key-size-description=Anahtar algoritmasının boyutunu ayarlayın. (Automatic Translation)
-button-remove-configured-timebased-otp=Yapılandırılmış zaman tabanlı tek seferlik parolayı kaldırın. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Saat Eğriltme (Automatic Translation)
 clock-skew-description=Bir kod reddedilmeden önce saatlerin farklı olabileceği milisaniyecinsinden zaman ayarlayın. Bu, denetleyicinin geçerli zamana ve ardından iki doğrulamaya (+ saat çarpık zaman / - saat çarpık saati) karşı bir doğrulama gerçekleştirebileceği anlamına gelir. (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Zaman Tabanlı Tek Seferlik Parola (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_uk.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_uk.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Розмір ключа алгоритму (Automatic Translation)
 algorithm-key-size-description=Встановіть розмір алгоритму ключа. (Automatic Translation)
-button-remove-configured-timebased-otp=Видалити настроєний час на основі одного пароля. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Годинники косі (Automatic Translation)
 clock-skew-description=Встановити час в мілісекундах, що Годинники можуть відрізнятися, перш ніж код буде відхилено. Це означає, що перевірка може виконати перевірку на поточний час, а потім ще два перевірки (+ годинник зсув часу/годинник нахил час). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Одночасовий пароль на основі часу (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_vi.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_vi.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=Kích thước khóa thuật toán (Automatic Translation)
 algorithm-key-size-description=Đặt kích thước của thuật toán khóa. (Automatic Translation)
-button-remove-configured-timebased-otp=Xóa mật khẩu một lần dựa trên cấu hình thời gian. (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=Đồng hồ skew (Automatic Translation)
 clock-skew-description=Đặt thời gian trong mili giây mà đồng hồ có thể khác nhau trước khi mã sẽ bị từ chối. Điều này có nghĩa là kiểm tra có thể thực hiện một xác nhận với thời gian hiện tại và sau đó thêm hai validations (+ đồng hồ nghiêng thời gian/-thời gian nghiêng đồng hồ). (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=Mật khẩu một lần dựa trên thời gian (Automatic Translation)

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_zh_CN.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=密钥算法大小
 algorithm-key-size-description=设置密钥算法的大小。
-button-remove-configured-timebased-otp=删除配置的基于时间的一次密码。 (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=时钟漂移
 clock-skew-description=以毫秒为单位设置时钟可以出现差异的最大时长，在此之后代码将被拒绝。这意味着检查器可以对当前时间进行验证并进行两次额外验证（+ 时钟漂移时间/ - 时钟漂移时间）。
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=基于时间的一次性密码

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/resources/content/Language_zh_TW.properties
@@ -1,6 +1,6 @@
 algorithm-key-size=演算法金鑰大小 (Automatic Translation)
 algorithm-key-size-description=設定金鑰演演算法的大小。 (Automatic Translation)
-button-remove-configured-timebased-otp=刪除配置的基於時間的一次密碼。 (Automatic Translation)
+button-remove-configured-timebased-otp=Remove configured time-based one-time password (Automatic Copy)
 clock-skew=時鐘傾斜 (Automatic Translation)
 clock-skew-description=設置時鐘在拒絕代碼之前可能不同的時間(以毫秒為單位)。這意味著檢查器可以針對當前時間執行驗證,然後執行兩個進一步的驗證(+ 時鐘偏斜時間 / - 時鐘偏斜時間)。 (Automatic Translation)
 com.liferay.multi.factor.authentication.timebased.otp.web.internal.checker.TimeBasedOTPBrowserSetupMFAChecker=基於時間的一次性密碼 (Automatic Translation)


### PR DESCRIPTION
Hey Brian! 👋 

Last Friday we sent you [a PR with small changes of UX for MFA](https://github.com/brianchandotcom/liferay-portal/pull/92419).
Among those changes is the removal of the dot from the text of a button:
![totp-user-config-remove-dot](https://user-images.githubusercontent.com/19305424/89795149-55083f00-db28-11ea-9074-73ee1ba8939b.jpg)

As [Zsigmond mentioned](https://github.com/brianchandotcom/liferay-portal/pull/92419#issuecomment-670549463), removing this dot is a request from the UX team; is there a specific way or format to mark the language key as belonging to a button so we can add it without the dot?

Thank you!