### PR TITLE
LPS-164521 Unify SAML column lengths

### DIFF
--- a/modules/dxp/apps/saml/saml-persistence-service/bnd.bnd
+++ b/modules/dxp/apps/saml/saml-persistence-service/bnd.bnd
@@ -28,6 +28,6 @@ Import-Package:\
 	\
 	*
 Liferay-Releng-Module-Group-Title: SAML
-Liferay-Require-SchemaVersion: 3.0.1
+Liferay-Require-SchemaVersion: 3.0.2
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/registry/SamlServiceUpgradeStepRegistrator.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/registry/SamlServiceUpgradeStepRegistrator.java
@@ -134,6 +134,15 @@ public class SamlServiceUpgradeStepRegistrator
 
 		registry.register(
 			"3.0.0", "3.0.1", new SamlSpIdpConnectionDataUpgradeProcess());
+
+		registry.register(
+			"3.0.1", "3.0.2",
+			UpgradeProcessFactory.alterColumnType(
+				"SamlPeerBinding", "samlPeerEntityId", "VARCHAR(1024) null"),
+			UpgradeProcessFactory.alterColumnType(
+				"SamlPeerBinding", "samlNameIdFormat", "VARCHAR(1024) null"),
+			UpgradeProcessFactory.alterColumnType(
+				"SamlPeerBinding", "samlNameIdValue", "VARCHAR(1024) null"));
 	}
 
 	@Reference

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v2_4_0/util/SamlPeerBindingTable.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/v2_4_0/util/SamlPeerBindingTable.java
@@ -37,8 +37,6 @@ public class SamlPeerBindingTable {
 	}
 
 	private static final String _TABLE_NAME = "SamlPeerBinding";
-
 	private static final String _TABLE_SQL_CREATE =
-		"create table SamlPeerBinding (samlPeerBindingId LONG not null primary key,companyId LONG,createDate DATE null,userId LONG,userName VARCHAR(75) null,deleted BOOLEAN,samlNameIdFormat VARCHAR(75) null,samlNameIdNameQualifier VARCHAR(75) null,samlNameIdSpNameQualifier VARCHAR(75) null,samlNameIdSpProvidedId VARCHAR(75) null,samlNameIdValue VARCHAR(75) null,samlPeerEntityId VARCHAR(75) null)";
-
+		"create table SamlPeerBinding (samlPeerBindingId LONG not null primary key,companyId LONG,createDate DATE null,userId LONG,userName VARCHAR(75) null,deleted BOOLEAN,samlNameIdFormat VARCHAR(1024) null,samlNameIdNameQualifier VARCHAR(75) null,samlNameIdSpNameQualifier VARCHAR(75) null,samlNameIdSpProvidedId VARCHAR(75) null,samlNameIdValue VARCHAR(1024) null,samlPeerEntityId VARCHAR(1024) null)";
 }

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/model/impl/SamlPeerBindingModelImpl.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/model/impl/SamlPeerBindingModelImpl.java
@@ -98,7 +98,7 @@ public class SamlPeerBindingModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table SamlPeerBinding (samlPeerBindingId LONG not null primary key,companyId LONG,createDate DATE null,userId LONG,userName VARCHAR(75) null,deleted BOOLEAN,samlNameIdFormat VARCHAR(75) null,samlNameIdNameQualifier VARCHAR(75) null,samlNameIdSpNameQualifier VARCHAR(75) null,samlNameIdSpProvidedId VARCHAR(75) null,samlNameIdValue VARCHAR(75) null,samlPeerEntityId VARCHAR(75) null)";
+		"create table SamlPeerBinding (samlPeerBindingId LONG not null primary key,companyId LONG,createDate DATE null,userId LONG,userName VARCHAR(75) null,deleted BOOLEAN,samlNameIdFormat VARCHAR(1024) null,samlNameIdNameQualifier VARCHAR(75) null,samlNameIdSpNameQualifier VARCHAR(75) null,samlNameIdSpProvidedId VARCHAR(75) null,samlNameIdValue VARCHAR(1024) null,samlPeerEntityId VARCHAR(1024) null)";
 
 	public static final String TABLE_SQL_DROP = "drop table SamlPeerBinding";
 

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -64,16 +64,16 @@
 		<field name="userName" type="String" />
 		<field name="deleted" type="boolean" />
 		<field name="samlNameIdFormat" type="String">
-			<hint name="max-length">1024</hint>
+			<hint-collection name="ENTITY-ID" />
 		</field>
 		<field name="samlNameIdNameQualifier" type="String" />
 		<field name="samlNameIdSpNameQualifier" type="String" />
 		<field name="samlNameIdSpProvidedId" type="String" />
 		<field name="samlNameIdValue" type="String">
-			<hint name="max-length">1024</hint>
+			<hint-collection name="ENTITY-ID" />
 		</field>
 		<field name="samlPeerEntityId" type="String">
-			<hint name="max-length">1024</hint>
+			<hint-collection name="ENTITY-ID" />
 		</field>
 	</model>
 	<model name="com.liferay.saml.persistence.model.SamlSpAuthRequest">

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -63,12 +63,18 @@
 		<field name="userId" type="long" />
 		<field name="userName" type="String" />
 		<field name="deleted" type="boolean" />
-		<field name="samlNameIdFormat" type="String" />
+		<field name="samlNameIdFormat" type="String">
+			<hint name="max-length">1024</hint>
+		</field>
 		<field name="samlNameIdNameQualifier" type="String" />
 		<field name="samlNameIdSpNameQualifier" type="String" />
 		<field name="samlNameIdSpProvidedId" type="String" />
