### PR TITLE
LPS-167995 Adds upgrade process to OAuth2 Service Module to upgrade to the new application name/scope aliases for custom objects

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay OAuth2 Provider Service
 Bundle-SymbolicName: com.liferay.oauth2.provider.service
 Bundle-Version: 4.0.40
-Liferay-Require-SchemaVersion: 4.2.1
+Liferay-Require-SchemaVersion: 4.3.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
@@ -18,6 +18,7 @@ import com.liferay.oauth2.provider.internal.upgrade.v2_0_0.OAuth2ApplicationScop
 import com.liferay.oauth2.provider.internal.upgrade.v3_0_0.OAuth2ApplicationClientCredentialUserUpgradeUser;
 import com.liferay.oauth2.provider.internal.upgrade.v3_2_0.OAuth2ApplicationFeatureUpgradeProcess;
 import com.liferay.oauth2.provider.internal.upgrade.v4_1_0.OAuth2ApplicationClientAuthenticationMethodUpgradeProcess;
+import com.liferay.oauth2.provider.internal.upgrade.v4_3_0.OAuth2ScopeGrantUpgradeProcess;
 import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
@@ -116,6 +117,10 @@ public class OAuth2ServiceUpgradeStepRegistrator
 				}
 
 			});
+
+		registry.register(
+			"4.2.1", "4.3.0",
+			new OAuth2ScopeGrantUpgradeProcess(_companyLocalService));
 	}
 
 	@Reference

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/v4_3_0/OAuth2ScopeGrantUpgradeProcess.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/v4_3_0/OAuth2ScopeGrantUpgradeProcess.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.internal.upgrade.v4_3_0;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Michael Bowerman
+ */
+public class OAuth2ScopeGrantUpgradeProcess extends UpgradeProcess {
+
+	public OAuth2ScopeGrantUpgradeProcess(
+		CompanyLocalService companyLocalService) {
+
+		_companyLocalService = companyLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_companyLocalService.forEachCompanyId(
+			companyId -> _upgradeCompany(companyId));
+	}
+
+	private void _upgradeCompany(long companyId) throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer();
+			PreparedStatement preparedStatement = connection.prepareStatement(
+				StringBundler.concat(
+					"select oAuth2ScopeGrantId, applicationName, scopeAliases ",
+					"from OAuth2ScopeGrant where companyId = ? and ",
+					"bundleSymbolicName = ?"))) {
+
+			preparedStatement.setLong(1, companyId);
+			preparedStatement.setString(2, _BUNDLE_SYMBOLIC_NAME);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				String companyIdString = String.valueOf(companyId);
+
+				while (resultSet.next()) {
+					String applicationName = resultSet.getString(
+						"applicationName");
+
+					if (Validator.isNull(applicationName) ||
+						applicationName.endsWith(companyIdString)) {
+
+						continue;
+					}
+
+					_upgradeOAuth2ScopeGrant(
+						resultSet.getLong("oAuth2ScopeGrantId"),
+						companyIdString, applicationName,
+						resultSet.getString("scopeAliases"));
+				}
+			}
+		}
+	}
+
+	private void _upgradeOAuth2ScopeGrant(
+			long oAuth2ScopeGrantId, String companyId, String applicationName,
+			String scopeAliases)
+		throws Exception {
+
+		String upgradedApplicationName = applicationName + companyId;
+
+		List<String> scopeAliasesList = Arrays.asList(
+			StringUtil.split(scopeAliases, StringPool.SPACE));
+
+		for (int i = 0; i < scopeAliasesList.size(); i++) {
+			String scopeAlias = scopeAliasesList.get(i);
+
+			if (!scopeAlias.startsWith(applicationName) ||
+				scopeAlias.startsWith(upgradedApplicationName)) {
+
+				continue;
+			}
+
+			scopeAliasesList.set(
+				i,
+				StringUtil.replaceFirst(
+					scopeAlias, applicationName, upgradedApplicationName));
+		}
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"update OAuth2ScopeGrant set applicationName = ?, " +
+					"scopeAliases = ? where oAuth2ScopeGrantId = ?")) {
+
+			preparedStatement.setString(1, upgradedApplicationName);
+			preparedStatement.setString(
+				2,
+				StringUtil.merge(
+					ListUtil.sort(scopeAliasesList), StringPool.SPACE));
+			preparedStatement.setLong(3, oAuth2ScopeGrantId);
+
+			preparedStatement.execute();
+		}
+	}
+
+	private static final String _BUNDLE_SYMBOLIC_NAME =
+		"com.liferay.object.rest.impl";
+
+	private final CompanyLocalService _companyLocalService;
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/v4_3_0/OAuth2ScopeGrantUpgradeProcess.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/v4_3_0/OAuth2ScopeGrantUpgradeProcess.java
@@ -16,6 +16,8 @@ package com.liferay.oauth2.provider.internal.upgrade.v4_3_0;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -46,6 +48,22 @@ public class OAuth2ScopeGrantUpgradeProcess extends UpgradeProcess {
 			companyId -> _upgradeCompany(companyId));
 	}
 
+	private boolean _hasObjectDefinition(long companyId, String name)
+		throws Exception {
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				"select * from ObjectDefinition where companyId = ? and name " +
+					"= ?")) {
+
+			preparedStatement.setLong(1, companyId);
+			preparedStatement.setString(2, name);
+
+			try (ResultSet resultSet = preparedStatement.executeQuery()) {
+				return resultSet.next();
+			}
+		}
+	}
+
 	private void _upgradeCompany(long companyId) throws Exception {
 		try (LoggingTimer loggingTimer = new LoggingTimer();
 			PreparedStatement preparedStatement = connection.prepareStatement(
@@ -66,6 +84,20 @@ public class OAuth2ScopeGrantUpgradeProcess extends UpgradeProcess {
 
 					if (Validator.isNull(applicationName) ||
 						applicationName.endsWith(companyIdString)) {
+
+						continue;
+					}
+
+					if (!_hasObjectDefinition(companyId, applicationName)) {
+						if (_log.isWarnEnabled()) {
+							_log.warn(
+								StringBundler.concat(
+									"Detected OAuth2 scope grant for ",
+									"object-related scope named '",
+									applicationName, "' in company ", companyId,
+									", but no object definition with that ",
+									"name exists in that company"));
+						}
 
 						continue;
 					}
@@ -121,6 +153,9 @@ public class OAuth2ScopeGrantUpgradeProcess extends UpgradeProcess {
 
 	private static final String _BUNDLE_SYMBOLIC_NAME =
 		"com.liferay.object.rest.impl";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OAuth2ScopeGrantUpgradeProcess.class);
 
 	private final CompanyLocalService _companyLocalService;
 


### PR DESCRIPTION
Ticket: [LPS-167995](https://issues.liferay.com/browse/LPS-167995)

In [LPS-163728](https://issues.liferay.com/browse/LPS-163728), we modified the name of the OSGi JAX-RS name of custom objects to include the company ID of the object. This caused the names of many services that were generated by custom objects to also get renamed with this same company ID naming scheme.

One such generated service that was renamed is the OAuth2 Application Scopes. Previously, these had been named without the company ID, but as of [LPS-163728](https://issues.liferay.com/browse/LPS-163728), their names now include the company ID.

The problem is that there was no upgrade process to upgrade the existing data that was referencing the old naming scheme. This means that if the user had previously granted any permissions on custom object scopes to an OAuth2 Application, those permissions will essentially be lost upon upgrading to a version of Liferay that includes [LPS-163728](https://issues.liferay.com/browse/LPS-163728).

This fix adds an upgrade process to update the names of these scopes in the database to match the new naming scheme.