### PR TITLE
LPS-159552 Add the context On-Demand Admin feature

### DIFF
--- a/modules/apps/on-demand-admin/on-demand-admin-impl/src/main/java/com/liferay/on/demand/admin/internal/manager/OnDemandAdminManagerImpl.java
+++ b/modules/apps/on-demand-admin/on-demand-admin-impl/src/main/java/com/liferay/on/demand/admin/internal/manager/OnDemandAdminManagerImpl.java
@@ -78,7 +78,7 @@ public class OnDemandAdminManagerImpl implements OnDemandAdminManager {
 			Company company, PortletRequest portletRequest, long userId)
 		throws PortalException {
 
-		StringBundler sb = new StringBundler(3);
+		StringBundler sb = new StringBundler(4);
 
 		boolean secure = _portal.isSecure(
 			_portal.getHttpServletRequest(portletRequest));
@@ -87,6 +87,8 @@ public class OnDemandAdminManagerImpl implements OnDemandAdminManager {
 			_portal.getPortalURL(
 				company.getVirtualHostname(),
 				_portal.getPortalServerPort(secure), secure));
+
+		sb.append(_portal.getPathContext());
 
 		sb.append("?ticketKey=");
 


### PR DESCRIPTION
[LPS-159552](https://issues.liferay.com/browse/LPS-159552)

When the context is not root and access to a virtual instance is requested (On-Demand Admin feature) the context was not taken into account (for more details see the ticket).

### Solution
When generating the url to make the request (in the getLoginURL method of the OnDemandAdminManagerImpl.java class) the context has been added to generate the url correctly.

### Manual Test
Tests have been performed with two situations:
* Modifying the context, as indicated in the ticket definition.
* Without modifying the context leaving it as ROOT, to verify that this case was not affected.