### PR TITLE
LPS-169367 Fix OAuthClientEntry exists with the primary key 0

### DIFF
--- a/modules/apps/login/login-authentication-openid-connect-web/src/main/java/com/liferay/login/authentication/openid/connect/web/internal/portlet/action/OpenIdConnectLoginRequestMVCActionCommand.java
+++ b/modules/apps/login/login-authentication-openid-connect-web/src/main/java/com/liferay/login/authentication/openid/connect/web/internal/portlet/action/OpenIdConnectLoginRequestMVCActionCommand.java
@@ -161,8 +161,11 @@ public class OpenIdConnectLoginRequestMVCActionCommand
 			long oAuthClientEntryId = ParamUtil.getLong(
 				actionRequest, "oAuthClientEntryId");
 
-			_openIdConnectAuthenticationHandler.requestAuthentication(
-				oAuthClientEntryId, httpServletRequest, httpServletResponse);
+			if (oAuthClientEntryId > 0) {
+				_openIdConnectAuthenticationHandler.requestAuthentication(
+					oAuthClientEntryId, httpServletRequest,
+					httpServletResponse);
+			}
 		}
 		catch (Exception exception) {
 			actionResponse.setRenderParameter(


### PR DESCRIPTION
Hi Team!

Could you plesae check my fix?

**Summary:**
Whenever an OIDC login is initiated, there is an error appearing in Liferay log: Unable to process the OpenID Connect login: No OAuthClientEntry exists with the primary key 0

**Fix:**
Check if oAuthClientEntryId  is not zero

https://issues.liferay.com/browse/LPS-169367

Thanks, Roland