### PR TITLE
LPS-142044

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -962,15 +962,16 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 		}
 	}
 
-	protected Set<Long> importGroup(
+	protected UserGroup importGroup(
 			LDAPImportContext ldapImportContext,
-			SafeLdapName userGroupDNSafeLdapName, User user,
-			Set<Long> newUserGroupIds)
+			SafeLdapName userGroupDNSafeLdapName, User user)
 		throws Exception {
 
 		String userGroupIdKey = null;
 
 		Long userGroupId = null;
+
+		UserGroup userGroup = null;
 
 		LDAPImportConfiguration ldapImportConfiguration =
 			_ldapImportConfigurationProvider.getConfiguration(
@@ -1014,12 +1015,12 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 					nameNotFoundException);
 			}
 
-			UserGroup userGroup = importUserGroup(
+			userGroup = importUserGroup(
 				ldapImportContext.getCompanyId(), groupAttributes,
 				ldapImportContext.getGroupMappings());
 
 			if (userGroup == null) {
-				return newUserGroupIds;
+				return null;
 			}
 
 			userGroupId = userGroup.getUserGroupId();
@@ -1035,9 +1036,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 					"Adding user ", user, " to user group ", userGroupId));
 		}
 
-		newUserGroupIds.add(userGroupId);
-
-		return newUserGroupIds;
+		return userGroup;
 	}
 
 	protected void importGroups(
@@ -1114,9 +1113,12 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 					SafeLdapName userGroupSafeLdapName =
 						SafeLdapNameFactory.from(searchResult);
 
-					newUserGroupIds = importGroup(
-						ldapImportContext, userGroupSafeLdapName, user,
-						newUserGroupIds);
+					UserGroup userGroup = importGroup(
+						ldapImportContext, userGroupSafeLdapName, user);
+
+					if (userGroup != null) {
+						newUserGroupIds.add(userGroup.getUserGroupId());
+					}
 				}
 			}
 		}
@@ -1147,9 +1149,12 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 				SafeLdapName groupSafeLdapName = SafeLdapNameFactory.from(
 					userGroupAttribute, i);
 
-				newUserGroupIds = importGroup(
-					ldapImportContext, groupSafeLdapName, user,
-					newUserGroupIds);
+				UserGroup userGroup = importGroup(
+					ldapImportContext, groupSafeLdapName, user);
+
+				if (userGroup != null) {
+					newUserGroupIds.add(userGroup.getUserGroupId());
+				}
 			}
 		}
 

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -1081,16 +1081,16 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 
 			String fullUserDN = userBinding.getNameInNamespace();
 
