### PR TITLE
LPS-123623 Add Portal CORS default configuration at System level

### DIFF
--- a/modules/apps/portal-remote/portal-remote-cors-api/configs/com.liferay.portal.remote.cors.configuration.PortalCORSConfiguration-default.config
+++ b/modules/apps/portal-remote/portal-remote-cors-api/configs/com.liferay.portal.remote.cors.configuration.PortalCORSConfiguration-default.config
@@ -1,0 +1,2 @@
+configuration.name="Default Portal CORS Configuration"
+enabled=B"true"

--- a/modules/apps/portal-remote/portal-remote-cors-test/build.gradle
+++ b/modules/apps/portal-remote/portal-remote-cors-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testIntegrationCompile group: "javax.ws.rs", name: "javax.ws.rs-api", version: "2.1"
 	testIntegrationCompile group: "org.apache.cxf", name: "cxf-rt-rs-client", version: "3.2.14"

--- a/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/PortalConfigurationCORSClientTest.java
+++ b/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/PortalConfigurationCORSClientTest.java
@@ -20,13 +20,10 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.CookieKeys;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
-import org.apache.cxf.jaxrs.client.spec.ClientBuilderImpl;
-import org.apache.cxf.jaxrs.impl.RuntimeDelegateImpl;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.client.Client;
@@ -41,9 +38,15 @@ import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.ext.RuntimeDelegate;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
+import org.apache.cxf.jaxrs.client.spec.ClientBuilderImpl;
+import org.apache.cxf.jaxrs.impl.RuntimeDelegateImpl;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 /**
  * @author Marta Medio

--- a/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/PortalConfigurationCORSClientTest.java
+++ b/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/PortalConfigurationCORSClientTest.java
@@ -20,10 +20,13 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.CookieKeys;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
-
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import org.apache.cxf.jaxrs.client.spec.ClientBuilderImpl;
+import org.apache.cxf.jaxrs.impl.RuntimeDelegateImpl;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.client.Client;
@@ -38,15 +41,9 @@ import javax.ws.rs.core.NewCookie;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
 import javax.ws.rs.ext.RuntimeDelegate;
-
-import org.apache.cxf.jaxrs.client.spec.ClientBuilderImpl;
-import org.apache.cxf.jaxrs.impl.RuntimeDelegateImpl;
-
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * @author Marta Medio
@@ -67,16 +64,20 @@ public class PortalConfigurationCORSClientTest extends BaseCORSClientTestCase {
 
 	@Test
 	public void testCORSUsingBasicWithDisableAuthorization() throws Exception {
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "CORS_DISABLE_AUTHORIZATION_CONTEXT_CHECK",
-			true);
+		boolean corsDisableAuthorizationContextCheck =
+			ReflectionTestUtil.getAndSetFieldValue(
+				PropsValues.class, "CORS_DISABLE_AUTHORIZATION_CONTEXT_CHECK",
+				true);
 
-		assertJsonWSUrl("/user/get-current-user", HttpMethod.OPTIONS, true);
-		assertJsonWSUrl("/user/get-current-user", HttpMethod.GET, true);
-
-		ReflectionTestUtil.setFieldValue(
-			PropsValues.class, "CORS_DISABLE_AUTHORIZATION_CONTEXT_CHECK",
-			false);
+		try {
+			assertJsonWSUrl("/user/get-current-user", HttpMethod.OPTIONS, true);
+			assertJsonWSUrl("/user/get-current-user", HttpMethod.GET, true);
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				PropsValues.class, "CORS_DISABLE_AUTHORIZATION_CONTEXT_CHECK",
+				corsDisableAuthorizationContextCheck);
+		}
 	}
 
 	@Test

--- a/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/PortalConfigurationCORSClientTest.java
+++ b/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/PortalConfigurationCORSClientTest.java
@@ -15,13 +15,12 @@
 package com.liferay.portal.remote.cors.client.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.CookieKeys;
-import com.liferay.portal.kernel.util.HashMapDictionary;
-import com.liferay.portal.remote.cors.configuration.PortalCORSConfiguration;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PropsValues;
 
-import java.util.Dictionary;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -61,24 +60,23 @@ public class PortalConfigurationCORSClientTest extends BaseCORSClientTestCase {
 		new LiferayIntegrationTestRule();
 
 	@Test
-	public void testCORSUsingBasicWithCustomConfig() throws Exception {
-		Dictionary<String, Object> properties = new HashMapDictionary<>();
-
-		properties.put("configuration.name", "test-cors");
-
-		properties.put("filter.mapping.url.pattern", "/api/jsonws/*");
-
-		createFactoryConfiguration(
-			PortalCORSConfiguration.class.getName(), properties);
-
+	public void testCORSUsingBasicWithDefaultConfig() throws Exception {
 		assertJsonWSUrl("/user/get-current-user", HttpMethod.OPTIONS, true);
 		assertJsonWSUrl("/user/get-current-user", HttpMethod.GET, false);
 	}
 
 	@Test
-	public void testCORSUsingBasicWithDefaultConfig() throws Exception {
+	public void testCORSUsingBasicWithDisableAuthorization() throws Exception {
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "CORS_DISABLE_AUTHORIZATION_CONTEXT_CHECK",
+			true);
+
 		assertJsonWSUrl("/user/get-current-user", HttpMethod.OPTIONS, true);
-		assertJsonWSUrl("/user/get-current-user", HttpMethod.GET, false);
+		assertJsonWSUrl("/user/get-current-user", HttpMethod.GET, true);
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "CORS_DISABLE_AUTHORIZATION_CONTEXT_CHECK",
+			false);
 	}
 
 	@Test


### PR DESCRIPTION
To solve this issue I think it's only necessary to add a default configuration associated to System Settings (blank _companyId_).

We're using _PortalCORSConfiguration_ class in two places:
1. On a [ModelListener](https://github.com/liferay-appsec/liferay-portal/blob/master/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/configuration/persistence/listener/PortalCORSConfigurationModelListener.java#L50) to validate the introduced values on the UI
2. On the [ServletFilter](https://github.com/liferay-appsec/liferay-portal/blob/master/modules/apps/portal-remote/portal-remote-cors-impl/src/main/java/com/liferay/portal/remote/cors/internal/servlet/filter/PortalCORSServletFilter.java#L302) to merge the multiple possible Configurations: we're creating a common configuration class based on the existing ones

Please @csierra & @arthurchan35, correct what you consider if I'm missing something.

Thanks!