### PR TITLE
Migrate struts Actions into MVC commands

### DIFF
--- a/modules/dxp/apps/saml/saml-api/bnd.bnd
+++ b/modules/dxp/apps/saml/saml-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay SAML API
 Bundle-SymbolicName: com.liferay.saml.api
-Bundle-Version: 6.0.4
+Bundle-Version: 7.0.0
 Export-Package:\
 	com.liferay.saml.constants,\
 	com.liferay.saml.runtime,\

--- a/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/constants/SamlCommandQueryConstants.java
+++ b/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/constants/SamlCommandQueryConstants.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.saml.constants;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+
+/**
+ * @author Arthur Chan
+ */
+public class SamlCommandQueryConstants {
+
+	public static final String ACS = StringBundler.concat(
+		CharPool.QUESTION, SamlCommandQueryConstants._P_P_ID,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._P_P_LIFECYCLE_ACTION,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._ACTION_COMMAND_NAME,
+		"/saml/assertion_consumer_service");
+
+	public static final String AUTH_REDIRECT = StringBundler.concat(
+		CharPool.QUESTION, SamlCommandQueryConstants._P_P_ID,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._P_P_LIFECYCLE_ACTION,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._ACTION_COMMAND_NAME,
+		"/saml/auth_redirect");
+
+	public static final String FINISH_SLO = StringBundler.concat(
+		CharPool.QUESTION, SamlCommandQueryConstants._P_P_ID,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._P_P_LIFECYCLE_RESOURCE,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._RESOURCE_COMMAND_NAME,
+		"/saml/finish_slo");
+
+	public static final String SELECT_IDP = StringBundler.concat(
+		CharPool.QUESTION, SamlCommandQueryConstants._P_P_ID,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._P_P_LIFECYCLE_RENDER,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._P_P_STATE,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._RENDER_COMMAND_NAME,
+		"/saml/select_idp");
+
+	public static final String SEND_SAML_SLO_REQUEST_INFOS =
+		StringBundler.concat(
+			CharPool.QUESTION, SamlCommandQueryConstants._P_P_ID,
+			CharPool.AMPERSAND,
+			SamlCommandQueryConstants._P_P_LIFECYCLE_RESOURCE,
+			CharPool.AMPERSAND,
+			SamlCommandQueryConstants._RESOURCE_COMMAND_NAME,
+			"/saml/send_saml_slo_request_infos");
+
+	public static final String SLO = StringBundler.concat(
+		CharPool.QUESTION, SamlCommandQueryConstants._P_P_ID,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._P_P_LIFECYCLE_RESOURCE,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._RESOURCE_COMMAND_NAME,
+		"/saml/slo");
+
+	public static final String SLO_LOGOUT = StringBundler.concat(
+		CharPool.QUESTION, SamlCommandQueryConstants._P_P_ID,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._P_P_LIFECYCLE_RENDER,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._P_P_STATE,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._RENDER_COMMAND_NAME,
+		"/saml/slo_logout");
+
+	public static final String SLO_SOAP = StringBundler.concat(
+		CharPool.QUESTION, SamlCommandQueryConstants._P_P_ID,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._P_P_LIFECYCLE_RESOURCE,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._RESOURCE_COMMAND_NAME,
+		"/saml/slo_soap");
+
+	public static final String WEB_SSO = StringBundler.concat(
+		CharPool.QUESTION, SamlCommandQueryConstants._P_P_ID,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._P_P_LIFECYCLE_RESOURCE,
+		CharPool.AMPERSAND, SamlCommandQueryConstants._RESOURCE_COMMAND_NAME,
+		"/saml/web_sso");
+
+	private static final String _ACTION_COMMAND_NAME =
+		CharPool.UNDERLINE + SamlPortletKeys.SAML + "_javax.portlet.action=";
+
+	private static final String _P_P_ID = "p_p_id=" + SamlPortletKeys.SAML;
+
+	private static final String _P_P_LIFECYCLE_ACTION = "p_p_lifecycle=1";
+
+	private static final String _P_P_LIFECYCLE_RENDER = "p_p_lifecycle=0";
+
+	private static final String _P_P_LIFECYCLE_RESOURCE = "p_p_lifecycle=2";
+
+	private static final String _P_P_STATE = "p_p_state=maximized";
+
+	private static final String _RENDER_COMMAND_NAME =
+		CharPool.UNDERLINE + SamlPortletKeys.SAML + "_mvcRenderCommandName=";
+
+	private static final String _RESOURCE_COMMAND_NAME = "p_p_resource_id=";
+
+}

