### PR TITLE
LPS-121070 The Multiple IDP selector form has bad width

### DIFF
--- a/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/util/JspUtil.java
+++ b/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/util/JspUtil.java
@@ -15,7 +15,9 @@
 package com.liferay.saml.util;
 
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.struts.Definition;
 import com.liferay.portal.struts.TilesUtil;
 
@@ -66,7 +68,26 @@ public class JspUtil {
 			httpServletRequest.getRequestDispatcher(
 				_PATH_HTML_COMMON_THEMES_PORTAL);
 
-		requestDispatcher.include(httpServletRequest, httpServletResponse);
+		if (popUp) {
+			requestDispatcher.include(httpServletRequest, httpServletResponse);
+
+			return;
+		}
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		boolean stateMaximized = themeDisplay.isStateMaximized();
+
+		themeDisplay.setStateMaximized(true);
+
+		try {
+			requestDispatcher.include(httpServletRequest, httpServletResponse);
+		}
+		finally {
+			themeDisplay.setStateMaximized(stateMaximized);
+		}
 	}
 
 	private static final String _PATH_HTML_COMMON_THEMES_PORTAL =

--- a/modules/dxp/apps/saml/saml-hook/docroot/META-INF/custom_jsps/html/portal/saml/select_idp.jsp
+++ b/modules/dxp/apps/saml/saml-hook/docroot/META-INF/custom_jsps/html/portal/saml/select_idp.jsp
@@ -24,7 +24,7 @@ JSONObject samlSsoLoginContext = (JSONObject)request.getAttribute("SAML_SSO_LOGI
 JSONArray relevantIdpConnectionsJSONArray = samlSsoLoginContext.getJSONArray("relevantIdpConnections");
 %>
 
-<aui:form action='<%= PortalUtil.getPortalURL(request) + "/c/portal/login" %>' method="get" name="fm">
+<aui:form action='<%= PortalUtil.getPortalURL(request) + "/c/portal/login" %>' method="get" name="fm" style="padding: 1rem;">
 	<aui:input name="saveLastPath" type="hidden" value="<%= false %>" />
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 


### PR DESCRIPTION
Using inline styles isn't desirable, but I think this is just a short term solution until we replace the saml-hook with a portlet that works alongside the login process much like MFA. Then we would get the standard styling.