### PR TITLE
[TS] LPS-122832 Upgrade from 6.2: we can only define ldap.connection properties in the portal.properties so we need to use the default ones when migrating to 7.x

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/verify/LDAPPropertiesVerifyProcess.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/verify/LDAPPropertiesVerifyProcess.java
@@ -39,13 +39,10 @@ import com.liferay.portal.security.ldap.exportimport.configuration.LDAPExportCon
 import com.liferay.portal.security.ldap.exportimport.configuration.LDAPImportConfiguration;
 import com.liferay.portal.verify.VerifyProcess;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Dictionary;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
@@ -467,24 +464,6 @@ public class LDAPPropertiesVerifyProcess extends VerifyProcess {
 	protected void verifySystemLDAPConfiguration(long companyId) {
 		Dictionary<String, Object> dictionary = new HashMapDictionary<>();
 
-		Properties connectionProperties = _props.getProperties(
-			LegacyLDAPPropsKeys.LDAP_CONNECTION_PROPERTY_PREFIX, true);
-
-		List<String> connectionPropertiesList = new ArrayList<>(
-			connectionProperties.size());
-
-		for (Map.Entry<Object, Object> entry :
-				connectionProperties.entrySet()) {
-
-			String connectionPropertyString =
-				entry.getKey() + StringPool.EQUAL + entry.getValue();
-
-			connectionPropertiesList.add(connectionPropertyString);
-		}
-
-		dictionary.put(
-			LDAPConstants.CONNECTION_PROPERTIES,
-			connectionPropertiesList.toArray(new String[0]));
 		dictionary.put(
 			LDAPConstants.ERROR_PASSWORD_AGE_KEYWORDS,
 			new String[] {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122832