+			String groupMappingsGroupName = GetterUtil.getString(
+				groupMappings.getProperty("groupName"));
+
+			groupMappingsGroupName = StringUtil.toLowerCase(
+				groupMappingsGroupName);
+
 			byte[] cookie = new byte[0];
 
 			while (cookie != null) {
 				List<SearchResult> searchResults = new ArrayList<>();
-
-				String groupMappingsGroupName = GetterUtil.getString(
-					groupMappings.getProperty("groupName"));
-
-				groupMappingsGroupName = StringUtil.toLowerCase(
-					groupMappingsGroupName);
 
 				cookie = _safePortalLDAP.getGroups(
 					ldapImportContext.getLdapServerId(),
@@ -1148,16 +1148,16 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 			Attribute userGroupAttribute = userAttributes.get(
 				userMappingsGroup);
 
+			String groupMappingsGroupName = GetterUtil.getString(
+				groupMappings.getProperty("groupName"));
+
+			groupMappingsGroupName = StringUtil.toLowerCase(
+				groupMappingsGroupName);
+
 			byte[] cookie = new byte[0];
 
 			while (cookie != null) {
 				List<SearchResult> searchResults = new ArrayList<>();
-
-				String groupMappingsGroupName = GetterUtil.getString(
-					groupMappings.getProperty("groupName"));
-
-				groupMappingsGroupName = StringUtil.toLowerCase(
-					groupMappingsGroupName);
 
 				cookie = _safePortalLDAP.getGroups(
 					ldapImportContext.getLdapServerId(),

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -1068,6 +1068,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 
 		String groupMappingsUser = groupMappings.getProperty("user");
 
+		Set<Long> ldapServerGroupIds = new LinkedHashSet<>();
 		Set<Long> newUserGroupIds = new LinkedHashSet<>();
 
 		if (Validator.isNotNull(groupMappingsUser) &&
@@ -1080,17 +1081,6 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 
 			String fullUserDN = userBinding.getNameInNamespace();
 
-			SafeLdapFilter safeLdapFilter = SafeLdapFilterConstraints.eq(
-				groupMappingsUser, fullUserDN);
-
-			SafeLdapFilter groupSearchSafeLdapFilter =
-				LDAPUtil.getGroupSearchSafeLdapFilter(
-					ldapServerConfiguration, _ldapFilterValidator);
-
-			if (groupSearchSafeLdapFilter != null) {
-				safeLdapFilter = safeLdapFilter.and(groupSearchSafeLdapFilter);
-			}
-
 			byte[] cookie = new byte[0];
 
 			while (cookie != null) {
@@ -1102,11 +1092,11 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 				groupMappingsGroupName = StringUtil.toLowerCase(
 					groupMappingsGroupName);
 
-				cookie = _safePortalLDAP.searchLDAP(
+				cookie = _safePortalLDAP.getGroups(
+					ldapImportContext.getLdapServerId(),
 					ldapImportContext.getCompanyId(),
 					ldapImportContext.getSafeLdapContext(), cookie, 0,
-					LDAPUtil.getBaseDNSafeLdapName(ldapServerConfiguration),
-					safeLdapFilter, new String[] {groupMappingsGroupName},
+					new String[] {groupMappingsGroupName, groupMappingsUser},
 					searchResults);
 
 				for (SearchResult searchResult : searchResults) {
@@ -1116,7 +1106,24 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 					UserGroup userGroup = importGroup(
 						ldapImportContext, userGroupSafeLdapName, user);
 
-					if (userGroup != null) {
+					if (userGroup == null) {
+						continue;
+					}
+
+					ldapServerGroupIds.add(userGroup.getUserGroupId());
+
+					Attributes groupAttributes = searchResult.getAttributes();
+
+					if (groupAttributes == null) {
+						continue;
+					}
+
+					Attribute userAttribute = groupAttributes.get(
+						groupMappingsUser);
+
+					if ((userAttribute != null) &&
+						userAttribute.contains(fullUserDN)) {
+
 						newUserGroupIds.add(userGroup.getUserGroupId());
 					}
 				}
@@ -1141,19 +1148,42 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 			Attribute userGroupAttribute = userAttributes.get(
 				userMappingsGroup);
 
-			if (userGroupAttribute == null) {
-				return;
-			}
+			byte[] cookie = new byte[0];
 
-			for (int i = 0; i < userGroupAttribute.size(); i++) {
-				SafeLdapName groupSafeLdapName = SafeLdapNameFactory.from(
-					userGroupAttribute, i);
+			while (cookie != null) {
+				List<SearchResult> searchResults = new ArrayList<>();
 
-				UserGroup userGroup = importGroup(
-					ldapImportContext, groupSafeLdapName, user);
+				String groupMappingsGroupName = GetterUtil.getString(
+					groupMappings.getProperty("groupName"));
 
-				if (userGroup != null) {
-					newUserGroupIds.add(userGroup.getUserGroupId());
+				groupMappingsGroupName = StringUtil.toLowerCase(
+					groupMappingsGroupName);
+
+				cookie = _safePortalLDAP.getGroups(
+					ldapImportContext.getLdapServerId(),
+					ldapImportContext.getCompanyId(),
+					ldapImportContext.getSafeLdapContext(), cookie, 0,
+					new String[] {groupMappingsGroupName}, searchResults);
+
+				for (SearchResult searchResult : searchResults) {
+					SafeLdapName userGroupSafeLdapName =
+						SafeLdapNameFactory.from(searchResult);
+
+					UserGroup userGroup = importGroup(
+						ldapImportContext, userGroupSafeLdapName, user);
+
+					if (userGroup == null) {
+						continue;
+					}
+
+					ldapServerGroupIds.add(userGroup.getUserGroupId());
+
+					if ((userGroupAttribute != null) &&
+						userGroupAttribute.contains(
+							searchResult.getNameInNamespace())) {
+
+						newUserGroupIds.add(userGroup.getUserGroupId());
+					}
 				}
 			}
 		}

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -735,7 +735,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 		return user;
 	}
 
-	protected void addUserGroupsNotAddedByLDAPImport(
+	protected void addUserGroupsNotBelongingToLDAPServer(
 			long userId, Set<Long> ldapServerGroupIds, Set<Long> userGroupIds)
 		throws Exception {
 
@@ -1188,7 +1188,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 			}
 		}
 
-		addUserGroupsNotAddedByLDAPImport(
+		addUserGroupsNotBelongingToLDAPServer(
 			user.getUserId(), ldapServerGroupIds, newUserGroupIds);
 
 		Set<Long> oldUserGroupIds = new LinkedHashSet<>();

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -736,14 +736,14 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 	}
 
 	protected void addUserGroupsNotAddedByLDAPImport(
-			long userId, Set<Long> userGroupIds)
+			long userId, Set<Long> ldapServerGroupIds, Set<Long> userGroupIds)
 		throws Exception {
 
 		List<UserGroup> userGroups = _userGroupLocalService.getUserUserGroups(
 			userId);
 
 		for (UserGroup userGroup : userGroups) {
-			if (!userGroup.isAddedByLDAPImport()) {
+			if (!ldapServerGroupIds.contains(userGroup.getUserGroupId())) {
 				userGroupIds.add(userGroup.getUserGroupId());
 			}
 		}
@@ -1188,7 +1188,8 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 			}
 		}
 
-		addUserGroupsNotAddedByLDAPImport(user.getUserId(), newUserGroupIds);
+		addUserGroupsNotAddedByLDAPImport(
+			user.getUserId(), ldapServerGroupIds, newUserGroupIds);
 
 		Set<Long> oldUserGroupIds = new LinkedHashSet<>();
 


### PR DESCRIPTION
Hi App Security Team,

This pull request is to implement the behavior discussed and agreed upon in [PTR-2708](https://issues.liferay.com/browse/PTR-2708). These changes modify the "importGroups" logic used during an "importUser" process such that we no longer remove the user from Groups that do not belong to the LDAP server.

I tested this fix pretty thoroughly in my local environment. I had an environment with the following two LDAP servers:
1. Server that contained one group "#test group 1", and one user "test.user.both"
2. Server that contained two groups "#test group 2" and "#temp group", and one user "test.user.both".
Within my LDAP envrionment, I assigned "test.user.both" to "#test group 1" and "#test group 2".

I then waited for everything to import into Liferay, and then performed the following testing steps:
1. Tried to authenticate as "test.user.both" with wrong password.
2. Verified that "test.user.both" was still assigned to "#test group 1" and "#test group 2" in Liferay.
3. In LDAP environment, added "test.user.both" to "#temp group".
4. Tried to authenticate as "test.user.both" with wrong password.
5. Verified that "test.user.both" was assigned to all three groups in Liferay.
6. In LDAP environment, removed "test.user.both" from "#temp group".
7. Tried to authenticate as "test.user.both" with wrong password.
8. Verified that "test.user.both" was assigned to only "#test group 1" and "#test group 2" in Liferay.
9. Modifed the configuration of the LDAP servers to remove the "user" attribute mapping from the Group attribute mappings (so as to test the logic inside [this else block](https://github.com/mbowerman/liferay-portal/blob/315d99695adaa87bd61b0fe6cc08ae8d28b2ccfd/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java#L1132-L1189)).
10. Tried to authenticate as "test.user.both" with wrong password.
11. Verified that "test.user.both" was still assigned to "#test group 1" and "#test group 2" in Liferay.
12. In LDAP environment, added "test.user.both" to "#temp group".
13. Tried to authenticate as "test.user.both" with wrong password.
14. Verified that "test.user.both" was assigned to all three groups in Liferay.
15. In LDAP environment, removed "test.user.both" from "#temp group".
16. Tried to authenticate as "test.user.both" with wrong password.
17. Verified that "test.user.both" was assigned to only "#test group 1" and "#test group 2" in Liferay.

Please don't hesitate to let me know if you have any questions about this fix.

https://issues.liferay.com/browse/LPS-142044