### PR TITLE
[TS] LPS-135566 Allow root-relative Logout Redirect URL in Token Based SSO at instance level configuration

### DIFF
--- a/modules/apps/portal-settings/portal-settings-authentication-token-web/src/main/java/com/liferay/portal/settings/authentication/token/web/internal/portlet/action/TokenPortalSettingsFormContributor.java
+++ b/modules/apps/portal-settings/portal-settings-authentication-token-web/src/main/java/com/liferay/portal/settings/authentication/token/web/internal/portlet/action/TokenPortalSettingsFormContributor.java
@@ -72,7 +72,7 @@ public class TokenPortalSettingsFormContributor
 			actionRequest, this, "logoutRedirectURL");
 
 		if (Validator.isNotNull(logoutRedirectURL) &&
-			!Validator.isUrl(logoutRedirectURL)) {
+			!Validator.isUrl(logoutRedirectURL, true)) {
 
 			SessionErrors.add(actionRequest, "logoutRedirectURLInvalid");
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-135566

Cannot configure a root-relative Logout Redirect URL in Token Based SSO at instance level configuration.

This problem is reproduced after the https://issues.liferay.com/browse/LPS-102185 changes.

Before that LPS, you were able to define a root-relative Logout Redirect URL at system level configuration.

This is necessary in case you have several site domains and you want to redirect to a generic page for every domain.
