### PR TITLE
LPS-120938 Only company admins can edit company admins

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/permission/UserPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/UserPermissionImpl.java
@@ -102,7 +102,9 @@ public class UserPermissionImpl
 
 				if (!actionId.equals(ActionKeys.VIEW) &&
 					!permissionChecker.isOmniadmin() &&
-					PortalUtil.isOmniadmin(user)) {
+					(PortalUtil.isOmniadmin(user) ||
+					 (!permissionChecker.isCompanyAdmin() &&
+					  PortalUtil.isCompanyAdmin(user)))) {
 
 					return false;
 				}


### PR DESCRIPTION
[LPS-120938](https://issues.liferay.com/browse/LPS-120938)

Dear App Security Team,

Please review my changes.

**Issue:** As of [LPS-68984](https://issues.liferay.com/browse/LPS-68984), regular users (with User Edit and Delete permissions) can edit company admins of non-default portal instances.

The cause is the removal of company admin check in [this commit](https://github.com/liferay/liferay-portal/commit/acbc7d81480e60c4b77062527f4ca5d6654bef58). The reason why the default portal instance is not affected is that OmniAdminImpl.isOmniadmin(User) returns true if the user has Administrator role and belongs to the default company.

The commit message of the mentioned commit says _"Do not need to guard cross-company user modification"_, but the effect doesn't seem to be in line with the commit message. Actually, the removed lines ensured that only company admins can edit company admins. At least, for any non-default portal instances the check seems to be necessary.

**Solution:** Giving back the company admin check to UserPermissionImpl solves the issue and fortunately doesn't impact LPS-68984.

Please let me know if you have any questions of concerns.

Thank you,
Istvan