### PR TITLE
[TS] LPS-133668 Add a warning message to the extend session request in case the session wasn't correctly extended

### DIFF
--- a/portal-web/docroot/html/portal/extend_session.jsp
+++ b/portal-web/docroot/html/portal/extend_session.jsp
@@ -17,6 +17,18 @@
 <%@ include file="/html/portal/init.jsp" %>
 
 <%
+if (_log.isWarnEnabled()) {
+	String requestedSessionId = request.getRequestedSessionId();
+
+	if (Validator.isNotNull(requestedSessionId) &&
+		!StringUtil.equals(requestedSessionId, session.getId())) {
+
+		_log.warn(
+			"Unable to extend session, in case this warning is displayed too " +
+			"frequently, review the session.timeout configuration properties");
+	}
+}
+
 for (String servletContextName : ServletContextPool.keySet()) {
 	ServletContext servletContext = ServletContextPool.get(servletContextName);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-133668

In order to make easier to configure the `session.timeout` portal properties, we must add some warn traces in the extend_session requests in case they are not able to extend the session. This can be easily implemented adding in the extend_session.jsp a check that compares the incoming and the effective session ids and write a warn trace in case the received session id is not the current one.

See the full explanation in the LPS description