### PR TITLE
LPS-129496 Use lazy initalizer idiom and fix context path

### DIFF
--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 6.1.0
+Bundle-Version: 7.0.0
 Export-Package:\
 	com.liferay.portal.asm,\
 	com.liferay.portal.bean,\

--- a/portal-impl/src/com/liferay/portal/security/access/control/AccessControlImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/access/control/AccessControlImpl.java
@@ -94,9 +94,11 @@ public class AccessControlImpl implements AccessControl {
 		Map<String, Object> settings = accessControlContext.getSettings();
 
 		if (!settings.containsKey(AuthVerifierPipeline.class.getName())) {
-			authVerifierResult =
-				AuthVerifierPipeline.PORTAL_AUTH_VERIFIER_PIPELINE.
-					verifyRequest(accessControlContext);
+			AuthVerifierPipeline portalAuthVerifierPipeline =
+				AuthVerifierPipeline.getPortalAuthVerifierPipeline();
+
+			authVerifierResult = portalAuthVerifierPipeline.verifyRequest(
+				accessControlContext);
 		}
 		else {
 			AuthVerifierPipeline authVerifierPipeline =
@@ -109,9 +111,11 @@ public class AccessControlImpl implements AccessControl {
 			if (authVerifierResult.getState() !=
 					AuthVerifierResult.State.SUCCESS) {
 
-				authVerifierResult =
-					AuthVerifierPipeline.PORTAL_AUTH_VERIFIER_PIPELINE.
-						verifyRequest(accessControlContext);
+				AuthVerifierPipeline portalAuthVerifierPipeline =
+					AuthVerifierPipeline.getPortalAuthVerifierPipeline();
+
+				authVerifierResult = portalAuthVerifierPipeline.verifyRequest(
+					accessControlContext);
 			}
 		}
 

--- a/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
@@ -59,14 +59,16 @@ public class AuthVerifierPipeline {
 
 	public static final String AUTH_TYPE = "auth.type";
 
-	public static final AuthVerifierPipeline PORTAL_AUTH_VERIFIER_PIPELINE;
-
 	public static String getAuthVerifierPropertyName(String className) {
 		String simpleClassName = StringUtil.extractLast(
 			className, StringPool.PERIOD);
 
 		return StringBundler.concat(
 			PropsKeys.AUTH_VERIFIER, simpleClassName, StringPool.PERIOD);
+	}
+
+	public static AuthVerifierPipeline getPortalAuthVerifierPipeline() {
+		return LazyInitializer._PORTAL_AUTH_VERIFIER_PIPELINE;
 	}
 
 	public AuthVerifierPipeline(
@@ -212,66 +214,6 @@ public class AuthVerifierPipeline {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AuthVerifierPipeline.class);
-
-	private static final ServiceTracker
-		<AuthVerifierConfiguration, AuthVerifierConfiguration> _serviceTracker;
-
-	static {
-		if (PortalUtil.getPortal() != null) {
-			PORTAL_AUTH_VERIFIER_PIPELINE = new AuthVerifierPipeline(
-				Collections.emptyList(), PortalUtil.getServletContextName());
-		}
-		else {
-			PORTAL_AUTH_VERIFIER_PIPELINE = new AuthVerifierPipeline(
-				Collections.emptyList(), "");
-		}
-
-		Registry registry = RegistryUtil.getRegistry();
-
-		_serviceTracker = registry.trackServices(
-			AuthVerifierConfiguration.class,
-			new ServiceTrackerCustomizer
-				<AuthVerifierConfiguration, AuthVerifierConfiguration>() {
-
-				@Override
-				public AuthVerifierConfiguration addingService(
-					ServiceReference<AuthVerifierConfiguration>
-						serviceReference) {
-
-					AuthVerifierConfiguration authVerifierConfiguration =
-						registry.getService(serviceReference);
-
-					if (authVerifierConfiguration != null) {
-						PORTAL_AUTH_VERIFIER_PIPELINE.
-							_addAuthVerifierConfiguration(
-								authVerifierConfiguration);
-					}
-
-					return authVerifierConfiguration;
-				}
-
-				@Override
-				public void modifiedService(
-					ServiceReference<AuthVerifierConfiguration>
-						serviceReference,
-					AuthVerifierConfiguration authVerifierConfiguration) {
-				}
-
-				@Override
-				public void removedService(
-					ServiceReference<AuthVerifierConfiguration>
-						serviceReference,
-					AuthVerifierConfiguration authVerifierConfiguration) {
-
-					PORTAL_AUTH_VERIFIER_PIPELINE.
-						_removeAuthVerifierConfiguration(
-							authVerifierConfiguration);
-				}
-
-			});
-
-		_serviceTracker.open();
-	}
 
 	private final List<AuthVerifierConfiguration> _authVerifierConfigurations;
 	private final String _contextPath;
@@ -435,6 +377,67 @@ public class AuthVerifierPipeline {
 		private final URLPatternMapper<List<AuthVerifierConfiguration>>
 			_excludeURLPatternMapper;
 		private final String _requestURI;
+
+	}
+
+	private static class LazyInitializer {
+
+		private static final AuthVerifierPipeline
+			_PORTAL_AUTH_VERIFIER_PIPELINE = new AuthVerifierPipeline(
+			Collections.emptyList(),
+			PortalUtil.getPathContext());;
+
+		private static final ServiceTracker
+			<AuthVerifierConfiguration, AuthVerifierConfiguration>
+				_serviceTracker;
+
+		static {
+			Registry registry = RegistryUtil.getRegistry();
+
+			_serviceTracker = registry.trackServices(
+				AuthVerifierConfiguration.class,
+				new ServiceTrackerCustomizer
+					<AuthVerifierConfiguration, AuthVerifierConfiguration>() {
+
+					@Override
+					public AuthVerifierConfiguration addingService(
+						ServiceReference<AuthVerifierConfiguration>
+							serviceReference) {
+
+						AuthVerifierConfiguration authVerifierConfiguration =
+							registry.getService(serviceReference);
+
+						if (authVerifierConfiguration != null) {
+							LazyInitializer._PORTAL_AUTH_VERIFIER_PIPELINE.
+								_addAuthVerifierConfiguration(
+									authVerifierConfiguration);
+						}
+
+						return authVerifierConfiguration;
+					}
+
+					@Override
+					public void modifiedService(
+						ServiceReference<AuthVerifierConfiguration>
+							serviceReference,
+						AuthVerifierConfiguration authVerifierConfiguration) {
+					}
+
+					@Override
+					public void removedService(
+						ServiceReference<AuthVerifierConfiguration>
+							serviceReference,
+						AuthVerifierConfiguration authVerifierConfiguration) {
+
+						LazyInitializer._PORTAL_AUTH_VERIFIER_PIPELINE.
+							_removeAuthVerifierConfiguration(
+								authVerifierConfiguration);
+					}
+
+				});
+
+			_serviceTracker.open();
+		}
 
 	}
 

--- a/portal-impl/src/com/liferay/portal/security/auth/packageinfo
+++ b/portal-impl/src/com/liferay/portal/security/auth/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0


### PR DESCRIPTION
I am not sure if this is what we need to do because I could not test this thoroughly. 
It looks like we used the wrong method from PortalUtil here https://github.com/liferay-appsec/liferay-portal/pull/325/commits/5ac545de1ca676d3b29689d8cb58347ff8fb2fea#diff-e3a5cfa6dfe6906c5475efaa0e823e0d435fa67cc98b3d60b3a81155571be362L222 because we were passing contextName where we expected contextPath (allegedly). 

If we also need this to be initialized lazily I suggest we use the initialization on demand holder idiom https://en.wikipedia.org/wiki/Initialization-on-demand_holder_idiom , which should initialize the portal pipeline only when it is used. 

@arthurchan35 please have a look at it and let me know what you think. 

Carlos.