### PR TITLE
LPP-47227 Use synchronized to avoid concurrency problems

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
@@ -103,8 +103,10 @@ public class AuthVerifierPipeline {
 			new AuthVerifierConfigurationConsumer(
 				accessControlContext, _excludeURLPatternMapper, requestURI);
 
-		_includeURLPatternMapper.consumeValues(
-			authVerifierConfigurationConsumer, requestURI);
+		synchronized (this) {
+			_includeURLPatternMapper.consumeValues(
+				authVerifierConfigurationConsumer, requestURI);
+		}
 
 		if (authVerifierConfigurationConsumer.getAuthVerifierResult() != null) {
 			return authVerifierConfigurationConsumer.getAuthVerifierResult();


### PR DESCRIPTION
Related ticket -> [LPP-47227](https://issues.liferay.com/browse/LPP-47227)
____
Hi team!
I was working on the LPP attached and seemed to be something related to the AuthVerified. Quick explanation, when there is two concurrent request, one of them "fails" returning a 403 due to it is not able to register even if the request is sending the authentication. I noticed that this is **only reproducible in Windows**.

## How to reproduce it
In a windows machine: 
* Start a Liferay
* Create web content with the test user
* Create a new user (test1) and set its password
* Make a concurrent call to the web content with the new user (test1)
  * I execute two terminals with the following script (filled the IDs and password with the correct data)
```
@echo OFF
FOR /L %%y IN (0, 1, 100) DO curl http://localhost:8080/o/headless-delivery/v1.0/sites/20121/structured-contents/by-key/42665 -u test1@liferay.com:1234
```
There is a video in the LPP where you can see the steps.

Digging into this, I found that the method `com.liferay.petra.url.pattern.mapper.internal.StaticSizeTrieURLPatternMapper#_getWildcardValuesBitmask` is requested by the two threads at the same time against the same instance of the class.

This PR is just a quick fix that solves the problem (at least with my tests) but I think it is not the best solution.

Can you take a look at this?

Thank you very much.