### PR TITLE
[TS] LPS-151394 Users are not unassigned from Liferay groups if the LDAP user group is empty

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -793,9 +793,13 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 			Attribute usersLdapAttribute)
 		throws Exception {
 
-		if (_log.isDebugEnabled()) {
-			int size = usersLdapAttribute.size();
+		int size = 0;
 
+		if (usersLdapAttribute != null) {
+			size = usersLdapAttribute.size();
+		}
+
+		if (_log.isDebugEnabled()) {
 			_log.debug(
 				StringBundler.concat(
 					"Importing ", size, " users from LDAP server ",
@@ -805,7 +809,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 
 		Set<Long> newUserIds = new LinkedHashSet<>();
 
-		for (int i = 0; i < usersLdapAttribute.size(); i++) {
+		for (int i = 0; i < size; i++) {
 			String fullUserDN = (String)usersLdapAttribute.get(i);
 
 			Long userId = ldapImportContext.getImportedUserId(fullUserDN);
@@ -1138,8 +1142,6 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 							_log.info(
 								"No users found in " + userGroup.getName());
 						}
-
-						continue;
 					}
 
 					importUsers(


### PR DESCRIPTION
Hello @liferay-appsec, 
this pull fixes [LPS-151394](https://issues.liferay.com/browse/LPS-151394).

The `continue;` has been removed so that empty LDAP groups can be processed, and users can be unassigned from the user group in Liferay as well.

We have doubts whether the following log messages should be modified in case LDAP groups are empty:
   "No users found in ..." 
   "Importing 0 users from LDAP server ..."

Please let me note if you have any questions.