### PR TITLE
LPS-168688 Propagate URL fragments for single and mutiple Idps throug…

### DIFF
--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
@@ -113,13 +113,6 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 				return null;
 			}
 		}
-		else if (samlSpIdpConnections.size() == 1) {
-			httpServletRequest.setAttribute(
-				SamlWebKeys.SAML_SP_IDP_CONNECTION,
-				samlSpIdpConnections.get(0));
-
-			return null;
-		}
 
 		httpServletRequest.setAttribute(
 			SamlWebKeys.SAML_SSO_LOGIN_CONTEXT,

--- a/portal-web/docroot/html/portal/saml/select_idp.jsp
+++ b/portal-web/docroot/html/portal/saml/select_idp.jsp
@@ -29,7 +29,21 @@ JSONArray relevantIdpConnectionsJSONArray = samlSsoLoginContext.getJSONArray("re
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 
 	<c:choose>
-		<c:when test="<%= relevantIdpConnectionsJSONArray.length() > 0 %>">
+		<c:when test="<%= relevantIdpConnectionsJSONArray.length() == 1 %>">
+
+			<%
+			JSONObject relevantIdpConnectionJSONObject = relevantIdpConnectionsJSONArray.getJSONObject(0);
+			%>
+
+			<aui:input name="idpEntityId" type="hidden" value='<%= HtmlUtil.escapeAttribute(relevantIdpConnectionJSONObject.getString("entityId")) %>' />
+
+			<aui:script sandbox="<%= true %>">
+				window.addEventListener("load", (event) => {
+					window.fm.submit();
+				});
+			</aui:script>
+		</c:when>
+		<c:when test="<%= relevantIdpConnectionsJSONArray.length() > 1 %>">
 			<p><liferay-ui:message key="please-select-your-identity-provider" /></p>
 
 			<aui:select label="identity-provider" name="idpEntityId">
@@ -61,3 +75,17 @@ JSONArray relevantIdpConnectionsJSONArray = samlSsoLoginContext.getJSONArray("re
 		</c:otherwise>
 	</c:choose>
 </aui:form>
+
+<c:if test="<%= Validator.isNotNull(redirect) %>">
+	<aui:script sandbox="<%= true %>">
+		var form = document.getElementById('<portlet:namespace />fm');
+
+		var redirect = form.querySelector('#<portlet:namespace />redirect');
+
+		if (redirect) {
+		var redirectVal = redirect.getAttribute('value');
+
+		redirect.setAttribute('value', redirectVal + window.location.hash);
+		}
+	</aui:script>
+</c:if>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-168688

The issue here was that URL fragments were not being persisted across SAML SSO login. This is because URL fragments are not part of the URL and are not sent to the server side.
To fix the issue, the logic for single IdP login was moved to select_idp.jsp and the fragment URL is propagated to the redirect before being sent to the IdP