### PR TITLE
LPS-166249

### DIFF
--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
@@ -302,14 +302,11 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 			return sql;
 		}
 
-		String resourcePermissionSubquerySQL =
-			_getResourcePermissionSubquerySQL(
-				permissionChecker, className, userIdField, groupIds,
-				bridgeJoin);
-
 		return _insertResourcePermissionSQL(
-			sql, className, classPKField, userIdField, groupIdField, groupIds,
-			resourcePermissionSubquerySQL);
+			sql,
+			_getResourcePermissionFilterConditionSQL(
+				permissionChecker, className, classPKField, userIdField,
+				groupIdField, groupIds, bridgeJoin));
 	}
 
 	@Activate
@@ -405,8 +402,9 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 	}
 
 	private String _getResourcePermissionFilterConditionSQL(
-		String className, String classPKField, String userIdField,
-		String groupIdField, long[] groupIds, String permissionSQL) {
+		PermissionChecker permissionChecker, String className,
+		String classPKField, String userIdField, String groupIdField,
+		long[] groupIds, String bridgeJoin) {
 
 		StringBundler sb = new StringBundler(13);
 
@@ -464,7 +462,12 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 		sb.append("(");
 		sb.append(classPKField);
 		sb.append(" IN (");
-		sb.append(permissionSQL);
+
+		sb.append(
+			_getResourcePermissionSubquerySQL(
+				permissionChecker, className, userIdField, groupIds,
+				bridgeJoin));
+
 		sb.append(")) ");
 
 		if (permissionSQLContributorsSQLSB != null) {
@@ -704,8 +707,7 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 	}
 
 	private String _insertResourcePermissionSQL(
-		String sql, String className, String classPKField, String userIdField,
-		String groupIdField, long[] groupIds, String permissionSQL) {
+		String sql, String resourcePermissionFilterConditionSQL) {
 
 		StringBundler sb = new StringBundler(4);
 
@@ -727,10 +729,7 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 
 			sb.append(_WHERE_CLAUSE);
 
-			sb.append(
-				_getResourcePermissionFilterConditionSQL(
-					className, classPKField, userIdField, groupIdField,
-					groupIds, permissionSQL));
+			sb.append(resourcePermissionFilterConditionSQL);
 
 			if (pos != -1) {
 				sb.append(sql.substring(pos));
@@ -741,10 +740,7 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 
 			sb.append(sql.substring(0, pos));
 
-			sb.append(
-				_getResourcePermissionFilterConditionSQL(
-					className, classPKField, userIdField, groupIdField,
-					groupIds, permissionSQL));
+			sb.append(resourcePermissionFilterConditionSQL);
 
 			sb.append("AND ");
 

--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
@@ -710,50 +710,6 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 		return (DSLQuery)childASTNode;
 	}
 
-	private String _insertResourcePermissionSQL(
-		String sql, String resourcePermissionFilterConditionSQL) {
-
-		StringBundler sb = new StringBundler(4);
-
-		int pos = sql.lastIndexOf(_WHERE_CLAUSE);
-
-		if (pos == -1) {
-			pos = sql.indexOf(_GROUP_BY_CLAUSE);
-
-			if (pos == -1) {
-				pos = sql.indexOf(_ORDER_BY_CLAUSE);
-			}
-
-			if (pos == -1) {
-				sb.append(sql);
-			}
-			else {
-				sb.append(sql.substring(0, pos));
-			}
-
-			sb.append(_WHERE_CLAUSE);
-
-			sb.append(resourcePermissionFilterConditionSQL);
-
-			if (pos != -1) {
-				sb.append(sql.substring(pos));
-			}
-		}
-		else {
-			pos += _WHERE_CLAUSE.length();
-
-			sb.append(sql.substring(0, pos));
-
-			sb.append(resourcePermissionFilterConditionSQL);
-
-			sb.append("AND ");
-
-			sb.append(sql.substring(pos));
-		}
-
-		return sb.toString();
-	}
-
 	private boolean _skipReplace(
 		PermissionChecker permissionChecker, String className,
 		Object classPKField, long[] groupIds) {
@@ -845,12 +801,6 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 
 		return false;
 	}
-
-	private static final String _GROUP_BY_CLAUSE = " GROUP BY ";
-
-	private static final String _ORDER_BY_CLAUSE = " ORDER BY ";
-
-	private static final String _WHERE_CLAUSE = " WHERE ";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		InlineSQLHelperImpl.class);

--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
@@ -302,12 +302,14 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 			return sql;
 		}
 
