### PR TITLE
[TS] LPS-125588 Deactivated users should not be imported from LDAP

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -61,6 +61,7 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PwdGenerator;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.security.exportimport.UserImporter;
 import com.liferay.portal.security.ldap.ContactConverterKeys;
 import com.liferay.portal.security.ldap.SafeLdapContext;
@@ -1141,7 +1142,10 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 
 			User user = getUser(ldapImportContext.getCompanyId(), ldapUser);
 
-			if ((user != null) && user.isDefaultUser()) {
+			if ((user != null) &&
+				(user.isDefaultUser() ||
+				 (user.getStatus() == WorkflowConstants.STATUS_INACTIVE))) {
+
 				return user;
 			}
 


### PR DESCRIPTION
[LPS-125588](https://issues.liferay.com/browse/LPS-125588)
Dear Application Security Team,

Pease review my changes.

**Issue:** Deactivated users get reactivated at next LDAP import.

**Solution:** We should check the user's status before re-importing from LDAP.

Thanks in advance,
István