### PR TITLE
[TS] LPS-121228 Authenticate the user prior to checking for an expired password

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -1552,8 +1552,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			return 0;
 		}
 
-		user = _checkPasswordPolicy(user);
-
 		if (!PropsValues.BASIC_AUTH_PASSWORD_REQUIRED) {
 			return user.getUserId();
 		}
@@ -1568,6 +1566,8 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			password, userPassword);
 
 		if (userPassword.equals(password) || userPassword.equals(encPassword)) {
+			user = _checkPasswordPolicy(user);
+
 			resetFailedLoginAttempts(user);
 
 			return user.getUserId();
@@ -1626,8 +1626,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			return 0;
 		}
 
-		user = _checkPasswordPolicy(user);
-
 		// Verify digest
 
 		if (Validator.isNull(user.getDigest())) {
@@ -1646,6 +1644,8 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 				Digester.MD5, ha1, nonce, ha2);
 
 			if (response.equals(curResponse)) {
+				user = _checkPasswordPolicy(user);
+
 				resetFailedLoginAttempts(user);
 
 				return user.getUserId();
@@ -5869,8 +5869,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			return Authenticator.FAILURE;
 		}
 
-		user = _checkPasswordPolicy(user);
-
 		if (!user.isPasswordEncrypted()) {
 			user.setPassword(PasswordEncryptorUtil.encrypt(user.getPassword()));
 			user.setPasswordEncrypted(true);
@@ -5899,6 +5897,10 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			else {
 				authResult = Authenticator.FAILURE;
 			}
+		}
+
+		if (authResult == Authenticator.SUCCESS) {
+			user = _checkPasswordPolicy(user);
 		}
 
 		// Post-authentication pipeline


### PR DESCRIPTION
There was some ambiguity on https://issues.liferay.com/browse/PTR-1945 so I'll leave my notes here. Anything that needs to be changed please let me know and I can send up a new pull.

1. The behavior is now changed when a user's password is expired. Previously, they would always be altered that it is expired. With these changes, if an incorrect password is supplied then they will be told that the authentication failed.

2. https://github.com/liferay-appsec/liferay-portal/commit/f54c261597bb31ced934dc1d12e12957ac43a0c0#diff-2b0cae0e7f9914274883423c68678ea1R5902 - This is wrapped because otherwise it would still throw an expired password exception instead of an authentication exception. I wasn't sure if it should be put into the following check but since that is denoted as the post-authentication pipeline I figured it would be better on its own.

3. https://github.com/liferay-appsec/liferay-portal/commit/f54c261597bb31ced934dc1d12e12957ac43a0c0#diff-2b0cae0e7f9914274883423c68678ea1R1555-R1557 - I assumed in this case if a password isn't required then we shouldn't need to check if it is expired. If this assumption is incorrect then more modifications will be necessary.

If there are any questions or concerns please let me know.