### PR TITLE
LPS-123020 Test for solution already in master

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2AuthorizationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2AuthorizationLocalServiceImpl.java
@@ -35,6 +35,7 @@ import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -261,6 +262,7 @@ public class OAuth2AuthorizationLocalServiceImpl
 	}
 
 	@Activate
+	@Modified
 	protected void activate(Map<String, Object> properties) {
 		OAuth2ProviderConfiguration oAuth2ProviderConfiguration =
 			ConfigurableUtil.createConfigurable(
@@ -274,7 +276,7 @@ public class OAuth2AuthorizationLocalServiceImpl
 			expiredAuthorizationsAfterlifeDuration * Time.SECOND;
 	}
 
-	private long _expiredAuthorizationsAfterlifeDurationMillis;
+	private volatile long _expiredAuthorizationsAfterlifeDurationMillis;
 
 	@Reference
 	private OAuth2ScopeGrantPersistence _oAuth2ScopeGrantPersistence;

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
@@ -17,11 +17,14 @@ package com.liferay.oauth2.provider.client.test;
 import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.scope.spi.prefix.handler.PrefixHandler;
 import com.liferay.oauth2.provider.scope.spi.prefix.handler.PrefixHandlerFactory;
 import com.liferay.oauth2.provider.scope.spi.scope.finder.ScopeFinder;
 import com.liferay.oauth2.provider.scope.spi.scope.mapper.ScopeMapper;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -45,6 +48,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.List;
@@ -111,6 +115,57 @@ public abstract class BaseTestPreparatorBundleActivator
 			() -> UserLocalServiceUtil.deleteUser(user.getUserId()));
 
 		return user;
+	}
+
+	protected OAuth2Authorization addOAuth2Authorization(
+		long companyId, User user, OAuth2Application oAuth2Application,
+		String accessTokenContent, Date accessTokenCreateDate,
+		Date accessTokenExpirationDate) {
+
+		return addOAuth2Authorization(
+			companyId, user, oAuth2Application, accessTokenContent,
+			accessTokenCreateDate, accessTokenExpirationDate, null, null, null);
+	}
+
+	protected OAuth2Authorization addOAuth2Authorization(
+		long companyId, User user, OAuth2Application oAuth2Application,
+		String accessTokenContent, Date accessTokenCreateDate,
+		Date accessTokenExpirationDate, String refreshTokenContent,
+		Date refreshTokenCreateDate, Date refreshTokenExpirationDate) {
+
+		ServiceReference<OAuth2AuthorizationLocalService> serviceReference =
+			bundleContext.getServiceReference(
+				OAuth2AuthorizationLocalService.class);
+
+		OAuth2AuthorizationLocalService oAuth2AuthorizationLocalService =
+			bundleContext.getService(serviceReference);
+
+		autoCloseables.add(() -> bundleContext.ungetService(serviceReference));
+
+		OAuth2Authorization oAuth2Authorization =
+			oAuth2AuthorizationLocalService.addOAuth2Authorization(
+				companyId, user.getUserId(), user.getFullName(),
+				oAuth2Application.getOAuth2ApplicationId(),
+				oAuth2Application.getOAuth2ApplicationScopeAliasesId(),
+				accessTokenContent, accessTokenCreateDate,
+				accessTokenExpirationDate, "localhost", "127.0.0.1",
+				refreshTokenContent, refreshTokenCreateDate,
+				refreshTokenExpirationDate);
+
+		autoCloseables.add(
+			() -> {
+				OAuth2Authorization fetchedAuth2Authorization =
+					OAuth2AuthorizationLocalServiceUtil.
+						fetchOAuth2Authorization(
+							oAuth2Authorization.getOAuth2AuthorizationId());
+
+				if (fetchedAuth2Authorization != null) {
+					OAuth2AuthorizationLocalServiceUtil.
+						deleteOAuth2Authorization(fetchedAuth2Authorization);
+				}
+			});
+
+		return oAuth2Authorization;
 	}
 
 	protected User addUser(Company company) throws Exception {

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ExpiredAuthorizationsAfterlifeTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ExpiredAuthorizationsAfterlifeTest.java
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.client.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.model.OAuth2Authorization;
+import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.BundleActivator;
+
+/**
+ * @author Jose L. Bango
+ */
+@RunWith(Arquillian.class)
+public class ExpiredAuthorizationsAfterlifeTest extends BaseClientTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void test() throws Exception {
+		_oAuth2AuthorizationLocalService.deleteExpiredOAuth2Authorizations();
+
+		OAuth2Authorization oAuth2Authorization1 =
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent("accessToken1");
+
+		Assert.assertNull(oAuth2Authorization1);
+
+		OAuth2Authorization oAuth2Authorization2 =
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent("accessToken2");
+
+		Assert.assertNotNull(oAuth2Authorization2);
+
+		OAuth2Authorization oAuth2Authorization3 =
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent("accessToken3");
+
+		Assert.assertNotNull(oAuth2Authorization3);
+	}
+
+	public static class
+		ExpiredAuthorizationsAfterlifeTestPreparatorBundleActivator
+			extends BaseTestPreparatorBundleActivator {
+
+		@Override
+		protected void prepareTest() throws Exception {
+			updateOAuth2ProviderConfiguration(
+				MapUtil.singletonDictionary(
+					"oauth2.expired.authorizations.afterlife.duration", 43200));
+
+			long defaultCompanyId = PortalUtil.getDefaultCompanyId();
+
+			User user = UserTestUtil.getAdminUser(defaultCompanyId);
+
+			OAuth2Application oAuth2Application = createOAuth2Application(
+				defaultCompanyId, user, "oauthTestApplication",
+				Arrays.asList("everything.read"));
+
+			Map<String, Date> accessTokenMap = HashMapBuilder.<String, Date>put(
+				"accessToken1",
+				new Date(System.currentTimeMillis() - (Time.HOUR * 15))
+			).put(
+				"accessToken2",
+				new Date(System.currentTimeMillis() - (Time.HOUR * 10))
+			).put(
+				"accessToken3",
+				new Date(System.currentTimeMillis() + (Time.HOUR * 1))
+			).build();
+
+			accessTokenMap.forEach(
+				(accessTokenContent, accessTokenExpirationDate) ->
+					addOAuth2Authorization(
+						defaultCompanyId, user, oAuth2Application,
+						accessTokenContent, new Date(),
+						accessTokenExpirationDate));
+		}
+
+	}
+
+	@Override
+	protected BundleActivator getBundleActivator() {
+		return new ExpiredAuthorizationsAfterlifeTestPreparatorBundleActivator();
+	}
+
+	@Inject
+	private OAuth2AuthorizationLocalService _oAuth2AuthorizationLocalService;
+
+}


### PR DESCRIPTION
Fix pr: #637

---

Hi @liferay-appsec ,

This is an addendum to the solution for [LPS-123020](https://issues.liferay.com/browse/LPS-123020) (already in master) with a test requested in https://github.com/brianchandotcom/liferay-portal/pull/116636#issuecomment-1110751507

The test makes sure that the only deleted authorizations are those whose expiration dates are older than the current afterlife duration value.

In addition, an extra commit needed to be added in order to allow `oauth2.expired.authorizations.afterlife.duration `configuration update to take effect (cc @marianoalvarosaiz).

Please let me know if you have any questions.

Thanks!