### PR TITLE
LPS-165014 | master

### DIFF
--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/BCryptPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/BCryptPasswordEncryptor.java
@@ -38,9 +38,14 @@ public class BCryptPasswordEncryptor
 
 	@Override
 	public String encrypt(
-		String algorithm, String plainTextPassword, String encryptedPassword) {
+		String algorithm, String plainTextPassword, String encryptedPassword,
+		Boolean upgradeHashSecurity) {
 
 		String salt = null;
+
+		if (upgradeHashSecurity) {
+			encryptedPassword = null;
+		}
 
 		if (Validator.isNull(encryptedPassword)) {
 			int rounds = _ROUNDS;

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/BasePasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/BasePasswordEncryptor.java
@@ -14,12 +14,18 @@
 
 package com.liferay.portal.security.password.encryptor.internal;
 
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PwdEncryptorException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.util.PropsUtil;
+import com.liferay.portal.util.PropsValues;
 
 /**
  * @author Michael C. Han
@@ -40,9 +46,65 @@ public abstract class BasePasswordEncryptor implements PasswordEncryptor {
 		return _PASSWORDS_ENCRYPTION_ALGORITHM;
 	}
 
+	@Override
+	public String getPasswordAlgorithmType(String encryptedPassword) {
+		String legacyAlgorithm =
+			PropsValues.PASSWORDS_ENCRYPTION_ALGORITHM_LEGACY;
+
+		if (_log.isDebugEnabled() && Validator.isNotNull(legacyAlgorithm)) {
+			if (Validator.isNull(encryptedPassword)) {
+				_log.debug(
+					StringBundler.concat(
+						"Using legacy detection scheme for algorithm ",
+						legacyAlgorithm, " with empty current password"));
+			}
+			else {
+				_log.debug(
+					StringBundler.concat(
+						"Using legacy detection scheme for algorithm ",
+						legacyAlgorithm, " with provided current password"));
+			}
+		}
+
+		if (Validator.isNotNull(encryptedPassword) &&
+			(encryptedPassword.charAt(0) != CharPool.OPEN_CURLY_BRACE)) {
+
+			if (_log.isDebugEnabled()) {
+				_log.debug("Using legacy algorithm " + legacyAlgorithm);
+			}
+
+			if (Validator.isNotNull(legacyAlgorithm)) {
+				return legacyAlgorithm;
+			}
+
+			return getDefaultPasswordAlgorithmType();
+		}
+		else if (Validator.isNotNull(encryptedPassword) &&
+				 (encryptedPassword.charAt(0) == CharPool.OPEN_CURLY_BRACE)) {
+
+			int index = encryptedPassword.indexOf(CharPool.CLOSE_CURLY_BRACE);
+
+			if (index > 0) {
+				String algorithm = encryptedPassword.substring(1, index);
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Upgraded password to use algorithm " + algorithm);
+				}
+
+				return algorithm;
+			}
+		}
+
+		return null;
+	}
+
 	private static final String _PASSWORDS_ENCRYPTION_ALGORITHM =
 		StringUtil.toUpperCase(
 			GetterUtil.getString(
 				PropsUtil.get(PropsKeys.PASSWORDS_ENCRYPTION_ALGORITHM)));
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BasePasswordEncryptor.class);
 
 }

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/BasePasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/BasePasswordEncryptor.java
@@ -14,18 +14,12 @@
 
 package com.liferay.portal.security.password.encryptor.internal;
 
-import com.liferay.petra.string.CharPool;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PwdEncryptorException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.util.PropsUtil;
-import com.liferay.portal.util.PropsValues;
 
 /**
  * @author Michael C. Han
@@ -42,69 +36,22 @@ public abstract class BasePasswordEncryptor implements PasswordEncryptor {
 	}
 
 	@Override
-	public String getDefaultPasswordAlgorithmType() {
-		return _PASSWORDS_ENCRYPTION_ALGORITHM;
+	public String encrypt(
+			String algorithm, String plainTextPassword,
+			String encryptedPassword)
+		throws PwdEncryptorException {
+
+		return encrypt(algorithm, plainTextPassword, encryptedPassword, false);
 	}
 
 	@Override
-	public String getPasswordAlgorithmType(String encryptedPassword) {
-		String legacyAlgorithm =
-			PropsValues.PASSWORDS_ENCRYPTION_ALGORITHM_LEGACY;
-
-		if (_log.isDebugEnabled() && Validator.isNotNull(legacyAlgorithm)) {
-			if (Validator.isNull(encryptedPassword)) {
-				_log.debug(
-					StringBundler.concat(
-						"Using legacy detection scheme for algorithm ",
-						legacyAlgorithm, " with empty current password"));
-			}
-			else {
-				_log.debug(
-					StringBundler.concat(
-						"Using legacy detection scheme for algorithm ",
-						legacyAlgorithm, " with provided current password"));
-			}
-		}
-
-		if (Validator.isNotNull(encryptedPassword) &&
-			(encryptedPassword.charAt(0) != CharPool.OPEN_CURLY_BRACE)) {
-
-			if (_log.isDebugEnabled()) {
-				_log.debug("Using legacy algorithm " + legacyAlgorithm);
-			}
-
-			if (Validator.isNotNull(legacyAlgorithm)) {
-				return legacyAlgorithm;
-			}
-
-			return getDefaultPasswordAlgorithmType();
-		}
-		else if (Validator.isNotNull(encryptedPassword) &&
-				 (encryptedPassword.charAt(0) == CharPool.OPEN_CURLY_BRACE)) {
-
-			int index = encryptedPassword.indexOf(CharPool.CLOSE_CURLY_BRACE);
-
-			if (index > 0) {
-				String algorithm = encryptedPassword.substring(1, index);
-
-				if (_log.isDebugEnabled()) {
-					_log.debug(
-						"Upgraded password to use algorithm " + algorithm);
-				}
-
-				return algorithm;
-			}
-		}
-
-		return null;
+	public String getDefaultPasswordAlgorithmType() {
+		return _PASSWORDS_ENCRYPTION_ALGORITHM;
 	}
 
 	private static final String _PASSWORDS_ENCRYPTION_ALGORITHM =
 		StringUtil.toUpperCase(
 			GetterUtil.getString(
 				PropsUtil.get(PropsKeys.PASSWORDS_ENCRYPTION_ALGORITHM)));
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		BasePasswordEncryptor.class);
 
 }

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/CompositePasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/CompositePasswordEncryptor.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.util.ClassUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.util.PropsValues;
 
 import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
@@ -49,22 +48,11 @@ public class CompositePasswordEncryptor
 			throw new PwdEncryptorException("Unable to encrypt blank password");
 		}
 
-		String legacyAlgorithm =
-			PropsValues.PASSWORDS_ENCRYPTION_ALGORITHM_LEGACY;
+		String encryptedPasswordAlgorithm = getPasswordAlgorithmType(
+			encryptedPassword);
 
-		if (_log.isDebugEnabled() && Validator.isNotNull(legacyAlgorithm)) {
-			if (Validator.isNull(encryptedPassword)) {
-				_log.debug(
-					StringBundler.concat(
-						"Using legacy detection scheme for algorithm ",
-						legacyAlgorithm, " with empty current password"));
-			}
-			else {
-				_log.debug(
-					StringBundler.concat(
-						"Using legacy detection scheme for algorithm ",
-						legacyAlgorithm, " with provided current password"));
-			}
+		if (Validator.isNotNull(encryptedPasswordAlgorithm)) {
+			algorithm = encryptedPasswordAlgorithm;
 		}
 
 		boolean prependAlgorithm = true;
@@ -72,13 +60,7 @@ public class CompositePasswordEncryptor
 		if (Validator.isNotNull(encryptedPassword) &&
 			(encryptedPassword.charAt(0) != CharPool.OPEN_CURLY_BRACE)) {
 
-			algorithm = legacyAlgorithm;
-
 			prependAlgorithm = false;
-
-			if (_log.isDebugEnabled()) {
-				_log.debug("Using legacy algorithm " + algorithm);
-			}
 		}
 		else if (Validator.isNotNull(encryptedPassword) &&
 				 (encryptedPassword.charAt(0) == CharPool.OPEN_CURLY_BRACE)) {
@@ -86,13 +68,7 @@ public class CompositePasswordEncryptor
 			int index = encryptedPassword.indexOf(CharPool.CLOSE_CURLY_BRACE);
 
 			if (index > 0) {
-				algorithm = encryptedPassword.substring(1, index);
-
 				encryptedPassword = encryptedPassword.substring(index + 1);
-			}
-
-			if (_log.isDebugEnabled()) {
-				_log.debug("Upgraded password to use algorithm " + algorithm);
 			}
 		}
 

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/CryptPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/CryptPasswordEncryptor.java
@@ -43,8 +43,12 @@ public class CryptPasswordEncryptor
 	@Override
 	public String encrypt(
 			String algorithm, String plainTextPassword,
-			String encryptedPassword)
+			String encryptedPassword, Boolean upgradeHashSecurity)
 		throws PwdEncryptorException {
+
+		if (upgradeHashSecurity) {
+			encryptedPassword = null;
+		}
 
 		byte[] saltBytes = getSalt(encryptedPassword);
 

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/DefaultPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/DefaultPasswordEncryptor.java
@@ -32,7 +32,8 @@ public class DefaultPasswordEncryptor
 
 	@Override
 	public String encrypt(
-		String algorithm, String plainTextPassword, String encryptedPassword) {
+		String algorithm, String plainTextPassword, String encryptedPassword,
+		Boolean upgradeHashSecurity) {
 
 		return DigesterUtil.digest(algorithm, plainTextPassword);
 	}

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/NullPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/NullPasswordEncryptor.java
@@ -31,7 +31,8 @@ public class NullPasswordEncryptor
 
 	@Override
 	public String encrypt(
-		String algorithm, String plainTextPassword, String encryptedPassword) {
+		String algorithm, String plainTextPassword, String encryptedPassword,
+		Boolean upgradeHashSecurity) {
 
 		return plainTextPassword;
 	}

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/PBKDF2PasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/PBKDF2PasswordEncryptor.java
@@ -49,10 +49,14 @@ public class PBKDF2PasswordEncryptor
 	@Override
 	public String encrypt(
 			String algorithm, String plainTextPassword,
-			String encryptedPassword)
+			String encryptedPassword, Boolean upgradeHashSecurity)
 		throws PwdEncryptorException {
 
 		try {
+			if (upgradeHashSecurity) {
+				encryptedPassword = null;
+			}
+
 			PBKDF2EncryptionConfiguration pbkdf2EncryptionConfiguration =
 				new PBKDF2EncryptionConfiguration();
 

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/SSHAPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/SSHAPasswordEncryptor.java
@@ -44,8 +44,12 @@ public class SSHAPasswordEncryptor
 	@Override
 	public String encrypt(
 			String algorithm, String plainTextPassword,
-			String encryptedPassword)
+			String encryptedPassword, Boolean upgradeHashSecurity)
 		throws PwdEncryptorException {
+
+		if (upgradeHashSecurity) {
+			encryptedPassword = null;
+		}
 
 		byte[] saltBytes = getSaltBytes(encryptedPassword);
 

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/CompositePasswordEncryptorTest.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/CompositePasswordEncryptorTest.java
@@ -255,7 +255,6 @@ public class CompositePasswordEncryptorTest {
 			String prependedAlgorithm)
 		throws Exception {
 
-		String algorithmType = getAlgorithmType(algorithm);
 		String encryptedPasswordWithPrependedAlgorithm = StringBundler.concat(
 			CharPool.OPEN_CURLY_BRACE, prependedAlgorithm,
 			CharPool.CLOSE_CURLY_BRACE, encryptedPassword);
@@ -264,12 +263,6 @@ public class CompositePasswordEncryptorTest {
 
 		testEncrypt(plainPassword, encryptedPasswordWithPrependedAlgorithm);
 
-		testGetPasswordAlgorithmType(
-			encryptedPasswordWithPrependedAlgorithm, algorithmType);
-
-		testGetPasswordAlgorithmTypeUsesLegacyAlgorithmForUnprependedPassword(
-			encryptedPassword, algorithmType);
-
 		testLegacyEncrypt(algorithm, plainPassword, encryptedPassword);
 	}
 
@@ -277,7 +270,7 @@ public class CompositePasswordEncryptorTest {
 		String plainPassword = "password";
 
 		String expectedPassword = PasswordEncryptorUtil.encrypt(
-			algorithm, plainPassword, null);
+			algorithm, plainPassword, (String)null);
 
 		testEncrypt(plainPassword, expectedPassword);
 	}
@@ -300,37 +293,6 @@ public class CompositePasswordEncryptorTest {
 			Assert.fail();
 		}
 		catch (Exception exception) {
-		}
-	}
-
-	protected void testGetPasswordAlgorithmType(
-			String password, String expectedAlgorithmType)
-		throws Exception {
-
-		Assert.assertEquals(
-			expectedAlgorithmType,
-			PasswordEncryptorUtil.getPasswordAlgorithmType(password));
-	}
-
-	protected void
-			testGetPasswordAlgorithmTypeUsesLegacyAlgorithmForUnprependedPassword(
-				String password, String expectedAlgorithmType)
-		throws Exception {
-
-		String originalLegacyAlgorithm =
-			PropsValues.PASSWORDS_ENCRYPTION_ALGORITHM_LEGACY;
-
-		try {
-			PropsValues.PASSWORDS_ENCRYPTION_ALGORITHM_LEGACY =
-				expectedAlgorithmType;
-
-			Assert.assertEquals(
-				expectedAlgorithmType,
-				PasswordEncryptorUtil.getPasswordAlgorithmType(password));
-		}
-		finally {
-			PropsValues.PASSWORDS_ENCRYPTION_ALGORITHM_LEGACY =
-				originalLegacyAlgorithm;
 		}
 	}
 

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
@@ -32,6 +32,8 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
+import com.liferay.portal.kernel.security.pwd.PasswordEncryptorUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
@@ -40,6 +42,7 @@ import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
@@ -534,6 +537,49 @@ public class UserLocalServiceTest {
 
 		Assert.assertTrue(
 			newPasswordModifiedDate.after(oldPasswordModifiedDate));
+	}
+
+	@Test
+	public void testUpdatePasswordWithChangedAlgorithm() throws Exception {
+		PasswordEncryptor passwordEncryptor = ReflectionTestUtil.getFieldValue(
+			PasswordEncryptorUtil.class, "_passwordEncryptor");
+
+		String oldPasswordsEncryptionAlgorithmFieldValue =
+			ReflectionTestUtil.getFieldValue(
+				passwordEncryptor.getClass(),
+				"_PASSWORDS_ENCRYPTION_ALGORITHM");
+
+		try {
+			ReflectionTestUtil.setFieldValue(
+				passwordEncryptor.getClass(), "_PASSWORDS_ENCRYPTION_ALGORITHM",
+				"PBKDF2WithHmacSHA1/160/720000");
+
+			User user = UserTestUtil.addUser();
+
+			String encryptedPassword = user.getPassword();
+
+			Assert.assertTrue(
+				encryptedPassword.startsWith("{PBKDF2WithHmacSHA1}"));
+
+			ReflectionTestUtil.setFieldValue(
+				passwordEncryptor.getClass(), "_PASSWORDS_ENCRYPTION_ALGORITHM",
+				"MD5");
+
+			String password = RandomTestUtil.randomString(
+				UniqueStringRandomizerBumper.INSTANCE);
+
+			user = _userLocalService.updatePassword(
+				user.getUserId(), password, password, false, true);
+
+			encryptedPassword = user.getPassword();
+
+			Assert.assertTrue(encryptedPassword.startsWith("{MD5}"));
+		}
+		finally {
+			ReflectionTestUtil.setFieldValue(
+				passwordEncryptor.getClass(), "_PASSWORDS_ENCRYPTION_ALGORITHM",
+				oldPasswordsEncryptionAlgorithmFieldValue);
+		}
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -213,7 +213,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -4801,7 +4800,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		if (user.isPasswordEncrypted()) {
 			newEncPwd = PasswordEncryptorUtil.encrypt(
-				password1, user.getPassword());
+				password1, user.getPassword(), true);
 		}
 		else {
 			newEncPwd = PasswordEncryptorUtil.encrypt(password1);
@@ -4841,17 +4840,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			else {
 				user.setPasswordModifiedDate(new Date());
 			}
-		}
-
-		String passwordAlgorithm =
-			PasswordEncryptorUtil.getPasswordAlgorithmType(user.getPassword());
-
-		if (Validator.isNotNull(passwordAlgorithm) &&
-			!Objects.equals(
-				PasswordEncryptorUtil.getDefaultPasswordAlgorithmType(),
-				passwordAlgorithm)) {
-
-			newEncPwd = PasswordEncryptorUtil.encrypt(password1);
 		}
 
 		user.setPassword(newEncPwd);

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -213,6 +213,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -4840,6 +4841,17 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			else {
 				user.setPasswordModifiedDate(new Date());
 			}
+		}
+
+		String passwordAlgorithm =
+			PasswordEncryptorUtil.getPasswordAlgorithmType(user.getPassword());
+
+		if (Validator.isNotNull(passwordAlgorithm) &&
+			!Objects.equals(
+				PasswordEncryptorUtil.getDefaultPasswordAlgorithmType(),
+				passwordAlgorithm)) {
+
+			newEncPwd = PasswordEncryptorUtil.encrypt(password1);
 		}
 
 		user.setPassword(newEncPwd);

--- a/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptor.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptor.java
@@ -53,4 +53,6 @@ public interface PasswordEncryptor {
 
 	public String getDefaultPasswordAlgorithmType();
 
+	public String getPasswordAlgorithmType(String encryptedPassword);
+
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptor.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptor.java
@@ -16,9 +16,12 @@ package com.liferay.portal.kernel.security.pwd;
 
 import com.liferay.portal.kernel.exception.PwdEncryptorException;
 
+import org.osgi.annotation.versioning.ProviderType;
+
 /**
  * @author Tomas Polesovsky
  */
+@ProviderType
 public interface PasswordEncryptor {
 
 	public static final String TYPE_BCRYPT = "BCRYPT";
@@ -51,8 +54,11 @@ public interface PasswordEncryptor {
 			String encryptedPassword)
 		throws PwdEncryptorException;
 
-	public String getDefaultPasswordAlgorithmType();
+	public String encrypt(
+			String algorithm, String plainTextPassword,
+			String encryptedPassword, Boolean upgradeHashSecurity)
+		throws PwdEncryptorException;
 
-	public String getPasswordAlgorithmType(String encryptedPassword);
+	public String getDefaultPasswordAlgorithmType();
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptorUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptorUtil.java
@@ -69,6 +69,10 @@ public class PasswordEncryptorUtil {
 		return _passwordEncryptor.getDefaultPasswordAlgorithmType();
 	}
 
+	public static String getPasswordAlgorithmType(String encryptedPassword) {
+		return _passwordEncryptor.getPasswordAlgorithmType(encryptedPassword);
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		PasswordEncryptorUtil.class);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptorUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptorUtil.java
@@ -30,7 +30,7 @@ public class PasswordEncryptorUtil {
 	public static String encrypt(String plainTextPassword)
 		throws PwdEncryptorException {
 
-		return encrypt(plainTextPassword, null);
+		return encrypt(plainTextPassword, (String)null);
 	}
 
 	public static String encrypt(
@@ -57,6 +57,19 @@ public class PasswordEncryptorUtil {
 	}
 
 	public static String encrypt(
+			String plainTextPassword, String encryptedPassword,
+			Boolean upgradeHashSecurity)
+		throws PwdEncryptorException {
+
+		if (upgradeHashSecurity) {
+			encryptedPassword = null;
+		}
+
+		return _passwordEncryptor.encrypt(
+			null, plainTextPassword, encryptedPassword, upgradeHashSecurity);
+	}
+
+	public static String encrypt(
 			String algorithm, String plainTextPassword,
 			String encryptedPassword)
 		throws PwdEncryptorException {
@@ -67,10 +80,6 @@ public class PasswordEncryptorUtil {
 
 	public static String getDefaultPasswordAlgorithmType() {
 		return _passwordEncryptor.getDefaultPasswordAlgorithmType();
-	}
-
-	public static String getPasswordAlgorithmType(String encryptedPassword) {
-		return _passwordEncryptor.getPasswordAlgorithmType(encryptedPassword);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-kernel/src/com/liferay/portal/kernel/security/pwd/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/pwd/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 3.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/security/pwd/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/pwd/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0


### PR DESCRIPTION
[LPS-165014](https://issues.liferay.com/browse/LPS-165014)

Existing user's password encryption algorithm is not updated on password reset. 
Continuation of Michael's pr  #862

### Reason for change
Please note that we have only changed the way, instead of extending the API we have overloaded the encrypt method with a parameter to indicate if the password is updated with the algorithm of the property. This also takes into account, for example, if any of the algorithm parameters are modified (as in ticket [LPS-144210](https://issues.liferay.com/browse/LPS-144210)).

### Test
The change involves adding a boolean to indicate whether to use when updating the password the algorithm with which the old password was already generated or to use the one defined in the property.

-  If the algorithm is kept, the tests are the same as those that already existed in CompositePasswordEncryptorTest.
- If you want to change the algorithm, try the UserLocalServiceTest test.

 
Tests performed manually:

- the case included in the description,
- If the algorithm used in the password and the one defined in the property are different, and an attempt is made to update the password by defining the same one, an error message is displayed indicating that the same password cannot be defined.
- The password is set using - forgot password
- Changes in algorithm parameters (e.g. ticket [LPS-144210](https://issues.liferay.com/browse/LPS-144210))