-		String resourcePermissionSQL = _getResourcePermissionSQL(
-			permissionChecker, className, userIdField, groupIds, bridgeJoin);
+		String resourcePermissionSubquerySQL =
+			_getResourcePermissionSubquerySQL(
+				permissionChecker, className, userIdField, groupIds,
+				bridgeJoin);
 
 		return _insertResourcePermissionSQL(
 			sql, className, classPKField, userIdField, groupIdField, groupIds,
-			resourcePermissionSQL);
+			resourcePermissionSubquerySQL);
 	}
 
 	@Activate
@@ -545,7 +547,7 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 		);
 	}
 
-	private String _getResourcePermissionSQL(
+	private String _getResourcePermissionSubquerySQL(
 		PermissionChecker permissionChecker, String className,
 		String userIdField, long[] groupIds, String bridgeJoin) {
 

--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
@@ -302,12 +302,20 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 			return sql;
 		}
 
+		int index = classPKField.indexOf(StringPool.PERIOD);
+
+		if (index == -1) {
+			throw new IllegalArgumentException(
+				"Unable to parse table name from class primary key field '" +
+					classPKField + "'");
+		}
+
 		InlineSQLParser inlineSQLParser = new InlineSQLParser(
 			sql,
 			_getResourcePermissionFilterConditionSQL(
 				permissionChecker, className, classPKField, userIdField,
 				groupIdField, groupIds, bridgeJoin),
-			classPKField.substring(0, classPKField.indexOf(StringPool.PERIOD)));
+			classPKField.substring(0, index));
 
 		return inlineSQLParser.
 			parseAndInsertResourcePermissionFilterConditionSQL();

--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
@@ -333,6 +333,77 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 			InlinePermissionConfiguration.class, properties);
 	}
 
+	private <T extends Table<T>> Predicate _getPermissionPredicate(
+		PermissionChecker permissionChecker, String modelClassName,
+		Column<T, Long> classPKColumn, long[] groupIds) {
+
+		T table = classPKColumn.getTable();
+
+		Column<T, Long> userIdColumn = table.getColumn("userId", Long.class);
+
+		DSLQuery resourcePermissionDSLQuery = _getResourcePermissionQuery(
+			permissionChecker, modelClassName, userIdColumn, groupIds);
+
+		Predicate permissionPredicate = classPKColumn.in(
+			resourcePermissionDSLQuery);
+
+		List<PermissionSQLContributor> permissionSQLContributors =
+			_serviceTrackerMap.getService(modelClassName);
+
+		if ((permissionSQLContributors != null) &&
+			!permissionSQLContributors.isEmpty()) {
+
+			for (PermissionSQLContributor permissionSQLContributor :
+					permissionSQLContributors) {
+
+				Predicate contributorPermissionPredicate =
+					permissionSQLContributor.getPermissionPredicate(
+						permissionChecker, modelClassName, classPKColumn,
+						groupIds);
+
+				permissionPredicate =
+					permissionPredicate = permissionPredicate.or(
+						() -> {
+							if (contributorPermissionPredicate != null) {
+								return contributorPermissionPredicate.
+									withParentheses();
+							}
+
+							return null;
+						});
+			}
+		}
+
+		Set<Long> groupIdSet = null;
+
+		for (long groupId : groupIds) {
+			if (!isEnabled(groupId)) {
+				if (groupIdSet == null) {
+					groupIdSet = new LinkedHashSet<>();
+				}
+
+				groupIdSet.add(groupId);
+			}
+		}
+
+		if (groupIdSet != null) {
+			Column<T, Long> groupIdColumn = table.getColumn(
+				"groupId", Long.class);
+
+			if (groupIdColumn == null) {
+				throw new IllegalArgumentException(
+					"No groupId column for table " + table.getTableName());
+			}
+
+			permissionPredicate = permissionPredicate.or(
+				groupIdColumn.in(groupIdSet.toArray(new Long[0])));
+
+			permissionPredicate = permissionPredicate.withParentheses();
+		}
+
+		return permissionPredicate;
+	}
+
 	private String _getResourcePermissionFilterConditionSQL(
 		String className, String classPKField, String userIdField,
 		String groupIdField, long[] groupIds, String permissionSQL) {
@@ -415,77 +486,6 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 		}
 
 		return sb.toString();
