### PR TITLE
LPS-145635 Cannot provision new SP users after upgrading to 7.4

### DIFF
--- a/modules/dxp/apps/saml/saml-persistence-service/bnd.bnd
+++ b/modules/dxp/apps/saml/saml-persistence-service/bnd.bnd
@@ -28,6 +28,6 @@ Import-Package:\
 	\
 	*
 Liferay-Releng-Module-Group-Title: SAML
-Liferay-Require-SchemaVersion: 3.0.0
+Liferay-Require-SchemaVersion: 3.0.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/SamlServiceUpgrade.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/SamlServiceUpgrade.java
@@ -23,6 +23,7 @@ import com.liferay.saml.persistence.internal.upgrade.v1_1_0.SamlSpAuthRequestUpg
 import com.liferay.saml.persistence.internal.upgrade.v1_1_0.SamlSpMessageUpgradeProcess;
 import com.liferay.saml.persistence.internal.upgrade.v2_1_0.SamlIdpSpConnectionUpgradeProcess;
 import com.liferay.saml.persistence.internal.upgrade.v2_4_0.util.SamlPeerBindingTable;
+import com.liferay.saml.persistence.internal.upgrade.v3_0_1.SamlSpIdpConnectionDataUpgradeProcess;
 
 import org.osgi.service.cm.ConfigurationAdmin;
 import org.osgi.service.component.annotations.Component;
@@ -136,6 +137,9 @@ public class SamlServiceUpgrade implements UpgradeStepRegistrator {
 				"SamlSpSession", "nameIdSPNameQualifier"),
 			UpgradeStepFactory.dropColumns("SamlSpSession", "nameIdValue"),
 			UpgradeStepFactory.dropColumns("SamlSpSession", "samlIdpEntityId"));
+
+		registry.register(
+			"3.0.0", "3.0.1", new SamlSpIdpConnectionDataUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_1/SamlSpIdpConnectionDataUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_1/SamlSpIdpConnectionDataUpgradeProcess.java
@@ -57,9 +57,7 @@ public class SamlSpIdpConnectionDataUpgradeProcess extends UpgradeProcess {
 
 				userAttributeMappingsProperties.forEach(
 					(key, value) -> {
-						if (Validator.isNull(value) &&
-							Validator.isNotNull(key)) {
-
+						if (Validator.isNull(value)) {
 							userAttributeMappingsProperties.replace(key, key);
 						}
 					});

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_1/SamlSpIdpConnectionDataUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_1/SamlSpIdpConnectionDataUpgradeProcess.java
@@ -17,6 +17,7 @@ package com.liferay.saml.persistence.internal.upgrade.v3_0_1;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringReader;
 import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderedProperties;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
@@ -37,17 +38,12 @@ public class SamlSpIdpConnectionDataUpgradeProcess extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		String selectUserAttributeMappingsSQL =
-			"select samlSpIdpConnectionId, userAttributeMappings from " +
-				"SamlSpIdpConnection";
-
 		try (Statement statement = connection.createStatement();
 			ResultSet resultSet = statement.executeQuery(
-				selectUserAttributeMappingsSQL)) {
+				"select samlSpIdpConnectionId, userAttributeMappings from " +
+					"SamlSpIdpConnection")) {
 
 			while (resultSet.next()) {
-				long samlSpIdpConnectionId = resultSet.getLong(
-					"samlSpIdpConnectionId");
 				String userAttributeMappings = resultSet.getString(
 					"userAttributeMappings");
 
@@ -77,7 +73,8 @@ public class SamlSpIdpConnectionDataUpgradeProcess extends UpgradeProcess {
 							"userAttributeMappings = '",
 							stringWriter.toString(),
 							"' where samlSpIdpConnectionId = ",
-							String.valueOf(samlSpIdpConnectionId)));
+							GetterUtil.getString(
+								resultSet.getLong("samlSpIdpConnectionId"))));
 				}
 			}
 		}

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_1/SamlSpIdpConnectionDataUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_1/SamlSpIdpConnectionDataUpgradeProcess.java
@@ -15,18 +15,15 @@
 package com.liferay.saml.persistence.internal.upgrade.v3_0_1;
 
 import com.liferay.portal.kernel.io.unsync.UnsyncStringReader;
-import com.liferay.portal.kernel.upgrade.UpgradeException;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderedProperties;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
 
