### PR TITLE
LPS-146238 Force flush on JSPWriter

### DIFF
--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/resources/META-INF/resources/mfa_verify/view.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/resources/META-INF/resources/mfa_verify/view.jsp
@@ -39,6 +39,10 @@ int mfaCheckerIndex = ParamUtil.getInteger(request, "mfaCheckerIndex");
 	<liferay-ui:error key="mfaVerificationFailed" message="multi-factor-authentication-has-failed" />
 
 	<%
+	const pageContent = pageContext.getOut();
+
+	pageContent.flush();
+
 	browserMFAChecker.includeBrowserVerification(request, response, mfaUserId);
 	%>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-146238

Using Wildfly, turning on Multi-Factor-Authentication and Email One-Time Password Configuration, the Submit button of the MFA is being created first and then the form. This causes the button to not register the submit click and the user is not able to log in.

A solution for this is to force a flush on the JSPWriter. This makes it so the form is created first with the buttons nested inside.

Let me know if there are questions or comments about this.
Thank you.