-	}
-
-	private <T extends Table<T>> Predicate _getPermissionPredicate(
-		PermissionChecker permissionChecker, String modelClassName,
-		Column<T, Long> classPKColumn, long[] groupIds) {
-
-		T table = classPKColumn.getTable();
-
-		Column<T, Long> userIdColumn = table.getColumn("userId", Long.class);
-
-		DSLQuery resourcePermissionDSLQuery = _getResourcePermissionQuery(
-			permissionChecker, modelClassName, userIdColumn, groupIds);
-
-		Predicate permissionPredicate = classPKColumn.in(
-			resourcePermissionDSLQuery);
-
-		List<PermissionSQLContributor> permissionSQLContributors =
-			_serviceTrackerMap.getService(modelClassName);
-
-		if ((permissionSQLContributors != null) &&
-			!permissionSQLContributors.isEmpty()) {
-
-			for (PermissionSQLContributor permissionSQLContributor :
-					permissionSQLContributors) {
-
-				Predicate contributorPermissionPredicate =
-					permissionSQLContributor.getPermissionPredicate(
-						permissionChecker, modelClassName, classPKColumn,
-						groupIds);
-
-				permissionPredicate =
-					permissionPredicate = permissionPredicate.or(
-						() -> {
-							if (contributorPermissionPredicate != null) {
-								return contributorPermissionPredicate.
-									withParentheses();
-							}
-
-							return null;
-						});
-			}
-		}
-
-		Set<Long> groupIdSet = null;
-
-		for (long groupId : groupIds) {
-			if (!isEnabled(groupId)) {
-				if (groupIdSet == null) {
-					groupIdSet = new LinkedHashSet<>();
-				}
-
-				groupIdSet.add(groupId);
-			}
-		}
-
-		if (groupIdSet != null) {
-			Column<T, Long> groupIdColumn = table.getColumn(
-				"groupId", Long.class);
-
-			if (groupIdColumn == null) {
-				throw new IllegalArgumentException(
-					"No groupId column for table " + table.getTableName());
-			}
-
-			permissionPredicate = permissionPredicate.or(
-				groupIdColumn.in(groupIdSet.toArray(new Long[0])));
-
-			permissionPredicate = permissionPredicate.withParentheses();
-		}
-
-		return permissionPredicate;
 	}
 
 	private DSLQuery _getResourcePermissionQuery(

--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
@@ -331,7 +331,7 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 			InlinePermissionConfiguration.class, properties);
 	}
 
