### PR TITLE
[7.4-only] LPS-122191 Removes unnecessary FlashMagicBytes checks

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/GetFileActionHelper.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/GetFileActionHelper.java
@@ -24,7 +24,6 @@ import com.liferay.document.library.web.internal.security.permission.resource.DL
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.flash.FlashMagicBytesUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileShortcut;
@@ -223,15 +222,6 @@ public class GetFileActionHelper {
 				contentType = MimeTypesUtil.getContentType(fileName);
 			}
 		}
-
-		FlashMagicBytesUtil.Result flashMagicBytesUtilResult =
-			FlashMagicBytesUtil.check(inputStream);
-
-		if (flashMagicBytesUtilResult.isFlash()) {
-			fileName = FileUtil.stripExtension(fileName) + ".swf";
-		}
-
-		inputStream = flashMagicBytesUtilResult.getInputStream();
 
 		ServletResponseUtil.sendFile(
 			httpServletRequest, httpServletResponse, fileName, inputStream,

--- a/modules/apps/image-uploader/image-uploader-web/src/main/java/com/liferay/image/uploader/web/internal/portlet/action/UploadImageMVCResourceCommand.java
+++ b/modules/apps/image-uploader/image-uploader-web/src/main/java/com/liferay/image/uploader/web/internal/portlet/action/UploadImageMVCResourceCommand.java
@@ -17,7 +17,6 @@ package com.liferay.image.uploader.web.internal.portlet.action;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.image.uploader.web.internal.constants.ImageUploaderPortletKeys;
 import com.liferay.image.uploader.web.internal.util.UploadImageUtil;
-import com.liferay.portal.kernel.flash.FlashMagicBytesUtil;
 import com.liferay.portal.kernel.image.ImageBag;
 import com.liferay.portal.kernel.image.ImageToolUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -63,16 +62,8 @@ public class UploadImageMVCResourceCommand extends BaseMVCResourceCommand {
 				FileEntry tempFileEntry = UploadImageUtil.getTempImageFileEntry(
 					resourceRequest);
 
-				FlashMagicBytesUtil.Result flashMagicBytesUtilResult =
-					FlashMagicBytesUtil.check(tempFileEntry.getContentStream());
-
-				if (flashMagicBytesUtilResult.isFlash()) {
-					return;
-				}
-
 				serveTempImageFile(
-					resourceResponse,
-					flashMagicBytesUtilResult.getInputStream());
+					resourceResponse, tempFileEntry.getContentStream());
 			}
 		}
 		catch (NoSuchFileEntryException noSuchFileEntryException) {

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/struts/GetPageAttachmentStrutsAction.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/struts/GetPageAttachmentStrutsAction.java
@@ -16,14 +16,12 @@ package com.liferay.wiki.web.internal.struts;
 
 import com.liferay.document.library.kernel.exception.NoSuchFileException;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.flash.FlashMagicBytesUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.struts.StrutsAction;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -32,8 +30,6 @@ import com.liferay.wiki.exception.NoSuchPageException;
 import com.liferay.wiki.model.WikiPage;
 import com.liferay.wiki.service.WikiPageService;
 import com.liferay.wiki.web.internal.importer.MediaWikiImporter;
-
-import java.io.InputStream;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -121,20 +117,10 @@ public class GetPageAttachmentStrutsAction implements StrutsAction {
 			fileName = _trashHelper.getOriginalTitle(fileEntry.getTitle());
 		}
 
-		InputStream inputStream = fileEntry.getContentStream();
-
-		FlashMagicBytesUtil.Result flashMagicBytesUtilResult =
-			FlashMagicBytesUtil.check(inputStream);
-
-		if (flashMagicBytesUtilResult.isFlash()) {
-			fileName = FileUtil.stripExtension(fileName) + ".swf";
-		}
-
-		inputStream = flashMagicBytesUtilResult.getInputStream();
-
 		ServletResponseUtil.sendFile(
-			httpServletRequest, httpServletResponse, fileName, inputStream,
-			fileEntry.getSize(), fileEntry.getMimeType());
+			httpServletRequest, httpServletResponse, fileName,
+			fileEntry.getContentStream(), fileEntry.getSize(),
+			fileEntry.getMimeType());
 	}
 
 	@Reference(unbind = "-")

--- a/portal-impl/src/com/liferay/portal/webdav/methods/GetMethodImpl.java
+++ b/portal-impl/src/com/liferay/portal/webdav/methods/GetMethodImpl.java
@@ -14,11 +14,9 @@
 
 package com.liferay.portal.webdav.methods;
 
