### PR TITLE
[TS] LPS-123020 Not expired authorizations are removed every 1 hour

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2AuthorizationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2AuthorizationLocalServiceImpl.java
@@ -110,7 +110,7 @@ public class OAuth2AuthorizationLocalServiceImpl
 		Date purgeDate = new Date();
 
 		purgeDate.setTime(
-			purgeDate.getTime() +
+			purgeDate.getTime() -
 				_expiredAuthorizationsAfterlifeDurationMillis);
 
 		for (OAuth2Authorization oAuth2Authorization :


### PR DESCRIPTION
Hi @liferay-appsec!

We need to substract `_expiredAuthorizationsAfterlifeDurationMillis` (default 1 day) in order to remove only old tokens. Currently we are removing tokens not expired yet because `purgeDate` has a value in the future (+1 day by default). 

The SQL query called by `oAuth2AuthorizationFinder.findByPurgeDate()` in `OAuth2AuthorizationLocalServiceImpl#deleteExpiredOAuth2Authorizations()` method can be found [here](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/custom-sql/default.xml#L4-L20).

More info in [LPS-123020](https://issues.liferay.com/browse/LPS-123020). 
Original LPS Story: [LPS-105156](https://issues.liferay.com/browse/LPS-105156).

Let me know if you have any doubts.

Thanks!