### PR TITLE
[TS] LPS-158622

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.auth.registry.AuthVerifierRegistry;
 
 import java.util.ArrayList;
@@ -96,7 +97,12 @@ public class AuthVerifierPipeline {
 		HttpServletRequest httpServletRequest =
 			accessControlContext.getRequest();
 
+		String pathProxy = PortalUtil.getPathProxy();
 		String requestURI = httpServletRequest.getRequestURI();
+
+		if (Validator.isNotNull(pathProxy)) {
+			requestURI = pathProxy + requestURI;
+		}
 
 		AuthVerifierConfigurationConsumer authVerifierConfigurationConsumer =
 			new AuthVerifierConfigurationConsumer(

--- a/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
@@ -131,7 +131,8 @@ public class AuthVerifierFilter extends BasePortalFilter {
 				AuthVerifierPipeline.class.getName(),
 				new AuthVerifierPipeline(
 					_buildAuthVerifierConfigurations(_initParametersMap),
-					servletContext.getContextPath()));
+					PortalUtil.getPathContext(
+						servletContext.getContextPath())));
 		}
 	}
 

--- a/portal-impl/test/unit/com/liferay/portal/security/auth/AuthVerifierPipelineTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/security/auth/AuthVerifierPipelineTest.java
@@ -82,8 +82,8 @@ public class AuthVerifierPipelineTest {
 		String includeURLs = StringBundler.concat(
 			_BASE_URL, "/regular/*,", _BASE_URL, "/legacy*");
 
-		String legacyRequestURI = _BASE_URL + "/legacy/Hello";
-		String regularRequestURI = _BASE_URL + "/regular/Hello";
+		String legacyRequestURI = contextPath + _BASE_URL + "/legacy/Hello";
+		String regularRequestURI = contextPath + _BASE_URL + "/regular/Hello";
 
 		AuthVerifierResult.State expectedState =
 			AuthVerifierResult.State.SUCCESS;
@@ -102,7 +102,7 @@ public class AuthVerifierPipelineTest {
 		String includeURLs = StringBundler.concat(
 			_BASE_URL, "/regular/*,", _BASE_URL, "/legacy*");
 
-		String requestURI = _BASE_URL + "/non/matching";
+		String requestURI = contextPath + _BASE_URL + "/non/matching";
 
 		AuthVerifierResult.State expectedState =
 			AuthVerifierResult.State.UNSUCCESSFUL;

--- a/portal-impl/test/unit/com/liferay/portal/security/auth/AuthVerifierPipelineTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/security/auth/AuthVerifierPipelineTest.java
@@ -15,6 +15,7 @@
 package com.liferay.portal.security.auth;
 
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
@@ -25,6 +26,7 @@ import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierConfiguratio
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierResult;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
@@ -92,6 +94,69 @@ public class AuthVerifierPipelineTest {
 			contextPath, includeURLs, legacyRequestURI, expectedState);
 		_assertVerifyRequest(
 			contextPath, includeURLs, regularRequestURI, expectedState);
+	}
+
+	@Test
+	public void testVerifyRequestWithContextPath() throws PortalException {
+		String contextPath = "/abc";
+		String includeURLs = StringBundler.concat(
+			_BASE_URL, "/regular/*,", _BASE_URL, "/legacy*");
+
+		String requestURI = contextPath + _BASE_URL + "/regular/Hello";
+
+		AuthVerifierResult.State expectedState =
+			AuthVerifierResult.State.SUCCESS;
+
+		_assertVerifyRequest(
+			contextPath, includeURLs, requestURI, expectedState);
+	}
+
+	@Test
+	public void testVerifyRequestWithContextPathAndPortalPathContext()
+		throws PortalException {
+
+		String contextPath = "/abc";
+		String includeURLs = StringBundler.concat(
+			_BASE_URL, "/regular/*,", _BASE_URL, "/legacy*");
+
+		String requestURI = contextPath + _BASE_URL + "/regular/Hello";
+
+		AuthVerifierResult.State expectedState =
+			AuthVerifierResult.State.SUCCESS;
+
+		String portalUtilPathContext = PortalUtil.getPathContext(contextPath);
+
+		_assertVerifyRequest(
+			portalUtilPathContext, includeURLs, requestURI, expectedState);
+	}
+
+	@Test
+	public void testVerifyRequestWithContextPathAndPortalPathContextAndPortalProxyPath()
+		throws PortalException {
+
+		String contextPath = "/abc";
+		String includeURLs = StringBundler.concat(
+			_BASE_URL, "/regular/*,", _BASE_URL, "/legacy*");
+
+		String requestURI = contextPath + _BASE_URL + "/regular/Hello";
+
+		AuthVerifierResult.State expectedState =
+			AuthVerifierResult.State.SUCCESS;
+
+		String proxyPath = "/proxy";
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"PORTAL_PROXY_PATH", proxyPath)) {
+
+			_setUpPortalUtil();
+
+			String portalUtilPathContext = PortalUtil.getPathContext(
+				contextPath);
+
+			_assertVerifyRequest(
+				portalUtilPathContext, includeURLs, requestURI, expectedState);
+		}
 	}
 
 	@Test


### PR DESCRIPTION
Hi Team,

Can you help review this PR?

https://issues.liferay.com/browse/LPS-158622

**PR Commits**
- The majority of the commits are to refactor the unit test
- The test case to illustrate this issue: 
  - **AuthVerifierPipelineTest#testVerifyRequestWithContextPathAndPortalPathContextAndPortalProxyPath**
- The fix is the last commit: 
  - [LPS-158622 Account for portal proxy path when providing a context path for AuthVerifierPipeline](https://github.com/liferay-appsec/liferay-portal/commit/cbdfcb3f2ea32dffffb1c7069fc08edf03748365)

**Issue**
The current usage / implementation of AuthVerifierPipeline does not account for the Portal Proxy Path property when preparing the AuthVerifierPipeline and when verifying a request.

**The proposed fix:**
- Will now expect the provided **_contextPath** to account for Portal Proxy Path
- Will now account for portal proxy path when verifying a request

I figured this would be the more consistent approach, since many places in Liferay code already account for the proxy path when referring to the context path.

Please let me know if you have any questions.
Thanks!