### PR TITLE
LPS-158385 the role is added to the user when the issuer is the same that is defined in property

### DIFF
--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectUserInfoProcessorImpl.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectUserInfoProcessorImpl.java
@@ -140,7 +140,7 @@ public class OpenIdConnectUserInfoProcessorImpl
 
 	private long[] _getRoleIds(long companyId, String issuer) {
 		if (Validator.isNull(issuer) ||
-			Objects.equals(
+			!Objects.equals(
 				issuer,
 				_props.get(
 					"open.id.connect.user.info.processor.impl.issuer"))) {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/openidconnect/OpenIDConnect.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/openidconnect/OpenIDConnect.testcase
@@ -15,7 +15,7 @@ definition {
 	@description = "This is a use case for LPS-139642 TC-10: A regular role is assigned to OIDC user if a regular role is defined through the property."
 	@priority = "5"
 	test AssertRegularRoleIsAssignedToOIDCUser {
-		property custom.properties = "open.id.connect.user.info.processor.impl.issuer=https://dev-5081331.okta.com/${line.separator}open.id.connect.user.info.processor.impl.regular.role=Administrator";
+		property custom.properties = "open.id.connect.user.info.processor.impl.issuer=https://dev-5081331.okta.com${line.separator}open.id.connect.user.info.processor.impl.regular.role=Administrator";
 		property osgi.module.configuration.file.names = "com.liferay.portal.security.sso.openid.connect.configuration.OpenIdConnectConfiguration.config";
 		property osgi.module.configurations = "enabled=&quot;true&quot;${line.separator}tokenRefreshOffset=&quot;120&quot;";
 		property portal.acceptance = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/openidconnect/OpenIDConnect.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/openidconnect/OpenIDConnect.testcase
@@ -256,6 +256,44 @@ definition {
 		}
 	}
 
+	@description = "This is a use case for LPS-154744. TC4-1: The OIDC user is assigned the regular role which contains multiple spaces given through the property."
+	@priority = "4"
+	test MultipleSpacesRoleNameCanBeAssignedToOIDCUser {
+		property custom.properties = "open.id.connect.user.info.processor.impl.issuer=https://dev-5081331.okta.com${line.separator}open.id.connect.user.info.processor.impl.regular.role=My Custom Regular Role";
+		property osgi.module.configuration.file.names = "com.liferay.portal.security.sso.openid.connect.configuration.OpenIdConnectConfiguration.config";
+		property osgi.module.configurations = "enabled=&quot;true&quot;${line.separator}tokenRefreshOffset=&quot;120&quot;";
+		property test.name.skip.portal.instance = "OpenIDConnect#MultipleSpacesRoleNameCanBeAssignedToOIDCUser";
+
+		var userEmailAddress = PropsUtil.get("openid.provider.okta.test.account.email.address");
+		var userPassword = PropsUtil.get("openid.provider.okta.test.account.password");
+
+		task ("Given: Set up OKTA OIDC Provider") {
+			OSGiConfig.copyOSGiConfigFile(
+				osgiConfigFileBaseDir = "test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/openidconnect/dependencies",
+				osgiConfigFileName = "com.liferay.portal.security.sso.openid.connect.internal.configuration.OpenIdConnectProviderConfiguration~Okta.config");
+		}
+
+		task ("And: Add a regular role which contains multiple spaces") {
+			JSONRole.addRegularRole(
+				roleKey = "My Custom Regular Role",
+				roleTitle = "My Custom Regular Role");
+		}
+
+		task ("When: Login with OpenID Connect") {
+			User.logoutPG();
+
+			User.loginUserWithOpenIDConnectEnabledPG(
+				userEmailAddress = "${userEmailAddress}",
+				userPassword = "${userPassword}");
+		}
+
+		task ("Then: Multiple spaces role name can be assigned to OKTA user") {
+			MyAccount.openMyAccountAdmin();
+
+			User.viewUserInfomationRolesCP(roleTitle = "My Custom Regular Role");
+		}
+	}
+
 	@description = "This is a use case for LPS-105151. Users could login with instance-level configured OpenID Connect provider."
 	@priority = "4"
 	test OpenIDConnectOnInstanceLevelSmoke {


### PR DESCRIPTION
Comments from @alvarosaugarlr:
[LPS-158385](https://issues.liferay.com/browse/LPS-158385)

### Changes
In the _getRoleIds method (OpenIdConnectUserInfoProcessorImpl) the condition is modified, so that if the issuer is not equal to the one defined in the properties, the role is not assigned to the user.

### Manual test
The steps indicated in the ticket have been followed (and the opposite case to validate the code). 