-import java.io.IOException;
 import java.io.StringWriter;
 
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.sql.Statement;
 
 import java.util.Properties;
@@ -75,9 +72,6 @@ public class SamlSpIdpConnectionDataUpgradeProcess extends UpgradeProcess {
 								resultSet.getLong("samlSpIdpConnectionId"))));
 				}
 			}
-		}
-		catch (IOException | SQLException exception) {
-			throw new UpgradeException(exception);
 		}
 	}
 

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_1/SamlSpIdpConnectionDataUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_1/SamlSpIdpConnectionDataUpgradeProcess.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.saml.persistence.internal.upgrade.v3_0_1;
+
+import com.liferay.portal.kernel.io.unsync.UnsyncStringReader;
+import com.liferay.portal.kernel.upgrade.UpgradeException;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.OrderedProperties;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import java.util.Properties;
+
+/**
+ * @author Olivér Kecskeméty
+ */
+public class SamlSpIdpConnectionDataUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		String selectUserAttributeMappingsSQL =
+			"select samlSpIdpConnectionId, userAttributeMappings from " +
+				"SamlSpIdpConnection";
+
+		try (Statement statement = connection.createStatement();
+			ResultSet resultSet = statement.executeQuery(
+				selectUserAttributeMappingsSQL)) {
+
+			while (resultSet.next()) {
+				long samlSpIdpConnectionId = resultSet.getLong(
+					"samlSpIdpConnectionId");
+				String userAttributeMappings = resultSet.getString(
+					"userAttributeMappings");
+
+				Properties userAttributeMappingsProperties =
+					new OrderedProperties();
+
+				if (Validator.isNotNull(userAttributeMappings)) {
+					userAttributeMappingsProperties.load(
+						new UnsyncStringReader(userAttributeMappings));
+				}
+
+				userAttributeMappingsProperties.forEach(
+					(key, value) -> {
+						if (Validator.isNull(value) &&
+							Validator.isNotNull(key)) {
+
+							userAttributeMappingsProperties.replace(key, key);
+						}
+					});
+
+				try (StringWriter stringWriter = new StringWriter()) {
+					userAttributeMappingsProperties.store(stringWriter, null);
+
+					runSQL(
+						StringBundler.concat(
+							"update SamlSpIdpConnection set ",
+							"userAttributeMappings = '",
+							stringWriter.toString(),
+							"' where samlSpIdpConnectionId = ",
+							String.valueOf(samlSpIdpConnectionId)));
+				}
+			}
+		}
+		catch (IOException | SQLException exception) {
+			throw new UpgradeException(exception);
+		}
+	}
+
+}

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_1/SamlSpIdpConnectionDataUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v3_0_1/SamlSpIdpConnectionDataUpgradeProcess.java
@@ -44,13 +44,15 @@ public class SamlSpIdpConnectionDataUpgradeProcess extends UpgradeProcess {
 				String userAttributeMappings = resultSet.getString(
 					"userAttributeMappings");
 
+				if (Validator.isNull(userAttributeMappings)) {
+					continue;
+				}
+
 				Properties userAttributeMappingsProperties =
 					new OrderedProperties();
 
-				if (Validator.isNotNull(userAttributeMappings)) {
-					userAttributeMappingsProperties.load(
-						new UnsyncStringReader(userAttributeMappings));
-				}
+				userAttributeMappingsProperties.load(
+					new UnsyncStringReader(userAttributeMappings));
 
 				userAttributeMappingsProperties.forEach(
 					(key, value) -> {

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/model/impl/SamlSpIdpConnectionImpl.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/model/impl/SamlSpIdpConnectionImpl.java
@@ -48,7 +48,9 @@ public class SamlSpIdpConnectionImpl extends SamlSpIdpConnectionBaseImpl {
 	}
 
 	private String _removeDefaultPrefix(String userFieldExpression) {
-		if (userFieldExpression.charAt(0) == CharPool.COLON) {
+		if (Validator.isNotNull(userFieldExpression) &&
+			(userFieldExpression.charAt(0) == CharPool.COLON)) {
+
 			return userFieldExpression.substring(1);
 		}
 


### PR DESCRIPTION
As discussed I think we should also include the simple `isNotNull` runtime to avoid the NPE issue when the mappings are broken.

To recap; The main purpose of the upgrade process as fixing the data so that on the SAML IDP connection screen it will show the User Field Expression that is being mapped instead of a blank selection.