-	private String _appendPermissionSQL(
+	private String _getResourcePermissionFilterConditionSQL(
 		String className, String classPKField, String userIdField,
 		String groupIdField, long[] groupIds, String permissionSQL) {
 
@@ -726,7 +726,7 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 			sb.append(_WHERE_CLAUSE);
 
 			sb.append(
-				_appendPermissionSQL(
+				_getResourcePermissionFilterConditionSQL(
 					className, classPKField, userIdField, groupIdField,
 					groupIds, permissionSQL));
 
@@ -740,7 +740,7 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 			sb.append(sql.substring(0, pos));
 
 			sb.append(
-				_appendPermissionSQL(
+				_getResourcePermissionFilterConditionSQL(
 					className, classPKField, userIdField, groupIdField,
 					groupIds, permissionSQL));
 

--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
@@ -331,10 +331,11 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 			InlinePermissionConfiguration.class, properties);
 	}
 
-	private void _appendPermissionSQL(
-		StringBundler sb, String className, String classPKField,
-		String userIdField, String groupIdField, long[] groupIds,
-		String permissionSQL) {
+	private String _appendPermissionSQL(
+		String className, String classPKField, String userIdField,
+		String groupIdField, long[] groupIds, String permissionSQL) {
+
+		StringBundler sb = new StringBundler(13);
 
 		List<PermissionSQLContributor> permissionSQLContributors =
 			_serviceTrackerMap.getService(className);
@@ -410,6 +411,8 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 
 			sb.append(") ");
 		}
+
+		return sb.toString();
 	}
 
 	private <T extends Table<T>> Predicate _getPermissionPredicate(
@@ -702,7 +705,7 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 		String sql, String className, String classPKField, String userIdField,
 		String groupIdField, long[] groupIds, String permissionSQL) {
 
-		StringBundler sb = new StringBundler(11);
+		StringBundler sb = new StringBundler(4);
 
 		int pos = sql.lastIndexOf(_WHERE_CLAUSE);
 
@@ -722,9 +725,10 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 
 			sb.append(_WHERE_CLAUSE);
 
-			_appendPermissionSQL(
-				sb, className, classPKField, userIdField, groupIdField,
-				groupIds, permissionSQL);
+			sb.append(
+				_appendPermissionSQL(
+					className, classPKField, userIdField, groupIdField,
+					groupIds, permissionSQL));
 
 			if (pos != -1) {
 				sb.append(sql.substring(pos));
@@ -735,9 +739,10 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 
 			sb.append(sql.substring(0, pos));
 
-			_appendPermissionSQL(
-				sb, className, classPKField, userIdField, groupIdField,
-				groupIds, permissionSQL);
+			sb.append(
+				_appendPermissionSQL(
+					className, classPKField, userIdField, groupIdField,
+					groupIds, permissionSQL));
 
 			sb.append("AND ");
 

--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
@@ -302,11 +302,15 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 			return sql;
 		}
 
-		return _insertResourcePermissionSQL(
+		InlineSQLParser inlineSQLParser = new InlineSQLParser(
 			sql,
 			_getResourcePermissionFilterConditionSQL(
 				permissionChecker, className, classPKField, userIdField,
-				groupIdField, groupIds, bridgeJoin));
+				groupIdField, groupIds, bridgeJoin),
+			classPKField.substring(0, classPKField.indexOf(StringPool.PERIOD)));
+
+		return inlineSQLParser.
+			parseAndInsertResourcePermissionFilterConditionSQL();
 	}
 
 	@Activate

--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLParser.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLParser.java
@@ -1,0 +1,374 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.permission.internal;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Michael Bowerman
+ */
+public class InlineSQLParser {
+
+	public InlineSQLParser(
+		String originalSQLQuery, String resourcePermissionFilterConditionSQL,
+		String tableName) {
+
+		_originalSQLQuery = originalSQLQuery;
+		_resourcePermissionFilterConditionSQL =
+			resourcePermissionFilterConditionSQL;
+		_tableName = tableName;
+	}
+
+	public String parseAndInsertResourcePermissionFilterConditionSQL() {
+		String lowerCaseSql = StringUtil.toLowerCase(_originalSQLQuery);
+
+		_computeSelectQueries(lowerCaseSql, 0);
+
+		TreeMap<Integer, String> resourcePermissionSQLInsertions =
+			new TreeMap<>();
+
+		for (SelectQuery selectQuery : _flattenedSelectQueries) {
+			String resourcePermissionSQL =
+				selectQuery.getResourcePermissionSQL();
+
+			if (resourcePermissionSQL != null) {
+				resourcePermissionSQLInsertions.put(
+					selectQuery.getResourcePermissionSQLIndex(),
+					resourcePermissionSQL);
+			}
+		}
+
+		StringBundler sb = new StringBundler(
+			1 + (2 * resourcePermissionSQLInsertions.size()));
+
+		int previousIndex = 0;
+
+		for (Map.Entry<Integer, String> resourcePermissionSQLInsertionEntry :
+				resourcePermissionSQLInsertions.entrySet()) {
+
+			int index = resourcePermissionSQLInsertionEntry.getKey();
+
+			sb.append(_originalSQLQuery.substring(previousIndex, index));
+
+			sb.append(resourcePermissionSQLInsertionEntry.getValue());
+
+			previousIndex = index;
+		}
+
+		sb.append(_originalSQLQuery.substring(previousIndex));
+
+		return sb.toString();
+	}
+
+	private List<SelectQuery> _computeSelectQueries(
+		String sql, int originalParenthesesDepth) {
+
+		List<SelectQuery> selectQueries = new ArrayList<>();
+
+		_index = StringUtil.indexOfAny(sql, _SELECT_PARSE_KEYWORDS, _index);
+
+		int parenthesesDepth = originalParenthesesDepth;
+
+		SelectQuery curSelectQuery = null;
+
+		while ((_index >= 0) && (_index < sql.length())) {
+			if (sql.charAt(_index) == CharPool.OPEN_PARENTHESIS) {
+				parenthesesDepth++;
+
+				if (curSelectQuery == null) {
+					_index++;
+
+					return _computeSelectQueries(sql, parenthesesDepth);
+				}
+			}
+			else if (sql.charAt(_index) == CharPool.CLOSE_PARENTHESIS) {
+				parenthesesDepth--;
+
+				if (parenthesesDepth < originalParenthesesDepth) {
+					if (curSelectQuery != null) {
+						curSelectQuery.setEnd(_index);
+
+						_flattenedSelectQueries.add(curSelectQuery);
+						selectQueries.add(curSelectQuery);
+					}
+
+					_index--;
+
+					return selectQueries;
+				}
+			}
+			else if ((_index < sql.length()) &&
+					 (sql.charAt(_index + 1) == CharPool.LOWER_CASE_U)) {
+
+				curSelectQuery.setEnd(_index);
+
+				_flattenedSelectQueries.add(curSelectQuery);
+				selectQueries.add(curSelectQuery);
+
+				curSelectQuery = null;
+			}
+			else if ((_index == 0) ||
+					 Validator.isWhitespace(sql.charAt(_index - 1)) ||
+					 (sql.charAt(_index - 1) == CharPool.OPEN_PARENTHESIS)) {
+
+				if ((parenthesesDepth > originalParenthesesDepth) &&
+					(curSelectQuery != null)) {
+
+					curSelectQuery.addSubqueries(
+						_computeSelectQueries(sql, parenthesesDepth));
+				}
+				else {
+					curSelectQuery = new SelectQuery(_index);
+				}
+			}
+
+			_index = StringUtil.indexOfAny(
+				sql, _SELECT_PARSE_KEYWORDS, _index + 1);
+		}
+
+		if (curSelectQuery != null) {
+			curSelectQuery.setEnd(sql.length());
+
+			_flattenedSelectQueries.add(curSelectQuery);
+			selectQueries.add(curSelectQuery);
+		}
+
+		return selectQueries;
+	}
+
+	private static final String _FROM = " from ";
+
+	private static final String _GROUP_BY = " group by ";
+
+	private static final String _JOIN = " join ";
+
+	private static final String _ORDER_BY = " order by ";
+
+	private static final String[] _SELECT_PARSE_KEYWORDS = {
+		StringPool.OPEN_PARENTHESIS, StringPool.CLOSE_PARENTHESIS, "select ",
+		" union "
+	};
+
+	private static final String _WHERE = " where ";
+
+	private final List<SelectQuery> _flattenedSelectQueries = new ArrayList<>();
+	private int _index;
+	private final String _originalSQLQuery;
+	private final String _resourcePermissionFilterConditionSQL;
+	private final String _tableName;
+
+	private class SelectQuery {
+
+		public SelectQuery(int start) {
+			_start = start;
+		}
+
+		public void addSubqueries(List<SelectQuery> selectSubqueries) {
+			_selectSubqueries.addAll(selectSubqueries);
+		}
+
+		public int getEnd() {
+			return _end;
+		}
+
+		public String getResourcePermissionSQL() {
+			return _resourcePermissionSQL;
+		}
+
+		public int getResourcePermissionSQLIndex() {
+			return _resourcePermissionSQLIndex;
+		}
+
+		public int getStart() {
+			return _start;
+		}
+
+		public void setEnd(int end) {
+			_end = end;
+
+			_selectSQL = _originalSQLQuery.substring(_start, _end);
+
+			_computeResourcePermissionSQLParameters();
+		}
+
+		private void _computeResourcePermissionSQLParameters() {
+			if (!_selectsFromTableName()) {
+				_resourcePermissionSQL = null;
+				_resourcePermissionSQLIndex = -1;
+
+				return;
+			}
+
+			int index = _indexOfExcludingSubqueries(_WHERE);
+
+			if (index >= 0) {
+				_resourcePermissionSQL =
+					_resourcePermissionFilterConditionSQL + " AND ";
+				_resourcePermissionSQLIndex = index + _start + _WHERE.length();
+
+				return;
+			}
+
+			_resourcePermissionSQL =
+				" WHERE " + _resourcePermissionFilterConditionSQL;
+
+			index = _indexOfExcludingSubqueries(_GROUP_BY);
+
+			if (index == -1) {
+				index = _indexOfExcludingSubqueries(_ORDER_BY);
+			}
+
+			if (index == -1) {
+				_resourcePermissionSQLIndex = _end;
+
+				return;
+			}
+
+			_resourcePermissionSQLIndex = index + _start;
+		}
+
+		private String[] _getSelectedTableNames() {
+			Set<String> selectedTableNameSet = new HashSet<>();
+
+			int index = 0;
+
+			while ((index = _indexOfExcludingSubqueries(_FROM, index)) != -1) {
+				index += _FROM.length();
+
+				int[] indexes = _getTableNameIndexes(index);
+
+				if (indexes != null) {
+					selectedTableNameSet.add(
+						_selectSQL.substring(indexes[0], indexes[1]));
+				}
+			}
+
+			index = 0;
+
+			while ((index = _indexOfExcludingSubqueries(_JOIN, index)) != -1) {
+				index += _JOIN.length();
+
+				int[] indexes = _getTableNameIndexes(index);
+
+				if (indexes != null) {
+					selectedTableNameSet.add(
+						_selectSQL.substring(indexes[0], indexes[1]));
+				}
+			}
+
+			return selectedTableNameSet.toArray(new String[0]);
+		}
+
+		private int[] _getTableNameIndexes(int index) {
+			int start = -1;
+			int end = _selectSQL.length();
+
+			for (int i = index; i < _selectSQL.length(); i++) {
+				char c = _selectSQL.charAt(i);
+
+				if (c == CharPool.OPEN_PARENTHESIS) {
+
+					// There is a subquery in the current clause, so no need to
+					// parse for a table name
+
+					break;
+				}
+				else if ((c == CharPool.SPACE) ||
+						 (c == CharPool.CLOSE_PARENTHESIS)) {
+
+					if (start != -1) {
+						end = i;
+
+						break;
+					}
+				}
+				else if (start == -1) {
+					start = i;
+				}
+			}
+
+			if (start == -1) {
+				return null;
+			}
+
+			return new int[] {start, end};
+		}
+
+		private int _indexOfExcludingSubqueries(String keyword) {
+			return _indexOfExcludingSubqueries(keyword, 0);
+		}
+
+		private int _indexOfExcludingSubqueries(String keyword, int fromIndex) {
+			String lowerCaseSQL = StringUtil.toLowerCase(_selectSQL);
+			String lowerCaseKeyword = StringUtil.toLowerCase(keyword);
+
+			int index = lowerCaseSQL.indexOf(lowerCaseKeyword, fromIndex);
+
+			while (index >= 0) {
+				if (!_isInSubqueryBounds(index + _start)) {
+					return index;
+				}
+
+				index = lowerCaseSQL.indexOf(keyword, index + 1);
+			}
+
+			return -1;
+		}
+
+		private boolean _isInSubqueryBounds(int index) {
+			for (SelectQuery selectSubquery : _selectSubqueries) {
+				if ((index >= selectSubquery.getStart()) &&
+					(index < selectSubquery.getEnd())) {
+
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		private boolean _selectsFromTableName() {
+			for (String selectedTableName : _getSelectedTableNames()) {
+				if (StringUtil.equalsIgnoreCase(
+						selectedTableName, _tableName)) {
+
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		private int _end;
+		private String _resourcePermissionSQL;
+		private int _resourcePermissionSQLIndex;
+		private String _selectSQL;
+		private List<SelectQuery> _selectSubqueries = new ArrayList<>();
+		private final int _start;
+
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-permission-test/build.gradle
+++ b/modules/apps/portal-security/portal-security-permission-test/build.gradle
@@ -1,4 +1,7 @@
 dependencies {
+	testCompile project(":apps:portal-security:portal-security-permission-impl")
+	testCompile project(":core:petra:petra-string")
+
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "org.hibernate", name: "hibernate-core", version: "5.6.7.Final"
 	testIntegrationCompile project(":apps:change-tracking:change-tracking-test-util")

--- a/modules/apps/portal-security/portal-security-permission-test/src/test/java/com/liferay/portal/security/permission/InlineSQLParserTest.java
+++ b/modules/apps/portal-security/portal-security-permission-test/src/test/java/com/liferay/portal/security/permission/InlineSQLParserTest.java
@@ -1,0 +1,243 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.permission;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.security.permission.internal.InlineSQLParser;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Michael Bowerman
+ */
+public class InlineSQLParserTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testComplexSQL() {
+		_testInlineSQLParser(
+			StringBundler.concat(
+				"((SELECT * FROM Table1 INNER JOIN ((SELECT * FROM Table2 ",
+				"LEFT JOIN (SELECT * FROM Table1 WHERE field1 LIKE '%test%') ",
+				"UNION ALL SELECT * FROM Table3 WHERE field2 > 0)) UNION ",
+				"(SELECT * FROM Table2 INNER JOIN ((SELECT * FROM Table2 LEFT ",
+				"JOIN Table1 ON Table1.field1 = Table2.field1 UNION ALL ",
+				"SELECT * FROM Table1 WHERE field2 > 0)))))"),
+			StringBundler.concat(
+				"((SELECT * FROM Table1 INNER JOIN ((SELECT * FROM Table2 ",
+				"LEFT JOIN (SELECT * FROM Table1 WHERE ",
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL, " AND field1 LIKE ",
+				"'%test%') UNION ALL SELECT * FROM Table3 WHERE field2 > 0)) ",
+				"WHERE ", _RESOURCE_PERMISSION_FILTER_CONDITION_SQL, " UNION ",
+				"(SELECT * FROM Table2 INNER JOIN ((SELECT * FROM Table2 LEFT ",
+				"JOIN Table1 ON Table1.field1 = Table2.field1 WHERE ",
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL, " UNION ALL SELECT ",
+				"* FROM Table1 WHERE ",
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL, " AND field2 > ",
+				"0)))))"));
+	}
+
+	@Test
+	public void testSelectFromDifferentTable() {
+		String sql = "SELECT * FROM Table2";
+
+		_testInlineSQLParser(sql, sql);
+	}
+
+	@Test
+	public void testSelectFromDifferentTableJoinedOnDifferentTable() {
+		String sql = "SELECT * FROM Table2 INNER JOIN Table3";
+
+		_testInlineSQLParser(sql, sql);
+	}
+
+	@Test
+	public void testSelectFromDifferentTableJoinedOnSelectFromTable() {
+		_testInlineSQLParser(
+			"SELECT * FROM Table2 INNER JOIN (SELECT * FROM Table1)",
+			"SELECT * FROM Table2 INNER JOIN (SELECT * FROM Table1 WHERE " +
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL + ")");
+	}
+
+	@Test
+	public void testSelectFromDifferentTableJoinedOnTable() {
+		_testInlineSQLParser(
+			"SELECT * FROM Table2 INNER JOIN Table1",
+			"SELECT * FROM Table2 INNER JOIN Table1 WHERE " +
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL);
+	}
+
+	@Test
+	public void testSelectFromDifferentTableWithWhereJoinedOnSelectFromTable() {
+		_testInlineSQLParser(
+			"SELECT * FROM Table2 INNER JOIN (SELECT * FROM Table1) WHERE id " +
+				"> 10000",
+			StringBundler.concat(
+				"SELECT * FROM Table2 INNER JOIN (SELECT * FROM Table1 WHERE ",
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL, ") WHERE id > ",
+				"10000"));
+	}
+
+	@Test
+	public void testSelectFromTable() {
+		_testInlineSQLParser(
+			"SELECT * FROM Table1",
+			"SELECT * FROM Table1 WHERE " +
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL);
+	}
+
+	@Test
+	public void testSelectFromTableInParentheses() {
+		_testInlineSQLParser(
+			"(SELECT * FROM Table1)",
+			"(SELECT * FROM Table1 WHERE " +
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL + ")");
+	}
+
+	@Test
+	public void testSelectFromTableJoinedOnSelectFromDifferentTable() {
+		_testInlineSQLParser(
+			"SELECT * FROM Table1 INNER JOIN (SELECT * FROM Table2)",
+			"SELECT * FROM Table1 INNER JOIN (SELECT * FROM Table2) WHERE " +
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL);
+	}
+
+	@Test
+	public void testSelectFromTableJoinedOnSelectFromDifferentTableWithWhere() {
+		_testInlineSQLParser(
+			"SELECT * FROM Table1 INNER JOIN (SELECT * FROM Table2 WHERE id " +
+				"> 10000)",
+			"SELECT * FROM Table1 INNER JOIN (SELECT * FROM Table2 WHERE id " +
+				"> 10000) WHERE " + _RESOURCE_PERMISSION_FILTER_CONDITION_SQL);
+	}
+
+	@Test
+	public void testSelectFromTableWithGroupBy() {
+		_testInlineSQLParser(
+			"SELECT * FROM Table1 GROUP BY field1",
+			"SELECT * FROM Table1 WHERE " +
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL + " GROUP BY field1");
+	}
+
+	@Test
+	public void testSelectFromTableWithGroupByAndOrderBy() {
+		_testInlineSQLParser(
+			"SELECT * FROM Table1 GROUP BY field1 ORDER BY field2",
+			StringBundler.concat(
+				"SELECT * FROM Table1 WHERE ",
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL, " GROUP BY field1 ",
+				"ORDER BY field2"));
+	}
+
+	@Test
+	public void testSelectFromTableWithOrderBy() {
+		_testInlineSQLParser(
+			"SELECT * FROM Table1 ORDER BY field1",
+			"SELECT * FROM Table1 WHERE " +
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL + " ORDER BY field1");
+	}
+
+	@Test
+	public void testSelectFromTableWithWhere() {
+		_testInlineSQLParser(
+			"SELECT * FROM Table1 WHERE id > 10000",
+			StringBundler.concat(
+				"SELECT * FROM Table1 WHERE ",
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL, " AND id > 10000"));
+	}
+
+	@Test
+	public void testUnionAllBothOnTable() {
+		_testInlineSQLParser(
+			"SELECT * FROM Table1 UNION ALL SELECT * FROM Table1",
+			StringBundler.concat(
+				"SELECT * FROM Table1 WHERE ",
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL, " UNION ALL SELECT ",
+				"* FROM Table1 WHERE ",
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL));
+	}
+
+	@Test
+	public void testUnionAllFirstOnTable() {
+		_testInlineSQLParser(
+			"SELECT * FROM Table1 UNION ALL SELECT * FROM Table2",
+			StringBundler.concat(
+				"SELECT * FROM Table1 WHERE ",
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL, " UNION ALL SELECT ",
+				"* FROM Table2"));
+	}
+
+	@Test
+	public void testUnionAllSecondOnTable() {
+		_testInlineSQLParser(
+			"SELECT * FROM Table2 UNION ALL SELECT * FROM Table1",
+			"SELECT * FROM Table2 UNION ALL SELECT * FROM Table1 WHERE " +
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL);
+	}
+
+	@Test
+	public void testUnionBothOnTable() {
+		_testInlineSQLParser(
+			"SELECT * FROM Table1 UNION SELECT * FROM Table1",
+			StringBundler.concat(
+				"SELECT * FROM Table1 WHERE ",
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL, " UNION SELECT * ",
+				"FROM Table1 WHERE ",
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL));
+	}
+
+	@Test
+	public void testUnionFirstOnTable() {
+		_testInlineSQLParser(
+			"SELECT * FROM Table1 UNION SELECT * FROM Table2",
+			StringBundler.concat(
+				"SELECT * FROM Table1 WHERE ",
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL, " UNION SELECT * ",
+				"FROM Table2"));
+	}
+
+	@Test
+	public void testUnionSecondOnTable() {
+		_testInlineSQLParser(
+			"SELECT * FROM Table2 UNION SELECT * FROM Table1",
+			"SELECT * FROM Table2 UNION SELECT * FROM Table1 WHERE " +
+				_RESOURCE_PERMISSION_FILTER_CONDITION_SQL);
+	}
+
+	private void _testInlineSQLParser(String originalSQL, String expectedSQL) {
+		InlineSQLParser inlineSQLParser = new InlineSQLParser(
+			originalSQL, _RESOURCE_PERMISSION_FILTER_CONDITION_SQL,
+			_TABLE_NAME);
+
+		Assert.assertEquals(
+			expectedSQL,
+			inlineSQLParser.
+				parseAndInsertResourcePermissionFilterConditionSQL());
+	}
+
+	private static final String _RESOURCE_PERMISSION_FILTER_CONDITION_SQL =
+		"[$RESOURCE_PERMISSION_FILTER_CONDITION$]";
+
+	private static final String _TABLE_NAME = "Table1";
+
+}

--- a/modules/apps/portal-security/portal-security-permission-test/src/testIntegration/java/com/liferay/portal/security/permission/test/InlineSQLHelperImplTest.java
+++ b/modules/apps/portal-security/portal-security-permission-test/src/testIntegration/java/com/liferay/portal/security/permission/test/InlineSQLHelperImplTest.java
@@ -402,6 +402,23 @@ public class InlineSQLHelperImplTest {
 		_checkSQLComposition(sql);
 	}
 
+	@Test
+	public void testSQLCompositionOuterNested() throws Exception {
+		_addGroupRole(_groupOne, RoleConstants.SITE_MEMBER);
+		_addGroupRole(_groupTwo, RoleConstants.SITE_MEMBER);
+
+		_setPermissionChecker();
+
+		String sql = _replacePermissionCheckJoin(
+			StringBundler.concat(
+				"SELECT * FROM JournalArticle WHERE id_ IN (SELECT articlePK ",
+				"FROM JournalArticleLocalization WHERE ",
+				"JournalArticleLocalization.languageId = 'en_US')"),
+			_groupIds);
+
+		_checkSQLComposition(sql);
+	}
+
 	private void _addGroupRole(Group group, String roleName) throws Exception {
 		Role role = _roleLocalService.getRole(
 			TestPropsValues.getCompanyId(), roleName);


### PR DESCRIPTION
**Ticket**: https://issues.liferay.com/browse/LPS-166249

### Background
Previously, the InlineSQLHelper was naïve with regards to where it inserts the permissions SQL. It would always insert it at the last `WHERE` statement. This worked most of the time, but for more complicated SQL queries, this wouldn't necessarily work. For instance, consider the SQL statement I added in my integration test [here](https://github.com/liferay-appsec/liferay-portal/commit/1475c35e08296d2c958c1fb5682789dc83a80629#diff-b9acd409e89f64eed30602fc79d009b782412184ad6fcaa006efe11d13376365R414-R416):
```
SELECT 
  * 
FROM 
  JournalArticle 
WHERE 
  id_ IN (
    SELECT 
      articlePK 
    FROM 
      JournalArticleLocalization 
    WHERE 
      JournalArticleLocalization.languageId = 'en_US'
  )
```
In this case, if you were adding the permissions SQL for the JournalArticle table (rather than the JournalArticleLocalization table), you would need to append the permissions SQL after the *first* `WHERE`, rather than the second `WHERE`.

### Solution
The solution adds an InlineSQLParser class which breaks the SQL query up into different `SELECT` statements and determines whether the relevant table (the one referenced by the permissions SQL) is being queried in each `SELECT` statement. For the `SELECT` statements that do query the relevant table, we append the permissions SQL to them.

Note that I largely copied the logic from the [SQLQueryTableNamesUtil](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/dao/orm/hibernate/SQLQueryTableNamesUtil.java) class for the [_getSelectedTableNames and _getTableNameIndexes](https://github.com/liferay-appsec/liferay-portal/compare/master...mbowerman:LPS-166249?expand=1#diff-5b23f5a6db50ff549c94e2dd931a43cb8be99aa6c1ccf223b1a3d79105a5fcd9R253-R318) methods. However, I did have to diverge a little bit from them by including the "ignoreSubqueries" logic when searching for the index of " from " and " join" , which is why I didn't just call that class directly.

I added a lot of unit tests to validate the correctness of the new parser, since they are cheap to add and the parser logic is quite complicated to understand.