### PR TITLE
LPS-119169 Followup 2

### DIFF
--- a/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/FastURLToCORSSupportMapper.java
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/FastURLToCORSSupportMapper.java
@@ -37,12 +37,7 @@ public class FastURLToCORSSupportMapper extends BaseURLToCORSSupportMapper {
 			}
 		}
 
-		if (maxURLPatternLength < 1) {
-			_maxURLPatternLength = 64;
-		}
-		else {
-			_maxURLPatternLength = maxURLPatternLength + 1;
-		}
+		_maxURLPatternLength = maxURLPatternLength + 1;
 
 		_extensionTrieMatrix =
 			new long[2][_maxURLPatternLength][_ASCII_CHARACTER_RANGE];

--- a/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/FastURLToCORSSupportMapper.java
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/FastURLToCORSSupportMapper.java
@@ -91,13 +91,9 @@ public class FastURLToCORSSupportMapper extends BaseURLToCORSSupportMapper {
 		int column = 0;
 		int row = 0;
 
-		for (; row < urlPath.length(); ++row) {
-			if (row > (_maxURLPatternLength - 1)) {
-				bitmask = 0;
+		int maxRow = Math.min(urlPath.length(), _maxURLPatternLength - 1);
 
-				break;
-			}
-
+		for (; row < maxRow; ++row) {
 			char character = urlPath.charAt(row);
 
 			column = character - _ASCII_PRINTABLE_OFFSET;
@@ -107,6 +103,10 @@ public class FastURLToCORSSupportMapper extends BaseURLToCORSSupportMapper {
 			if (bitmask == 0) {
 				break;
 			}
+		}
+
+		if (row > (_maxURLPatternLength - 1)) {
+			bitmask = 0;
 		}
 
 		if (bitmask != 0) {
@@ -123,11 +123,9 @@ public class FastURLToCORSSupportMapper extends BaseURLToCORSSupportMapper {
 	private CORSSupport _getExtensionCORSSupport(String urlPath) {
 		long currentBitmask = _BITMASK;
 
-		for (int row = 0; row < urlPath.length(); ++row) {
-			if (row > (_maxURLPatternLength - 1)) {
-				break;
-			}
+		int maxRow = Math.min(urlPath.length(), _maxURLPatternLength - 1);
 
+		for (int row = 0; row < maxRow; ++row) {
 			char character = urlPath.charAt(urlPath.length() - 1 - row);
 
 			if (character == '/') {
@@ -231,13 +229,9 @@ public class FastURLToCORSSupportMapper extends BaseURLToCORSSupportMapper {
 		long currentBitmask = _BITMASK;
 		int row = 0;
 
-		for (; row < urlPath.length(); ++row) {
-			if (row > (_maxURLPatternLength - 1)) {
-				currentBitmask = 0;
+		int maxRow = Math.min(urlPath.length(), _maxURLPatternLength - 1);
 
-				break;
-			}
-
+		for (; row < maxRow; ++row) {
 			char character = urlPath.charAt(row);
 
 			column = character - _ASCII_PRINTABLE_OFFSET;
@@ -259,6 +253,10 @@ public class FastURLToCORSSupportMapper extends BaseURLToCORSSupportMapper {
 					bestMatchBitmask = bitmask;
 				}
 			}
+		}
+
+		if (row > (_maxURLPatternLength - 1)) {
+			currentBitmask = 0;
 		}
 
 		if (currentBitmask == 0) {

--- a/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/SimpleURLToCORSSupportMapper.java
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/SimpleURLToCORSSupportMapper.java
@@ -77,6 +77,10 @@ public class SimpleURLToCORSSupportMapper extends BaseURLToCORSSupportMapper {
 	protected void put(CORSSupport corsSupport, String urlPattern)
 		throws IllegalArgumentException {
 
+		if (Validator.isBlank(urlPattern)) {
+			throw new IllegalArgumentException("urlPattern is empty");
+		}
+
 		if (isWildcardURLPattern(urlPattern)) {
 			if (!_wildcardURLPatternCORSSupports.containsKey(urlPattern)) {
 				_wildcardURLPatternCORSSupports.put(urlPattern, corsSupport);

--- a/modules/apps/portal-remote/portal-remote-cors-impl/src/test/java/com/liferay/portal/remote/cors/internal/FastURLToCORSSupportMapperTest.java
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/src/test/java/com/liferay/portal/remote/cors/internal/FastURLToCORSSupportMapperTest.java
@@ -16,7 +16,6 @@ package com.liferay.portal.remote.cors.internal;
 
 import java.util.Map;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -25,7 +24,6 @@ import org.junit.Test;
 public class FastURLToCORSSupportMapperTest
 	extends SimpleURLToCORSSupportMapperTest {
 
-	@Ignore
 	@Test
 	public void testGet() {
 		super.testGet();

--- a/modules/apps/portal-remote/portal-remote-cors-impl/src/test/java/com/liferay/portal/remote/cors/internal/SimpleURLToCORSSupportMapperTest.java
+++ b/modules/apps/portal-remote/portal-remote-cors-impl/src/test/java/com/liferay/portal/remote/cors/internal/SimpleURLToCORSSupportMapperTest.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.remote.cors.internal;
 
 import com.liferay.portal.kernel.util.KeyValuePair;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -74,6 +75,10 @@ public class SimpleURLToCORSSupportMapperTest {
 		Map<String, CORSSupport> corsSupports = new HashMap<>();
 
 		for (KeyValuePair keyValuePair : keyValuePairs) {
+			if (Validator.isBlank(keyValuePair.getValue())) {
+				continue;
+			}
+
 			CORSSupport corsSupport = new CORSSupport();
 
 			corsSupport.setHeader("pattern", keyValuePair.getValue());


### PR DESCRIPTION
/cc @arthurchan35

hey Brian, 
I will try to comment on your comments one by one:

regarding 600ed9ae98dcae48fbcf2aba0142255aeddb3c07 : reverting that optimization makes it dependent on the JVM being used. Not all JITs behave the same. Anyway we are sending a7e050511540729d46621607f9ca2c328ed8509f which is an improvement since it eliminates a check inside the loop.

regarding 47b87779a99b0aefe33931ba8f71afa97eb48cd2 : I see that you mention we don't need to add the annotations because they are inherited. Let me know if you expect any further action on this. It looks like tests are working now.

regarding 47b87779a99b0aefe33931ba8f71afa97eb48cd2 : I did not add the interface because you explicitly removed it in 5e0d063c37b6d8027aec7c611d502d3ac318021f together along with the factory we had to select the implementation. We are trying to follow your lead here. As I mentioned in the pull text: 
> in this pull I only extracted a base class to avoid an initialization problem introduced in a3e060d

because I was not sure what you wanted to do and wanted to illustrate the problem. 

regarding 797f8dd6e8047a178cfd6464a31676acdbf4deee : I increased the iterations because, when running the _"benchmark"_ several times, the deviation from the average I get is much bigger with 100K than with 1M. I believe that points to a greater contribution from _"noise"_. But I don't think this is very important. 

We'll send a follow up pull after this one with the rest of the implementation.

Carlos.

