### PR TITLE
LPS-159598 Returning 401 when credentials are invalid

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/security/auth/verifier/OAuth2RESTAuthVerifier.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/security/auth/verifier/OAuth2RESTAuthVerifier.java
@@ -78,6 +78,9 @@ public class OAuth2RESTAuthVerifier implements AuthVerifier {
 				accessControlContext);
 
 			if (accessToken == null) {
+				authVerifierResult.setState(
+					AuthVerifierResult.State.INVALID_CREDENTIALS);
+
 				return authVerifierResult;
 			}
 

--- a/portal-impl/src/com/liferay/portal/security/access/control/AccessControlImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/access/control/AccessControlImpl.java
@@ -108,8 +108,10 @@ public class AccessControlImpl implements AccessControl {
 			authVerifierResult = authVerifierPipeline.verifyRequest(
 				accessControlContext);
 
-			if (authVerifierResult.getState() !=
-					AuthVerifierResult.State.SUCCESS) {
+			if ((authVerifierResult.getState() !=
+					AuthVerifierResult.State.SUCCESS) &&
+				(authVerifierResult.getState() !=
+					AuthVerifierResult.State.INVALID_CREDENTIALS)) {
 
 				AuthVerifierPipeline portalAuthVerifierPipeline =
 					AuthVerifierPipeline.getPortalAuthVerifierPipeline();

--- a/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
@@ -176,6 +176,9 @@ public class AuthVerifierFilter extends BasePortalFilter {
 			if (_log.isDebugEnabled()) {
 				_log.debug("Result state does not allow us to continue");
 			}
+
+			httpServletResponse.sendError(
+				HttpServletResponse.SC_UNAUTHORIZED, "Invalid credentials");
 		}
 		else if (state == AuthVerifierResult.State.NOT_APPLICABLE) {
 			_log.error("Invalid state " + state);


### PR DESCRIPTION
Hi!

We're working on [LPS-159598](https://issues.liferay.com/browse/LPS-159598). When users make API requests with an expired token the response is a 200 which is not ideal because they can't trigger the login process again. The [linked PTR](https://issues.liferay.com/browse/PTR-3246) contains more specific details on how to reproduce the issue.

This PR does the bare minimum to return a 401 error when an auth token is not valid. I fear this can break many other things that's why I want you guys to have a look and let me know what you think.

Thanks!