### PR TITLE
LPS-132754

### DIFF
--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlIdpSpSessionUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlIdpSpSessionUpgradeProcess.java
@@ -70,7 +70,7 @@ public class SamlIdpSpSessionUpgradeProcess extends UpgradeProcess {
 			runSQL(
 				StringBundler.concat(
 					"update SamlIdpSpSession sidp set samlPeerBindingId = (",
-					"select SamlPeerBindingId from SamlPeerBinding spb where ",
+					"select samlPeerBindingId from SamlPeerBinding spb where ",
 					"sidp.companyId = spb.companyId and sidp.userId = ",
 					"spb.userId and sidp.samlSpEntityId = ",
 					"spb.samlPeerEntityId and sidp.nameIdFormat = ",

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlIdpSpSessionUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlIdpSpSessionUpgradeProcess.java
@@ -32,7 +32,7 @@ public class SamlIdpSpSessionUpgradeProcess extends UpgradeProcess {
 	@Override
 	protected void doUpgrade() throws Exception {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			if (!hasColumn("samlIdpSpSession", "samlPeerBindingId")) {
+			if (!hasColumn(SamlIdpSpSessionTable.TABLE_NAME, "samlPeerBindingId")) {
 				alter(
 					SamlIdpSpSessionTable.class,
 					new AlterTableAddColumn("samlPeerBindingId", "LONG null"));

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlIdpSpSessionUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlIdpSpSessionUpgradeProcess.java
@@ -32,7 +32,9 @@ public class SamlIdpSpSessionUpgradeProcess extends UpgradeProcess {
 	@Override
 	protected void doUpgrade() throws Exception {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			if (!hasColumn(SamlIdpSpSessionTable.TABLE_NAME, "samlPeerBindingId")) {
+			if (!hasColumn(
+					SamlIdpSpSessionTable.TABLE_NAME, "samlPeerBindingId")) {
+
 				alter(
 					SamlIdpSpSessionTable.class,
 					new AlterTableAddColumn("samlPeerBindingId", "LONG null"));

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlIdpSpSessionUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlIdpSpSessionUpgradeProcess.java
@@ -65,8 +65,7 @@ public class SamlIdpSpSessionUpgradeProcess extends UpgradeProcess {
 					"deleted, nameIdFormat, null as nameIdNameQualifier, null ",
 					"as nameIdSpProvidedId, nameIdValue, samlSpEntityId from ",
 					"SamlIdpSpSession group by companyId, userId, userName, ",
-					"samlSpEntityId, nameIdFormat, nameIdValue, ",
-					"samlSpEntityId"));
+					"samlSpEntityId, nameIdFormat, nameIdValue"));
 
 			runSQL(
 				StringBundler.concat(


### PR DESCRIPTION
Hey @stian-sigvartsen, could you take a look to this changes? 

This is what I have found about this issue:
- First we execute [this process](https://github.com/liferay-appsec/liferay-portal/blob/master/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/SamlServiceUpgrade.java#L123), where we select some fields to move their value into `SamlPeerBinding` and then [we drop those columns](https://github.com/liferay-appsec/liferay-portal/blob/master/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/SamlServiceUpgrade.java#L130) from `SamlIdpSpSession`: I mention this because yesterday we were surprised that we selected columns that we thought did not exist.
- ~Note I have changed how we calculate the final value of `samlPeerBindingId`, [I've extracted it to Java](https://github.com/liferay-appsec/liferay-portal/commit/d0a7ab1f66fa2c930953c478580fe0cfb0805203), so please check that I'm really doing what's expected.~
- I think the duplicate `group by` field is causing problems on some databases
- I think [this lowercase](https://github.com/liferay-appsec/liferay-portal/commit/4052c6e05f55e5ba97f97d4d7379127595b6fbed) change is mandatory for some databases

Thanks!