### PR TITLE
[TS] LPS-167111 Avoiding crash when user doesn't exist

### DIFF
--- a/modules/apps/portal-security-audit/portal-security-audit-wiring/src/main/java/com/liferay/portal/security/audit/wiring/internal/servlet/filter/AuditFilter.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-wiring/src/main/java/com/liferay/portal/security/audit/wiring/internal/servlet/filter/AuditFilter.java
@@ -106,18 +106,20 @@ public class AuditFilter extends BaseFilter implements TryFilter {
 					CompanyThreadLocal.setWithSafeCloseable(
 						_portal.getCompanyId(httpServletRequest))) {
 
-				User user = _userLocalService.getUser(userId);
+				User user = _userLocalService.fetchUser(userId);
 
-				userEmailAddress = user.getEmailAddress();
+				if (user != null) {
+					userEmailAddress = user.getEmailAddress();
 
-				auditRequestThreadLocal.setRealUserEmailAddress(
-					userEmailAddress);
+					auditRequestThreadLocal.setRealUserEmailAddress(
+						userEmailAddress);
 
-				auditRequestThreadLocal.setRealUserId(userId);
+					auditRequestThreadLocal.setRealUserId(userId);
 
-				userLogin = _getUserLogin(user);
+					userLogin = _getUserLogin(user);
 
-				auditRequestThreadLocal.setRealUserLogin(userLogin);
+					auditRequestThreadLocal.setRealUserLogin(userLogin);
+				}
 			}
 		}
 


### PR DESCRIPTION
Hi team,
Please help us to review this PR and leave your comments. Thanks.
Ticket: https://issues.liferay.com/browse/LPS-167111
What happens when following the steps:

After saving the Wizard configuration, the User Admin will be created and stored in the hypersonic database and the userId will be set to the session (https://github.com/liferay/liferay-portal-ee/blob/master/portal-impl/src/com/liferay/portal/setup/SetupWizardUtil.java#L369-L401).
On the portal restart, a new DB will be initialized. It means the user created in SetupWizard will not exist in the new DB and we couldn't get the User with the userId already set in the session. So we'll get an exception here. (https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/portal-security-audit/portal-security-audit-wiring/src/main/java/com/liferay/portal/security/audit/wiring/internal/servlet/filter/AuditFilter.java#L100-L109).
Solution: Use the fetch function instead of the get function.
Previous PR: liferay-usm#826
@tototrinh