### PR TITLE
LPS-167995 Add upgrade process to remove the companyId from the ObjectEntry JAX-RS application

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay OAuth2 Provider Service
 Bundle-SymbolicName: com.liferay.oauth2.provider.service
 Bundle-Version: 4.0.42
-Liferay-Require-SchemaVersion: 4.2.1
+Liferay-Require-SchemaVersion: 4.2.2
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
@@ -18,6 +18,7 @@ import com.liferay.oauth2.provider.internal.upgrade.v2_0_0.OAuth2ApplicationScop
 import com.liferay.oauth2.provider.internal.upgrade.v3_0_0.OAuth2ApplicationClientCredentialUserUpgradeUser;
 import com.liferay.oauth2.provider.internal.upgrade.v3_2_0.OAuth2ApplicationFeatureUpgradeProcess;
 import com.liferay.oauth2.provider.internal.upgrade.v4_1_0.OAuth2ApplicationClientAuthenticationMethodUpgradeProcess;
+import com.liferay.oauth2.provider.internal.upgrade.v4_2_1.OAuth2ScopeGrantRemoveCompanyIdUpgradeProcess;
 import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
@@ -116,6 +117,10 @@ public class OAuth2ServiceUpgradeStepRegistrator
 				}
 
 			});
+
+		registry.register(
+			"4.2.1", "4.2.2",
+			new OAuth2ScopeGrantRemoveCompanyIdUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/v4_2_1/OAuth2ScopeGrantRemoveCompanyIdUpgradeProcess.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/v4_2_1/OAuth2ScopeGrantRemoveCompanyIdUpgradeProcess.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.internal.upgrade.v4_2_1;
+
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Carlos Correa
+ */
+public class OAuth2ScopeGrantRemoveCompanyIdUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer();
+			ResultSet oAuth2ScopeGrantResultSet =
+				_getOAuth2ScopeGrantResultSet()) {
+
+			while (oAuth2ScopeGrantResultSet.next()) {
+				String applicationName = oAuth2ScopeGrantResultSet.getString(
+					"applicationName");
+				long companyId = oAuth2ScopeGrantResultSet.getLong("companyId");
+
+				if (!StringUtil.endsWith(
+						applicationName, String.valueOf(companyId))) {
+
+					continue;
+				}
+
+				List<String> scopeAliases = Arrays.asList(
+					StringUtil.split(
+						oAuth2ScopeGrantResultSet.getString("scopeAliases"),
+						StringPool.SPACE));
+
+				String newApplicationName = StringUtil.removeLast(
+					applicationName, String.valueOf(companyId));
+
+				List<String> newScopeAliases = TransformUtil.transform(
+					scopeAliases,
+					scopeAlias -> StringUtil.replace(
+						scopeAlias, applicationName, newApplicationName));
+
+				_updateOAuth2ScopeGrant(
+					newApplicationName,
+					oAuth2ScopeGrantResultSet.getLong("oauth2ScopeGrantId"),
+					newScopeAliases);
+			}
+		}
+	}
+
+	private ResultSet _getOAuth2ScopeGrantResultSet() throws SQLException {
+		String sql =
+			"select * from OAuth2ScopeGrant where " +
+				"bundleSymbolicName='com.liferay.object.rest.impl'";
+
+		PreparedStatement preparedStatement = connection.prepareStatement(sql);
+
+		return preparedStatement.executeQuery();
+	}
+
+	private void _updateOAuth2ScopeGrant(
+			String applicationName, long oAuth2ScopeGrantId,
+			List<String> scopeAliases)
+		throws SQLException {
+
+		String sql =
+			"update OAuth2ScopeGrant set applicationName = ?," +
+				"scopeAliases = ? where oAuth2ScopeGrantId = ?";
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				sql)) {
+
+			preparedStatement.setString(1, applicationName);
+			preparedStatement.setString(
+				2,
+				StringUtil.merge(
+					ListUtil.sort(new ArrayList<>(scopeAliases)),
+					StringPool.SPACE));
+			preparedStatement.setLong(3, oAuth2ScopeGrantId);
+
+			preparedStatement.execute();
+		}
+	}
+
+}


### PR DESCRIPTION
This PR contains the Upgrade process to fix the rows from the `OAuth2ScopeGrant` table caused by this bug: [LPS-167995](https://issues.liferay.com/browse/LPS-167995)

For all the rows whose `bundleSymbolicName = 'com.liferay.object.rest.impl'` and whose `applicationName` ends with the value of the `companyId` column, the `applicationName` and `scopeAliases` fields will be updated by removing the `companyId` value

