### PR TITLE
[TS] LPS-137638 allow s tag on sanitizer configuration

### DIFF
--- a/modules/apps/portal-security/portal-security-antisamy/build.gradle
+++ b/modules/apps/portal-security/portal-security-antisamy/build.gradle
@@ -143,7 +143,7 @@ private String _filterDefaultSanitizer(String line) {
 			|		<tag name="rp" action="validate" />
 			|		<tag name="rt" action="validate" />
 			|		<tag name="ruby" action="validate" />
-					<tag name="s" action="validate" />
+			|		<tag name="s" action="validate" />
 			|		<tag name="section" action="validate" />
 			|		<tag name="source" action="validate">
 			|			<attribute name="srcset">

--- a/modules/apps/portal-security/portal-security-antisamy/build.gradle
+++ b/modules/apps/portal-security/portal-security-antisamy/build.gradle
@@ -143,6 +143,7 @@ private String _filterDefaultSanitizer(String line) {
 			|		<tag name="rp" action="validate" />
 			|		<tag name="rt" action="validate" />
 			|		<tag name="ruby" action="validate" />
+					<tag name="s" action="validate" />
 			|		<tag name="section" action="validate" />
 			|		<tag name="source" action="validate">
 			|			<attribute name="srcset">

--- a/modules/apps/portal-security/portal-security-antisamy/src/main/resources/META-INF/resources/knowledge-base-sanitizer-configuration.xml
+++ b/modules/apps/portal-security/portal-security-antisamy/src/main/resources/META-INF/resources/knowledge-base-sanitizer-configuration.xml
@@ -538,6 +538,7 @@ http://www.w3.org/TR/html401/struct/global.html
 		<tag name="rp" action="validate" />
 		<tag name="rt" action="validate" />
 		<tag name="ruby" action="validate" />
+		<tag name="s" action="validate" />
 		<tag name="section" action="validate" />
 		<tag name="source" action="validate">
 			<attribute name="srcset">

--- a/modules/apps/portal-security/portal-security-antisamy/src/main/resources/META-INF/resources/sanitizer-configuration.xml
+++ b/modules/apps/portal-security/portal-security-antisamy/src/main/resources/META-INF/resources/sanitizer-configuration.xml
@@ -528,6 +528,7 @@ http://www.w3.org/TR/html401/struct/global.html
 		<tag name="rp" action="validate" />
 		<tag name="rt" action="validate" />
 		<tag name="ruby" action="validate" />
+		<tag name="s" action="validate" />
 		<tag name="section" action="validate" />
 		<tag name="source" action="validate">
 			<attribute name="srcset">


### PR DESCRIPTION
Hi team,

Can you help review this PR?

**Notes from @leticia-maciel:**

> **Issue**: CKEditor uses the `<s>` tag to strike through the words on body text but Questions portlet and Message Board execute the Anti Sanitizer method before saving on the database and it was filtering the `<s>` tag. That was happening because the `sanitizer-configuration.xml` did not have the `<s>` tag added on its tag-rules to accept the tag and not filter it. 
> 
> **Fix**: The `<s>` tag was added on tag-rules on `sanitizer-configuration.xml` by `build.gradle`. Similar case on [LPS-91238](https://issues.liferay.com/browse/LPS-91238).

Please let us know if you have any questions.
Thanks!