--- a/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/constants/SamlPortletKeys.java
+++ b/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/constants/SamlPortletKeys.java
@@ -19,6 +19,9 @@ package com.liferay.saml.constants;
  */
 public class SamlPortletKeys {
 
+	public static final String SAML =
+		"com_liferay_saml_web_internal_portlet_SamlPortlet";
+
 	public static final String SAML_ADMIN =
 		"com_liferay_saml_web_internal_portlet_SamlAdminPortlet";
 

--- a/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/runtime/servlet/profile/SingleLogoutProfile.java
+++ b/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/runtime/servlet/profile/SingleLogoutProfile.java
@@ -28,6 +28,11 @@ public interface SingleLogoutProfile {
 	public SamlSpSession getSamlSpSession(
 		HttpServletRequest httpServletRequest);
 
+	public void initiateIdpSingleLogout(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception;
+
 	public boolean isSingleLogoutSupported(
 		HttpServletRequest httpServletRequest);
 

--- a/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/util/JspUtil.java
+++ b/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/util/JspUtil.java
@@ -33,6 +33,9 @@ public class JspUtil {
 	public static final String PATH_PORTAL_SAML_ERROR =
 		"/portal/saml/error.jsp";
 
+	public static final String PATH_PORTAL_SAML_SELECT_IDP =
+		"/portal/saml/select_idp.jsp";
+
 	public static final String PATH_PORTAL_SAML_SLO = "/portal/saml/slo.jsp";
 
 	public static final String PATH_PORTAL_SAML_SLO_SP_STATUS =

--- a/modules/dxp/apps/saml/saml-api/src/main/resources/com/liferay/saml/constants/packageinfo
+++ b/modules/dxp/apps/saml/saml-api/src/main/resources/com/liferay/saml/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.4.0
+version 2.5.0

--- a/modules/dxp/apps/saml/saml-api/src/main/resources/com/liferay/saml/runtime/servlet/profile/packageinfo
+++ b/modules/dxp/apps/saml/saml-api/src/main/resources/com/liferay/saml/runtime/servlet/profile/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/dxp/apps/saml/saml-api/src/main/resources/com/liferay/saml/util/packageinfo
+++ b/modules/dxp/apps/saml/saml-api/src/main/resources/com/liferay/saml/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SamlIdpSsoFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SamlIdpSsoFilter.java
@@ -17,6 +17,7 @@ package com.liferay.saml.internal.servlet.filter;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.CookieKeys;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
@@ -110,7 +111,13 @@ public class SamlIdpSsoFilter extends BaseSamlPortalFilter {
 				httpServletRequest, SamlWebKeys.SAML_SSO_SESSION_ID);
 
 			if (Validator.isNotNull(samlSsoSessionId)) {
-				_singleLogoutProfile.processIdpLogout(
+				httpServletResponse.addHeader(
+					HttpHeaders.CACHE_CONTROL,
+					HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE);
+				httpServletResponse.addHeader(
+					HttpHeaders.PRAGMA, HttpHeaders.PRAGMA_NO_CACHE_VALUE);
+
+				_singleLogoutProfile.initiateIdpSingleLogout(
 					httpServletRequest, httpServletResponse);
 			}
 			else {

--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SamlSameSiteLaxCookiesFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SamlSameSiteLaxCookiesFilter.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.saml.constants.SamlPortletKeys;
 
 import java.io.PrintWriter;
 
@@ -51,8 +52,7 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
 		"init-param.url-regex-ignore-pattern=^/html/.+\\.(css|gif|html|ico|jpg|js|png)(\\?.*)?$",
 		"servlet-context-name=",
 		"servlet-filter-name=SAML SameSite Lax Support Filter",
-		"url-pattern=/c/portal/saml/acs", "url-pattern=/c/portal/saml/slo",
-		"url-pattern=/c/portal/saml/sso"
+		"url-pattern=/web/*"
 	},
 	service = Filter.class
 )
@@ -76,7 +76,24 @@ public class SamlSameSiteLaxCookiesFilter extends BaseSamlPortalFilter {
 			return false;
 		}
 
-		return true;
+		String commandName = ParamUtil.getString(
+			httpServletRequest,
+			'_' + SamlPortletKeys.SAML + "_javax.portlet.action");
+
+		if (commandName.equals("/saml/assertion_consumer_service")) {
+			return true;
+		}
+
+		commandName = ParamUtil.getString(
+			httpServletRequest, "p_p_resource_id");
+
+		if (commandName.equals("/saml/web_sso") ||
+			commandName.equals("/saml/slo")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	@Activate
@@ -109,11 +126,15 @@ public class SamlSameSiteLaxCookiesFilter extends BaseSamlPortalFilter {
 			return;
 		}
 
-		StringBundler sb = new StringBundler(7 + (5 * _PARAMS.length));
+		StringBundler sb = new StringBundler(11 + (5 * _PARAMS.length));
 
 		sb.append("<!DOCTYPE html>\n\n");
 		sb.append("<html><body onload=\"document.forms[0].submit()\">");
-		sb.append("<form action=\"?continue=true\" method=\"post\"");
+		sb.append("<form action=\"");
+		sb.append(httpServletRequest.getRequestURI());
+		sb.append('?');
+		sb.append(httpServletRequest.getQueryString());
+		sb.append("&continue=true\" method=\"post\"");
 		sb.append("name=\"fm\">");
 
 		for (String param : _PARAMS) {

--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SamlSpSsoFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SamlSpSsoFilter.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.saml.constants.SamlCommandQueryConstants;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.persistence.model.SamlSpIdpConnection;
 import com.liferay.saml.persistence.model.SamlSpSession;
@@ -45,7 +46,6 @@ import java.util.stream.Stream;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
-import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -157,14 +157,9 @@ public class SamlSpSsoFilter extends BaseSamlPortalFilter {
 				_enabledSamlSpIdpConnections(httpServletRequest);
 
 			if (enabledSamlSpIdpConnections.size() > 1) {
-				RequestDispatcher requestDispatcher =
-					_servletContext.getRequestDispatcher(
-						"/c/portal/saml/login");
-
-				httpServletResponse.setContentType("text/html");
-
-				requestDispatcher.include(
-					httpServletRequest, httpServletResponse);
+				httpServletResponse.sendRedirect(
+					_portal.getRelativeHomeURL(httpServletRequest) +
+						SamlCommandQueryConstants.SELECT_IDP);
 
 				return;
 			}

--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SamlSpSsoFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SamlSpSsoFilter.java
@@ -28,12 +28,19 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.saml.constants.SamlWebKeys;
+import com.liferay.saml.persistence.model.SamlSpIdpConnection;
 import com.liferay.saml.persistence.model.SamlSpSession;
+import com.liferay.saml.persistence.service.SamlSpIdpConnectionLocalService;
 import com.liferay.saml.runtime.configuration.SamlProviderConfiguration;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
+import com.liferay.saml.runtime.servlet.profile.SamlSpIdpConnectionsProfile;
 import com.liferay.saml.runtime.servlet.profile.SingleLogoutProfile;
 import com.liferay.saml.runtime.servlet.profile.WebSsoProfile;
 import com.liferay.saml.util.SamlHttpRequestUtil;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -46,6 +53,9 @@ import javax.servlet.http.HttpSession;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Mika Koivisto
@@ -143,17 +153,27 @@ public class SamlSpSsoFilter extends BaseSamlPortalFilter {
 				_portal.getCurrentCompleteURL(httpServletRequest));
 		}
 		else if (requestPath.equals("/c/portal/login")) {
-			RequestDispatcher requestDispatcher =
-				_servletContext.getRequestDispatcher("/c/portal/saml/login");
+			List<SamlSpIdpConnection> enabledSamlSpIdpConnections =
+				_enabledSamlSpIdpConnections(httpServletRequest);
 
-			httpServletResponse.setContentType("text/html");
+			if (enabledSamlSpIdpConnections.size() > 1) {
+				RequestDispatcher requestDispatcher =
+					_servletContext.getRequestDispatcher(
+						"/c/portal/saml/login");
 
-			requestDispatcher.include(httpServletRequest, httpServletResponse);
+				httpServletResponse.setContentType("text/html");
 
-			Object samlSpIdpConnection = httpServletRequest.getAttribute(
-				SamlWebKeys.SAML_SP_IDP_CONNECTION);
+				requestDispatcher.include(
+					httpServletRequest, httpServletResponse);
 
-			if (samlSpIdpConnection != null) {
+				return;
+			}
+
+			if (enabledSamlSpIdpConnections.size() == 1) {
+				httpServletRequest.setAttribute(
+					SamlWebKeys.SAML_SP_IDP_CONNECTION,
+					enabledSamlSpIdpConnections.get(0));
+
 				try {
 					login(httpServletRequest, httpServletResponse);
 				}
@@ -164,21 +184,15 @@ public class SamlSpSsoFilter extends BaseSamlPortalFilter {
 								portalException.getMessage());
 					}
 				}
+
+				return;
 			}
-			else {
-				SamlProviderConfiguration samlProviderConfiguration =
-					_samlProviderConfigurationHelper.
-						getSamlProviderConfiguration();
 
-				Object samlSsologinContext = httpServletRequest.getAttribute(
-					SamlWebKeys.SAML_SSO_LOGIN_CONTEXT);
+			SamlProviderConfiguration samlProviderConfiguration =
+				_samlProviderConfigurationHelper.getSamlProviderConfiguration();
 
-				if ((samlSsologinContext == null) &&
-					samlProviderConfiguration.allowShowingTheLoginPortlet()) {
-
-					filterChain.doFilter(
-						httpServletRequest, httpServletResponse);
-				}
+			if (samlProviderConfiguration.allowShowingTheLoginPortlet()) {
+				filterChain.doFilter(httpServletRequest, httpServletResponse);
 			}
 		}
 		else if (requestPath.equals("/c/portal/logout")) {
@@ -241,6 +255,35 @@ public class SamlSpSsoFilter extends BaseSamlPortalFilter {
 			httpServletRequest, httpServletResponse, relayState);
 	}
 
+	private List<SamlSpIdpConnection> _enabledSamlSpIdpConnections(
+		HttpServletRequest httpServletRequest) {
+
+		List<SamlSpIdpConnection> samlSpIdpConnections =
+			_samlSpIdpConnectionLocalService.getSamlSpIdpConnections(
+				_portal.getCompanyId(httpServletRequest));
+
+		Stream<SamlSpIdpConnection> stream = samlSpIdpConnections.stream();
+
+		return stream.filter(
+			samlSpIdpConnection -> _isEnabled(
+				samlSpIdpConnection, httpServletRequest)
+		).collect(
+			Collectors.toList()
+		);
+	}
+
+	private boolean _isEnabled(
+		SamlSpIdpConnection samlSpIdpConnection,
+		HttpServletRequest httpServletRequest) {
+
+		if (_samlSpIdpConnectionsProfile != null) {
+			return _samlSpIdpConnectionsProfile.isEnabled(
+				samlSpIdpConnection, httpServletRequest);
+		}
+
+		return samlSpIdpConnection.isEnabled();
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		SamlSpSsoFilter.class);
 
@@ -255,6 +298,16 @@ public class SamlSpSsoFilter extends BaseSamlPortalFilter {
 
 	@Reference
 	private SamlProviderConfigurationHelper _samlProviderConfigurationHelper;
+
+	@Reference
+	private SamlSpIdpConnectionLocalService _samlSpIdpConnectionLocalService;
+
+	@Reference(
+		cardinality = ReferenceCardinality.OPTIONAL,
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY
+	)
+	private volatile SamlSpIdpConnectionsProfile _samlSpIdpConnectionsProfile;
 
 	private ServletContext _servletContext;
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataGeneratorUtil.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataGeneratorUtil.java
@@ -148,16 +148,14 @@ public class MetadataGeneratorUtil {
 		SingleLogoutService postSingleLogoutService =
 			OpenSamlUtil.buildSingleLogoutService(
 				SAMLConstants.SAML2_POST_BINDING_URI,
-				StringBundler.concat(
-					portalURL, PortalUtil.getPathMain(), "/portal/saml/slo"));
+				portalURL + "/web/guest" + SamlCommandQueryConstants.SLO);
 
 		singleLogoutServices.add(postSingleLogoutService);
 
 		SingleLogoutService redirectSingleLogoutService =
 			OpenSamlUtil.buildSingleLogoutService(
 				SAMLConstants.SAML2_REDIRECT_BINDING_URI,
-				StringBundler.concat(
-					portalURL, PortalUtil.getPathMain(), "/portal/saml/slo"));
+				portalURL + "/web/guest" + SamlCommandQueryConstants.SLO);
 
 		singleLogoutServices.add(redirectSingleLogoutService);
 
@@ -242,25 +240,21 @@ public class MetadataGeneratorUtil {
 		SingleLogoutService postSingleLogoutService =
 			OpenSamlUtil.buildSingleLogoutService(
 				SAMLConstants.SAML2_POST_BINDING_URI,
-				StringBundler.concat(
-					portalURL, PortalUtil.getPathMain(), "/portal/saml/slo"));
+				portalURL + "/web/guest" + SamlCommandQueryConstants.SLO);
 
 		singleLogoutServices.add(postSingleLogoutService);
 
 		SingleLogoutService redirectSingleLogoutService =
 			OpenSamlUtil.buildSingleLogoutService(
 				SAMLConstants.SAML2_REDIRECT_BINDING_URI,
-				StringBundler.concat(
-					portalURL, PortalUtil.getPathMain(), "/portal/saml/slo"));
+				portalURL + "/web/guest" + SamlCommandQueryConstants.SLO);
 
 		singleLogoutServices.add(redirectSingleLogoutService);
 
 		SingleLogoutService soapSingleLogoutService =
 			OpenSamlUtil.buildSingleLogoutService(
 				SAMLConstants.SAML2_SOAP11_BINDING_URI,
-				StringBundler.concat(
-					portalURL, PortalUtil.getPathMain(),
-					"/portal/saml/slo_soap"));
+				portalURL + "/web/guest" + SamlCommandQueryConstants.SLO_SOAP);
 
 		singleLogoutServices.add(soapSingleLogoutService);
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataGeneratorUtil.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataGeneratorUtil.java
@@ -59,9 +59,9 @@ import org.opensaml.xmlsec.encryption.impl.KeySizeBuilder;
 public class MetadataGeneratorUtil {
 
 	public static EntityDescriptor buildIdpEntityDescriptor(
-			String portalURL, String entityId, boolean wantAuthnRequestSigned,
-			boolean signMetadata, Credential credential,
-			Credential encryptionCredential)
+			String portalURL, String relativeHomeURL, String entityId,
+			boolean wantAuthnRequestSigned, boolean signMetadata,
+			Credential credential, Credential encryptionCredential)
 		throws Exception {
 
 		if (Validator.isNull(entityId)) {
@@ -81,8 +81,8 @@ public class MetadataGeneratorUtil {
 			entityDescriptor.getRoleDescriptors();
 
 		RoleDescriptor roleDescriptor = buildIdpSsoDescriptor(
-			portalURL, entityId, wantAuthnRequestSigned, credential,
-			encryptionCredential);
+			portalURL, relativeHomeURL, entityId, wantAuthnRequestSigned,
+			credential, encryptionCredential);
 
 		Extensions extensions = (Extensions)XMLObjectSupport.buildXMLObject(
 			Extensions.DEFAULT_ELEMENT_NAME);
@@ -103,8 +103,9 @@ public class MetadataGeneratorUtil {
 	}
 
 	public static IDPSSODescriptor buildIdpSsoDescriptor(
-			String portalURL, String entityId, boolean wantAuthnRequestSigned,
-			Credential credential, Credential encryptionCredential)
+			String portalURL, String relativeHomeURL, String entityId,
+			boolean wantAuthnRequestSigned, Credential credential,
+			Credential encryptionCredential)
 		throws Exception {
 
 		IDPSSODescriptor idpSSODescriptor =
@@ -139,7 +140,7 @@ public class MetadataGeneratorUtil {
 
 		singleSignOnService = OpenSamlUtil.buildSingleSignOnService(
 			SAMLConstants.SAML2_POST_BINDING_URI,
-			portalURL + "/web/guest" + SamlCommandQueryConstants.WEB_SSO);
+			portalURL + relativeHomeURL + SamlCommandQueryConstants.WEB_SSO);
 
 		singleSignOnServices.add(singleSignOnService);
 
@@ -149,7 +150,7 @@ public class MetadataGeneratorUtil {
 		SingleLogoutService postSingleLogoutService =
 			OpenSamlUtil.buildSingleLogoutService(
 				SAMLConstants.SAML2_POST_BINDING_URI,
-				portalURL + "/web/guest" + SamlCommandQueryConstants.SLO);
+				portalURL + relativeHomeURL + SamlCommandQueryConstants.SLO);
 
 		singleLogoutServices.add(postSingleLogoutService);
 
@@ -165,9 +166,10 @@ public class MetadataGeneratorUtil {
 	}
 
 	public static EntityDescriptor buildSpEntityDescriptor(
-			String portalURL, String entityId, boolean signAuthnRequests,
-			boolean signMetadata, boolean wantAssertionsSigned,
-			Credential credential, Credential encryptionCredential)
+			String portalURL, String relativeHomeURL, String entityId,
+			boolean signAuthnRequests, boolean signMetadata,
+			boolean wantAssertionsSigned, Credential credential,
+			Credential encryptionCredential)
 		throws Exception {
 
 		EntityDescriptor entityDescriptor =
@@ -179,8 +181,8 @@ public class MetadataGeneratorUtil {
 			entityDescriptor.getRoleDescriptors();
 
 		RoleDescriptor roleDescriptor = buildSpSsoDescriptor(
-			portalURL, entityId, signAuthnRequests, wantAssertionsSigned,
-			credential, encryptionCredential);
+			portalURL, relativeHomeURL, entityId, signAuthnRequests,
+			wantAssertionsSigned, credential, encryptionCredential);
 
 		Extensions extensions = (Extensions)XMLObjectSupport.buildXMLObject(
 			Extensions.DEFAULT_ELEMENT_NAME);
@@ -201,9 +203,9 @@ public class MetadataGeneratorUtil {
 	}
 
 	public static SPSSODescriptor buildSpSsoDescriptor(
-			String portalURL, String entityId, boolean signAuthnRequests,
-			boolean wantAssertionsSigned, Credential credential,
-			Credential encryptionCredential)
+			String portalURL, String relativeHomeURL, String entityId,
+			boolean signAuthnRequests, boolean wantAssertionsSigned,
+			Credential credential, Credential encryptionCredential)
 		throws Exception {
 
 		SPSSODescriptor spSSODescriptor = OpenSamlUtil.buildSpSsoDescriptor();
@@ -219,7 +221,7 @@ public class MetadataGeneratorUtil {
 		AssertionConsumerService assertionConsumerService =
 			OpenSamlUtil.buildAssertionConsumerService(
 				SAMLConstants.SAML2_POST_BINDING_URI, 1, true,
-				portalURL + "/web/guest" + SamlCommandQueryConstants.ACS);
+				portalURL + relativeHomeURL + SamlCommandQueryConstants.ACS);
 
 		assertionConsumerServices.add(assertionConsumerService);
 
@@ -242,7 +244,7 @@ public class MetadataGeneratorUtil {
 		SingleLogoutService postSingleLogoutService =
 			OpenSamlUtil.buildSingleLogoutService(
 				SAMLConstants.SAML2_POST_BINDING_URI,
-				portalURL + "/web/guest" + SamlCommandQueryConstants.SLO);
+				portalURL + relativeHomeURL + SamlCommandQueryConstants.SLO);
 
 		singleLogoutServices.add(postSingleLogoutService);
 
@@ -257,7 +259,8 @@ public class MetadataGeneratorUtil {
 		SingleLogoutService soapSingleLogoutService =
 			OpenSamlUtil.buildSingleLogoutService(
 				SAMLConstants.SAML2_SOAP11_BINDING_URI,
-				portalURL + "/web/guest" + SamlCommandQueryConstants.SLO_SOAP);
+				portalURL + relativeHomeURL +
+					SamlCommandQueryConstants.SLO_SOAP);
 
 		singleLogoutServices.add(soapSingleLogoutService);
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataGeneratorUtil.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataGeneratorUtil.java
@@ -132,7 +132,8 @@ public class MetadataGeneratorUtil {
 		SingleSignOnService singleSignOnService =
 			OpenSamlUtil.buildSingleSignOnService(
 				SAMLConstants.SAML2_REDIRECT_BINDING_URI,
-				portalURL + "/web/guest" + SamlCommandQueryConstants.WEB_SSO);
+				portalURL + PortalUtil.getPathMain() +
+					"/portal/saml/redirect/sso");
 
 		singleSignOnServices.add(singleSignOnService);
 
@@ -155,7 +156,8 @@ public class MetadataGeneratorUtil {
 		SingleLogoutService redirectSingleLogoutService =
 			OpenSamlUtil.buildSingleLogoutService(
 				SAMLConstants.SAML2_REDIRECT_BINDING_URI,
-				portalURL + "/web/guest" + SamlCommandQueryConstants.SLO);
+				portalURL + PortalUtil.getPathMain() +
+					"/portal/saml/redirect/slo");
 
 		singleLogoutServices.add(redirectSingleLogoutService);
 
@@ -247,7 +249,8 @@ public class MetadataGeneratorUtil {
 		SingleLogoutService redirectSingleLogoutService =
 			OpenSamlUtil.buildSingleLogoutService(
 				SAMLConstants.SAML2_REDIRECT_BINDING_URI,
-				portalURL + "/web/guest" + SamlCommandQueryConstants.SLO);
+				portalURL + PortalUtil.getPathMain() +
+					"/portal/saml/redirect/slo");
 
 		singleLogoutServices.add(redirectSingleLogoutService);
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataGeneratorUtil.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataGeneratorUtil.java
@@ -132,15 +132,13 @@ public class MetadataGeneratorUtil {
 		SingleSignOnService singleSignOnService =
 			OpenSamlUtil.buildSingleSignOnService(
 				SAMLConstants.SAML2_REDIRECT_BINDING_URI,
-				StringBundler.concat(
-					portalURL, PortalUtil.getPathMain(), "/portal/saml/sso"));
+				portalURL + "/web/guest" + SamlCommandQueryConstants.WEB_SSO);
 
 		singleSignOnServices.add(singleSignOnService);
 
 		singleSignOnService = OpenSamlUtil.buildSingleSignOnService(
 			SAMLConstants.SAML2_POST_BINDING_URI,
-			StringBundler.concat(
-				portalURL, PortalUtil.getPathMain(), "/portal/saml/sso"));
+			portalURL + "/web/guest" + SamlCommandQueryConstants.WEB_SSO);
 
 		singleSignOnServices.add(singleSignOnService);
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataGeneratorUtil.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataGeneratorUtil.java
@@ -14,9 +14,9 @@
 
 package com.liferay.saml.opensaml.integration.internal.metadata;
 
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.saml.constants.SamlCommandQueryConstants;
 import com.liferay.saml.opensaml.integration.internal.util.OpenSamlUtil;
 import com.liferay.saml.runtime.exception.CredentialException;
 import com.liferay.saml.runtime.exception.EntityIdException;
@@ -221,8 +221,7 @@ public class MetadataGeneratorUtil {
 		AssertionConsumerService assertionConsumerService =
 			OpenSamlUtil.buildAssertionConsumerService(
 				SAMLConstants.SAML2_POST_BINDING_URI, 1, true,
-				StringBundler.concat(
-					portalURL, PortalUtil.getPathMain(), "/portal/saml/acs"));
+				portalURL + "/web/guest" + SamlCommandQueryConstants.ACS);
 
 		assertionConsumerServices.add(assertionConsumerService);
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataManagerImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataManagerImpl.java
@@ -183,18 +183,21 @@ public class MetadataManagerImpl
 				httpServletRequest,
 				isSSLRequired() || _portal.isSecure(httpServletRequest));
 			String localEntityId = _localEntityManager.getLocalEntityId();
+			String relativeHomeURL = _portal.getRelativeHomeURL(
+				httpServletRequest);
 
 			if (_samlProviderConfigurationHelper.isRoleIdp()) {
 				return MetadataGeneratorUtil.buildIdpEntityDescriptor(
-					portalURL, localEntityId, isWantAuthnRequestSigned(),
-					isSignMetadata(), getSigningCredential(),
-					encryptionCredential);
+					portalURL, relativeHomeURL, localEntityId,
+					isWantAuthnRequestSigned(), isSignMetadata(),
+					getSigningCredential(), encryptionCredential);
 			}
 			else if (_samlProviderConfigurationHelper.isRoleSp()) {
 				return MetadataGeneratorUtil.buildSpEntityDescriptor(
-					portalURL, localEntityId, isSignAuthnRequest(),
-					isSignMetadata(), isWantAssertionsSigned(),
-					getSigningCredential(), encryptionCredential);
+					portalURL, relativeHomeURL, localEntityId,
+					isSignAuthnRequest(), isSignMetadata(),
+					isWantAssertionsSigned(), getSigningCredential(),
+					encryptionCredential);
 			}
 
 			return null;

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataManagerImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/MetadataManagerImpl.java
@@ -296,8 +296,8 @@ public class MetadataManagerImpl
 
 		String contextPath = httpServletRequest.getContextPath();
 
-		if (Validator.isNotNull(contextPath) &&
-			!contextPath.equals(StringPool.SLASH)) {
+		if ((contextPath != null) && !contextPath.equals(StringPool.SLASH) &&
+			requestURI.startsWith(contextPath)) {
 
 			requestURI = requestURI.substring(contextPath.length());
 		}

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
@@ -253,21 +253,20 @@ public class SingleLogoutProfileImpl
 		SamlBinding samlBinding = null;
 
 		String method = httpServletRequest.getMethod();
-		String requestPath = _samlHttpRequestUtil.getRequestPath(
-			httpServletRequest);
+		String actionName = httpServletRequest.getParameter("p_p_resource_id");
 
-		if (requestPath.endsWith("/slo") &&
+		if (actionName.endsWith("/slo") &&
 			StringUtil.equalsIgnoreCase(method, HttpMethods.GET)) {
 
 			samlBinding = getSamlBinding(
 				SAMLConstants.SAML2_REDIRECT_BINDING_URI);
 		}
-		else if (requestPath.endsWith("/slo") &&
+		else if (actionName.endsWith("/slo") &&
 				 StringUtil.equalsIgnoreCase(method, HttpMethods.POST)) {
 
 			samlBinding = getSamlBinding(SAMLConstants.SAML2_POST_BINDING_URI);
 		}
-		else if (requestPath.endsWith("/slo_soap") &&
+		else if (actionName.endsWith("/slo_soap") &&
 				 StringUtil.equalsIgnoreCase(method, HttpMethods.POST)) {
 
 			samlBinding = getSamlBinding(

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
@@ -128,10 +128,7 @@ public class SingleLogoutProfileImpl
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
-		SamlSloContext samlSloContext = getSamlSloContext(
-			httpServletRequest, null);
-
-		if (samlSloContext != null) {
+		if (hasSamlSloContext(httpServletRequest, null)) {
 			String redirect = StringBundler.concat(
 				portal.getPortalURL(httpServletRequest), portal.getPathMain(),
 				"/portal/saml/slo_logout");
@@ -469,6 +466,39 @@ public class SingleLogoutProfileImpl
 		SamlSloContext samlSloContext = (SamlSloContext)session.getAttribute(
 			SamlWebKeys.SAML_SLO_CONTEXT);
 
+		if (samlSloContext != null) {
+			return samlSloContext;
+		}
+
+		String samlSsoSessionId = getSamlSsoSessionId(
+			httpServletRequest, messageContext);
+
+		if (Validator.isNull(samlSsoSessionId)) {
+			return null;
+		}
+
+		SamlIdpSsoSession samlIdpSsoSession =
+			_samlIdpSsoSessionLocalService.fetchSamlIdpSso(samlSsoSessionId);
+
+		if (samlIdpSsoSession != null) {
+			samlSloContext = new SamlSloContext(
+				samlIdpSsoSession, messageContext,
+				_samlIdpSpConnectionLocalService, _samlIdpSpSessionLocalService,
+				_samlPeerBindingLocalService, _userLocalService);
+
+			samlSloContext.setSamlSsoSessionId(samlSsoSessionId);
+			samlSloContext.setUserId(portal.getUserId(httpServletRequest));
+
+			session.setAttribute(SamlWebKeys.SAML_SLO_CONTEXT, samlSloContext);
+		}
+
+		return samlSloContext;
+	}
+
+	protected String getSamlSsoSessionId(
+		HttpServletRequest httpServletRequest,
+		MessageContext<?> messageContext) {
+
 		String samlSsoSessionId = getSamlSsoSessionId(httpServletRequest);
 
 		if (messageContext != null) {
@@ -490,27 +520,37 @@ public class SingleLogoutProfileImpl
 			}
 		}
 
-		if ((samlSloContext == null) && Validator.isNotNull(samlSsoSessionId)) {
-			SamlIdpSsoSession samlIdpSsoSession =
-				_samlIdpSsoSessionLocalService.fetchSamlIdpSso(
-					samlSsoSessionId);
+		return samlSsoSessionId;
+	}
 
-			if (samlIdpSsoSession != null) {
-				samlSloContext = new SamlSloContext(
-					samlIdpSsoSession, messageContext,
-					_samlIdpSpConnectionLocalService,
-					_samlIdpSpSessionLocalService, _samlPeerBindingLocalService,
-					_userLocalService);
+	protected boolean hasSamlSloContext(
+		HttpServletRequest httpServletRequest,
+		MessageContext<?> messageContext) {
 
-				samlSloContext.setSamlSsoSessionId(samlSsoSessionId);
-				samlSloContext.setUserId(portal.getUserId(httpServletRequest));
+		HttpSession session = httpServletRequest.getSession();
 
-				session.setAttribute(
-					SamlWebKeys.SAML_SLO_CONTEXT, samlSloContext);
-			}
+		SamlSloContext samlSloContext = (SamlSloContext)session.getAttribute(
+			SamlWebKeys.SAML_SLO_CONTEXT);
+
+		if (samlSloContext != null) {
+			return true;
 		}
 
-		return samlSloContext;
+		String samlSsoSessionId = getSamlSsoSessionId(
+			httpServletRequest, messageContext);
+
+		if (Validator.isNull(samlSsoSessionId)) {
+			return false;
+		}
+
+		SamlIdpSsoSession samlIdpSsoSession =
+			_samlIdpSsoSessionLocalService.fetchSamlIdpSso(samlSsoSessionId);
+
+		if (samlIdpSsoSession != null) {
+			return true;
+		}
+
+		return false;
 	}
 
 	protected void performIdpFinishLogout(

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.saml.constants.SamlCommandQueryConstants;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.opensaml.integration.internal.binding.SamlBinding;
 import com.liferay.saml.opensaml.integration.internal.metadata.MetadataManager;
@@ -51,7 +52,6 @@ import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
 import com.liferay.saml.runtime.exception.UnsolicitedLogoutResponseException;
 import com.liferay.saml.runtime.exception.UnsupportedBindingException;
 import com.liferay.saml.runtime.servlet.profile.SingleLogoutProfile;
-import com.liferay.saml.util.JspUtil;
 import com.liferay.saml.util.SamlHttpRequestUtil;
 
 import java.io.Writer;
@@ -129,11 +129,9 @@ public class SingleLogoutProfileImpl
 		throws Exception {
 
 		if (hasSamlSloContext(httpServletRequest, null)) {
-			String redirect = StringBundler.concat(
-				portal.getPortalURL(httpServletRequest), portal.getPathMain(),
-				"/portal/saml/slo_logout");
-
-			httpServletResponse.sendRedirect(redirect);
+			httpServletResponse.sendRedirect(
+				_portal.getRelativeHomeURL(httpServletRequest) +
+					SamlCommandQueryConstants.SLO_LOGOUT);
 		}
 		else {
 			redirectToLogout(httpServletRequest, httpServletResponse);
@@ -205,9 +203,6 @@ public class SingleLogoutProfileImpl
 			HttpServletResponse httpServletResponse)
 		throws PortalException {
 
-		String requestPath = _samlHttpRequestUtil.getRequestPath(
-			httpServletRequest);
-
 		try {
 			httpServletResponse.addHeader(
 				HttpHeaders.CACHE_CONTROL,
@@ -215,43 +210,33 @@ public class SingleLogoutProfileImpl
 			httpServletResponse.addHeader(
 				HttpHeaders.PRAGMA, HttpHeaders.PRAGMA_NO_CACHE_VALUE);
 
-			if (requestPath.equals("/c/portal/saml/slo_logout")) {
-				SamlSloContext samlSloContext = getSamlSloContext(
-					httpServletRequest, null);
+			SamlSloContext samlSloContext = getSamlSloContext(
+				httpServletRequest, null);
 
-				if (samlSloContext == null) {
-					redirectToLogout(httpServletRequest, httpServletResponse);
+			if (samlSloContext == null) {
+				redirectToLogout(httpServletRequest, httpServletResponse);
 
-					return;
-				}
+				return;
+			}
 
-				String cmd = ParamUtil.getString(
-					httpServletRequest, Constants.CMD);
+			String cmd = ParamUtil.getString(httpServletRequest, Constants.CMD);
 
-				if (Validator.isNull(cmd)) {
-					httpServletRequest.setAttribute(
-						SamlWebKeys.SAML_SLO_CONTEXT,
-						samlSloContext.toJSONObject());
-
-					JspUtil.dispatch(
-						httpServletRequest, httpServletResponse,
-						JspUtil.PATH_PORTAL_SAML_SLO, "single-sign-out");
-				}
-				else if (cmd.equals("logout")) {
-					performIdpSpLogout(
-						httpServletRequest, httpServletResponse,
-						samlSloContext);
-				}
-				else if (cmd.equals("finish")) {
-					performIdpFinishLogout(
-						httpServletRequest, httpServletResponse,
-						samlSloContext);
-				}
-				else if (cmd.equals("status")) {
-					performIdpStatus(
-						httpServletRequest, httpServletResponse,
-						samlSloContext);
-				}
+			if (Validator.isNull(cmd)) {
+				httpServletRequest.setAttribute(
+					SamlWebKeys.SAML_SLO_CONTEXT,
+					samlSloContext.toJSONObject());
+			}
+			else if (cmd.equals("logout")) {
+				performIdpSpLogout(
+					httpServletRequest, httpServletResponse, samlSloContext);
+			}
+			else if (cmd.equals("finish")) {
+				performIdpFinishLogout(
+					httpServletRequest, httpServletResponse, samlSloContext);
+			}
+			else if (cmd.equals("status")) {
+				performIdpStatus(
+					httpServletRequest, httpServletResponse, samlSloContext);
 			}
 		}
 		catch (Exception exception) {
@@ -596,17 +581,9 @@ public class SingleLogoutProfileImpl
 			samlSloContext.getSamlSloRequestInfo(entityId);
 
 		if (samlSloRequestInfo == null) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					"Received logout request for service provider " + entityId +
-						" that the user is not logged into");
-			}
-
-			JspUtil.dispatch(
-				httpServletRequest, httpServletResponse,
-				JspUtil.PATH_PORTAL_SAML_ERROR, "single-sign-out", true);
-
-			return;
+			throw new Exception(
+				"Received logout request for service provider " + entityId +
+					" that the user is not logged into");
 		}
 
 		if (samlSloRequestInfo.getStatus() ==
@@ -615,11 +592,6 @@ public class SingleLogoutProfileImpl
 			httpServletRequest.setAttribute(
 				SamlWebKeys.SAML_SLO_REQUEST_INFO,
 				samlSloRequestInfo.toJSONObject());
-
-			JspUtil.dispatch(
-				httpServletRequest, httpServletResponse,
-				JspUtil.PATH_PORTAL_SAML_SLO_SP_STATUS, "single-sign-out",
-				true);
 
 			return;
 		}
@@ -652,11 +624,6 @@ public class SingleLogoutProfileImpl
 			httpServletRequest.setAttribute(
 				SamlWebKeys.SAML_SLO_REQUEST_INFO,
 				samlSloRequestInfo.toJSONObject());
-
-			JspUtil.dispatch(
-				httpServletRequest, httpServletResponse,
-				JspUtil.PATH_PORTAL_SAML_SLO_SP_STATUS, "single-sign-out",
-				true);
 		}
 		else {
 			try {
@@ -686,11 +653,6 @@ public class SingleLogoutProfileImpl
 				httpServletRequest.setAttribute(
 					SamlWebKeys.SAML_SLO_REQUEST_INFO,
 					samlSloRequestInfo.toJSONObject());
-
-				JspUtil.dispatch(
-					httpServletRequest, httpServletResponse,
-					JspUtil.PATH_PORTAL_SAML_SLO_SP_STATUS, "single-sign-out",
-					true);
 			}
 		}
 	}
@@ -820,10 +782,6 @@ public class SingleLogoutProfileImpl
 		httpServletRequest.setAttribute(
 			SamlWebKeys.SAML_SLO_REQUEST_INFO,
 			samlSloRequestInfo.toJSONObject());
-
-		JspUtil.dispatch(
-			httpServletRequest, httpServletResponse,
-			JspUtil.PATH_PORTAL_SAML_SLO_SP_STATUS, "single-sign-out", true);
 	}
 
 	protected void processSingleLogoutRequest(
@@ -1166,11 +1124,6 @@ public class SingleLogoutProfileImpl
 			httpServletRequest.setAttribute(
 				SamlWebKeys.SAML_SLO_REQUEST_INFO,
 				samlSloRequestInfo.toJSONObject());
-
-			JspUtil.dispatch(
-				httpServletRequest, httpServletResponse,
-				JspUtil.PATH_PORTAL_SAML_SLO_SP_STATUS, "single-sign-out",
-				true);
 		}
 		else {
 			sendAsyncLogoutRequest(
@@ -1553,6 +1506,9 @@ public class SingleLogoutProfileImpl
 
 	@Reference
 	private HttpClient _httpClient;
+
+	@Reference
+	private Portal _portal;
 
 	private SamlHttpRequestUtil _samlHttpRequestUtil;
 	private SamlIdpSpConnectionLocalService _samlIdpSpConnectionLocalService;

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
@@ -123,6 +123,27 @@ public class SingleLogoutProfileImpl
 	extends BaseProfile implements SingleLogoutProfile {
 
 	@Override
+	public void initiateIdpSingleLogout(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception {
+
+		SamlSloContext samlSloContext = getSamlSloContext(
+			httpServletRequest, null);
+
+		if (samlSloContext != null) {
+			String redirect = StringBundler.concat(
+				portal.getPortalURL(httpServletRequest), portal.getPathMain(),
+				"/portal/saml/slo_logout");
+
+			httpServletResponse.sendRedirect(redirect);
+		}
+		else {
+			redirectToLogout(httpServletRequest, httpServletResponse);
+		}
+	}
+
+	@Override
 	public boolean isSingleLogoutSupported(
 		HttpServletRequest httpServletRequest) {
 
@@ -197,11 +218,7 @@ public class SingleLogoutProfileImpl
 			httpServletResponse.addHeader(
 				HttpHeaders.PRAGMA, HttpHeaders.PRAGMA_NO_CACHE_VALUE);
 
-			if (requestPath.equals("/c/portal/logout")) {
-				initiateIdpSingleLogout(
-					httpServletRequest, httpServletResponse);
-			}
-			else if (requestPath.equals("/c/portal/saml/slo_logout")) {
+			if (requestPath.equals("/c/portal/saml/slo_logout")) {
 				SamlSloContext samlSloContext = getSamlSloContext(
 					httpServletRequest, null);
 
@@ -494,26 +511,6 @@ public class SingleLogoutProfileImpl
 		}
 
 		return samlSloContext;
-	}
-
-	protected void initiateIdpSingleLogout(
-			HttpServletRequest httpServletRequest,
-			HttpServletResponse httpServletResponse)
-		throws Exception {
-
-		SamlSloContext samlSloContext = getSamlSloContext(
-			httpServletRequest, null);
-
-		if (samlSloContext != null) {
-			String redirect = StringBundler.concat(
-				portal.getPortalURL(httpServletRequest), portal.getPathMain(),
-				"/portal/saml/slo_logout");
-
-			httpServletResponse.sendRedirect(redirect);
-		}
-		else {
-			redirectToLogout(httpServletRequest, httpServletResponse);
-		}
 	}
 
 	protected void performIdpFinishLogout(

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.saml.constants.SamlCommandQueryConstants;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.opensaml.integration.internal.binding.SamlBinding;
 import com.liferay.saml.opensaml.integration.internal.metadata.MetadataManager;
@@ -1008,15 +1009,11 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			HttpServletRequest httpServletRequest)
 		throws PortalException {
 
-		StringBundler sb = new StringBundler(3);
+		StringBundler sb = new StringBundler(4);
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		sb.append(themeDisplay.getPathMain());
-
-		sb.append("/portal/saml/auth_redirect?redirect=");
+		sb.append(_portal.getRelativeHomeURL(httpServletRequest));
+		sb.append(SamlCommandQueryConstants.AUTH_REDIRECT);
+		sb.append("&redirect=");
 
 		SAMLBindingContext samlBindingContext = messageContext.getSubcontext(
 			SAMLBindingContext.class);

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -1353,9 +1353,10 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 	}
 
 	protected void redirectToLogin(
-		HttpServletRequest httpServletRequest,
-		HttpServletResponse httpServletResponse,
-		SamlSsoRequestContext samlSsoRequestContext, boolean forceAuthn) {
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse,
+			SamlSsoRequestContext samlSsoRequestContext, boolean forceAuthn)
+		throws PortalException {
 
 		HttpSession httpSession = httpServletRequest.getSession();
 
@@ -1394,8 +1395,8 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 
 		StringBundler redirectSB = new StringBundler(4);
 
-		redirectSB.append(themeDisplay.getPathMain());
-		redirectSB.append("/portal/saml/sso");
+		redirectSB.append(_portal.getRelativeHomeURL(httpServletRequest));
+		redirectSB.append(SamlCommandQueryConstants.WEB_SSO);
 
 		SAMLPeerEntityContext samlPeerEntityContext =
 			samlMessageContext.getSubcontext(SAMLPeerEntityContext.class);
@@ -1415,13 +1416,13 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			if ((samlMessageInfoContext != null) &&
 				(samlMessageInfoContext.getMessageId() != null)) {
 
-				redirectSB.append("?saml_message_id=");
+				redirectSB.append("&saml_message_id=");
 				redirectSB.append(
 					URLCodec.encodeURL(samlMessageInfoContext.getMessageId()));
 			}
 		}
 		else if (samlPeerEntityContext.getEntityId() != null) {
-			redirectSB.append("?entityId=");
+			redirectSB.append("&entityId=");
 			redirectSB.append(
 				URLCodec.encodeURL(samlPeerEntityContext.getEntityId()));
 		}

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/BaseSamlTestCase.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/BaseSamlTestCase.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.saml.constants.SamlCommandQueryConstants;
 import com.liferay.saml.constants.SamlProviderConfigurationKeys;
 import com.liferay.saml.opensaml.integration.internal.binding.HttpPostBinding;
 import com.liferay.saml.opensaml.integration.internal.binding.HttpRedirectBinding;
@@ -583,6 +584,12 @@ public abstract class BaseSamlTestCase extends PowerMockito {
 				new String[] {"8080", "8443"})
 		);
 
+		when(
+			portal.getRelativeHomeURL(Mockito.any(MockHttpServletRequest.class))
+		).thenReturn(
+			RELATIVE_HOME_URL
+		);
+
 		groupLocalService = getMockPortalService(
 			GroupLocalServiceUtil.class, GroupLocalService.class);
 
@@ -647,7 +654,8 @@ public abstract class BaseSamlTestCase extends PowerMockito {
 	}
 
 	protected static final String ACS_URL =
-		"http://localhost:8080/c/portal/saml/acs";
+		"http://localhost:8080" + BaseSamlTestCase.RELATIVE_HOME_URL +
+			SamlCommandQueryConstants.ACS;
 
 	protected static final long COMPANY_ID = 1;
 
@@ -664,18 +672,21 @@ public abstract class BaseSamlTestCase extends PowerMockito {
 
 	protected static final String PORTAL_URL = "http://localhost:8080";
 
+	protected static final String RELATIVE_HOME_URL = "/web/guest";
+
 	protected static final String RELAY_STATE =
 		"http://localhost:8080/relaystate";
 
 	protected static final long SESSION_ID = 2;
 
 	protected static final String SLO_LOGOUT_URL =
-		"http://localhost:8080/c/portal/saml/slo_logout";
+		"http://localhost:8080" + RELATIVE_HOME_URL +
+			SamlCommandQueryConstants.SLO_LOGOUT;
 
 	protected static final String SP_ENTITY_ID = "testsp";
 
 	protected static final String SSO_URL =
-		"http://localhost:8080/c/portal/saml/sso";
+		"http://localhost:8080/c/portal/saml/redirect/sso";
 
 	protected static final String UNKNOWN_ENTITY_ID = "testunknown";
 
@@ -740,8 +751,8 @@ public abstract class BaseSamlTestCase extends PowerMockito {
 			if (entityId.equals(IDP_ENTITY_ID)) {
 				EntityDescriptor entityDescriptor =
 					MetadataGeneratorUtil.buildIdpEntityDescriptor(
-						PORTAL_URL, entityId, _idpNeedsSignature, true,
-						credential, null);
+						PORTAL_URL, RELATIVE_HOME_URL, entityId,
+						_idpNeedsSignature, true, credential, null);
 
 				IDPSSODescriptor idpSSODescriptor =
 					entityDescriptor.getIDPSSODescriptor(
@@ -781,7 +792,8 @@ public abstract class BaseSamlTestCase extends PowerMockito {
 			}
 			else if (entityId.equals(SP_ENTITY_ID)) {
 				return MetadataGeneratorUtil.buildSpEntityDescriptor(
-					PORTAL_URL, entityId, true, true, false, credential, null);
+					PORTAL_URL, RELATIVE_HOME_URL, entityId, true, true, false,
+					credential, null);
 			}
 
 			return null;

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
@@ -17,8 +17,6 @@ package com.liferay.saml.opensaml.integration.internal.servlet.profile;
 import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.struts.Definition;
-import com.liferay.portal.struts.TilesUtil;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.opensaml.integration.internal.BaseSamlTestCase;
 import com.liferay.saml.opensaml.integration.internal.binding.SamlBinding;
@@ -34,11 +32,9 @@ import com.liferay.saml.persistence.service.SamlIdpSpSessionLocalService;
 import com.liferay.saml.persistence.service.SamlIdpSpSessionLocalServiceUtil;
 import com.liferay.saml.persistence.service.SamlSpSessionLocalService;
 import com.liferay.saml.persistence.service.SamlSpSessionLocalServiceUtil;
-import com.liferay.saml.util.JspUtil;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,6 +54,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpSession;
 
 /**
  * @author Matthew Tambara
@@ -103,29 +100,26 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 		prepareServiceProvider(SP_ENTITY_ID);
 	}
 
-	@Test
+	@Test(expected = Exception.class)
 	public void testPerformIdpSpLogoutInvalidSloRequestInfo() throws Exception {
 		MockHttpServletRequest mockHttpServletRequest =
-			getMockHttpServletRequest(SLO_LOGOUT_URL + "?cmd=logout");
+			getMockHttpServletRequest(SLO_LOGOUT_URL + "&cmd=logout");
 
 		SamlSloContext samlSloContext = new SamlSloContext(
 			null, _samlIdpSpConnectionLocalService,
 			_samlIdpSpSessionLocalService, samlPeerBindingLocalService,
 			userLocalService);
 
+		MockHttpSession mockHttpSession = new MockHttpSession();
+
+		mockHttpSession.setAttribute(
+			SamlWebKeys.SAML_SLO_CONTEXT, samlSloContext);
+
+		mockHttpServletRequest.setSession(mockHttpSession);
+
 		_singleLogoutProfileImpl.performIdpSpLogout(
 			mockHttpServletRequest, new MockHttpServletResponse(),
 			samlSloContext);
-
-		Definition definition = (Definition)mockHttpServletRequest.getAttribute(
-			TilesUtil.DEFINITION);
-
-		Map<String, String> definitionAttributes = definition.getAttributes();
-
-		Assert.assertEquals(
-			JspUtil.PATH_PORTAL_SAML_ERROR,
-			definitionAttributes.get("content"));
-		Assert.assertTrue(Boolean.valueOf(definitionAttributes.get("pop_up")));
 	}
 
 	@Test
@@ -154,7 +148,7 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 		);
 
 		MockHttpServletRequest mockHttpServletRequest =
-			getMockHttpServletRequest(SLO_LOGOUT_URL + "?cmd=logout");
+			getMockHttpServletRequest(SLO_LOGOUT_URL + "&cmd=logout");
 
 		mockHttpServletRequest.setParameter("entityId", SP_ENTITY_ID);
 
@@ -168,6 +162,13 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 			_samlIdpSpSessionLocalService, samlPeerBindingLocalService,
 			userLocalService);
 
+		MockHttpSession mockHttpSession = new MockHttpSession();
+
+		mockHttpServletRequest.setSession(mockHttpSession);
+
+		mockHttpSession.setAttribute(
+			SamlWebKeys.SAML_SLO_CONTEXT, samlSloContext);
+
 		SamlSloRequestInfo samlSloRequestInfo =
 			samlSloContext.getSamlSloRequestInfo(SP_ENTITY_ID);
 
@@ -176,16 +177,6 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 		_singleLogoutProfileImpl.performIdpSpLogout(
 			mockHttpServletRequest, new MockHttpServletResponse(),
 			samlSloContext);
-
-		Definition definition = (Definition)mockHttpServletRequest.getAttribute(
-			TilesUtil.DEFINITION);
-
-		Map<String, String> definitionAttributes = definition.getAttributes();
-
-		Assert.assertEquals(
-			JspUtil.PATH_PORTAL_SAML_SLO_SP_STATUS,
-			definitionAttributes.get("content"));
-		Assert.assertTrue(Boolean.valueOf(definitionAttributes.get("pop_up")));
 
 		JSONObject jsonObject = (JSONObject)mockHttpServletRequest.getAttribute(
 			SamlWebKeys.SAML_SLO_REQUEST_INFO);
@@ -202,7 +193,8 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 		prepareIdentityProvider(IDP_ENTITY_ID);
 
 		MockHttpServletRequest mockHttpServletRequest =
-			getMockHttpServletRequest(SLO_LOGOUT_URL + "?cmd=logout");
+			getMockHttpServletRequest(SLO_LOGOUT_URL + "&cmd=logout");
+
 		MockHttpServletResponse mockHttpServletResponse =
 			new MockHttpServletResponse();
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
@@ -17,6 +17,7 @@ package com.liferay.saml.opensaml.integration.internal.servlet.profile;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.saml.constants.SamlCommandQueryConstants;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.opensaml.integration.internal.BaseSamlTestCase;
 import com.liferay.saml.opensaml.integration.internal.bootstrap.SecurityConfigurationBootstrap;
@@ -941,7 +942,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 		samlBindingContext.setBindingUri(SAMLConstants.SAML2_POST_BINDING_URI);
 
 		_webSsoProfileImpl.verifyDestination(
-			messageContext, "http://www.fail.com/c/portal/saml/acs");
+			messageContext,
+			"http://www.fail.com/web/guest" + SamlCommandQueryConstants.ACS);
 	}
 
 	@Test

--- a/modules/dxp/apps/saml/saml-test/build.gradle
+++ b/modules/dxp/apps/saml/saml-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testIntegrationCompile project(":core:petra:petra-string")
+	testIntegrationCompile project(":dxp:apps:saml:saml-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/dxp/apps/saml/saml-test/src/testIntegration/java/com/liferay/saml/internal/servlet/filter/test/SamlSameSiteLaxCookiesFilterTest.java
+++ b/modules/dxp/apps/saml/saml-test/src/testIntegration/java/com/liferay/saml/internal/servlet/filter/test/SamlSameSiteLaxCookiesFilterTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.saml.constants.SamlCommandQueryConstants;
 
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
@@ -82,17 +83,26 @@ public class SamlSameSiteLaxCookiesFilterTest {
 
 	@Test
 	public void testACSSameSiteLaxCookiesSupport() throws Exception {
-		_execute(new URL("http://localhost:8080/c/portal/saml/acs"));
+		_execute(
+			new URL(
+				"http://localhost:8080/web/guest" +
+					SamlCommandQueryConstants.ACS));
 	}
 
 	@Test
 	public void testSLOSameSiteLaxCookies() throws Exception {
-		_execute(new URL("http://localhost:8080/c/portal/saml/slo"));
+		_execute(
+			new URL(
+				"http://localhost:8080/web/guest" +
+					SamlCommandQueryConstants.SLO));
 	}
 
 	@Test
 	public void testSSOSameSiteLaxCookies() throws Exception {
-		_execute(new URL("http://localhost:8080/c/portal/saml/sso"));
+		_execute(
+			new URL(
+				"http://localhost:8080/web/guest" +
+					SamlCommandQueryConstants.WEB_SSO));
 	}
 
 	private void _execute(URL url) throws Exception {
@@ -104,6 +114,7 @@ public class SamlSameSiteLaxCookiesFilterTest {
 
 		httpClient.setDoOutput(true);
 		httpClient.setRequestMethod("POST");
+		httpClient.setRequestProperty("Accept", "text/html");
 
 		try (DataOutputStream dataOutputStream = new DataOutputStream(
 				httpClient.getOutputStream())) {

--- a/modules/dxp/apps/saml/saml-web/build.gradle
+++ b/modules/dxp/apps/saml/saml-web/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
 	compileOnly group: "commons-fileupload", name: "commons-fileupload", version: "1.3.3"

--- a/modules/dxp/apps/saml/saml-web/build.gradle
+++ b/modules/dxp/apps/saml/saml-web/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
 	compileOnly group: "commons-fileupload", name: "commons-fileupload", version: "1.3.3"

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/SamlPortlet.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/SamlPortlet.java
@@ -15,23 +15,11 @@
 package com.liferay.saml.web.internal.portlet;
 
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.PropsKeys;
-import com.liferay.portal.util.PropsUtil;
-import com.liferay.portal.util.PropsValues;
 import com.liferay.saml.constants.SamlPortletKeys;
-import com.liferay.saml.constants.SamlWebKeys;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 
 import javax.portlet.Portlet;
 
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Deactivate;
 
 /**
  * @author Arthur Chan
@@ -53,51 +41,4 @@ import org.osgi.service.component.annotations.Deactivate;
 	service = Portlet.class
 )
 public class SamlPortlet extends MVCPortlet {
-
-	@Activate
-	protected void activate(Map<String, Object> properties) {
-		_loginDialogDisabled = GetterUtil.getBoolean(
-			PropsUtil.get(PropsKeys.LOGIN_DIALOG_DISABLED));
-
-		PropsUtil.set(PropsKeys.LOGIN_DIALOG_DISABLED, "true");
-
-		if (!PropsValues.SESSION_ENABLE_PHISHING_PROTECTION) {
-			return;
-		}
-
-		List<String> sessionPhishingProtectedAttributes = new ArrayList<>(
-			Arrays.asList(PropsValues.SESSION_PHISHING_PROTECTED_ATTRIBUTES));
-
-		sessionPhishingProtectedAttributes.add(SamlWebKeys.SAML_SP_SESSION_KEY);
-		sessionPhishingProtectedAttributes.add(
-			SamlWebKeys.SAML_SSO_REQUEST_CONTEXT);
-
-		PropsValues.SESSION_PHISHING_PROTECTED_ATTRIBUTES =
-			sessionPhishingProtectedAttributes.toArray(new String[0]);
-	}
-
-	@Deactivate
-	protected void deactivate() {
-		PropsUtil.set(
-			PropsKeys.LOGIN_DIALOG_DISABLED,
-			String.valueOf(_loginDialogDisabled));
-
-		if (!PropsValues.SESSION_ENABLE_PHISHING_PROTECTION) {
-			return;
-		}
-
-		List<String> sessionPhishingProtectedAttributes = new ArrayList<>(
-			Arrays.asList(PropsValues.SESSION_PHISHING_PROTECTED_ATTRIBUTES));
-
-		sessionPhishingProtectedAttributes.remove(
-			SamlWebKeys.SAML_SP_SESSION_KEY);
-		sessionPhishingProtectedAttributes.remove(
-			SamlWebKeys.SAML_SSO_REQUEST_CONTEXT);
-
-		PropsValues.SESSION_PHISHING_PROTECTED_ATTRIBUTES =
-			sessionPhishingProtectedAttributes.toArray(new String[0]);
-	}
-
-	private boolean _loginDialogDisabled;
-
 }

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/SamlPortlet.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/SamlPortlet.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.saml.web.internal.portlet;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.util.PropsUtil;
+import com.liferay.portal.util.PropsValues;
+import com.liferay.saml.constants.SamlPortletKeys;
+import com.liferay.saml.constants.SamlWebKeys;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import javax.portlet.Portlet;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+
+/**
+ * @author Arthur Chan
+ */
+@Component(
+	immediate = true,
+	property = {
+		"com.liferay.portlet.add-default-resource=true",
+		"com.liferay.portlet.application-type=full-page-application",
+		"com.liferay.portlet.display-category=category.hidden",
+		"com.liferay.portlet.preferences-owned-by-group=true",
+		"com.liferay.portlet.single-page-application=false",
+		"com.liferay.portlet.use-default-template=true",
+		"javax.portlet.display-name=SAML", "javax.portlet.expiration-cache=0",
+		"javax.portlet.name=" + SamlPortletKeys.SAML,
+		"javax.portlet.resource-bundle=content.Language",
+		"javax.portlet.security-role-ref=guest,power-user,user"
+	},
+	service = Portlet.class
+)
+public class SamlPortlet extends MVCPortlet {
+
+	@Activate
+	protected void activate(Map<String, Object> properties) {
+		_loginDialogDisabled = GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.LOGIN_DIALOG_DISABLED));
+
+		PropsUtil.set(PropsKeys.LOGIN_DIALOG_DISABLED, "true");
+
+		if (!PropsValues.SESSION_ENABLE_PHISHING_PROTECTION) {
+			return;
+		}
+
+		List<String> sessionPhishingProtectedAttributes = new ArrayList<>(
+			Arrays.asList(PropsValues.SESSION_PHISHING_PROTECTED_ATTRIBUTES));
+
+		sessionPhishingProtectedAttributes.add(SamlWebKeys.SAML_SP_SESSION_KEY);
+		sessionPhishingProtectedAttributes.add(
+			SamlWebKeys.SAML_SSO_REQUEST_CONTEXT);
+
+		PropsValues.SESSION_PHISHING_PROTECTED_ATTRIBUTES =
+			sessionPhishingProtectedAttributes.toArray(new String[0]);
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		PropsUtil.set(
+			PropsKeys.LOGIN_DIALOG_DISABLED,
+			String.valueOf(_loginDialogDisabled));
+
+		if (!PropsValues.SESSION_ENABLE_PHISHING_PROTECTION) {
+			return;
+		}
+
+		List<String> sessionPhishingProtectedAttributes = new ArrayList<>(
+			Arrays.asList(PropsValues.SESSION_PHISHING_PROTECTED_ATTRIBUTES));
+
+		sessionPhishingProtectedAttributes.remove(
+			SamlWebKeys.SAML_SP_SESSION_KEY);
+		sessionPhishingProtectedAttributes.remove(
+			SamlWebKeys.SAML_SSO_REQUEST_CONTEXT);
+
+		PropsValues.SESSION_PHISHING_PROTECTED_ATTRIBUTES =
+			sessionPhishingProtectedAttributes.toArray(new String[0]);
+	}
+
+	private boolean _loginDialogDisabled;
+
+}

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/AssertionConsumerServiceMVCActionCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/AssertionConsumerServiceMVCActionCommand.java
@@ -12,18 +12,18 @@
  *
  */
 
-package com.liferay.saml.web.internal.struts;
+package com.liferay.saml.web.internal.portlet.action;
 
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.ContactNameException;
-import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.exception.UserEmailAddressException;
 import com.liferay.portal.kernel.exception.UserEmailAddressException.MustNotUseCompanyMx;
 import com.liferay.portal.kernel.exception.UserScreenNameException;
-import com.liferay.portal.kernel.struts.StrutsAction;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.saml.constants.SamlPortletKeys;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.persistence.service.SamlSpIdpConnectionLocalService;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
@@ -31,8 +31,6 @@ import com.liferay.saml.runtime.exception.AuthnAgeException;
 import com.liferay.saml.runtime.exception.EntityInteractionException;
 import com.liferay.saml.runtime.exception.SubjectException;
 import com.liferay.saml.runtime.servlet.profile.WebSsoProfile;
-
-import java.io.IOException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -45,18 +43,30 @@ import org.osgi.service.component.annotations.Reference;
  * @author Mika Koivisto
  */
 @Component(
-	immediate = true, property = "path=/portal/saml/acs",
-	service = StrutsAction.class
+	immediate = true,
+	property = {
+		"auth.token.ignore.mvc.action=true",
+		"javax.portlet.name=" + SamlPortletKeys.SAML,
+		"mvc.command.name=/saml/assertion_consumer_service"
+	},
+	service = MVCActionCommand.class
 )
-public class AssertionConsumerServiceAction extends BaseSamlStrutsAction {
+public class AssertionConsumerServiceMVCActionCommand
+	extends BaseSamlMVCActionCommand {
 
 	@Override
 	public boolean isEnabled() {
-		if (samlProviderConfigurationHelper.isRoleSp()) {
-			return super.isEnabled();
+		if (super.isEnabled()) {
+			return samlProviderConfigurationHelper.isRoleSp();
 		}
 
 		return false;
+	}
+
+	@Override
+	@Reference(unbind = "-")
+	public void setPortal(Portal portal) {
+		super.setPortal(portal);
 	}
 
 	@Override
@@ -69,7 +79,7 @@ public class AssertionConsumerServiceAction extends BaseSamlStrutsAction {
 	}
 
 	@Override
-	protected String doExecute(
+	protected void doProcessAction(
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws Exception {
@@ -79,10 +89,7 @@ public class AssertionConsumerServiceAction extends BaseSamlStrutsAction {
 				httpServletRequest, httpServletResponse);
 		}
 		catch (EntityInteractionException entityInteractionException) {
-			HttpServletRequest originalHttpServletRequest =
-				_portal.getOriginalServletRequest(httpServletRequest);
-
-			HttpSession httpSession = originalHttpServletRequest.getSession();
+			HttpSession httpSession = httpServletRequest.getSession();
 
 			httpSession.setAttribute(
 				com.liferay.saml.web.internal.constants.SamlWebKeys.
@@ -127,27 +134,15 @@ public class AssertionConsumerServiceAction extends BaseSamlStrutsAction {
 			String redirect = ParamUtil.getString(
 				httpServletRequest, "RelayState");
 
-			redirect = _portal.escapeRedirect(redirect);
+			redirect = portal.escapeRedirect(redirect);
 
 			if (Validator.isNull(redirect)) {
-				redirect = _portal.getHomeURL(httpServletRequest);
+				redirect = portal.getHomeURL(httpServletRequest);
 			}
 
-			try {
-				httpServletResponse.sendRedirect(redirect);
-
-				return null;
-			}
-			catch (IOException ioException) {
-				throw new SystemException(ioException);
-			}
+			httpServletResponse.sendRedirect(redirect);
 		}
-
-		return null;
 	}
-
-	@Reference
-	private Portal _portal;
 
 	@Reference
 	private SamlSpIdpConnectionLocalService _samlSpIdpConnectionLocalService;

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/AuthRedirectMVCActionCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/AuthRedirectMVCActionCommand.java
@@ -12,16 +12,14 @@
  *
  */
 
-package com.liferay.saml.web.internal.struts;
+package com.liferay.saml.web.internal.portlet.action;
 
-import com.liferay.portal.kernel.exception.SystemException;
-import com.liferay.portal.kernel.struts.StrutsAction;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.saml.constants.SamlPortletKeys;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
-
-import java.io.IOException;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -31,20 +29,32 @@ import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Tomas Polesovsky
+ * @author Arthur Chan
  */
 @Component(
-	immediate = true, property = "path=/portal/saml/auth_redirect",
-	service = StrutsAction.class
+	immediate = true,
+	property = {
+		"auth.token.ignore.mvc.action=true",
+		"javax.portlet.name=" + SamlPortletKeys.SAML,
+		"mvc.command.name=/saml/auth_redirect"
+	},
+	service = MVCActionCommand.class
 )
-public class AuthRedirectAction extends BaseSamlStrutsAction {
+public class AuthRedirectMVCActionCommand extends BaseSamlMVCActionCommand {
 
 	@Override
 	public boolean isEnabled() {
-		if (samlProviderConfigurationHelper.isRoleSp()) {
-			return super.isEnabled();
+		if (super.isEnabled()) {
+			return samlProviderConfigurationHelper.isRoleSp();
 		}
 
 		return false;
+	}
+
+	@Override
+	@Reference(unbind = "-")
+	public void setPortal(Portal portal) {
+		super.setPortal(portal);
 	}
 
 	@Override
@@ -57,30 +67,20 @@ public class AuthRedirectAction extends BaseSamlStrutsAction {
 	}
 
 	@Override
-	protected String doExecute(
+	protected void doProcessAction(
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
 		String redirect = ParamUtil.getString(httpServletRequest, "redirect");
 
-		redirect = _portal.escapeRedirect(redirect);
+		redirect = portal.escapeRedirect(redirect);
 
 		if (Validator.isNull(redirect)) {
-			redirect = _portal.getHomeURL(httpServletRequest);
+			redirect = portal.getHomeURL(httpServletRequest);
 		}
 
-		try {
-			httpServletResponse.sendRedirect(redirect);
-		}
-		catch (IOException ioException) {
-			throw new SystemException(ioException);
-		}
-
-		return null;
+		httpServletResponse.sendRedirect(redirect);
 	}
-
-	@Reference
-	private Portal _portal;
 
 }

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/BaseSamlMVCActionCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/BaseSamlMVCActionCommand.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.saml.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
+import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
+import com.liferay.saml.runtime.exception.StatusException;
+import com.liferay.saml.util.JspUtil;
+
+import java.io.IOException;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+import javax.portlet.PortletException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mika Koivisto
+ * @author Arthur Chan
+ */
+public abstract class BaseSamlMVCActionCommand extends BaseMVCActionCommand {
+
+	public boolean isEnabled() {
+		return samlProviderConfigurationHelper.isEnabled();
+	}
+
+	@Override
+	public boolean processAction(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws PortletException {
+
+		if (!isEnabled()) {
+			try {
+				redirectToLogin(actionRequest, actionResponse);
+			}
+			catch (IOException ioException) {
+				if (_log.isInfoEnabled()) {
+					_log.info(ioException, ioException);
+				}
+			}
+
+			return false;
+		}
+
+		Thread currentThread = Thread.currentThread();
+
+		ClassLoader contextClassLoader = currentThread.getContextClassLoader();
+
+		try {
+			Class<? extends BaseSamlMVCActionCommand> clazz = getClass();
+
+			currentThread.setContextClassLoader(clazz.getClassLoader());
+
+			doProcessAction(actionRequest, actionResponse);
+
+			return true;
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception, exception);
+			}
+			else {
+				_log.error(exception.getMessage());
+			}
+
+			Class<?> clazz = exception.getClass();
+
+			SessionErrors.add(actionRequest, clazz.getName());
+
+			if (exception instanceof StatusException) {
+				StatusException statusException = (StatusException)exception;
+
+				SessionErrors.add(
+					actionRequest, "statusCodeURI",
+					statusException.getMessage());
+			}
+
+			actionResponse.setRenderParameter(
+				"mvcPath", JspUtil.PATH_PORTAL_SAML_ERROR);
+
+			return false;
+		}
+		finally {
+			currentThread.setContextClassLoader(contextClassLoader);
+		}
+	}
+
+	public void setPortal(Portal portal) {
+		this.portal = portal;
+	}
+
+	public void setSamlProviderConfigurationHelper(
+		SamlProviderConfigurationHelper samlProviderConfigurationHelper) {
+
+		this.samlProviderConfigurationHelper = samlProviderConfigurationHelper;
+	}
+
+	protected void doProcessAction(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+
+		HttpServletRequest httpServletRequest =
+			portal.getOriginalServletRequest(
+				portal.getHttpServletRequest(actionRequest));
+
+		HttpServletResponse httpServletResponse = portal.getHttpServletResponse(
+			actionResponse);
+
+		httpServletRequest.setAttribute(
+			WebKeys.RESOURCE_BUNDLE_LOADER, resourceBundleLoader);
+
+		doProcessAction(httpServletRequest, httpServletResponse);
+	}
+
+	protected abstract void doProcessAction(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception;
+
+	protected Portal portal;
+
+	@Reference(target = "(bundle.symbolic.name=com.liferay.saml.web)")
+	protected ResourceBundleLoader resourceBundleLoader;
+
+	protected SamlProviderConfigurationHelper samlProviderConfigurationHelper;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseSamlMVCActionCommand.class);
+
+}

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/BaseSamlMVCActionCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/BaseSamlMVCActionCommand.java
@@ -18,12 +18,11 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
-import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
-import com.liferay.saml.runtime.exception.StatusException;
 import com.liferay.saml.util.JspUtil;
+import com.liferay.saml.web.internal.portlet.action.util.SamlMVCCommandUtil;
 
 import java.io.IOException;
 
@@ -64,38 +63,18 @@ public abstract class BaseSamlMVCActionCommand extends BaseMVCActionCommand {
 			return false;
 		}
 
-		Thread currentThread = Thread.currentThread();
+		Class<? extends BaseSamlMVCActionCommand> clazz = getClass();
 
-		ClassLoader contextClassLoader = currentThread.getContextClassLoader();
+		ClassLoader currentClassLoader =
+			SamlMVCCommandUtil.switchContextClassLoader(clazz.getClassLoader());
 
 		try {
-			Class<? extends BaseSamlMVCActionCommand> clazz = getClass();
-
-			currentThread.setContextClassLoader(clazz.getClassLoader());
-
 			doProcessAction(actionRequest, actionResponse);
 
 			return true;
 		}
 		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception, exception);
-			}
-			else {
-				_log.error(exception.getMessage());
-			}
-
-			Class<?> clazz = exception.getClass();
-
-			SessionErrors.add(actionRequest, clazz.getName());
-
-			if (exception instanceof StatusException) {
-				StatusException statusException = (StatusException)exception;
-
-				SessionErrors.add(
-					actionRequest, "statusCodeURI",
-					statusException.getMessage());
-			}
+			SamlMVCCommandUtil.handleException(exception, actionRequest, _log);
 
 			actionResponse.setRenderParameter(
 				"mvcPath", JspUtil.PATH_PORTAL_SAML_ERROR);
@@ -103,7 +82,7 @@ public abstract class BaseSamlMVCActionCommand extends BaseMVCActionCommand {
 			return false;
 		}
 		finally {
-			currentThread.setContextClassLoader(contextClassLoader);
+			SamlMVCCommandUtil.switchContextClassLoader(currentClassLoader);
 		}
 	}
 

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/BaseSamlMVCRenderCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/BaseSamlMVCRenderCommand.java
@@ -18,12 +18,11 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
-import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
-import com.liferay.saml.runtime.exception.StatusException;
 import com.liferay.saml.util.JspUtil;
+import com.liferay.saml.web.internal.portlet.action.util.SamlMVCCommandUtil;
 
 import javax.portlet.PortletException;
 import javax.portlet.RenderRequest;
@@ -53,41 +52,21 @@ public abstract class BaseSamlMVCRenderCommand implements MVCRenderCommand {
 			return "/common/referer_js.jsp";
 		}
 
-		Thread currentThread = Thread.currentThread();
+		Class<? extends BaseSamlMVCRenderCommand> clazz = getClass();
 
-		ClassLoader contextClassLoader = currentThread.getContextClassLoader();
+		ClassLoader currentClassLoader =
+			SamlMVCCommandUtil.switchContextClassLoader(clazz.getClassLoader());
 
 		try {
-			Class<? extends BaseSamlMVCRenderCommand> clazz = getClass();
-
-			currentThread.setContextClassLoader(clazz.getClassLoader());
-
 			return doRender(renderRequest, renderResponse);
 		}
 		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception, exception);
-			}
-			else {
-				_log.error(exception.getMessage());
-			}
-
-			Class<?> clazz = exception.getClass();
-
-			SessionErrors.add(renderRequest, clazz.getName());
-
-			if (exception instanceof StatusException) {
-				StatusException statusException = (StatusException)exception;
-
-				SessionErrors.add(
-					renderRequest, "statusCodeURI",
-					statusException.getMessage());
-			}
+			SamlMVCCommandUtil.handleException(exception, renderRequest, _log);
 
 			return JspUtil.PATH_PORTAL_SAML_ERROR;
 		}
 		finally {
-			currentThread.setContextClassLoader(contextClassLoader);
+			SamlMVCCommandUtil.switchContextClassLoader(currentClassLoader);
 		}
 	}
 

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/BaseSamlMVCRenderCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/BaseSamlMVCRenderCommand.java
@@ -1,0 +1,136 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.saml.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
+import com.liferay.saml.runtime.exception.StatusException;
+import com.liferay.saml.util.JspUtil;
+
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Mika Koivisto
+ * @author Arthur Chan
+ */
+public abstract class BaseSamlMVCRenderCommand implements MVCRenderCommand {
+
+	public boolean isEnabled() {
+		return samlProviderConfigurationHelper.isEnabled();
+	}
+
+	@Override
+	public String render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws PortletException {
+
+		if (!isEnabled()) {
+			return "/common/referer_js.jsp";
+		}
+
+		Thread currentThread = Thread.currentThread();
+
+		ClassLoader contextClassLoader = currentThread.getContextClassLoader();
+
+		try {
+			Class<? extends BaseSamlMVCRenderCommand> clazz = getClass();
+
+			currentThread.setContextClassLoader(clazz.getClassLoader());
+
+			return doRender(renderRequest, renderResponse);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception, exception);
+			}
+			else {
+				_log.error(exception.getMessage());
+			}
+
+			Class<?> clazz = exception.getClass();
+
+			SessionErrors.add(renderRequest, clazz.getName());
+
+			if (exception instanceof StatusException) {
+				StatusException statusException = (StatusException)exception;
+
+				SessionErrors.add(
+					renderRequest, "statusCodeURI",
+					statusException.getMessage());
+			}
+
+			return JspUtil.PATH_PORTAL_SAML_ERROR;
+		}
+		finally {
+			currentThread.setContextClassLoader(contextClassLoader);
+		}
+	}
+
+	public void setPortal(Portal portal) {
+		this.portal = portal;
+	}
+
+	public void setSamlProviderConfigurationHelper(
+		SamlProviderConfigurationHelper samlProviderConfigurationHelper) {
+
+		this.samlProviderConfigurationHelper = samlProviderConfigurationHelper;
+	}
+
+	protected abstract String doRender(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception;
+
+	protected String doRender(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws Exception {
+
+		HttpServletRequest httpServletRequest =
+			portal.getOriginalServletRequest(
+				portal.getHttpServletRequest(renderRequest));
+
+		HttpServletResponse httpServletResponse = portal.getHttpServletResponse(
+			renderResponse);
+
+		httpServletRequest.setAttribute(
+			WebKeys.RESOURCE_BUNDLE_LOADER, resourceBundleLoader);
+
+		return doRender(httpServletRequest, httpServletResponse);
+	}
+
+	protected Portal portal;
+
+	@Reference(target = "(bundle.symbolic.name=com.liferay.saml.web)")
+	protected ResourceBundleLoader resourceBundleLoader;
+
+	protected SamlProviderConfigurationHelper samlProviderConfigurationHelper;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseSamlMVCRenderCommand.class);
+
+}

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/BaseSamlMVCResourceCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/BaseSamlMVCResourceCommand.java
@@ -12,17 +12,24 @@
  *
  */
 
-package com.liferay.saml.web.internal.struts;
+package com.liferay.saml.web.internal.portlet.action;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
 import com.liferay.portal.kernel.servlet.SessionErrors;
-import com.liferay.portal.kernel.struts.StrutsAction;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
 import com.liferay.saml.runtime.exception.StatusException;
 import com.liferay.saml.util.JspUtil;
+
+import java.io.IOException;
+
+import javax.portlet.PortletException;
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -30,33 +37,52 @@ import javax.servlet.http.HttpServletResponse;
 import org.osgi.service.component.annotations.Reference;
 
 /**
- * @author Mika Koivisto
+ * @author Arthur Chan
  */
-public abstract class BaseSamlStrutsAction implements StrutsAction {
+public abstract class BaseSamlMVCResourceCommand
+	extends BaseMVCResourceCommand {
+
+	public boolean isEnabled() {
+		return samlProviderConfigurationHelper.isEnabled();
+	}
 
 	@Override
-	public String execute(
-			HttpServletRequest httpServletRequest,
-			HttpServletResponse httpServletResponse)
-		throws Exception {
+	public boolean serveResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws PortletException {
+
+		//PortletRequestDispatcher portletRequestDispatcher =
+		//	getPortletRequestDispatcher(
+		//		resourceRequest, JspUtil.PATH_PORTAL_SAML_ERROR);
 
 		if (!isEnabled()) {
-			return "/common/referer_js.jsp";
-		}
+			try {
+				//portletRequestDispatcher.forward(
+				//	resourceRequest, resourceResponse);
 
-		httpServletRequest.setAttribute(
-			WebKeys.RESOURCE_BUNDLE_LOADER, resourceBundleLoader);
+				include(
+					resourceRequest, resourceResponse,
+					JspUtil.PATH_PORTAL_SAML_ERROR);
+
+				return false;
+			}
+			catch (IOException ioException) {
+				throw new PortletException(ioException);
+			}
+		}
 
 		Thread currentThread = Thread.currentThread();
 
 		ClassLoader contextClassLoader = currentThread.getContextClassLoader();
 
 		try {
-			Class<? extends BaseSamlStrutsAction> clazz = getClass();
+			Class<? extends BaseSamlMVCResourceCommand> clazz = getClass();
 
 			currentThread.setContextClassLoader(clazz.getClassLoader());
 
-			return doExecute(httpServletRequest, httpServletResponse);
+			doServeResource(resourceRequest, resourceResponse);
+
+			return true;
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
@@ -68,29 +94,36 @@ public abstract class BaseSamlStrutsAction implements StrutsAction {
 
 			Class<?> clazz = exception.getClass();
 
-			SessionErrors.add(httpServletRequest, clazz.getName());
+			SessionErrors.add(resourceRequest, clazz.getName());
 
 			if (exception instanceof StatusException) {
 				StatusException statusException = (StatusException)exception;
 
 				SessionErrors.add(
-					httpServletRequest, "statusCodeURI",
+					resourceRequest, "statusCodeURI",
 					statusException.getMessage());
 			}
 
-			JspUtil.dispatch(
-				httpServletRequest, httpServletResponse,
-				JspUtil.PATH_PORTAL_SAML_ERROR, "status");
+			try {
+				include(
+					resourceRequest, resourceResponse,
+					JspUtil.PATH_PORTAL_SAML_ERROR);
+				//portletRequestDispatcher.forward(
+				//	resourceRequest, resourceResponse);
+
+				return false;
+			}
+			catch (IOException ioException) {
+				throw new PortletException(ioException);
+			}
 		}
 		finally {
 			currentThread.setContextClassLoader(contextClassLoader);
 		}
-
-		return null;
 	}
 
-	public boolean isEnabled() {
-		return samlProviderConfigurationHelper.isEnabled();
+	public void setPortal(Portal portal) {
+		this.portal = portal;
 	}
 
 	public void setSamlProviderConfigurationHelper(
@@ -99,10 +132,29 @@ public abstract class BaseSamlStrutsAction implements StrutsAction {
 		this.samlProviderConfigurationHelper = samlProviderConfigurationHelper;
 	}
 
-	protected abstract String doExecute(
+	protected abstract void doServeResource(
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws Exception;
+
+	protected void doServeResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		HttpServletRequest httpServletRequest =
+			portal.getOriginalServletRequest(
+				portal.getHttpServletRequest(resourceRequest));
+
+		HttpServletResponse httpServletResponse = portal.getHttpServletResponse(
+			resourceResponse);
+
+		httpServletRequest.setAttribute(
+			WebKeys.RESOURCE_BUNDLE_LOADER, resourceBundleLoader);
+
+		doServeResource(httpServletRequest, httpServletResponse);
+	}
+
+	protected Portal portal;
 
 	@Reference(target = "(bundle.symbolic.name=com.liferay.saml.web)")
 	protected ResourceBundleLoader resourceBundleLoader;
@@ -110,6 +162,6 @@ public abstract class BaseSamlStrutsAction implements StrutsAction {
 	protected SamlProviderConfigurationHelper samlProviderConfigurationHelper;
 
 	private static final Log _log = LogFactoryUtil.getLog(
-		BaseSamlStrutsAction.class);
+		BaseSamlMVCResourceCommand.class);
 
 }

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/BaseSamlMVCResourceCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/BaseSamlMVCResourceCommand.java
@@ -18,12 +18,11 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.resource.bundle.ResourceBundleLoader;
-import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
-import com.liferay.saml.runtime.exception.StatusException;
 import com.liferay.saml.util.JspUtil;
+import com.liferay.saml.web.internal.portlet.action.util.SamlMVCCommandUtil;
 
 import java.io.IOException;
 
@@ -71,38 +70,19 @@ public abstract class BaseSamlMVCResourceCommand
 			}
 		}
 
-		Thread currentThread = Thread.currentThread();
+		Class<? extends BaseSamlMVCResourceCommand> clazz = getClass();
 
-		ClassLoader contextClassLoader = currentThread.getContextClassLoader();
+		ClassLoader currentClassLoader =
+			SamlMVCCommandUtil.switchContextClassLoader(clazz.getClassLoader());
 
 		try {
-			Class<? extends BaseSamlMVCResourceCommand> clazz = getClass();
-
-			currentThread.setContextClassLoader(clazz.getClassLoader());
-
 			doServeResource(resourceRequest, resourceResponse);
 
 			return true;
 		}
 		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception, exception);
-			}
-			else {
-				_log.error(exception.getMessage());
-			}
-
-			Class<?> clazz = exception.getClass();
-
-			SessionErrors.add(resourceRequest, clazz.getName());
-
-			if (exception instanceof StatusException) {
-				StatusException statusException = (StatusException)exception;
-
-				SessionErrors.add(
-					resourceRequest, "statusCodeURI",
-					statusException.getMessage());
-			}
+			SamlMVCCommandUtil.handleException(
+				exception, resourceRequest, _log);
 
 			try {
 				include(
@@ -118,7 +98,7 @@ public abstract class BaseSamlMVCResourceCommand
 			}
 		}
 		finally {
-			currentThread.setContextClassLoader(contextClassLoader);
+			SamlMVCCommandUtil.switchContextClassLoader(currentClassLoader);
 		}
 	}
 

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/FinishSLOMVCResourceCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/FinishSLOMVCResourceCommand.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.saml.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.saml.constants.SamlPortletKeys;
+import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
+import com.liferay.saml.runtime.servlet.profile.SingleLogoutProfile;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Arthur Chan
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + SamlPortletKeys.SAML,
+		"mvc.command.name=/saml/finish_slo"
+	},
+	service = MVCResourceCommand.class
+)
+public class FinishSLOMVCResourceCommand extends BaseSamlMVCResourceCommand {
+
+	@Override
+	public boolean isEnabled() {
+		if (super.isEnabled()) {
+			return samlProviderConfigurationHelper.isRoleIdp();
+		}
+
+		return false;
+	}
+
+	@Override
+	@Reference(unbind = "-")
+	public void setPortal(Portal portal) {
+		super.setPortal(portal);
+	}
+
+	@Override
+	@Reference(unbind = "-")
+	public void setSamlProviderConfigurationHelper(
+		SamlProviderConfigurationHelper samlProviderConfigurationHelper) {
+
+		super.setSamlProviderConfigurationHelper(
+			samlProviderConfigurationHelper);
+	}
+
+	@Override
+	protected void doServeResource(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception {
+
+		_singleLogoutProfile.processIdpLogout(
+			httpServletRequest, httpServletResponse);
+	}
+
+	@Reference
+	private SingleLogoutProfile _singleLogoutProfile;
+
+}

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/SelectIdpMVCRenderCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/SelectIdpMVCRenderCommand.java
@@ -19,11 +19,7 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
-import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.saml.constants.SamlPortletKeys;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.persistence.model.SamlSpIdpConnection;
@@ -87,35 +83,9 @@ public class SelectIdpMVCRenderCommand extends BaseSamlMVCRenderCommand {
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
-		String entityId = ParamUtil.getString(
-			httpServletRequest, "idpEntityId");
-
-		long companyId = portal.getCompanyId(httpServletRequest);
-
-		if (Validator.isNotNull(entityId)) {
-			SamlSpIdpConnection samlSpIdpConnection =
-				_samlSpIdpConnectionLocalService.getSamlSpIdpConnection(
-					companyId, entityId);
-
-			httpServletRequest.setAttribute(
-				SamlWebKeys.SAML_SP_IDP_CONNECTION, samlSpIdpConnection);
-
-			if (GetterUtil.getBoolean(
-					ParamUtil.getBoolean(httpServletRequest, "forceAuthn"))) {
-
-				AuthTokenUtil.checkCSRFToken(
-					httpServletRequest,
-					SelectIdpMVCRenderCommand.class.getName());
-
-				httpServletRequest.setAttribute(
-					SamlWebKeys.FORCE_REAUTHENTICATION, Boolean.TRUE);
-			}
-
-			return null;
-		}
-
 		List<SamlSpIdpConnection> samlSpIdpConnections =
-			_samlSpIdpConnectionLocalService.getSamlSpIdpConnections(companyId);
+			_samlSpIdpConnectionLocalService.getSamlSpIdpConnections(
+				portal.getCompanyId(httpServletRequest));
 
 		Stream<SamlSpIdpConnection> stream = samlSpIdpConnections.stream();
 

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/SelectIdpMVCRenderCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/SelectIdpMVCRenderCommand.java
@@ -12,18 +12,19 @@
  *
  */
 
-package com.liferay.saml.web.internal.struts;
+package com.liferay.saml.web.internal.portlet.action;
 
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
-import com.liferay.portal.kernel.struts.StrutsAction;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.saml.constants.SamlPortletKeys;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.persistence.model.SamlSpIdpConnection;
 import com.liferay.saml.persistence.service.SamlSpIdpConnectionLocalService;
@@ -48,18 +49,27 @@ import org.osgi.service.component.annotations.ReferencePolicyOption;
  * @author Stian Sigvartsen
  */
 @Component(
-	immediate = true, property = "path=/portal/saml/login",
-	service = StrutsAction.class
+	property = {
+		"javax.portlet.name=" + SamlPortletKeys.SAML,
+		"mvc.command.name=/saml/select_idp"
+	},
+	service = MVCRenderCommand.class
 )
-public class SamlLoginAction extends BaseSamlStrutsAction {
+public class SelectIdpMVCRenderCommand extends BaseSamlMVCRenderCommand {
 
 	@Override
 	public boolean isEnabled() {
-		if (samlProviderConfigurationHelper.isRoleSp()) {
-			return super.isEnabled();
+		if (super.isEnabled()) {
+			return samlProviderConfigurationHelper.isRoleSp();
 		}
 
 		return false;
+	}
+
+	@Override
+	@Reference(unbind = "-")
+	public void setPortal(Portal portal) {
+		super.setPortal(portal);
 	}
 
 	@Override
@@ -72,7 +82,7 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 	}
 
 	@Override
-	protected String doExecute(
+	protected String doRender(
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws Exception {
@@ -80,7 +90,7 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 		String entityId = ParamUtil.getString(
 			httpServletRequest, "idpEntityId");
 
-		long companyId = _portal.getCompanyId(httpServletRequest);
+		long companyId = portal.getCompanyId(httpServletRequest);
 
 		if (Validator.isNotNull(entityId)) {
 			SamlSpIdpConnection samlSpIdpConnection =
@@ -94,7 +104,8 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 					ParamUtil.getBoolean(httpServletRequest, "forceAuthn"))) {
 
 				AuthTokenUtil.checkCSRFToken(
-					httpServletRequest, SamlLoginAction.class.getName());
+					httpServletRequest,
+					SelectIdpMVCRenderCommand.class.getName());
 
 				httpServletRequest.setAttribute(
 					SamlWebKeys.FORCE_REAUTHENTICATION, Boolean.TRUE);
@@ -119,12 +130,7 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 			SamlWebKeys.SAML_SSO_LOGIN_CONTEXT,
 			toJSONObject(samlSpIdpConnections));
 
-		JspUtil.dispatch(
-			httpServletRequest, httpServletResponse,
-			JspUtil.PATH_PORTAL_SAML_SELECT_IDP,
-			"please-select-your-identity-provider", false);
-
-		return null;
+		return JspUtil.PATH_PORTAL_SAML_SELECT_IDP;
 	}
 
 	protected boolean isEnabled(
@@ -157,9 +163,6 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 
 		return JSONUtil.put("relevantIdpConnections", jsonArray);
 	}
-
-	@Reference
-	private Portal _portal;
 
 	@Reference
 	private SamlSpIdpConnectionLocalService _samlSpIdpConnectionLocalService;

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/SendAuthnRequestMVCResourceCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/SendAuthnRequestMVCResourceCommand.java
@@ -1,0 +1,150 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.saml.web.internal.portlet.action;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.struts.LastPath;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.saml.constants.SamlPortletKeys;
+import com.liferay.saml.constants.SamlWebKeys;
+import com.liferay.saml.persistence.model.SamlSpIdpConnection;
+import com.liferay.saml.persistence.service.SamlSpIdpConnectionLocalService;
+import com.liferay.saml.runtime.servlet.profile.WebSsoProfile;
+
+import javax.portlet.PortletException;
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Arthur Chan
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + SamlPortletKeys.SAML,
+		"mvc.command.name=/saml/send_authn_request"
+	},
+	service = MVCResourceCommand.class
+)
+public class SendAuthnRequestMVCResourceCommand implements MVCResourceCommand {
+
+	@Override
+	public boolean serveResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws PortletException {
+
+		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
+			resourceRequest);
+
+		String entityId = ParamUtil.getString(
+			httpServletRequest, "idpEntityId");
+
+		if (Validator.isNull(entityId)) {
+			return false;
+		}
+
+		long companyId = _portal.getCompanyId(httpServletRequest);
+
+		try {
+			SamlSpIdpConnection samlSpIdpConnection =
+				_samlSpIdpConnectionLocalService.getSamlSpIdpConnection(
+					companyId, entityId);
+
+			httpServletRequest.setAttribute(
+				SamlWebKeys.SAML_SP_IDP_CONNECTION, samlSpIdpConnection);
+
+			_login(
+				httpServletRequest,
+				_portal.getHttpServletResponse(resourceResponse));
+		}
+		catch (Exception exception) {
+			if (_log.isInfoEnabled()) {
+				_log.info(exception, exception);
+			}
+
+			return false;
+		}
+
+		return true;
+	}
+
+	private void _login(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws PortalException {
+
+		String relayState = ParamUtil.getString(httpServletRequest, "redirect");
+
+		if (Validator.isNotNull(relayState)) {
+			relayState = _portal.escapeRedirect(relayState);
+		}
+
+		HttpSession session = httpServletRequest.getSession();
+
+		LastPath lastPath = (LastPath)session.getAttribute(WebKeys.LAST_PATH);
+
+		if (GetterUtil.getBoolean(
+				_props.get(PropsKeys.AUTH_FORWARD_BY_LAST_PATH)) &&
+			(lastPath != null) && Validator.isNull(relayState)) {
+
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(_portal.getPortalURL(httpServletRequest));
+			sb.append(lastPath.getContextPath());
+			sb.append(lastPath.getPath());
+			sb.append(lastPath.getParameters());
+
+			relayState = sb.toString();
+		}
+		else if (Validator.isNull(relayState)) {
+			relayState = _portal.getHomeURL(httpServletRequest);
+		}
+
+		_webSsoProfile.sendAuthnRequest(
+			httpServletRequest, httpServletResponse, relayState);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SendAuthnRequestMVCResourceCommand.class);
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private Props _props;
+
+	@Reference
+	private SamlSpIdpConnectionLocalService _samlSpIdpConnectionLocalService;
+
+	@Reference
+	private WebSsoProfile _webSsoProfile;
+
+}

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/SendSamlSloRequestInfosMVCResourceCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/SendSamlSloRequestInfosMVCResourceCommand.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.saml.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.saml.constants.SamlPortletKeys;
+import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
+import com.liferay.saml.runtime.servlet.profile.SingleLogoutProfile;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Arthur Chan
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + SamlPortletKeys.SAML,
+		"mvc.command.name=/saml/send_saml_slo_request_infos"
+	},
+	service = MVCResourceCommand.class
+)
+public class SendSamlSloRequestInfosMVCResourceCommand
+	extends BaseSamlMVCResourceCommand {
+
+	@Override
+	public boolean isEnabled() {
+		if (super.isEnabled()) {
+			return samlProviderConfigurationHelper.isRoleIdp();
+		}
+
+		return false;
+	}
+
+	@Override
+	@Reference(unbind = "-")
+	public void setPortal(Portal portal) {
+		super.setPortal(portal);
+	}
+
+	@Override
+	@Reference(unbind = "-")
+	public void setSamlProviderConfigurationHelper(
+		SamlProviderConfigurationHelper samlProviderConfigurationHelper) {
+
+		super.setSamlProviderConfigurationHelper(
+			samlProviderConfigurationHelper);
+	}
+
+	@Override
+	protected void doServeResource(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception {
+
+		_singleLogoutProfile.processIdpLogout(
+			httpServletRequest, httpServletResponse);
+	}
+
+	@Reference
+	private SingleLogoutProfile _singleLogoutProfile;
+
+}

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/SingleLogoutMVCResourceCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/SingleLogoutMVCResourceCommand.java
@@ -12,9 +12,11 @@
  *
  */
 
-package com.liferay.saml.web.internal.struts;
+package com.liferay.saml.web.internal.portlet.action;
 
-import com.liferay.portal.kernel.struts.StrutsAction;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.saml.constants.SamlPortletKeys;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
 import com.liferay.saml.runtime.servlet.profile.SingleLogoutProfile;
 
@@ -29,10 +31,19 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	immediate = true,
-	property = {"path=/portal/saml/slo", "path=/portal/saml/slo_soap"},
-	service = StrutsAction.class
+	property = {
+		"javax.portlet.name=" + SamlPortletKeys.SAML,
+		"mvc.command.name=/saml/slo", "mvc.command.name=/saml/slo_soap"
+	},
+	service = MVCResourceCommand.class
 )
-public class SingleLogoutAction extends BaseSamlStrutsAction {
+public class SingleLogoutMVCResourceCommand extends BaseSamlMVCResourceCommand {
+
+	@Override
+	@Reference(unbind = "-")
+	public void setPortal(Portal portal) {
+		super.setPortal(portal);
+	}
 
 	@Override
 	@Reference(unbind = "-")
@@ -44,15 +55,13 @@ public class SingleLogoutAction extends BaseSamlStrutsAction {
 	}
 
 	@Override
-	protected String doExecute(
+	protected void doServeResource(
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
 		_singleLogoutProfile.processSingleLogout(
 			httpServletRequest, httpServletResponse);
-
-		return null;
 	}
 
 	@Reference

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/SloLogoutMVCRenderCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/SloLogoutMVCRenderCommand.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.saml.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.constants.MVCRenderConstants;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.saml.constants.SamlPortletKeys;
+import com.liferay.saml.constants.SamlWebKeys;
+import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
+import com.liferay.saml.runtime.servlet.profile.SingleLogoutProfile;
+import com.liferay.saml.util.JspUtil;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Arthur Chan
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + SamlPortletKeys.SAML,
+		"mvc.command.name=/saml/slo_logout"
+	},
+	service = MVCRenderCommand.class
+)
+public class SloLogoutMVCRenderCommand extends BaseSamlMVCRenderCommand {
+
+	@Override
+	public boolean isEnabled() {
+		if (super.isEnabled()) {
+			return samlProviderConfigurationHelper.isRoleIdp();
+		}
+
+		return false;
+	}
+
+	@Override
+	@Reference(unbind = "-")
+	public void setPortal(Portal portal) {
+		super.setPortal(portal);
+	}
+
+	@Override
+	@Reference(unbind = "-")
+	public void setSamlProviderConfigurationHelper(
+		SamlProviderConfigurationHelper samlProviderConfigurationHelper) {
+
+		super.setSamlProviderConfigurationHelper(
+			samlProviderConfigurationHelper);
+	}
+
+	@Override
+	protected String doRender(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception {
+
+		_singleLogoutProfile.processIdpLogout(
+			httpServletRequest, httpServletResponse);
+
+		Object samlSLOContext = httpServletRequest.getAttribute(
+			SamlWebKeys.SAML_SLO_CONTEXT);
+
+		if (samlSLOContext != null) {
+			return JspUtil.PATH_PORTAL_SAML_SLO;
+		}
+
+		Object samlSLORequestInfo = httpServletRequest.getAttribute(
+			SamlWebKeys.SAML_SLO_REQUEST_INFO);
+
+		if (samlSLORequestInfo != null) {
+			return JspUtil.PATH_PORTAL_SAML_SLO_SP_STATUS;
+		}
+
+		return MVCRenderConstants.MVC_PATH_VALUE_SKIP_DISPATCH;
+	}
+
+	@Reference
+	private SingleLogoutProfile _singleLogoutProfile;
+
+}

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/WebSsoMVCResourceCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/WebSsoMVCResourceCommand.java
@@ -12,9 +12,11 @@
  *
  */
 
-package com.liferay.saml.web.internal.struts;
+package com.liferay.saml.web.internal.portlet.action;
 
-import com.liferay.portal.kernel.struts.StrutsAction;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.saml.constants.SamlPortletKeys;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
 import com.liferay.saml.runtime.servlet.profile.WebSsoProfile;
 
@@ -28,18 +30,28 @@ import org.osgi.service.component.annotations.Reference;
  * @author Mika Koivisto
  */
 @Component(
-	immediate = true, property = "path=/portal/saml/sso",
-	service = StrutsAction.class
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + SamlPortletKeys.SAML,
+		"mvc.command.name=/saml/web_sso"
+	},
+	service = MVCResourceCommand.class
 )
-public class WebSsoAction extends BaseSamlStrutsAction {
+public class WebSsoMVCResourceCommand extends BaseSamlMVCResourceCommand {
 
 	@Override
 	public boolean isEnabled() {
-		if (samlProviderConfigurationHelper.isRoleIdp()) {
-			return super.isEnabled();
+		if (super.isEnabled()) {
+			return samlProviderConfigurationHelper.isRoleIdp();
 		}
 
 		return false;
+	}
+
+	@Override
+	@Reference(unbind = "-")
+	public void setPortal(Portal portal) {
+		super.setPortal(portal);
 	}
 
 	@Override
@@ -52,15 +64,13 @@ public class WebSsoAction extends BaseSamlStrutsAction {
 	}
 
 	@Override
-	protected String doExecute(
+	protected void doServeResource(
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
 		_webSsoProfile.processAuthnRequest(
 			httpServletRequest, httpServletResponse);
-
-		return null;
 	}
 
 	@Reference(unbind = "-")

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/util/SamlMVCCommandUtil.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/util/SamlMVCCommandUtil.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.saml.web.internal.portlet.action.util;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.saml.runtime.exception.StatusException;
+
+import javax.portlet.PortletRequest;
+
+/**
+ * @author Arthur Chan
+ */
+public class SamlMVCCommandUtil {
+
+	public static void handleException(
+		Exception exception, PortletRequest portletRequest, Log log) {
+
+		if (log.isDebugEnabled()) {
+			log.debug(exception, exception);
+		}
+		else {
+			log.error(exception.getMessage());
+		}
+
+		Class<?> clazz = exception.getClass();
+
+		SessionErrors.add(portletRequest, clazz.getName());
+
+		if (exception instanceof StatusException) {
+			StatusException statusException = (StatusException)exception;
+
+			SessionErrors.add(
+				portletRequest, "statusCodeURI", statusException.getMessage());
+		}
+	}
+
+	public static ClassLoader switchContextClassLoader(
+		ClassLoader classLoader) {
+
+		Thread currentThread = Thread.currentThread();
+
+		ClassLoader currentClassLoader = currentThread.getContextClassLoader();
+
+		currentThread.setContextClassLoader(classLoader);
+
+		return currentClassLoader;
+	}
+
+}

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/servlet/filter/SamlMetadataFilter.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/servlet/filter/SamlMetadataFilter.java
@@ -12,15 +12,19 @@
  *
  */
 
-package com.liferay.saml.web.internal.struts;
+package com.liferay.saml.web.internal.servlet.filter;
 
-import com.liferay.portal.kernel.struts.StrutsAction;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.servlet.BaseFilter;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
 import com.liferay.saml.util.SamlHttpRequestUtil;
 
 import java.io.PrintWriter;
 
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -31,24 +35,35 @@ import org.osgi.service.component.annotations.Reference;
  * @author Mika Koivisto
  */
 @Component(
-	immediate = true, property = "path=/portal/saml/metadata",
-	service = StrutsAction.class
+	immediate = true,
+	property = {
+		"before-filter=Auto Login Filter", "dispatcher=FORWARD",
+		"dispatcher=REQUEST", "servlet-context-name=",
+		"servlet-filter-name=SSO SAML Metadata Filter",
+		"url-pattern=/c/portal/saml/metadata"
+	},
+	service = Filter.class
 )
-public class MetadataAction extends BaseSamlStrutsAction {
+public class SamlMetadataFilter extends BaseFilter {
 
 	@Override
-	@Reference(unbind = "-")
-	public void setSamlProviderConfigurationHelper(
-		SamlProviderConfigurationHelper samlProviderConfigurationHelper) {
+	public boolean isFilterEnabled() {
+		if (_samlProviderConfigurationHelper.isEnabled()) {
+			return true;
+		}
 
-		super.setSamlProviderConfigurationHelper(
-			samlProviderConfigurationHelper);
+		return false;
 	}
 
 	@Override
-	protected String doExecute(
+	protected Log getLog() {
+		return _log;
+	}
+
+	@Override
+	protected void processFilter(
 			HttpServletRequest httpServletRequest,
-			HttpServletResponse httpServletResponse)
+			HttpServletResponse httpServletResponse, FilterChain filterChain)
 		throws Exception {
 
 		httpServletResponse.setContentType(ContentTypes.TEXT_XML);
@@ -59,11 +74,15 @@ public class MetadataAction extends BaseSamlStrutsAction {
 			httpServletRequest);
 
 		printWriter.print(metadata);
-
-		return null;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SamlMetadataFilter.class);
 
 	@Reference
 	private SamlHttpRequestUtil _samlHttpRequestUtil;
+
+	@Reference
+	private SamlProviderConfigurationHelper _samlProviderConfigurationHelper;
 
 }

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/servlet/filter/SamlRedirectFilter.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/servlet/filter/SamlRedirectFilter.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.saml.web.internal.servlet.filter;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.servlet.BaseFilter;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.saml.constants.SamlCommandQueryConstants;
+import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Arthur Chan
+ */
+@Component(
+	immediate = true,
+	property = {
+		"before-filter=Auto Login Filter", "dispatcher=FORWARD",
+		"dispatcher=REQUEST", "servlet-context-name=",
+		"servlet-filter-name=SSO SAML Redirect Filter",
+		"url-pattern=/c/portal/saml/redirect/slo",
+		"url-pattern=/c/portal/saml/redirect/sso"
+	},
+	service = Filter.class
+)
+public class SamlRedirectFilter extends BaseFilter {
+
+	@Override
+	public boolean isFilterEnabled() {
+		return _samlProviderConfigurationHelper.isEnabled();
+	}
+
+	@Override
+	protected Log getLog() {
+		return _log;
+	}
+
+	@Override
+	protected void processFilter(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, FilterChain filterChain)
+		throws Exception {
+
+		String pathInfo = httpServletRequest.getPathInfo();
+
+		StringBundler sb = null;
+
+		if (pathInfo.endsWith("sso")) {
+			if (!_samlProviderConfigurationHelper.isRoleIdp()) {
+				return;
+			}
+
+			sb = new StringBundler(4);
+
+			sb.append(_portal.getRelativeHomeURL(httpServletRequest));
+
+			sb.append(SamlCommandQueryConstants.WEB_SSO);
+		}
+		else {
+			sb = new StringBundler(4);
+
+			sb.append(_portal.getRelativeHomeURL(httpServletRequest));
+
+			sb.append(SamlCommandQueryConstants.SLO);
+		}
+
+		sb.append('&');
+		sb.append(httpServletRequest.getQueryString());
+
+		httpServletResponse.sendRedirect(sb.toString());
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SamlRedirectFilter.class);
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private SamlProviderConfigurationHelper _samlProviderConfigurationHelper;
+
+}

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
@@ -138,7 +138,7 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 
 		JspUtil.dispatch(
 			httpServletRequest, httpServletResponse,
-			"/portal/saml/select_idp.jsp",
+			JspUtil.PATH_PORTAL_SAML_SELECT_IDP,
 			"please-select-your-identity-provider", false);
 
 		return null;

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.persistence.model.SamlSpIdpConnection;
 import com.liferay.saml.persistence.service.SamlSpIdpConnectionLocalService;
-import com.liferay.saml.runtime.configuration.SamlProviderConfiguration;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
 import com.liferay.saml.runtime.servlet.profile.SamlSpIdpConnectionsProfile;
 import com.liferay.saml.util.JspUtil;
@@ -115,22 +114,6 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 		).collect(
 			Collectors.toList()
 		);
-
-		if (samlSpIdpConnections.isEmpty()) {
-			SamlProviderConfiguration samlProviderConfiguration =
-				samlProviderConfigurationHelper.getSamlProviderConfiguration();
-
-			if (samlProviderConfiguration.allowShowingTheLoginPortlet()) {
-				return null;
-			}
-		}
-		else if (samlSpIdpConnections.size() == 1) {
-			httpServletRequest.setAttribute(
-				SamlWebKeys.SAML_SP_IDP_CONNECTION,
-				samlSpIdpConnections.get(0));
-
-			return null;
-		}
 
 		httpServletRequest.setAttribute(
 			SamlWebKeys.SAML_SSO_LOGIN_CONTEXT,

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SingleLogoutAction.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SingleLogoutAction.java
@@ -29,10 +29,7 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	immediate = true,
-	property = {
-		"path=/portal/saml/slo", "path=/portal/saml/slo_logout",
-		"path=/portal/saml/slo_soap"
-	},
+	property = {"path=/portal/saml/slo", "path=/portal/saml/slo_soap"},
 	service = StrutsAction.class
 )
 public class SingleLogoutAction extends BaseSamlStrutsAction {
@@ -52,18 +49,8 @@ public class SingleLogoutAction extends BaseSamlStrutsAction {
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
-		String requestURI = httpServletRequest.getRequestURI();
-
-		if (samlProviderConfigurationHelper.isRoleIdp() &&
-			requestURI.endsWith("/slo_logout")) {
-
-			_singleLogoutProfile.processIdpLogout(
-				httpServletRequest, httpServletResponse);
-		}
-		else {
-			_singleLogoutProfile.processSingleLogout(
-				httpServletRequest, httpServletResponse);
-		}
+		_singleLogoutProfile.processSingleLogout(
+			httpServletRequest, httpServletResponse);
 
 		return null;
 	}

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/certificate_info.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/certificate_info.jsp
@@ -21,6 +21,10 @@ CertificateTool certificateTool = (CertificateTool)request.getAttribute(SamlWebK
 
 LocalEntityManager.CertificateUsage certificateUsage = LocalEntityManager.CertificateUsage.valueOf(ParamUtil.getString(request, "certificateUsage"));
 
+GeneralTabDefaultViewDisplayContext generalTabDefaultViewDisplayContext = (GeneralTabDefaultViewDisplayContext)renderRequest.getAttribute(GeneralTabDefaultViewDisplayContext.class.getName());
+
+SamlProviderConfiguration samlProviderConfiguration = samlProviderConfigurationHelper.getSamlProviderConfiguration();
+
 GeneralTabDefaultViewDisplayContext.X509CertificateStatus x509CertificateStatus = generalTabDefaultViewDisplayContext.getX509CertificateStatus(certificateUsage);
 
 X509Certificate x509Certificate = x509CertificateStatus.getX509Certificate();

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/edit_identity_provider_connection.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/edit_identity_provider_connection.jsp
@@ -21,6 +21,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 
 AttributeMappingDisplayContext attributeMappingDisplayContext = (AttributeMappingDisplayContext)request.getAttribute(AttributeMappingDisplayContext.class.getName());
 long clockSkew = GetterUtil.getLong(request.getAttribute(SamlWebKeys.SAML_CLOCK_SKEW));
+NameIdTypeValues nameIdTypeValues = NameIdTypeValuesUtil.getNameIdTypeValues();
 SamlSpIdpConnection samlSpIdpConnection = (SamlSpIdpConnection)request.getAttribute(SamlWebKeys.SAML_SP_IDP_CONNECTION);
 UserFieldExpressionResolverRegistry userFieldExpressionResolverRegistry = (UserFieldExpressionResolverRegistry)request.getAttribute(UserFieldExpressionResolverRegistry.class.getName());
 

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/edit_service_provider_connection.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/edit_service_provider_connection.jsp
@@ -19,7 +19,11 @@
 <%
 String redirect = ParamUtil.getString(request, "redirect");
 
+NameIdTypeValues nameIdTypeValues = NameIdTypeValuesUtil.getNameIdTypeValues();
+
 SamlIdpSpConnection samlIdpSpConnection = (SamlIdpSpConnection)request.getAttribute(SamlWebKeys.SAML_IDP_SP_CONNECTION);
+
+SamlProviderConfiguration samlProviderConfiguration = samlProviderConfigurationHelper.getSamlProviderConfiguration();
 
 long assertionLifetime = GetterUtil.getLong(request.getAttribute(SamlWebKeys.SAML_ASSERTION_LIFETIME), samlProviderConfiguration.defaultAssertionLifetime());
 %>

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/general.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/general.jsp
@@ -17,6 +17,10 @@
 <%@ include file="/init.jsp" %>
 
 <%
+GeneralTabDefaultViewDisplayContext generalTabDefaultViewDisplayContext = (GeneralTabDefaultViewDisplayContext)renderRequest.getAttribute(GeneralTabDefaultViewDisplayContext.class.getName());
+
+LocalEntityManager localEntityManager = (LocalEntityManager)request.getAttribute(LocalEntityManager.class.getName());
+
 UnicodeProperties properties = PropertiesParamUtil.getProperties(request, "settings--");
 
 String entityId = properties.getProperty(PortletPropsKeys.SAML_ENTITY_ID, (String)request.getAttribute(SamlWebKeys.SAML_ENTITY_ID));
@@ -30,6 +34,8 @@ if (Validator.isNotNull(entityId)) {
 	keystoreException = x509CertificateStatus.getStatus() == GeneralTabDefaultViewDisplayContext.X509CertificateStatus.Status.SAML_KEYSTORE_EXCEPTION;
 	keystoreIncorrectPassword = x509CertificateStatus.getStatus() == GeneralTabDefaultViewDisplayContext.X509CertificateStatus.Status.SAML_KEYSTORE_PASSWORD_INCORRECT;
 }
+
+SamlProviderConfiguration samlProviderConfiguration = samlProviderConfigurationHelper.getSamlProviderConfiguration();
 
 String samlRole = properties.getProperty(PortletPropsKeys.SAML_ROLE, samlProviderConfiguration.role());
 boolean samlRoleIdpOptionDisabled = StringUtil.equalsIgnoreCase(samlProviderConfiguration.role(), SamlProviderConfigurationKeys.SAML_ROLE_SP) && !generalTabDefaultViewDisplayContext.isRoleIdPAvailable();

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/identity_provider.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/identity_provider.jsp
@@ -16,6 +16,10 @@
 
 <%@ include file="/init.jsp" %>
 
+<%
+SamlProviderConfiguration samlProviderConfiguration = samlProviderConfigurationHelper.getSamlProviderConfiguration();
+%>
+
 <portlet:actionURL name="/admin/update_identity_provider" var="updateIdentityProviderURL">
 	<portlet:param name="tabs1" value="identity-provider" />
 </portlet:actionURL>

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/service_provider.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/admin/service_provider.jsp
@@ -16,6 +16,10 @@
 
 <%@ include file="/init.jsp" %>
 
+<%
+SamlProviderConfiguration samlProviderConfiguration = samlProviderConfigurationHelper.getSamlProviderConfiguration();
+%>
+
 <portlet:actionURL name="/admin/update_service_provider" var="updateServiceProviderURL">
 	<portlet:param name="tabs1" value="service-provider" />
 </portlet:actionURL>

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/init.jsp
@@ -46,6 +46,7 @@ page import="com.liferay.portal.kernel.util.StringUtil" %><%@
 page import="com.liferay.portal.kernel.util.UnicodeProperties" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
+page import="com.liferay.saml.constants.SamlCommandQueryConstants" %><%@
 page import="com.liferay.saml.constants.SamlProviderConfigurationKeys" %><%@
 page import="com.liferay.saml.constants.SamlWebKeys" %><%@
 page import="com.liferay.saml.opensaml.integration.field.expression.handler.UserFieldExpressionHandler" %><%@
@@ -100,14 +101,5 @@ page import="java.util.Objects" %>
 <%
 String currentURL = PortalUtil.getCurrentURL(request);
 
-LocalEntityManager localEntityManager = (LocalEntityManager)request.getAttribute(LocalEntityManager.class.getName());
-NameIdTypeValues nameIdTypeValues = NameIdTypeValuesUtil.getNameIdTypeValues();
-GeneralTabDefaultViewDisplayContext generalTabDefaultViewDisplayContext = (GeneralTabDefaultViewDisplayContext)renderRequest.getAttribute(GeneralTabDefaultViewDisplayContext.class.getName());
 SamlProviderConfigurationHelper samlProviderConfigurationHelper = (SamlProviderConfigurationHelper)request.getAttribute(SamlProviderConfigurationHelper.class.getName());
-
-SamlProviderConfiguration samlProviderConfiguration = null;
-
-if (samlProviderConfigurationHelper != null) {
-	samlProviderConfiguration = samlProviderConfigurationHelper.getSamlProviderConfiguration();
-}
 %>

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/init.jsp
@@ -28,10 +28,13 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 <%@ page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.JSPNavigationItemList" %><%@
 page import="com.liferay.petra.portlet.url.builder.PortletURLBuilder" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
+page import="com.liferay.portal.kernel.json.JSONArray" %><%@
+page import="com.liferay.portal.kernel.json.JSONObject" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.language.UnicodeLanguageUtil" %><%@
 page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
 page import="com.liferay.portal.kernel.repository.model.FileEntry" %><%@
+page import="com.liferay.portal.kernel.servlet.SessionErrors" %><%@
 page import="com.liferay.portal.kernel.upload.UploadServletRequestConfigurationHelperUtil" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/error.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/error.jsp
@@ -2,15 +2,15 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
  *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
+ *
+ *
  */
 --%>
 

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/error.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/error.jsp
@@ -18,13 +18,13 @@
 
 <c:choose>
 	<c:when test='<%= Objects.equals(SessionErrors.get(request, "statusCodeURI"), "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed") %>'>
-		<h3 class="portlet-msg-error">
+		<div class="portlet-msg-error">
 			<liferay-ui:message key="authentication-failed" />
-		</h3>
+		</div>
 	</c:when>
 	<c:otherwise>
-		<h3 class="portlet-msg-error">
+		<div class="portlet-msg-error">
 			<liferay-ui:message key="unable-to-process-saml-request" />
-		</h3>
+		</div>
 	</c:otherwise>
 </c:choose>

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/error.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/error.jsp
@@ -14,7 +14,7 @@
  */
 --%>
 
-<%@ include file="/html/portal/init.jsp" %>
+<%@ include file="/init.jsp" %>
 
 <c:choose>
 	<c:when test='<%= Objects.equals(SessionErrors.get(request, "statusCodeURI"), "urn:oasis:names:tc:SAML:2.0:status:AuthnFailed") %>'>

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/select_idp.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/select_idp.jsp
@@ -2,15 +2,15 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
  *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
+ *
+ *
  */
 --%>
 

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/select_idp.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/select_idp.jsp
@@ -24,9 +24,11 @@ JSONObject samlSsoLoginContext = (JSONObject)request.getAttribute("SAML_SSO_LOGI
 JSONArray relevantIdpConnectionsJSONArray = samlSsoLoginContext.getJSONArray("relevantIdpConnections");
 %>
 
-<aui:form action='<%= PortalUtil.getPortalURL(request) + "/c/portal/login" %>' method="get" name="fm" style="padding: 1rem;">
-	<aui:input name="saveLastPath" type="hidden" value="<%= false %>" />
+<liferay-portlet:resourceURL id="/saml/send_authn_request" var="sendAuthnRequestURL" />
+
+<aui:form action="<%= sendAuthnRequestURL %>" id="fm" name="fm" style="padding: 1rem;">
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
+	<aui:input name="saveLastPath" type="hidden" value="<%= false %>" />
 
 	<c:choose>
 		<c:when test="<%= relevantIdpConnectionsJSONArray.length() > 0 %>">

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/select_idp.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/select_idp.jsp
@@ -14,7 +14,7 @@
  */
 --%>
 
-<%@ include file="/html/portal/init.jsp" %>
+<%@ include file="/init.jsp" %>
 
 <%
 String redirect = ParamUtil.getString(request, "redirect");

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo.jsp
@@ -2,15 +2,15 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
  *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
+ *
+ *
  */
 --%>
 

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo.jsp
@@ -21,6 +21,8 @@ JSONObject samlSloContextJSONObject = (JSONObject)request.getAttribute("SAML_SLO
 
 JSONArray samlSloRequestInfosJSONArray = samlSloContextJSONObject.getJSONArray("samlSloRequestInfos");
 
+String finishSLOResourceCommand = PortalUtil.getRelativeHomeURL(request) + SamlCommandQueryConstants.FINISH_SLO;
+
 String sloLogoutRenderCommand = PortalUtil.getRelativeHomeURL(request) + SamlCommandQueryConstants.SLO_LOGOUT;
 %>
 
@@ -65,7 +67,7 @@ String sloLogoutRenderCommand = PortalUtil.getRelativeHomeURL(request) + SamlCom
 		<liferay-ui:message arguments="<%= 5 %>" key="all-service-providers-are-processed.-continuing-sign-out-automatically-in-x-seconds" />
 	</div>
 
-	<a href="<%= sloLogoutRenderCommand %>&cmd=finish" id="samlCompleteSignOutLink"><liferay-ui:message key="complete-sign-out" /></a>
+	<a href="<%= finishSLOResourceCommand %>&cmd=finish" id="samlCompleteSignOutLink"><liferay-ui:message key="complete-sign-out" /></a>
 </div>
 
 <noscript>
@@ -89,7 +91,7 @@ String sloLogoutRenderCommand = PortalUtil.getRelativeHomeURL(request) + SamlCom
 	%>
 
 	<div>
-		<a href="<%= sloLogoutRenderCommand %>&cmd=finish">
+		<a href="<%= finishSLOResourceCommand %>&cmd=finish">
 			<liferay-ui:message key="complete-sign-out" />
 		</a>
 	</div>
@@ -256,7 +258,7 @@ String sloLogoutRenderCommand = PortalUtil.getRelativeHomeURL(request) + SamlCom
 		finishLogout: function() {
 			detachHandlers();
 
-			location.href = '<%= sloLogoutRenderCommand %>&cmd=finish';
+			location.href = '<%= finishSLOResourceCommand %>&cmd=finish';
 		},
 
 		retryLogout: function(entityId) {

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo.jsp
@@ -14,7 +14,7 @@
  */
 --%>
 
-<%@ include file="/html/portal/init.jsp" %>
+<%@ include file="/init.jsp" %>
 
 <%
 JSONObject samlSloContextJSONObject = (JSONObject)request.getAttribute("SAML_SLO_CONTEXT");

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo.jsp
@@ -217,9 +217,10 @@ String sloLogoutRenderCommand = PortalUtil.getRelativeHomeURL(request) + SamlCom
 			var instance = this;
 
 			A.io.request(
-				'<%= sloLogoutRenderCommand %>&cmd=status',
+				'<%= PortalUtil.getRelativeHomeURL(request) + SamlCommandQueryConstants.SEND_SAML_SLO_REQUEST_INFOS %>&cmd=status',
 				{
 					dataType: 'JSON',
+					method: 'POST',
 					on: {
 						success: function(event) {
 							var logoutPending = false;

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo.jsp
@@ -20,6 +20,8 @@
 JSONObject samlSloContextJSONObject = (JSONObject)request.getAttribute("SAML_SLO_CONTEXT");
 
 JSONArray samlSloRequestInfosJSONArray = samlSloContextJSONObject.getJSONArray("samlSloRequestInfos");
+
+String sloLogoutRenderCommand = PortalUtil.getRelativeHomeURL(request) + SamlCommandQueryConstants.SLO_LOGOUT;
 %>
 
 <style type="text/css">
@@ -63,7 +65,7 @@ JSONArray samlSloRequestInfosJSONArray = samlSloContextJSONObject.getJSONArray("
 		<liferay-ui:message arguments="<%= 5 %>" key="all-service-providers-are-processed.-continuing-sign-out-automatically-in-x-seconds" />
 	</div>
 
-	<a href="?cmd=finish" id="samlCompleteSignOutLink"><liferay-ui:message key="complete-sign-out" /></a>
+	<a href="<%= sloLogoutRenderCommand %>&cmd=finish" id="samlCompleteSignOutLink"><liferay-ui:message key="complete-sign-out" /></a>
 </div>
 
 <noscript>
@@ -77,7 +79,7 @@ JSONArray samlSloRequestInfosJSONArray = samlSloContextJSONObject.getJSONArray("
 	%>
 
 		<div class="saml-sp">
-			<a class="saml-sp-label" href="?cmd=logout&entityId=<%= samlSloRequestInfoJSONObject.getString("entityId") %>" target="_blank">
+			<a class="saml-sp-label" href="<%= sloLogoutRenderCommand %>&cmd=logout&entityId=<%= samlSloRequestInfoJSONObject.getString("entityId") %>" target="_blank">
 				<liferay-ui:message arguments='<%= samlSloRequestInfoJSONObject.getString("name") %>' key="sign-out-from-x" />
 			</a>
 		</div>
@@ -87,7 +89,7 @@ JSONArray samlSloRequestInfosJSONArray = samlSloContextJSONObject.getJSONArray("
 	%>
 
 	<div>
-		<a href="?cmd=finish">
+		<a href="<%= sloLogoutRenderCommand %>&cmd=finish">
 			<liferay-ui:message key="complete-sign-out" />
 		</a>
 	</div>
@@ -168,7 +170,7 @@ JSONArray samlSloRequestInfosJSONArray = samlSloContextJSONObject.getJSONArray("
 			'<div class="saml-sp" id="samlSp{$i}">',
 				'<span class="portlet-msg-progress-label saml-sp-label">{name}</span>',
 				'<a class="hide saml-sp-retry" data-entityId="{entityId}" href="javascript:;"><%= UnicodeLanguageUtil.get(request, "retry") %></a>',
-				'<iframe class="hide-accessible" src="?cmd=logout&entityId={entityId}"></iframe>',
+				'<iframe class="hide-accessible" src="<%= sloLogoutRenderCommand %>&cmd=logout&entityId={entityId}"></iframe>',
 			'</div>',
 		'</tpl>'
 	);
@@ -215,7 +217,7 @@ JSONArray samlSloRequestInfosJSONArray = samlSloContextJSONObject.getJSONArray("
 			var instance = this;
 
 			A.io.request(
-				'?cmd=status',
+				'<%= sloLogoutRenderCommand %>&cmd=status',
 				{
 					dataType: 'JSON',
 					on: {
@@ -253,7 +255,7 @@ JSONArray samlSloRequestInfosJSONArray = samlSloContextJSONObject.getJSONArray("
 		finishLogout: function() {
 			detachHandlers();
 
-			location.href = '?cmd=finish';
+			location.href = '<%= sloLogoutRenderCommand %>&cmd=finish';
 		},
 
 		retryLogout: function(entityId) {
@@ -273,7 +275,7 @@ JSONArray samlSloRequestInfosJSONArray = samlSloContextJSONObject.getJSONArray("
 
 				entityNode.one('.saml-sp-retry').hide();
 
-				entityNode.one('iframe').set('src', '?cmd=logout&entityId=' + entityId);
+				entityNode.one('iframe').set('src', '<%= sloLogoutRenderCommand %>&cmd=logout&entityId=' + entityId);
 
 				instance.checkStatus();
 			}

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo.jsp
@@ -98,38 +98,36 @@ String sloLogoutRenderCommand = PortalUtil.getRelativeHomeURL(request) + SamlCom
 </noscript>
 
 <aui:script use="aui-base,aui-io-request-deprecated,aui-template-deprecated">
-	var confirmLogout = function() {
-		return confirm('<liferay-ui:message key="leaving-this-window-might-leave-logout-unfinished" />');
+	var confirmLogout = function () {
+		return confirm(
+			'<liferay-ui:message key="leaving-this-window-might-leave-logout-unfinished" />'
+		);
 	};
 
 	var eventHandlers = [];
 
-	var detachHandlers = function() {
-		(new A.EventHandle(eventHandlers)).detach();
+	var detachHandlers = function () {
+		new A.EventHandle(eventHandlers).detach();
 	};
 
 	eventHandlers.push(
-		A.getWin().on(
-			'beforeunload',
-			function(event) {
-				event.preventDefault('<liferay-ui:message key="leaving-this-window-might-leave-logout-unfinished" />');
-			}
-		)
+		A.getWin().on('beforeunload', (event) => {
+			event.preventDefault(
+				'<liferay-ui:message key="leaving-this-window-might-leave-logout-unfinished" />'
+			);
+		})
 	);
 
 	if (Liferay.SPA && Liferay.SPA.app) {
 		eventHandlers.push(
-			Liferay.on(
-				'beforeNavigate',
-				function(event) {
-					if (!confirmLogout()) {
-						event.originalEvent.preventDefault();
-					}
-					else {
-						SAML.SLO.clearFinishTimeout();
-					}
+			Liferay.on('beforeNavigate', (event) => {
+				if (!confirmLogout()) {
+					event.originalEvent.preventDefault();
 				}
-			)
+				else {
+					SAML.SLO.clearFinishTimeout();
+				}
+			})
 		);
 
 		Liferay.once('endNavigate', detachHandlers);
@@ -141,70 +139,73 @@ String sloLogoutRenderCommand = PortalUtil.getRelativeHomeURL(request) + SamlCom
 		2: {
 			cssClass: 'portlet-msg-success-label',
 			retry: false,
-			title: '<%= UnicodeLanguageUtil.get(request, "single-sign-out-completed-successfully") %>'
+			title:
+				'<%= UnicodeLanguageUtil.get(request, "single-sign-out-completed-successfully") %>',
 		},
 		3: {
 			cssClass: 'portlet-msg-error-label',
 			retry: true,
-			title: '<%= UnicodeLanguageUtil.get(request, "single-sign-out-request-failed") %>'
+			title:
+				'<%= UnicodeLanguageUtil.get(request, "single-sign-out-request-failed") %>',
 		},
 		4: {
 			cssClass: 'portlet-msg-no-support-label',
 			retry: false,
-			title: '<%= UnicodeLanguageUtil.get(request, "this-service-provider-does-not-support-single-sign-out") %>'
+			title:
+				'<%= UnicodeLanguageUtil.get(request, "this-service-provider-does-not-support-single-sign-out") %>',
 		},
 		5: {
 			cssClass: 'portlet-msg-timed-out-label',
 			retry: true,
-			title: '<%= UnicodeLanguageUtil.get(request, "single-sign-out-request-timed-out") %>'
+			title:
+				'<%= UnicodeLanguageUtil.get(request, "single-sign-out-request-timed-out") %>',
 		},
 		defaultStatus: {
 			cssClass: 'portlet-msg-progress-label',
 			retry: false,
-			title: '<%= UnicodeLanguageUtil.get(request, "single-sign-out-in-progress") %>'
-		}
+			title:
+				'<%= UnicodeLanguageUtil.get(request, "single-sign-out-in-progress") %>',
+		},
 	};
 
 	var SAML = Liferay.namespace('SAML');
 
 	var TPL_SAML_ENTITY = new A.Template(
 		'<tpl for="items">',
-			'<div class="saml-sp" id="samlSp{$i}">',
-				'<span class="portlet-msg-progress-label saml-sp-label">{name}</span>',
-				'<a class="hide saml-sp-retry" data-entityId="{entityId}" href="javascript:;"><%= UnicodeLanguageUtil.get(request, "retry") %></a>',
-				'<iframe class="hide-accessible" src="<%= sloLogoutRenderCommand %>&cmd=logout&entityId={entityId}"></iframe>',
-			'</div>',
+		'<div class="saml-sp" id="samlSp{$i}">',
+		'<span class="portlet-msg-progress-label saml-sp-label">{name}</span>',
+		'<a class="hide saml-sp-retry" data-entityId="{entityId}" href="javascript:;"><%= UnicodeLanguageUtil.get(request, "retry") %></a>',
+		'<iframe class="hide-accessible" src="<%= sloLogoutRenderCommand %>&cmd=logout&entityId={entityId}"></iframe>',
+		'</div>',
 		'</tpl>'
 	);
 
 	SAML.SLO = {
-		init: function(items) {
+		init: function (items) {
 			var instance = this;
 
 			var entities = instance._entities;
 			var entityStatus = instance._entityStatus;
 
-			items.forEach(
-				function(item, index, collection) {
-					var entityId = item.entityId;
+			items.forEach((item, index, collection) => {
+				var entityId = item.entityId;
 
-					entities[entityId] = 'samlSp' + index;
-					entityStatus[entityId] = 0;
-				}
-			);
+				entities[entityId] = 'samlSp' + index;
+				entityStatus[entityId] = 0;
+			});
 
 			var outputNode = A.one('#samlSloResults');
 
 			TPL_SAML_ENTITY.render(
 				{
-					items: items
+					items: items,
 				},
 				outputNode
 			);
 
 			outputNode.delegate(
 				'click',
-				function(event) {
+				(event) => {
 					instance.retryLogout(event.currentTarget.attr('data-entityId'));
 				},
 				'.saml-sp-retry'
@@ -215,7 +216,7 @@ String sloLogoutRenderCommand = PortalUtil.getRelativeHomeURL(request) + SamlCom
 			instance.checkStatus();
 		},
 
-		checkStatus: function() {
+		checkStatus: function () {
 			var instance = this;
 
 			A.io.request(
@@ -224,11 +225,11 @@ String sloLogoutRenderCommand = PortalUtil.getRelativeHomeURL(request) + SamlCom
 					dataType: 'JSON',
 					method: 'POST',
 					on: {
-						success: function(event) {
+						success: function (event) {
 							var logoutPending = false;
 
 							this.get('responseData.samlSloRequestInfos').forEach(
-								function(item, index, collection) {
+								(item, index, collection) => {
 									logoutPending |= item.status < 2;
 
 									instance.updateStatus(item);
@@ -241,27 +242,30 @@ String sloLogoutRenderCommand = PortalUtil.getRelativeHomeURL(request) + SamlCom
 							else {
 								instance._completeSignOut.show();
 
-								instance.finishTimeout = setTimeout(A.bind('finishLogout', instance), 5000);
+								instance.finishTimeout = setTimeout(
+									A.bind('finishLogout', instance),
+									5000
+								);
 							}
-						}
-					}
+						},
+					},
 				}
 			);
 		},
 
-		clearFinishTimeout: function() {
+		clearFinishTimeout: function () {
 			var instance = this;
 
 			clearTimeout(instance.finishTimeout);
 		},
 
-		finishLogout: function() {
+		finishLogout: function () {
 			detachHandlers();
 
 			location.href = '<%= finishSLOResourceCommand %>&cmd=finish';
 		},
 
-		retryLogout: function(entityId) {
+		retryLogout: function (entityId) {
 			var instance = this;
 
 			var entityNode = A.one('#' + instance._entities[entityId]);
@@ -269,22 +273,26 @@ String sloLogoutRenderCommand = PortalUtil.getRelativeHomeURL(request) + SamlCom
 			if (entityNode) {
 				var defaultStatus = MAP_ENTITY_STATUS.defaultStatus;
 
-				entityNode.one('.saml-sp-label').attr(
-					{
-						className: 'saml-sp-label ' + defaultStatus.cssClass,
-						title: defaultStatus.title
-					}
-				);
+				entityNode.one('.saml-sp-label').attr({
+					className: 'saml-sp-label ' + defaultStatus.cssClass,
+					title: defaultStatus.title,
+				});
 
 				entityNode.one('.saml-sp-retry').hide();
 
-				entityNode.one('iframe').set('src', '<%= sloLogoutRenderCommand %>&cmd=logout&entityId=' + entityId);
+				entityNode
+					.one('iframe')
+					.set(
+						'src',
+						'<%= sloLogoutRenderCommand %>&cmd=logout&entityId=' +
+							entityId
+					);
 
 				instance.checkStatus();
 			}
 		},
 
-		updateStatus: function(samlSloRequestInfo) {
+		updateStatus: function (samlSloRequestInfo) {
 			var instance = this;
 
 			var infoStatus = samlSloRequestInfo.status;
@@ -300,21 +308,21 @@ String sloLogoutRenderCommand = PortalUtil.getRelativeHomeURL(request) + SamlCom
 
 				var entityNode = A.one('#' + instance._entities[entityId]);
 
-				var statusDetails = MAP_ENTITY_STATUS[infoStatus] || MAP_ENTITY_STATUS.defaultStatus;
+				var statusDetails =
+					MAP_ENTITY_STATUS[infoStatus] ||
+					MAP_ENTITY_STATUS.defaultStatus;
 
-				entityNode.one('.saml-sp-label').attr(
-					{
-						className: 'saml-sp-label ' + statusDetails.cssClass,
-						title: statusDetails.title
-					}
-				);
+				entityNode.one('.saml-sp-label').attr({
+					className: 'saml-sp-label ' + statusDetails.cssClass,
+					title: statusDetails.title,
+				});
 
 				entityNode.one('.saml-sp-retry').toggle(statusDetails.retry);
 			}
 		},
 
 		_entities: {},
-		_entityStatus: {}
+		_entityStatus: {},
 	};
 
 	Liferay.SAML.SLO.init(<%= samlSloRequestInfosJSONArray %>);

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo_sp_status.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo_sp_status.jsp
@@ -2,15 +2,15 @@
 /**
  * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
  *
- * This library is free software; you can redistribute it and/or modify it under
- * the terms of the GNU Lesser General Public License as published by the Free
- * Software Foundation; either version 2.1 of the License, or (at your option)
- * any later version.
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
  *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
+ *
+ *
  */
 --%>
 

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo_sp_status.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo_sp_status.jsp
@@ -14,7 +14,7 @@
  */
 --%>
 
-<%@ include file="/html/portal/init.jsp" %>
+<%@ include file="/init.jsp" %>
 
 <%
 JSONObject samlSloRequestInfoJSONObject = (JSONObject)request.getAttribute("SAML_SLO_REQUEST_INFO");

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo_sp_status.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo_sp_status.jsp
@@ -57,6 +57,8 @@ int status = samlSloRequestInfoJSONObject.getInt("status");
 
 <aui:script>
 	if (window.parent.Liferay.SAML.SLO) {
-		window.parent.Liferay.SAML.SLO.updateStatus(<%= samlSloRequestInfoJSONObject %>);
+		window.parent.Liferay.SAML.SLO.updateStatus(
+			<%= samlSloRequestInfoJSONObject %>
+		);
 	}
 </aui:script>

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo_sp_status.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/portal/saml/slo_sp_status.jsp
@@ -37,7 +37,7 @@ int status = samlSloRequestInfoJSONObject.getInt("status");
 			<div class="portlet-msg-error">
 				<liferay-ui:message key="single-sign-out-request-failed" />
 
-				<a href="?cmd=logout&entityId=<%= samlSloRequestInfoJSONObject.getString("entityId") %>">
+				<a href="<%= PortalUtil.getRelativeHomeURL(request) + SamlCommandQueryConstants.SLO_LOGOUT %>&cmd=logout&entityId=<%= samlSloRequestInfoJSONObject.getString("entityId") %>">
 					<liferay-ui:message key="retry" />
 				</a>
 			</div>

--- a/modules/dxp/apps/saml/saml-web/src/main/resources/content/Language.properties
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/content/Language.properties
@@ -48,6 +48,7 @@ incorrect-keystore-password=Incorrect keystore password.
 javax.portlet.title.1_WAR_samlportlet=SAML Keep Alive
 javax.portlet.title.2_WAR_samlportlet=SAML Admin
 javax.portlet.title.com_liferay_saml_web_internal_portlet_SamlAdminPortlet=SAML Admin
+javax.portlet.title.com_liferay_saml_web_internal_portlet_SamlPortlet=SAML
 kerberos=Kerberos
 key-algorithm=Key Algorithm
 key-length-bits=Key Length (Bits)

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -522,6 +522,7 @@
         com_liferay_portlet_configuration_css_web_portlet_PortletConfigurationCSSPortlet,\
         com_liferay_portlet_configuration_web_portlet_PortletConfigurationPortlet,\
         com_liferay_product_navigation_simulation_web_portlet_SimulationPortlet,\
+        com_liferay_saml_web_internal_portlet_SamlPortlet,\
         com_liferay_staging_bar_web_portlet_StagingBarPortlet
 
     #

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Portlet.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Portlet.path
@@ -84,6 +84,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>MESSAGE_ERROR</td>
+	<td>//div[contains(@class,'portlet-msg-error')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>MESSAGE_INFO</td>
 	<td>//div[contains(@class,'portlet-msg-info')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAML.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAML.testcase
@@ -402,7 +402,7 @@ definition {
 			value1 = "Sign In");
 
 		AssertTextEquals(
-			locator1 = "Portlet#PORTLET_CONTENT",
+			locator1 = "Portlet#MESSAGE_ERROR",
 			value1 = "Unable to process SAML request.");
 
 		AssertConsoleTextPresent(value1 = "Validation of protocol message signature failed");
@@ -429,7 +429,7 @@ definition {
 		var portalURL = PropsUtil.get("portal.url");
 
 		SAML.executeIdPInitiatedSSO(
-			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
+			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/redirect/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
 			password = "test",
 			samlEnabled = "true",
 			spURL = "http://www.able.com:9080",
@@ -460,10 +460,12 @@ definition {
 
 		User.logoutPG();
 
+		Pause(locator1 = "20000");
+
 		User.viewLoggedOutPG();
 
 		SAML.executeIdPInitiatedSSO(
-			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
+			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/redirect/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
 			password = "test",
 			samlEnabled = "true",
 			spURL = "http://www.able.com:9080",
@@ -475,7 +477,7 @@ definition {
 
 		SAML.executeIdPInitiatedSSO(
 			autoLogin = "true",
-			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
+			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/redirect/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
 			password = "test",
 			samlEnabled = "true",
 			spURL = "http://www.able.com:9080",
@@ -512,7 +514,7 @@ definition {
 		var portalURL = PropsUtil.get("portal.url");
 
 		SAML.executeIdPInitiatedSSO(
-			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
+			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/redirect/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
 			password = "test",
 			spURL = "http://www.able.com:9080",
 			userEmailAddress = "test@liferay.com");
@@ -555,7 +557,7 @@ definition {
 		var portalURL = PropsUtil.get("portal.url");
 
 		SAML.executeIdPInitiatedSSO(
-			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
+			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/redirect/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
 			password = "test",
 			samlEnabled = "true",
 			spURL = "http://www.able.com:9080",
@@ -639,9 +641,7 @@ definition {
 			specificURL = "http://www.able.com:9080",
 			userEmailAddress = "test@liferay.com");
 
-		AssertTextEquals(
-			locator1 = "Portlet#PORTLET_CONTENT",
-			value1 = "Unable to process SAML request.");
+		User.viewLoggedOutPG();
 
 		Clustering.viewTextPresentOnSpecificNode(
 			expectedText = "Data encryption key was null",
@@ -677,7 +677,7 @@ definition {
 		var portalURL = PropsUtil.get("portal.url");
 
 		SAML.executeIdPInitiatedSSO(
-			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
+			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/redirect/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
 			password = "test",
 			spURL = "http://www.able.com:9080",
 			userEmailAddress = "test@liferay.com");
@@ -790,7 +790,9 @@ definition {
 
 		Navigator.gotoLoginPage();
 
-		AssertConsoleTextPresent(value1 = "org.opensaml.messaging.handler.MessageHandlerException: Message context was not authenticated");
+		AssertTextEquals(
+			locator1 = "Portlet#MESSAGE_ERROR",
+			value1 = "Unable to process SAML request.");
 	}
 
 	@description = "This is a use case for LPS-129373"
@@ -1175,7 +1177,7 @@ definition {
 		// Verify SP is logged in
 
 		SAML.executeIdPInitiatedSSO(
-			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
+			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/redirect/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
 			password = "test",
 			spURL = "http://www.able.com:9080",
 			userEmailAddress = "test@liferay.com");
@@ -1221,7 +1223,7 @@ definition {
 		// Verify SP is logged in
 
 		SAML.executeIdPInitiatedSSO(
-			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
+			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/redirect/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
 			password = "test",
 			rememberMeChecked = "true",
 			spURL = "http://www.able.com:9080",
@@ -1556,7 +1558,7 @@ definition {
 		var portalURL = PropsUtil.get("portal.url");
 
 		SAML.executeIdPInitiatedSSO(
-			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
+			idpInitiatedSSOURL = "${portalURL}/c/portal/saml/redirect/sso?entityId=samlsp&amp;RelayState=http://www.able.com:9080",
 			password = "test",
 			rememberMeChecked = "true",
 			spURL = "http://www.able.com:9080",


### PR DESCRIPTION
@brianchandotcom:

This is the 1st pull in a series to refactor SAML related source. Reason for the refactor:

1. SAML was first written long time ago, which uses old technology like struts.
2. Over years, SAML code base has become quit difficult to work with, to maintain and to add new features.
3. Some of the JSPs are forced into portal-web
