### PR TITLE
[TS] LPS-127989 Inactive portal users cannot be exported to LDAP

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserExporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserExporterImpl.java
@@ -97,7 +97,9 @@ public class LDAPUserExporterImpl implements UserExporter {
 			contact.getContactId());
 
 		if (user.isDefaultUser() ||
-			(user.getStatus() != WorkflowConstants.STATUS_APPROVED)) {
+			((user.getStatus() != WorkflowConstants.STATUS_APPROVED) &&
+			 (user.getStatus() != WorkflowConstants.STATUS_INACTIVE)) ||
+			_isAnonymousUser(user)) {
 
 			return;
 		}
@@ -274,7 +276,9 @@ public class LDAPUserExporterImpl implements UserExporter {
 		throws Exception {
 
 		if (user.isDefaultUser() ||
-			(user.getStatus() != WorkflowConstants.STATUS_APPROVED)) {
+			((user.getStatus() != WorkflowConstants.STATUS_APPROVED) &&
+			 (user.getStatus() != WorkflowConstants.STATUS_INACTIVE)) ||
+			_isAnonymousUser(user)) {
 
 			return;
 		}

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserExporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserExporterImpl.java
@@ -462,14 +462,12 @@ public class LDAPUserExporterImpl implements UserExporter {
 	}
 
 	private User _getAnonymousUser(long companyId) throws Exception {
-		String filterString = String.format(
-			"(&(service.factoryPid=%s)(companyId=%s))",
-			"com.liferay.user.associated.data.web.internal.configuration." +
-				"AnonymousUserConfiguration",
-			companyId);
-
 		Configuration[] configurations = _configurationAdmin.listConfigurations(
-			filterString);
+			String.format(
+				"(&(service.factoryPid=%s)(companyId=%s))",
+				"com.liferay.user.associated.data.web.internal.configuration." +
+					"AnonymousUserConfiguration",
+				companyId));
 
 		if (configurations == null) {
 			return null;


### PR DESCRIPTION
> LPS-127989
> 
> Dear Reviewer,
> 
> My changes intend to enable exporting INACTIVE users to LDAP with the exception of anonymous users.
> 
> Related PTR ticket gives an explanation on why creating new method(s) for anonymous user check was necessary and how it was done. I'm not sure about the correct place of these methods, but I didn't find any util class in portal-security-ldap-impl.
> 
> Please let me know if you have any questions or concerns.
> 
> Thank you,
> Istvan