-import com.liferay.portal.kernel.flash.FlashMagicBytesUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.webdav.Resource;
 import com.liferay.portal.kernel.webdav.WebDAVException;
 import com.liferay.portal.kernel.webdav.WebDAVRequest;
@@ -57,15 +55,6 @@ public class GetMethodImpl implements Method {
 
 			if (inputStream != null) {
 				String fileName = resource.getDisplayName();
-
-				FlashMagicBytesUtil.Result flashMagicBytesUtilResult =
-					FlashMagicBytesUtil.check(inputStream);
-
-				if (flashMagicBytesUtilResult.isFlash()) {
-					fileName = FileUtil.stripExtension(fileName) + ".swf";
-				}
-
-				inputStream = flashMagicBytesUtilResult.getInputStream();
 
 				try {
 					ServletResponseUtil.sendFileWithRangeHeader(

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -33,7 +33,6 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
-import com.liferay.portal.kernel.flash.FlashMagicBytesUtil;
 import com.liferay.portal.kernel.image.ImageBag;
 import com.liferay.portal.kernel.image.ImageToolUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -1109,15 +1108,6 @@ public class WebServerServlet extends HttpServlet {
 			}
 		}
 
-		FlashMagicBytesUtil.Result flashMagicBytesUtilResult =
-			FlashMagicBytesUtil.check(inputStream);
-
-		if (flashMagicBytesUtilResult.isFlash()) {
-			fileName = FileUtil.stripExtension(fileName) + ".swf";
-		}
-
-		inputStream = flashMagicBytesUtilResult.getInputStream();
-
 		// Determine proper content type
 
 		String contentType = null;
@@ -1257,20 +1247,10 @@ public class WebServerServlet extends HttpServlet {
 				HttpHeaders.CONTENT_DISPOSITION_ATTACHMENT);
 		}
 		else {
-			InputStream inputStream = fileEntry.getContentStream();
-
-			FlashMagicBytesUtil.Result flashMagicBytesUtilResult =
-				FlashMagicBytesUtil.check(inputStream);
-
-			inputStream = flashMagicBytesUtilResult.getInputStream();
-
-			if (flashMagicBytesUtilResult.isFlash()) {
-				fileName = FileUtil.stripExtension(fileName) + ".swf";
-			}
-
 			ServletResponseUtil.sendFile(
-				httpServletRequest, httpServletResponse, fileName, inputStream,
-				fileEntry.getSize(), fileEntry.getMimeType());
+				httpServletRequest, httpServletResponse, fileName,
+				fileEntry.getContentStream(), fileEntry.getSize(),
+				fileEntry.getMimeType());
 		}
 	}
 

--- a/portal-impl/test/unit/com/liferay/portal/kernel/flash/FlashMagicBytesUtilTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/flash/FlashMagicBytesUtilTest.java
@@ -25,7 +25,9 @@ import org.junit.Test;
 
 /**
  * @author Tomas Polesovsky
+ * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
  */
