### PR TITLE
[TS] LPS-75442 Avoid "User 0 is not allowed to access URL" warn traces when the user has no cookie enabled

### DIFF
--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/login.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/login.jsp
@@ -51,6 +51,9 @@
 		String password = StringPool.BLANK;
 		boolean rememberMe = ParamUtil.getBoolean(request, "rememberMe");
 
+		boolean validateCookies = PropsValues.SESSION_ENABLE_PERSISTENT_COOKIES &&
+			PropsValues.SESSION_TEST_COOKIE_SUPPORT;
+
 		if (Validator.isNull(authType)) {
 			authType = company.getAuthType();
 		}
@@ -112,6 +115,12 @@
 						</div>
 					</c:when>
 				</c:choose>
+
+				<c:if test="<%= validateCookies %>">
+					<div class="alert alert-danger" id="<portlet:namespace />cookieDisabled" style="display: none;">
+						<liferay-ui:message key="authentication-failed-please-enable-browser-cookies" />
+					</div>
+				</c:if>
 
 				<liferay-ui:error exception="<%= AuthException.class %>" message="authentication-failed" />
 				<liferay-ui:error exception="<%= CompanyMaxUsersException.class %>" message="unable-to-log-in-because-the-maximum-number-of-users-has-been-reached" />
@@ -195,6 +204,17 @@
 
 			if (form) {
 				form.addEventListener('submit', (event) => {
+					<c:if test="<%= validateCookies %>">
+
+						if (!navigator.cookieEnabled) {
+							document.getElementById(
+								'<portlet:namespace />cookieDisabled'
+							).style.display = '';
+
+							return;
+						}
+					</c:if>
+
 					<c:if test="<%= Validator.isNotNull(redirect) %>">
 						var redirect = form.querySelector('#<portlet:namespace />redirect');
 

--- a/portal-impl/src/com/liferay/portal/security/auth/SessionAuthToken.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/SessionAuthToken.java
@@ -157,15 +157,20 @@ public class SessionAuthToken implements AuthToken {
 			}
 		}
 
+		String sessionToken = getSessionAuthenticationToken(
+			httpServletRequest, _CSRF, false);
+
+		if (Validator.isNull(sessionToken)) {
+			throw new PrincipalException.MustHaveSessionCSRFToken(
+				PortalUtil.getUserId(httpServletRequest), origin);
+		}
+
 		String csrfToken = ParamUtil.getString(httpServletRequest, "p_auth");
 
 		if (Validator.isNull(csrfToken)) {
 			csrfToken = GetterUtil.getString(
 				httpServletRequest.getHeader("X-CSRF-Token"));
 		}
-
-		String sessionToken = getSessionAuthenticationToken(
-			httpServletRequest, _CSRF, false);
 
 		if (!csrfToken.equals(sessionToken)) {
 			throw new PrincipalException.MustHaveValidCSRFToken(

--- a/portal-impl/src/com/liferay/portlet/SecurityPortletContainerWrapper.java
+++ b/portal-impl/src/com/liferay/portlet/SecurityPortletContainerWrapper.java
@@ -405,6 +405,14 @@ public class SecurityPortletContainerWrapper implements PortletContainer {
 			_log.debug(principalException, principalException);
 		}
 
+		if (principalException instanceof
+				PrincipalException.MustHaveSessionCSRFToken) {
+
+			httpServletResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+			return ActionResult.EMPTY_ACTION_RESULT;
+		}
+
 		if (_log.isWarnEnabled()) {
 			String url = getOriginalURL(httpServletRequest);
 
@@ -464,6 +472,12 @@ public class SecurityPortletContainerWrapper implements PortletContainer {
 			HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE);
 
 		httpServletResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+		if (principalException instanceof
+				PrincipalException.MustHaveSessionCSRFToken) {
+
+			return;
+		}
 
 		if (_log.isWarnEnabled()) {
 			String url = getOriginalURL(httpServletRequest);

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 11.1.2
+Bundle-Version: 11.2.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.test.*,\

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/PrincipalException.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/PrincipalException.java
@@ -229,6 +229,30 @@ public class PrincipalException extends PortalException {
 
 	}
 
+	public static class MustHaveSessionCSRFToken extends PrincipalException {
+
+		public MustHaveSessionCSRFToken(long userId, String origin) {
+			this(userId, origin, null);
+		}
+
+		public MustHaveSessionCSRFToken(
+			long userId, String origin, Throwable throwable) {
+
+			super(
+				String.format(
+					"User %s session does not have a CSRF token for %s", userId,
+					origin),
+				throwable);
+
+			this.userId = userId;
+			this.origin = origin;
+		}
+
+		public final String origin;
+		public final long userId;
+
+	}
+
 	public static class MustHaveValidCSRFToken extends PrincipalException {
 
 		public MustHaveValidCSRFToken(long userId, String origin) {
@@ -261,7 +285,8 @@ public class PrincipalException extends PortalException {
 		PrincipalException.MustBeOmniadmin.class,
 		PrincipalException.MustBePortletStrutsPath.class,
 		PrincipalException.MustHavePermission.class,
-		PrincipalException.MustHaveValidCSRFToken.class
+		PrincipalException.MustHaveValidCSRFToken.class,
+		PrincipalException.MustHaveSessionCSRFToken.class
 	};
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
@@ -1,1 +1,1 @@
-version 2.6.0
+version 2.7.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/CookieKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/CookieKeys.java
@@ -101,9 +101,11 @@ public class CookieKeys {
 
 		httpServletResponse.addCookie(cookie);
 
-		Map<String, Cookie> cookieMap = _getCookieMap(httpServletRequest);
+		if (httpServletRequest != null) {
+			Map<String, Cookie> cookieMap = _getCookieMap(httpServletRequest);
 
-		cookieMap.put(StringUtil.toUpperCase(name), cookie);
+			cookieMap.put(StringUtil.toUpperCase(name), cookie);
+		}
 	}
 
 	public static void addSupportCookie(
@@ -115,7 +117,9 @@ public class CookieKeys {
 		cookieSupportCookie.setPath(StringPool.SLASH);
 		cookieSupportCookie.setMaxAge(MAX_AGE);
 
-		addCookie(httpServletRequest, httpServletResponse, cookieSupportCookie);
+		addCookie(
+			null, httpServletResponse, cookieSupportCookie,
+			httpServletRequest.isSecure());
 	}
 
 	public static void deleteCookies(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-75442

The `User 0 is not allowed to access URL xxx and portlet xxx: User 0 did not provide a valid CSRF token for com.liferay.portlet.SecurityPortletContainerWrapper` warning is a issue that the customers are reporting repeatedly (the LPS has 9 votes and 8 watchers and in the last 2 years we have 109 tickets in HelpCenter with this trace) 

I have detected that sometimes the issue can be caused by a misconfiguration of the session.timeout.auto.extend, but most of the times the issue is produced by requests received without session information:

- Because an user has blocked the cookies in his browser.
- Because a bot is trying to indexing the site and it is requesting an URL protected by the CSRF validations.

To avoid this issues, I am doing following changes:

1. [`f6c1bd8` (#395)](https://github.com/liferay-appsec/liferay-portal/pull/395/commits/f6c1bd8b40b9a14c33a28955bd92d1e5b5de7dd3) - In the browser side, I have added a warning message in case the customer tries to login in a browser with the cookies disabled and session.test.cookie.support=true portal-ext.property setting enabled
2. [`7323ff3` (#395)](https://github.com/liferay-appsec/liferay-portal/pull/395/commits/7323ff38055d8231e7e1497496767e1b43e764ca) and [`979ce92` (#395)](https://github.com/liferay-appsec/liferay-portal/pull/395/commits/979ce92e48395cbaa1bbe91026c6fe514fd68501) - In the server side, in case the current session doesn't have a CSRF token, I am throwing a new `PrincipalException.MustHaveSessionCSRFToken` exception that will block the access to the requested resource, but no warn trace will be written to the log file to avoid writing warning messages that can be ignored (a debug trace can be enabled anytime)

Detected related issue related to the support cookie in the backend:
- Fix: [`549bbeb` (#395)](https://github.com/liferay-appsec/liferay-portal/pull/395/commits/549bbebb199b9df6a73199941d216a827caf9dd0)
- I have detected that the support cookie check is not working correctly: after the LPS-63765 changes, the support cookie is added here https://github.com/liferay-appsec/liferay-portal/blob/ca00c3b11f7a6aa04d7216b586cfdac6b5e88423/portal-impl/src/com/liferay/portal/events/ServicePreAction.java#L957-L972 to both httprequest and httpresponse, so the validation that is done in the AuthenticatedSessionManagerImpl.login method will never fail as it was added to the incoming request.
- With this [`549bbeb` (#395)](https://github.com/liferay-appsec/liferay-portal/pull/395/commits/549bbebb199b9df6a73199941d216a827caf9dd0) commit, the support cookie will only be added to the response, so this method will work in the same way than before LPS-63765 changes. 
- However, If the CSRF validations are enabled, all the requests received without the session cookie will fail, so the cookie validation of `AuthenticatedSessionManagerImpl.login` it will only catch wrong requests in case the CSRF validations are manually disabled or whitelisted.

Regards,
Jorge