### PR TITLE
LPS-158385 the role is added to the user when the issuer is the same that is defined in property

### DIFF
--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectUserInfoProcessorImpl.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectUserInfoProcessorImpl.java
@@ -140,7 +140,7 @@ public class OpenIdConnectUserInfoProcessorImpl
 
 	private long[] _getRoleIds(long companyId, String issuer) {
 		if (Validator.isNull(issuer) ||
-			Objects.equals(
+			!Objects.equals(
 				issuer,
 				_props.get(
 					"open.id.connect.user.info.processor.impl.issuer"))) {


### PR DESCRIPTION

[LPS-158385](https://issues.liferay.com/browse/LPS-158385)

### Changes
In the _getRoleIds method (OpenIdConnectUserInfoProcessorImpl) the condition is modified, so that if the issuer is not equal to the one defined in the properties, the role is not assigned to the user.

### Manual test
The steps indicated in the ticket have been followed (and the opposite case to validate the code).