### PR TITLE
LPS-159598 Return 401 for invalid OAuth 2 access tokens

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/security/auth/verifier/OAuth2JSONWSAuthVerifier.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/security/auth/verifier/OAuth2JSONWSAuthVerifier.java
@@ -56,6 +56,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Component;
@@ -85,14 +86,35 @@ public class OAuth2JSONWSAuthVerifier implements AuthVerifier {
 
 		AuthVerifierResult authVerifierResult = new AuthVerifierResult();
 
-		OAuth2Authorization oAuth2Authorization = _getOAuth2Authorization(
+		String accessTokenContent = _getAccessTokenContent(
 			accessControlContext);
+
+		if (Validator.isBlank(accessTokenContent)) {
+			authVerifierResult.setState(
+				AuthVerifierResult.State.NOT_APPLICABLE);
+
+			return authVerifierResult;
+		}
+
+		OAuth2Authorization oAuth2Authorization =
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent(
+					accessTokenContent);
 
 		try {
 			BearerTokenProvider.AccessToken accessToken = _getAccessToken(
 				oAuth2Authorization);
 
 			if (accessToken == null) {
+				HttpServletResponse httpServletResponse =
+					accessControlContext.getResponse();
+
+				httpServletResponse.setStatus(
+					HttpServletResponse.SC_UNAUTHORIZED);
+
+				authVerifierResult.setState(
+					AuthVerifierResult.State.INVALID_CREDENTIALS);
+
 				return authVerifierResult;
 			}
 
@@ -233,7 +255,7 @@ public class OAuth2JSONWSAuthVerifier implements AuthVerifier {
 			oAuth2Authorization.getUserName());
 	}
 
-	private OAuth2Authorization _getOAuth2Authorization(
+	private String _getAccessTokenContent(
 		AccessControlContext accessControlContext) {
 
 		HttpServletRequest httpServletRequest =
@@ -254,14 +276,7 @@ public class OAuth2JSONWSAuthVerifier implements AuthVerifier {
 			return null;
 		}
 
-		String token = authorizationParts[1];
-
-		if (Validator.isBlank(token)) {
-			return null;
-		}
-
-		return _oAuth2AuthorizationLocalService.
-			fetchOAuth2AuthorizationByAccessTokenContent(token);
+		return authorizationParts[1];
 	}
 
 	private static final String _TOKEN_KEY = "Bearer";

--- a/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/security/auth/verifier/OAuth2JSONWSAuthVerifier.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-jsonws/src/main/java/com/liferay/oauth2/provider/jsonws/internal/security/auth/verifier/OAuth2JSONWSAuthVerifier.java
@@ -89,7 +89,7 @@ public class OAuth2JSONWSAuthVerifier implements AuthVerifier {
 		String accessTokenContent = _getAccessTokenContent(
 			accessControlContext);
 
-		if (Validator.isBlank(accessTokenContent)) {
+		if (accessTokenContent == null) {
 			authVerifierResult.setState(
 				AuthVerifierResult.State.NOT_APPLICABLE);
 
@@ -274,6 +274,10 @@ public class OAuth2JSONWSAuthVerifier implements AuthVerifier {
 
 		if (!StringUtil.equalsIgnoreCase(scheme, _TOKEN_KEY)) {
 			return null;
+		}
+
+		if (authorizationParts.length < 2) {
+			return StringPool.BLANK;
 		}
 
 		return authorizationParts[1];

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/security/auth/verifier/OAuth2RESTAuthVerifier.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/security/auth/verifier/OAuth2RESTAuthVerifier.java
@@ -89,6 +89,12 @@ public class OAuth2RESTAuthVerifier implements AuthVerifier {
 				accessTokenContent);
 
 			if (accessToken == null) {
+				HttpServletResponse httpServletResponse =
+					accessControlContext.getResponse();
+
+				httpServletResponse.setStatus(
+					HttpServletResponse.SC_UNAUTHORIZED);
+
 				authVerifierResult.setState(
 					AuthVerifierResult.State.INVALID_CREDENTIALS);
 

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/security/auth/verifier/OAuth2RESTAuthVerifier.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/security/auth/verifier/OAuth2RESTAuthVerifier.java
@@ -78,7 +78,7 @@ public class OAuth2RESTAuthVerifier implements AuthVerifier {
 			String accessTokenContent = _getAccessTokenContent(
 				accessControlContext);
 
-			if (Validator.isBlank(accessTokenContent)) {
+			if (accessTokenContent == null) {
 				authVerifierResult.setState(
 					AuthVerifierResult.State.NOT_APPLICABLE);
 
@@ -139,6 +139,10 @@ public class OAuth2RESTAuthVerifier implements AuthVerifier {
 	private BearerTokenProvider.AccessToken _getAccessToken(
 			String accessTokenContent)
 		throws PortalException {
+
+		if (Validator.isBlank(accessTokenContent)) {
+			return null;
+		}
 
 		OAuth2Authorization oAuth2Authorization =
 			_oAuth2AuthorizationLocalService.
@@ -207,6 +211,10 @@ public class OAuth2RESTAuthVerifier implements AuthVerifier {
 
 		if (!StringUtil.equalsIgnoreCase(scheme, _TOKEN_KEY)) {
 			return null;
+		}
+
+		if (authorizationParts.length < 2) {
+			return StringPool.BLANK;
 		}
 
 		return authorizationParts[1];

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/security/auth/verifier/OAuth2RESTAuthVerifier.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/security/auth/verifier/OAuth2RESTAuthVerifier.java
@@ -78,6 +78,9 @@ public class OAuth2RESTAuthVerifier implements AuthVerifier {
 				accessControlContext);
 
 			if (accessToken == null) {
+				authVerifierResult.setState(
+					AuthVerifierResult.State.INVALID_CREDENTIALS);
+
 				return authVerifierResult;
 			}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/CORSApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/CORSApplicationClientTest.java
@@ -111,9 +111,9 @@ public class CORSApplicationClientTest extends BaseClientTestCase {
 		String corsHeaderString = response.getHeaderString(
 			"Access-Control-Allow-Origin");
 
-		Assert.assertEquals(_TEST_CORS_URI, corsHeaderString);
+		Assert.assertEquals(null, corsHeaderString);
 
-		Assert.assertEquals(403, response.getStatus());
+		Assert.assertEquals(401, response.getStatus());
 	}
 
 	@Test

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/RefreshTokenTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/RefreshTokenTest.java
@@ -101,7 +101,7 @@ public class RefreshTokenTest extends BaseClientTestCase {
 
 			Response response = invocationBuilder.get();
 
-			Assert.assertEquals(403, response.getStatus());
+			Assert.assertEquals(401, response.getStatus());
 		}
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenExpeditionTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenExpeditionTest.java
@@ -149,7 +149,7 @@ public class TokenExpeditionTest extends BaseClientTestCase {
 
 			Response response = invocationBuilder.get();
 
-			Assert.assertEquals(403, response.getStatus());
+			Assert.assertEquals(401, response.getStatus());
 
 			invocationBuilder = webTarget.request(
 			).header(
@@ -158,7 +158,7 @@ public class TokenExpeditionTest extends BaseClientTestCase {
 
 			response = invocationBuilder.get();
 
-			Assert.assertEquals(403, response.getStatus());
+			Assert.assertEquals(401, response.getStatus());
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/security/access/control/AccessControlImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/access/control/AccessControlImpl.java
@@ -108,8 +108,10 @@ public class AccessControlImpl implements AccessControl {
 			authVerifierResult = authVerifierPipeline.verifyRequest(
 				accessControlContext);
 
-			if (authVerifierResult.getState() !=
-					AuthVerifierResult.State.SUCCESS) {
+			if ((authVerifierResult.getState() !=
+					AuthVerifierResult.State.SUCCESS) &&
+				(authVerifierResult.getState() !=
+					AuthVerifierResult.State.INVALID_CREDENTIALS)) {
 
 				AuthVerifierPipeline portalAuthVerifierPipeline =
 					AuthVerifierPipeline.getPortalAuthVerifierPipeline();

--- a/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
@@ -176,6 +176,9 @@ public class AuthVerifierFilter extends BasePortalFilter {
 			if (_log.isDebugEnabled()) {
 				_log.debug("Result state does not allow us to continue");
 			}
+
+			httpServletResponse.sendError(
+				HttpServletResponse.SC_UNAUTHORIZED, "Invalid credentials");
 		}
 		else if (state == AuthVerifierResult.State.NOT_APPLICABLE) {
 			_log.error("Invalid state " + state);

--- a/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
@@ -176,9 +176,6 @@ public class AuthVerifierFilter extends BasePortalFilter {
 			if (_log.isDebugEnabled()) {
 				_log.debug("Result state does not allow us to continue");
 			}
-
-			httpServletResponse.sendError(
-				HttpServletResponse.SC_UNAUTHORIZED, "Invalid credentials");
 		}
 		else if (state == AuthVerifierResult.State.NOT_APPLICABLE) {
 			_log.error("Invalid state " + state);


### PR DESCRIPTION
The main reason for this change is to allow clients to detect when to refresh an access token (HTTP 401), and when re-authorization is needed (HTTP 403).

**Old behaviour:**

- Invalid access tokens are ignored
- Because many API applications have `guest.allowed`, the request is processed successfully as guest. Which is not expected because the client provided an access token
- Other API applications are not `guest.allowed` and will then issue a HTTP 403 if some scope is not granted

**New behaviour:**

- OAuth 2 AuthVerifiers response with `INVALID_CREDENTIALS` when the provided token is invalid (i.e. does not exist, is expired, or revoked) and this causes immediate `AuthVerifierPipeline` processing termination and the HTTP response is sent in `AuthVerifierFilter`.
- The AuthVerifier add the HTTP 401 code in preparation for that. It is done in the `AuthVerifier`s because the response encoding is protocol specific.  This follows pattern established by the `BasicAuthHeaderAuthVerifier`.
- The HTTP 403 behaviour is unchanged for valid access tokens