### PR TITLE
LPS-155687 - add the context to URL when configuring multiple IdPs in non-root context

### DIFF
--- a/portal-web/docroot/html/portal/saml/select_idp.jsp
+++ b/portal-web/docroot/html/portal/saml/select_idp.jsp
@@ -24,7 +24,7 @@ JSONObject samlSsoLoginContext = (JSONObject)request.getAttribute("SAML_SSO_LOGI
 JSONArray relevantIdpConnectionsJSONArray = samlSsoLoginContext.getJSONArray("relevantIdpConnections");
 %>
 
-<aui:form action='<%= PortalUtil.getPortalURL(request) + "/c/portal/login" %>' method="get" name="fm" style="padding: 1rem;">
+<aui:form action='<%= PortalUtil.getPortalURL(request) + PortalUtil.getPathMain() + "/portal/login" %>' method="get" name="fm" style="padding: 1rem;">
 	<aui:input name="saveLastPath" type="hidden" value="<%= false %>" />
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 


### PR DESCRIPTION
[LPS-155687](https://issues.liferay.com/browse/LPS-155687)

When the context is not root and several IdPs are defined in SAML for the SSO, when choosing, the context was not considered (see the ticket for more details).

### Solution
In the form where the submission is made (`select_idp.jsp`), the context has been added (using the `PortalUtil.getPathMain() `method) to generate the url correctly.


### Manual Tests
Tests have been performed with two situations:
* Modifying the context, as indicated in the ticket definition.
* Without modifying the context leaving it as ROOt, to verify that this case was not affected.

In both cases we have tested with several IdPs (as indicated in the ticket) and with a single IdP.