-		<field name="samlNameIdValue" type="String" />
-		<field name="samlPeerEntityId" type="String" />
+		<field name="samlNameIdValue" type="String">
+			<hint name="max-length">1024</hint>
+		</field>
+		<field name="samlPeerEntityId" type="String">
+			<hint name="max-length">1024</hint>
+		</field>
 	</model>
 	<model name="com.liferay.saml.persistence.model.SamlSpAuthRequest">
 		<field name="samlSpAuthnRequestId" type="long" />

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/indexes.sql
@@ -6,9 +6,9 @@ create index IX_713E871E on SamlIdpSpSession (samlIdpSsoSessionId, samlPeerBindi
 create index IX_E5D1CDD3 on SamlIdpSsoSession (createDate);
 create index IX_5E8BFDF9 on SamlIdpSsoSession (samlIdpSsoSessionKey[$COLUMN_LENGTH:75$]);
 
-create index IX_E642E1AE on SamlPeerBinding (companyId, deleted, samlNameIdFormat[$COLUMN_LENGTH:75$], samlNameIdNameQualifier[$COLUMN_LENGTH:75$], samlNameIdValue[$COLUMN_LENGTH:75$], samlPeerEntityId[$COLUMN_LENGTH:75$]);
-create index IX_81ACF542 on SamlPeerBinding (companyId, deleted, samlNameIdFormat[$COLUMN_LENGTH:75$], samlNameIdNameQualifier[$COLUMN_LENGTH:75$], samlPeerEntityId[$COLUMN_LENGTH:75$]);
-create index IX_BC82BDFC on SamlPeerBinding (companyId, userId, deleted, samlNameIdFormat[$COLUMN_LENGTH:75$], samlNameIdNameQualifier[$COLUMN_LENGTH:75$], samlPeerEntityId[$COLUMN_LENGTH:75$]);
+create index IX_E642E1AE on SamlPeerBinding (companyId, deleted, samlNameIdFormat[$COLUMN_LENGTH:1024$], samlNameIdNameQualifier[$COLUMN_LENGTH:75$], samlNameIdValue[$COLUMN_LENGTH:1024$], samlPeerEntityId[$COLUMN_LENGTH:1024$]);
+create index IX_81ACF542 on SamlPeerBinding (companyId, deleted, samlNameIdFormat[$COLUMN_LENGTH:1024$], samlNameIdNameQualifier[$COLUMN_LENGTH:75$], samlPeerEntityId[$COLUMN_LENGTH:1024$]);
+create index IX_BC82BDFC on SamlPeerBinding (companyId, userId, deleted, samlNameIdFormat[$COLUMN_LENGTH:1024$], samlNameIdNameQualifier[$COLUMN_LENGTH:75$], samlPeerEntityId[$COLUMN_LENGTH:1024$]);
 
 create index IX_49073861 on SamlSpAuthRequest (createDate);
 create index IX_10D77E09 on SamlSpAuthRequest (samlIdpEntityId[$COLUMN_LENGTH:1024$], samlSpAuthRequestKey[$COLUMN_LENGTH:75$]);

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/tables.sql
@@ -48,12 +48,12 @@ create table SamlPeerBinding (
 	userId LONG,
 	userName VARCHAR(75) null,
 	deleted BOOLEAN,
-	samlNameIdFormat VARCHAR(75) null,
+	samlNameIdFormat VARCHAR(1024) null,
 	samlNameIdNameQualifier VARCHAR(75) null,
 	samlNameIdSpNameQualifier VARCHAR(75) null,
 	samlNameIdSpProvidedId VARCHAR(75) null,
-	samlNameIdValue VARCHAR(75) null,
-	samlPeerEntityId VARCHAR(75) null
+	samlNameIdValue VARCHAR(1024) null,
+	samlPeerEntityId VARCHAR(1024) null
 );
 
 create table SamlSpAuthRequest (


### PR DESCRIPTION
Hi @liferay-appsec team,

We need you to make a decision about how to fix this issue with the SAML module. A customer reported this error:
`com.liferay.portal.kernel.upgrade.UpgradeException: org.postgresql.util.PSQLException: ERROR: value too long for type character varying(75)`

And this happened in _SamlIdpSpSessionUpgradeProcess_ because we moved data from the following columns:
- SamlIdpSpSession.nameIdValue (VARCHAR 1024 char) -> SamlPeerBinding.samlNameIdValue (VARCHAR 75 char)
- SamlIdpSpSession.nameIdFormat (VARCHAR 1024 char) -> SamlPeerBinding.samlNameIdFormat (VARCHAR 75 char)
- SamlIdpSpSession.samlSpEntityId (VARCHAR 1024 char) -> SamlPeerBinding.samlPeerEntityId (VARCHAR 75 char)

As you can see, if the value stored in those columns is bigger than 75 chars we will get the mentioned error.

So @javalosjr96 implemented a direct solution, unifying SAML column lengths to 1024 (changes of this PR). However, this solution is not valid in Oracle because the maximum length for an index is 6398 bytes and we reached that limit when two of these columns are present, in this one for example:
`create index IX_E642E1AE on SamlPeerBinding (companyId, deleted, samlNameIdFormat[$COLUMN_LENGTH:1024$], samlNameIdNameQualifier[$COLUMN_LENGTH:75$], samlNameIdValue[$COLUMN_LENGTH:1024$], samlPeerEntityId[$COLUMN_LENGTH:1024$]);
`
Remember that 1024 chars in oracle and UTF8 can reach 1024 * 4 bytes = 4096 bytes)

So I would like to ask you for other options:
1. Can we reduce the size of those columns to 400 chars for example? (we can deal with customers with higher sizes during an upgrade)
2. Do you need those finders that generate the indexes?
3. Another option is using TEXT fields but I'd rather save unnecessary database space when possible.

Thanks.

- Tickets:
https://issues.liferay.com/browse/LPS-164521
https://issues.liferay.com/browse/LPP-46542



