### PR TITLE
[TS] LPS-143564 Show Sign In button when the Login Portlet is not in maximized state

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -121,6 +121,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.portlet.PortletMode;
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletURL;
+import javax.portlet.WindowState;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -1541,8 +1542,11 @@ public class ServicePreAction extends Action {
 		themeDisplay.setShowPortalIcon(true);
 		themeDisplay.setShowSignInIcon(
 			!signedIn &&
-			!Objects.equals(
-				PropsValues.AUTH_LOGIN_PORTLET_NAME, themeDisplay.getPpid()));
+			!(Objects.equals(
+				PropsValues.AUTH_LOGIN_PORTLET_NAME, themeDisplay.getPpid()) &&
+			  Objects.equals(
+				  ParamUtil.getString(httpServletRequest, "p_p_state"),
+				  WindowState.MAXIMIZED.toString())));
 
 		boolean showSignOutIcon = signedIn;
 


### PR DESCRIPTION
Hi appsec team,

Could you review my changes regarding [LPS-143564](https://issues.liferay.com/browse/LPS-143564), please?

I found out that [LPS-113815](https://issues.liferay.com/browse/LPS-113815) causes a regression.
We do not show the Sign In button after the email address verification redirection. The redirection URL ```http://localhost:8080/web/guest/home?p_p_id=com_liferay_login_web_portlet_LoginPortlet&p_p_lifecycle=0``` contains the login portlet ppid but it is not rendered because the maximized state is missing (p_p_state=maximised).

I added this criterion to the Sign In button render check.