### PR TITLE
[TS] LPS-119412 account-admin-web: Retrieved account details using value instead of property.

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/view.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_groups_admin/view.jsp
@@ -48,14 +48,14 @@ ViewAccountGroupsManagementToolbarDisplayContext viewAccountGroupsManagementTool
 					cssClass="table-cell-expand table-title"
 					href="<%= rowURL %>"
 					name="name"
-					property="name"
+					value="<%= HtmlUtil.escape(accountGroupDisplay.getName()) %>"
 				/>
 
 				<liferay-ui:search-container-column-text
 					cssClass="table-cell-expand"
 					href="<%= rowURL %>"
 					name="description"
-					property="description"
+					value="<%= HtmlUtil.escape(accountGroupDisplay.getDescription()) %>"
 				/>
 
 				<liferay-ui:search-container-column-jsp

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/select_account_entry.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/select_account_entry.jsp
@@ -63,14 +63,14 @@ if (selectAccountEntryManagementToolbarDisplayContext.isSingleSelect()) {
 			<liferay-ui:search-container-column-text
 				cssClass='<%= cssClass + " table-title" %>'
 				name="name"
-				property="name"
+				value="<%= HtmlUtil.escape(accountEntryDisplay.getName()) %>"
 			/>
 
 			<liferay-ui:search-container-column-text
 				cssClass="<%= cssClass %>"
 				name="type"
-				property="type"
 				translate="<%= true %>"
+				value="<%= HtmlUtil.escape(accountEntryDisplay.getType()) %>"
 			/>
 
 			<c:if test="<%= selectAccountEntryManagementToolbarDisplayContext.isSingleSelect() %>">

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/view.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_users_admin/view.jsp
@@ -73,7 +73,7 @@ AccountUsersAdminManagementToolbarDisplayContext accountUsersAdminManagementTool
 					cssClass="table-cell-expand-small table-cell-minw-150"
 					href="<%= rowURL %>"
 					name="name"
-					property="name"
+					value="<%= HtmlUtil.escape(accountUserDisplay.getName()) %>"
 				/>
 
 				<liferay-ui:search-container-column-text
@@ -87,14 +87,14 @@ AccountUsersAdminManagementToolbarDisplayContext accountUsersAdminManagementTool
 					cssClass="table-cell-expand-small table-cell-minw-150"
 					href="<%= rowURL %>"
 					name="job-title"
-					property="jobTitle"
+					value="<%= HtmlUtil.escape(accountUserDisplay.getJobTitle()) %>"
 				/>
 
 				<liferay-ui:search-container-column-text
 					cssClass='<%= "table-cell-expand-small table-cell-minw-150 " + accountUserDisplay.getAccountEntryNamesStyle() %>'
 					href="<%= rowURL %>"
 					name="accounts"
-					value="<%= accountUserDisplay.getAccountEntryNamesString(request) %>"
+					value="<%= HtmlUtil.escape(accountUserDisplay.getAccountEntryNamesString(request)) %>"
 				/>
 
 				<liferay-ui:search-container-column-text


### PR DESCRIPTION
Hi @liferay-appsec,

https://issues.liferay.com/browse/LPS-119412

Notes from @javalosjr96:

> Retrieved account details using value instead of property when tables are created.
> 
> The issue was that a user could use HTML Syntax in account details. This allowed the use of script syntax and would run when the details were called on.
> Using value allowed the use of HtmlUtil.escape which prevents scripts from running.

**Additional Thoughts**
Looking at the code, **account-admin-web** may not have accounted for XSS for their fields.

Feel free to let us know if you have any questions.
Thanks!