### PR TITLE
LPS-132754 DB2 & SQLServer Fix

### DIFF
--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlIdpSpSessionUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlIdpSpSessionUpgradeProcess.java
@@ -71,13 +71,16 @@ public class SamlIdpSpSessionUpgradeProcess extends UpgradeProcess {
 
 			runSQL(
 				StringBundler.concat(
-					"update SamlIdpSpSession sidp set samlPeerBindingId = (",
-					"select samlPeerBindingId from SamlPeerBinding spb where ",
-					"sidp.companyId = spb.companyId and sidp.userId = ",
-					"spb.userId and sidp.samlSpEntityId = ",
-					"spb.samlPeerEntityId and sidp.nameIdFormat = ",
-					"spb.samlNameIdFormat and sidp.nameIdValue = ",
-					"spb.samlNameIdValue)"));
+					"update SamlIdpSpSession set samlPeerBindingId = (",
+					"select samlPeerBindingId from SamlPeerBinding where ",
+					"SamlIdpSpSession.companyId = SamlPeerBinding.companyId ",
+					"and SamlIdpSpSession.userId = SamlPeerBinding.userId and ",
+					"SamlIdpSpSession.samlSpEntityId = ",
+					"SamlPeerBinding.samlPeerEntityId and ",
+					"SamlIdpSpSession.nameIdFormat = ",
+					"SamlPeerBinding.samlNameIdFormat and ",
+					"SamlIdpSpSession.nameIdValue = ",
+					"SamlPeerBinding.samlNameIdValue"));
 
 			CounterLocalServiceUtil.reset(
 				"com.liferay.saml.persistence.model.SamlPeerBinding",

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlIdpSpSessionUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlIdpSpSessionUpgradeProcess.java
@@ -82,7 +82,7 @@ public class SamlIdpSpSessionUpgradeProcess extends UpgradeProcess {
 					"SamlIdpSpSession.nameIdFormat = ",
 					"SamlPeerBinding.samlNameIdFormat and ",
 					"SamlIdpSpSession.nameIdValue = ",
-					"SamlPeerBinding.samlNameIdValue"));
+					"SamlPeerBinding.samlNameIdValue)"));
 
 			CounterLocalServiceUtil.reset(
 				"com.liferay.saml.persistence.model.SamlPeerBinding",

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlIdpSpSessionUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlIdpSpSessionUpgradeProcess.java
@@ -60,12 +60,14 @@ public class SamlIdpSpSessionUpgradeProcess extends UpgradeProcess {
 					"insert into SamlPeerBinding (samlPeerBindingId, ",
 					"companyId, createDate, userId, userName, deleted, ",
 					"samlNameIdFormat, samlNameIdNameQualifier, ",
-					"samlNameIdSpProvidedId, samlNameIdValue, ",
-					"samlPeerEntityId) select min(samlIdpSpSessionId) + ",
+					"samlNameIdSpNameQualifier, samlNameIdSpProvidedId, ",
+					"samlNameIdValue, samlPeerEntityId) select ",
+					"min(samlIdpSpSessionId) + ",
 					-samlIdpSpSessionIdOffset + latestSamlPeerBindingId,
 					", companyId, min(createDate), userId, userName, '0' as ",
 					"deleted, nameIdFormat, null as nameIdNameQualifier, null ",
-					"as nameIdSpProvidedId, nameIdValue, samlSpEntityId from ",
+					"as samlNameIdSpNameQualifier, null as ",
+					"nameIdSpProvidedId, nameIdValue, samlSpEntityId from ",
 					"SamlIdpSpSession group by companyId, userId, userName, ",
 					"samlSpEntityId, nameIdFormat, nameIdValue"));
 

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlSpSessionUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlSpSessionUpgradeProcess.java
@@ -72,7 +72,7 @@ public class SamlSpSessionUpgradeProcess extends UpgradeProcess {
 			runSQL(
 				StringBundler.concat(
 					"update SamlSpSession set samlPeerBindingId = (",
-					"select SamlPeerBindingId from SamlPeerBinding where ",
+					"select samlPeerBindingId from SamlPeerBinding where ",
 					"SamlSpSession.companyId = SamlPeerBinding.companyId and ",
 					"SamlSpSession.userId = SamlPeerBinding.userId and ",
 					"SamlSpSession.samlIdpEntityId = ",

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlSpSessionUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlSpSessionUpgradeProcess.java
@@ -59,15 +59,17 @@ public class SamlSpSessionUpgradeProcess extends UpgradeProcess {
 					"insert into SamlPeerBinding (samlPeerBindingId, ",
 					"companyId, createDate, userId, userName, deleted, ",
 					"samlNameIdFormat, samlNameIdNameQualifier, ",
-					"samlNameIdSpProvidedId, samlNameIdValue, ",
-					"samlPeerEntityId) select min(samlSpSessionId) + ",
+					"samlNameIdSpNameQualifier, samlNameIdSpProvidedId, ",
+					"samlNameIdValue, samlPeerEntityId) select ",
+					"min(samlSpSessionId) + ",
 					-samlSpSessionIdOffset + latestSamlPeerBindingId,
 					", companyId, min(createDate), userId, userName, '0' as ",
 					"deleted, nameIdFormat, nameIdNameQualifier, null as ",
-					"nameIdSpProvidedId, nameIdValue, samlIdpEntityId from ",
-					"SamlSpSession group by companyId, userId, userName, ",
-					"nameIdFormat, nameIdNameQualifier, ",
-					"nameIdSPNameQualifier, nameIdValue, samlIdpEntityId"));
+					"samlNameIdSpNameQualifier, null as nameIdSpProvidedId, ",
+					"nameIdValue, samlIdpEntityId from SamlSpSession group by ",
+					"companyId, userId, userName, nameIdFormat, ",
+					"nameIdNameQualifier, nameIdSPNameQualifier, nameIdValue, ",
+					"samlIdpEntityId"));
 
 			runSQL(
 				StringBundler.concat(

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlSpSessionUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_0/SamlSpSessionUpgradeProcess.java
@@ -32,7 +32,9 @@ public class SamlSpSessionUpgradeProcess extends UpgradeProcess {
 	@Override
 	protected void doUpgrade() throws Exception {
 		try (LoggingTimer loggingTimer = new LoggingTimer()) {
-			if (!hasColumn("samlSpSession", "samlPeerBindingId")) {
+			if (!hasColumn(
+					SamlSpSessionTable.TABLE_NAME, "samlPeerBindingId")) {
+
 				alter(
 					SamlSpSessionTable.class,
 					new AlterTableAddColumn("samlPeerBindingId", "LONG null"));


### PR DESCRIPTION
@stian-sigvartsen Please, take a look. As we have discussed we were missing a field in the `INSERT into SamlPeerBinding` and for some databases is mandatory to add it even if it can be `null`,  we also had a typo in an update execution and I changed the other update execution to use table names.