+@Deprecated
 public class FlashMagicBytesUtilTest {
 
 	@Test

--- a/portal-kernel/src/com/liferay/portal/kernel/flash/FlashMagicBytesUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/flash/FlashMagicBytesUtil.java
@@ -23,7 +23,9 @@ import java.io.PushbackInputStream;
 /**
  * @author Brian Wing Shun Chan
  * @author Mika Koivisto
+ * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
  */
+@Deprecated
 public class FlashMagicBytesUtil {
 
 	public static Result check(InputStream inputStream) throws IOException {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/permission/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/permission/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 4.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.util.StreamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.Validator;
+import org.osgi.annotation.versioning.ProviderType;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -57,6 +58,7 @@ import javax.servlet.http.HttpServletResponse;
  * @author Brian Wing Shun Chan
  * @author Shuyang Zhou
  */
+@ProviderType
 public class ServletResponseUtil {
 
 	public static boolean isClientAbortException(IOException ioException) {
@@ -562,64 +564,65 @@ public class ServletResponseUtil {
 		}
 	}
 
-	private static InputStream _copyRange(
-			InputStream inputStream, OutputStream outputStream, long start,
-			long length)
+	private static void _copyRangeFromPosition(
+			ByteArrayInputStream byteArrayInputStream,
+			OutputStream outputStream, Range range)
 		throws IOException {
 
-		if (inputStream instanceof ByteArrayInputStream) {
-			ByteArrayInputStream byteArrayInputStream =
-				(ByteArrayInputStream)inputStream;
+		byteArrayInputStream.reset();
 
-			byteArrayInputStream.reset();
+		byteArrayInputStream.skip(range.getStart());
 
-			byteArrayInputStream.skip(start);
-
-			try {
-				StreamUtil.transfer(
-					byteArrayInputStream, outputStream, StreamUtil.BUFFER_SIZE,
-					false, length);
-			}
-			catch (IOException ioException) {
-				_checkSocketException(ioException);
-			}
-
-			return byteArrayInputStream;
+		try {
+			StreamUtil.transfer(
+				byteArrayInputStream, outputStream, StreamUtil.BUFFER_SIZE,
+				false, range.getEnd());
 		}
-		else if (inputStream instanceof FileInputStream) {
-			FileInputStream fileInputStream = (FileInputStream)inputStream;
-
-			FileChannel fileChannel = fileInputStream.getChannel();
-
-			try {
-				fileChannel.transferTo(
-					start, length, Channels.newChannel(outputStream));
-			}
-			catch (IOException ioException) {
-				_checkSocketException(ioException);
-			}
-
-			return fileInputStream;
+		catch (IOException ioException) {
+			_checkSocketException(ioException);
 		}
-		else if (inputStream instanceof RandomAccessInputStream) {
-			RandomAccessInputStream randomAccessInputStream =
-				(RandomAccessInputStream)inputStream;
+	}
 
-			randomAccessInputStream.seek(start);
+	private static void _copyRangeFromPosition(
+			FileInputStream fileInputStream, OutputStream outputStream,
+			Range range)
+		throws IOException {
 
-			try {
-				StreamUtil.transfer(
-					randomAccessInputStream, outputStream,
-					StreamUtil.BUFFER_SIZE, false, length);
-			}
-			catch (IOException ioException) {
-				_checkSocketException(ioException);
-			}
+		FileChannel fileChannel = fileInputStream.getChannel();
 
-			return randomAccessInputStream;
+		try {
+			fileChannel.transferTo(
+				range.getStart(), range.getLength(),
+				Channels.newChannel(outputStream));
 		}
+		catch (IOException ioException) {
+			_checkSocketException(ioException);
+		}
+	}
 
-		inputStream.skip(start);
+	private static void _copyRangeFromPosition(
+			RandomAccessInputStream randomAccessInputStream,
+			OutputStream outputStream, Range range)
+		throws IOException {
+
+		randomAccessInputStream.seek(range.getStart());
+
+		try {
+			StreamUtil.transfer(
+				randomAccessInputStream, outputStream,
+				StreamUtil.BUFFER_SIZE, false, range.getLength());
+		}
+		catch (IOException ioException) {
+			_checkSocketException(ioException);
+		}
+	}
+
+	private static void _copyRangeSkipping(
+			InputStream inputStream, OutputStream outputStream,
+			long skipBytesCount, long length)
+		throws IOException {
+
+		inputStream.skip(skipBytesCount);
 
 		try {
 			StreamUtil.transfer(
@@ -629,8 +632,6 @@ public class ServletResponseUtil {
 		catch (IOException ioException) {
 			_checkSocketException(ioException);
 		}
-
-		return inputStream;
 	}
 
 	private static List<Range> _getRanges(
@@ -696,44 +697,6 @@ public class ServletResponseUtil {
 		return ranges;
 	}
 
-	private static boolean _isRandomAccessSupported(InputStream inputStream) {
-		if (inputStream instanceof ByteArrayInputStream ||
-			inputStream instanceof FileInputStream ||
-			inputStream instanceof RandomAccessInputStream) {
-
-			return true;
-		}
-
-		return false;
-	}
-
-	private static boolean _isSequentialRangeList(List<Range> ranges) {
-		Range previousRange = null;
-
-		for (Range range : ranges) {
-			if ((previousRange != null) &&
-				(range.getStart() <= previousRange.getEnd())) {
-
-				return false;
-			}
-
-			previousRange = range;
-		}
-
-		return true;
-	}
-
-	private static InputStream _toRandomAccessInputStream(
-			InputStream inputStream)
-		throws IOException {
-
-		if (_isRandomAccessSupported(inputStream)) {
-			return inputStream;
-		}
-
-		return new RandomAccessInputStream(inputStream);
-	}
-
 	private static void _write(
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse, String fileName,
@@ -763,7 +726,7 @@ public class ServletResponseUtil {
 					httpServletRequest, httpServletResponse, fileName,
 					contentType, null, fullRange);
 
-				_copyRange(
+				_copyRangeSkipping(
 					inputStream, outputStream, fullRange.getStart(),
 					fullRange.getLength());
 			}
@@ -783,7 +746,7 @@ public class ServletResponseUtil {
 				httpServletResponse.setStatus(
 					HttpServletResponse.SC_PARTIAL_CONTENT);
 
-				_copyRange(
+				_copyRangeSkipping(
 					inputStream, outputStream, range.getStart(),
 					range.getLength());
 			}
@@ -810,14 +773,6 @@ public class ServletResponseUtil {
 				httpServletResponse.setStatus(
 					HttpServletResponse.SC_PARTIAL_CONTENT);
 
-				boolean sequentialRangeList = _isSequentialRangeList(ranges);
-
-				if (!sequentialRangeList) {
-					inputStream = _toRandomAccessInputStream(inputStream);
-				}
-
-				Range previousRange = null;
-
 				for (Range curRange : ranges) {
 					servletOutputStream.println();
 					servletOutputStream.println(
@@ -829,19 +784,28 @@ public class ServletResponseUtil {
 							curRange.getContentRange());
 					servletOutputStream.println();
 
-					long start = curRange.getStart();
-
-					if (sequentialRangeList) {
-						if (previousRange != null) {
-							start -= previousRange.getEnd() + 1;
-						}
-
-						previousRange = curRange;
+					if(inputStream instanceof ByteArrayInputStream) {
+						_copyRangeFromPosition(
+							(ByteArrayInputStream)inputStream,
+							servletOutputStream, curRange);
 					}
+					else if(inputStream instanceof FileInputStream) {
+						_copyRangeFromPosition(
+							(FileInputStream) inputStream, servletOutputStream,
+							curRange);
+					}
+					else if(inputStream instanceof RandomAccessInputStream) {
+						_copyRangeFromPosition(
+							(RandomAccessInputStream) inputStream,
+							servletOutputStream, curRange);
+					}
+					else {
+						inputStream = new RandomAccessInputStream(inputStream);
 
-					_copyRange(
-						inputStream, servletOutputStream, start,
-						curRange.getLength());
+						_copyRangeFromPosition(
+							(RandomAccessInputStream) inputStream,
+							servletOutputStream, curRange);
+					}
 				}
 
 				servletOutputStream.println();

--- a/portal-kernel/src/com/liferay/portal/kernel/theme/ThemeDisplay.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/ThemeDisplay.java
@@ -567,7 +567,7 @@ public class ThemeDisplay
 	}
 
 	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
 	 */
 	@Deprecated
 	public String getPathFlash() {
@@ -1512,7 +1512,7 @@ public class ThemeDisplay
 	}
 
 	/**
-	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
+	 * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
 	 */
 	@Deprecated
 	public void setPathFlash(String pathFlash) {


### PR DESCRIPTION
Based on the analysis done at [Analyze security relevance of FlashMagicBytes check](https://issues.liferay.com/browse/LPS-121737):

> DXP uses a FlashMagicBytesUtil to check verify if some files are Adobe Flash movies (regardless of their extension). This was added for securtiy reasons to protect from CSRF attack using uploaded flash files

From @topolik:

> [...] this would be relevant as long as we support browsers that supports flash. Once all supported browsers discard flash we can remove. Thanks.

All browsers in our possible compatibility matrix for 7.4 will have dropped Flash by the time we release as per their roadmaps:
* **[Chrome](https://www.chromium.org/flash-roadmap#TOC-Flash-Player-blocked-as-out-of-date-Target:-All-Chrome-versions---Jan-2021-)**: Flash Player blocked as "out of date" (Target: All Chrome versions - Jan 2021) 
* **[Firefox](https://developer.mozilla.org/en-US/docs/Plugins/Roadmap)**: In January 2021, Firefox 85 will completely remove Flash support. Adobe will stop shipping security updates for Flash at the end of 2020.
* **[Safari](https://www.techspot.com/news/83681-apple-completely-remove-flash-support-next-version-safari.html)**: Apple just released the latest Safari Technology preview. It comes with many changes, most notably the removal of support for Adobe Flash.

Based on this, I think it's safe to remove the `FlashMagicBytes` checks.

**The solution:**
- `FlashMagicBytesUtil` uses a `PushbackInputStream` to read the first bytes of an `InputStream` and then simply rewinds it and provides means to access it. That means that when removing the usage, we can simply use the original `InputStream` to keep the same behaviour.
- To avoid a major kernel breaking change, we're simply deprecating both `FlashMagicBytesUtil` and `FlashMagicBytesUtilTest` instead of deleting them.

PS: I've added an additional commit fixing a wrong deprecation notice I myself pushed yesterday 🙏 