### PR TITLE
LPS-133178 SAML Fix user UUID field updating

### DIFF
--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/field/expression/handler/DefaultUserFieldExpressionHandler.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/field/expression/handler/DefaultUserFieldExpressionHandler.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.exportimport.UserImporter;
 import com.liferay.saml.opensaml.integration.field.expression.handler.UserFieldExpressionHandler;
 import com.liferay.saml.opensaml.integration.processor.context.ProcessorContext;
@@ -176,6 +177,10 @@ public class DefaultUserFieldExpressionHandler
 		int birthdayYear = 1970;
 		boolean sendEmail = false;
 
+		if (!Validator.isBlank(newUser.getUuid())) {
+			serviceContext.setUuid(newUser.getUuid());
+		}
+
 		User user = _userLocalService.addUser(
 			creatorUserId, newUser.getCompanyId(), autoPassword, password1,
 			password2, autoScreenName, newUser.getScreenName(),
@@ -208,6 +213,8 @@ public class DefaultUserFieldExpressionHandler
 			return _addUser(newUser, serviceContext);
 		}
 
+		currentUser = _userLocalService.getUserById(currentUser.getUserId());
+
 		if (!Objects.equals(
 				currentUser.getEmailAddress(), newUser.getEmailAddress())) {
 
@@ -224,6 +231,7 @@ public class DefaultUserFieldExpressionHandler
 			Objects.equals(currentUser.getLastName(), newUser.getLastName()) &&
 			Objects.equals(
 				currentUser.getScreenName(), newUser.getScreenName()) &&
+			Objects.equals(currentUser.getUuid(), newUser.getUuid()) &&
 			Objects.equals(
 				currentUser.getModifiedDate(), newUser.getModifiedDate())) {
 
@@ -236,6 +244,8 @@ public class DefaultUserFieldExpressionHandler
 		birthdayCalendar.setTime(contact.getBirthday());
 
 		Date modifiedDate = newUser.getModifiedDate();
+
+		serviceContext.setUuid(newUser.getUuid());
 
 		newUser = _userLocalService.updateUser(
 			newUser.getUserId(), StringPool.BLANK, StringPool.BLANK,

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/resolver/DefaultUserResolverTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/resolver/DefaultUserResolverTest.java
@@ -402,6 +402,12 @@ public class DefaultUserResolverTest extends BaseSamlTestCase {
 		);
 
 		when(
+			_userLocalService.getUserById(Mockito.anyLong())
+		).thenReturn(
+			user
+		);
+
+		when(
 			_userLocalService.getUserByScreenName(
 				Mockito.anyLong(),
 				Mockito.eq(_SUBJECT_NAME_IDENTIFIER_SCREEN_NAME))


### PR DESCRIPTION
The problem is a misalignment with how `UserProcessor` prepares the call to `UpdateFunction`, which is provided by the call to `UserProcessorContext.bind(...)`.

The `UpdateFunction` is called with a `currentUser` and `newUser`. The difference between the two is patching by applying the mappings that are registered by invocations on the `UserBind` object returned by aforementioned `bind(...)` .

There are no such invocations so `currentUser` and `newUser` are equal!

So the fix is to swap `currentUser` with the currently persisted user. This is because the whole reason for this `UpdateFunction` invocation is to do a single User persistence call after all `UserFieldExpressionHandler`s have done their patching. That is why it is provided with `Integer.MAX_VALUE` as the `processingIndex`. 

@martamedio