### PR TITLE
Revert LPS-119025 Mark deprecation for Facebook

### DIFF
--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/portlet/action/AssociateFacebookUserMVCRenderCommand.java
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/portlet/action/AssociateFacebookUserMVCRenderCommand.java
@@ -33,8 +33,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author     Stian Sigvartsen
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Stian Sigvartsen
  */
 @Component(
 	immediate = true,
@@ -45,7 +44,6 @@ import org.osgi.service.component.annotations.Reference;
 	},
 	service = MVCRenderCommand.class
 )
-@Deprecated
 public class AssociateFacebookUserMVCRenderCommand implements MVCRenderCommand {
 
 	@Override

--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/portlet/action/FacebookConnectLoginErrorMVCRenderCommand.java
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/portlet/action/FacebookConnectLoginErrorMVCRenderCommand.java
@@ -44,8 +44,7 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author     Stian Sigvartsen
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Stian Sigvartsen
  */
 @Component(
 	immediate = true,
@@ -56,7 +55,6 @@ import org.osgi.service.component.annotations.Reference;
 	},
 	service = MVCRenderCommand.class
 )
-@Deprecated
 public class FacebookConnectLoginErrorMVCRenderCommand
 	implements MVCRenderCommand {
 

--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/servlet/taglib/FacebookConnectNavigationPreJSPDynamicInclude.java
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/servlet/taglib/FacebookConnectNavigationPreJSPDynamicInclude.java
@@ -38,11 +38,9 @@ import org.osgi.service.component.annotations.Reference;
  * to the portlet if Facebook Connect authentication has been enabled for the
  * portal instance being accessed.
  *
- * @author     Michael C. Han
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Michael C. Han
  */
 @Component(immediate = true, service = DynamicInclude.class)
-@Deprecated
 public class FacebookConnectNavigationPreJSPDynamicInclude
 	extends BaseJSPDynamicInclude {
 

--- a/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/struts/FacebookConnectStrutsAction.java
+++ b/modules/apps/login/login-authentication-facebook-connect-web/src/main/java/com/liferay/login/authentication/facebook/connect/web/internal/struts/FacebookConnectStrutsAction.java
@@ -101,10 +101,9 @@ import org.osgi.service.component.annotations.Reference;
  * </li>
  * </ol>
  *
- * @author     Wilson Man
- * @author     Sergio González
- * @author     Mika Koivisto
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Wilson Man
+ * @author Sergio González
+ * @author Mika Koivisto
  */
 @Component(
 	immediate = true,
@@ -114,7 +113,6 @@ import org.osgi.service.component.annotations.Reference;
 	},
 	service = StrutsAction.class
 )
-@Deprecated
 public class FacebookConnectStrutsAction implements StrutsAction {
 
 	@Override

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/configuration/FacebookConnectConfiguration.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/configuration/FacebookConnectConfiguration.java
@@ -19,10 +19,8 @@ import aQute.bnd.annotation.metatype.Meta;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 
 /**
- * @author     Michael C. Han
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Michael C. Han
  */
-@Deprecated
 @ExtendedObjectClassDefinition(category = "sso")
 @Meta.OCD(
 	id = "com.liferay.portal.security.sso.facebook.connect.configuration.FacebookConnectConfiguration",

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/constants/FacebookConnectConfigurationKeys.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/constants/FacebookConnectConfigurationKeys.java
@@ -15,10 +15,8 @@
 package com.liferay.portal.security.sso.facebook.connect.constants;
 
 /**
- * @author     Mika Koivisto
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Mika Koivisto
  */
-@Deprecated
 public class FacebookConnectConfigurationKeys {
 
 	public static final String APP_ID = "appId";

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/constants/FacebookConnectConstants.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/constants/FacebookConnectConstants.java
@@ -15,10 +15,8 @@
 package com.liferay.portal.security.sso.facebook.connect.constants;
 
 /**
- * @author     Michael C. Han
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Michael C. Han
  */
-@Deprecated
 public class FacebookConnectConstants {
 
 	public static final String SERVICE_NAME =

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/constants/FacebookConnectWebKeys.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/constants/FacebookConnectWebKeys.java
@@ -15,10 +15,8 @@
 package com.liferay.portal.security.sso.facebook.connect.constants;
 
 /**
- * @author     Michael C. Han
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Michael C. Han
  */
-@Deprecated
 public interface FacebookConnectWebKeys {
 
 	public static final String FACEBOOK_ACCESS_TOKEN = "FACEBOOK_ACCESS_TOKEN";

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/constants/LegacyFacebookConnectPropsKeys.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/constants/LegacyFacebookConnectPropsKeys.java
@@ -15,10 +15,8 @@
 package com.liferay.portal.security.sso.facebook.connect.constants;
 
 /**
- * @author     Stian Sigvartsen
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Stian Sigvartsen
  */
-@Deprecated
 public class LegacyFacebookConnectPropsKeys {
 
 	public static final String APP_ID = "facebook.connect.app.id";

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/exception/MustVerifyEmailAddressException.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/exception/MustVerifyEmailAddressException.java
@@ -17,10 +17,8 @@ package com.liferay.portal.security.sso.facebook.connect.exception;
 import com.liferay.portal.kernel.exception.PortalException;
 
 /**
- * @author     Stian Sigvartsen
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Stian Sigvartsen
  */
-@Deprecated
 public class MustVerifyEmailAddressException extends PortalException {
 
 	public MustVerifyEmailAddressException(long companyId) {

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/exception/StrangersNotAllowedException.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/exception/StrangersNotAllowedException.java
@@ -17,10 +17,8 @@ package com.liferay.portal.security.sso.facebook.connect.exception;
 import com.liferay.portal.kernel.exception.PortalException;
 
 /**
- * @author     Stian Sigvartsen
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Stian Sigvartsen
  */
-@Deprecated
 public class StrangersNotAllowedException extends PortalException {
 
 	public StrangersNotAllowedException(long companyId) {

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/exception/UnknownErrorException.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/exception/UnknownErrorException.java
@@ -17,10 +17,8 @@ package com.liferay.portal.security.sso.facebook.connect.exception;
 import com.liferay.portal.kernel.exception.PortalException;
 
 /**
- * @author     Stian Sigvartsen
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Stian Sigvartsen
  */
-@Deprecated
 public class UnknownErrorException extends PortalException {
 
 	public UnknownErrorException() {

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/FacebookConnectImpl.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/FacebookConnectImpl.java
@@ -48,15 +48,13 @@ import org.osgi.service.component.annotations.Reference;
  * its methods statically.
  * </p>
  *
- * @author     Wilson Man
- * @author     Mika Koivisto
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Wilson Man
+ * @author Mika Koivisto
  */
 @Component(
 	configurationPid = "com.liferay.portal.security.sso.facebook.connect.configuration.FacebookConnectConfiguration",
 	immediate = true, service = FacebookConnect.class
 )
-@Deprecated
 public class FacebookConnectImpl implements FacebookConnect {
 
 	@Override

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/auth/publicpath/AuthPublicPath.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/auth/publicpath/AuthPublicPath.java
@@ -17,14 +17,12 @@ package com.liferay.portal.security.sso.facebook.connect.internal.auth.publicpat
 import org.osgi.service.component.annotations.Component;
 
 /**
- * @author     Stian Sigvartsen
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Stian Sigvartsen
  */
 @Component(
 	immediate = true,
 	property = "auth.public.path=/portal/facebook_connect_oauth",
 	service = Object.class
 )
-@Deprecated
 public class AuthPublicPath {
 }

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/auto/login/FacebookConnectAutoLogin.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/auto/login/FacebookConnectAutoLogin.java
@@ -44,11 +44,9 @@ import org.osgi.service.component.annotations.Reference;
  * challenge.
  * <p>
  *
- * @author     Wilson Man
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Wilson Man
  */
 @Component(immediate = true, service = AutoLogin.class)
-@Deprecated
 public class FacebookConnectAutoLogin extends BaseAutoLogin {
 
 	@Override

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/configuration/definition/FacebookConnectCompanyServiceConfigurationPidMapping.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/configuration/definition/FacebookConnectCompanyServiceConfigurationPidMapping.java
@@ -21,11 +21,9 @@ import com.liferay.portal.security.sso.facebook.connect.constants.FacebookConnec
 import org.osgi.service.component.annotations.Component;
 
 /**
- * @author     Mika Koivisto
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Mika Koivisto
  */
 @Component(service = ConfigurationPidMapping.class)
-@Deprecated
 public class FacebookConnectCompanyServiceConfigurationPidMapping
 	implements ConfigurationPidMapping {
 

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/settings/definition/FacebookConnectCompanyServiceConfigurationBeanDeclaration.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/settings/definition/FacebookConnectCompanyServiceConfigurationBeanDeclaration.java
@@ -20,11 +20,9 @@ import com.liferay.portal.security.sso.facebook.connect.configuration.FacebookCo
 import org.osgi.service.component.annotations.Component;
 
 /**
- * @author     Mika Koivisto
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Mika Koivisto
  */
 @Component(service = ConfigurationBeanDeclaration.class)
-@Deprecated
 public class FacebookConnectCompanyServiceConfigurationBeanDeclaration
 	implements ConfigurationBeanDeclaration {
 

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/FacebookConnectCompanySettingsVerifyProcess.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-impl/src/main/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/FacebookConnectCompanySettingsVerifyProcess.java
@@ -32,15 +32,13 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author     Stian Sigvartsen
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Stian Sigvartsen
  */
 @Component(
 	immediate = true,
 	property = "verify.process.name=com.liferay.portal.security.sso.facebook.connect",
 	service = VerifyProcess.class
 )
-@Deprecated
 public class FacebookConnectCompanySettingsVerifyProcess
 	extends BaseCompanySettingsVerifyProcess {
 

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-test/src/testIntegration/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/test/FacebookConnectCompanySettingsVerifyProcessTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-test/src/testIntegration/java/com/liferay/portal/security/sso/facebook/connect/internal/verify/test/FacebookConnectCompanySettingsVerifyProcessTest.java
@@ -34,10 +34,8 @@ import org.junit.Rule;
 import org.junit.runner.RunWith;
 
 /**
- * @author     Stian Sigvartsen
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Stian Sigvartsen
  */
-@Deprecated
 @RunWith(Arquillian.class)
 public class FacebookConnectCompanySettingsVerifyProcessTest
 	extends BaseCompanySettingsVerifyProcessTestCase {

--- a/modules/apps/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/java/com/liferay/portal/settings/authentication/facebook/connect/web/internal/constants/PortalSettingsFacebookConnectConstants.java
+++ b/modules/apps/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/java/com/liferay/portal/settings/authentication/facebook/connect/web/internal/constants/PortalSettingsFacebookConnectConstants.java
@@ -15,10 +15,8 @@
 package com.liferay.portal.settings.authentication.facebook.connect.web.internal.constants;
 
 /**
- * @author     Jose A. Jimenez
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Jose A. Jimenez
  */
-@Deprecated
 public class PortalSettingsFacebookConnectConstants {
 
 	public static final String FORM_PARAMETER_NAMESPACE = "facebook_";

--- a/modules/apps/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/java/com/liferay/portal/settings/authentication/facebook/connect/web/internal/portal/settings/configuration/admin/display/FacebookConnectPortalSettingsConfigurationScreenContributor.java
+++ b/modules/apps/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/java/com/liferay/portal/settings/authentication/facebook/connect/web/internal/portal/settings/configuration/admin/display/FacebookConnectPortalSettingsConfigurationScreenContributor.java
@@ -27,11 +27,9 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author     Drew Brokke
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Drew Brokke
  */
 @Component(service = PortalSettingsConfigurationScreenContributor.class)
-@Deprecated
 public class FacebookConnectPortalSettingsConfigurationScreenContributor
 	implements PortalSettingsConfigurationScreenContributor {
 

--- a/modules/apps/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/java/com/liferay/portal/settings/authentication/facebook/connect/web/internal/portlet/action/FacebookConnectPortalSettingsFormContributor.java
+++ b/modules/apps/portal-settings/portal-settings-authentication-facebook-connect-web/src/main/java/com/liferay/portal/settings/authentication/facebook/connect/web/internal/portlet/action/FacebookConnectPortalSettingsFormContributor.java
@@ -30,12 +30,10 @@ import javax.portlet.PortletException;
 import org.osgi.service.component.annotations.Component;
 
 /**
- * @author     Tomas Polesovsky
- * @author     Stian Sigvartsen
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Tomas Polesovsky
+ * @author Stian Sigvartsen
  */
 @Component(immediate = true, service = PortalSettingsFormContributor.class)
-@Deprecated
 public class FacebookConnectPortalSettingsFormContributor
 	implements PortalSettingsFormContributor {
 

--- a/portal-impl/src/com/liferay/portal/facebook/FacebookConnectUtil.java
+++ b/portal-impl/src/com/liferay/portal/facebook/FacebookConnectUtil.java
@@ -23,12 +23,10 @@ import com.liferay.registry.ServiceTracker;
 import javax.portlet.PortletRequest;
 
 /**
- * @author     Wilson Man
- * @author     Brian Wing Shun Chan
- * @author     Mika Koivisto
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Wilson Man
+ * @author Brian Wing Shun Chan
+ * @author Mika Koivisto
  */
-@Deprecated
 public class FacebookConnectUtil {
 
 	public static String getAccessToken(

--- a/portal-kernel/src/com/liferay/portal/kernel/facebook/FacebookConnect.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/facebook/FacebookConnect.java
@@ -19,12 +19,10 @@ import com.liferay.portal.kernel.json.JSONObject;
 import javax.portlet.PortletRequest;
 
 /**
- * @author     Wilson Man
- * @author     Brian Wing Shun Chan
- * @author     Mika Koivisto
- * @deprecated As of Athanasius (7.3.x), with no direct replacement
+ * @author Wilson Man
+ * @author Brian Wing Shun Chan
+ * @author Mika Koivisto
  */
-@Deprecated
 public interface FacebookConnect {
 
 	public String getAccessToken(long companyId, String redirect, String code);


### PR DESCRIPTION
Hey Brian 

A few days ago we sent you a request to deprecate Facebook Connect's Login mechanism.
We have verified that it is not possible to use OpenId Connect with Facebook, so we must keep these modules to maintain this functionality in the Portal.

I'm sending you the commits to be reversed.
Thanks.

cc/ @arthurchan35 