### PR TITLE
LPS-170427 - Migrate oauth2 usages of sessionStorage to new API

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/OAuth2Client.ts
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/OAuth2Client.ts
@@ -101,9 +101,10 @@ class OAuth2Client {
 					resolve(tokenResponse);
 
 					tokenResponse.then((response) =>
-						sessionStorage.setItem(
+						Liferay.Util.SessionStorage.setItem(
 							sessionKey,
-							JSON.stringify(response)
+							JSON.stringify(response),
+							Liferay.Util.SessionStorage.TYPES.NECESSARY
 						)
 					);
 				}
@@ -167,9 +168,12 @@ class OAuth2Client {
 		const sessionKey = `${oauth2Client.clientId}-${Liferay.authToken}-token`;
 
 		return new Promise((resolve) => {
-			const cachedTokenData = sessionStorage.getItem(sessionKey);
+			const cachedTokenData = Liferay.Util.SessionStorage.getItem(
+				sessionKey,
+				Liferay.Util.SessionStorage.TYPES.NECESSARY
+			);
 
-			if (cachedTokenData !== null) {
+			if (cachedTokenData !== null && cachedTokenData !== undefined) {
 				resolve(JSON.parse(cachedTokenData));
 
 				return;


### PR DESCRIPTION
### References

- [LPS-165343](https://issues.liferay.com/browse/LPS-165343) - FI issue
- [LPS-170427](https://issues.liferay.com/browse/LPS-170427) - Appsec issue

### What is the goal?

* Migrate usages of `sessionStorage` in `oauth2-provider` to new consent-based API in `frontend-js-web`.

### Notes

If this is unexpected, here's some info on why you're getting this PR!

We've recently been making some changes to make Liferay comply with data legislation, such as GDPR. For this purpose, in Frontend Infrastructure we recently added some JS APIs that will only allow storing information in the user's device if they have consented to it, and this affects both Cookies and Web Storage (`localStorage`/`sessionStorage`).

For this specific case, we have found usages of `sessionStorage` in one of your modules, specifically `oauth2-provider-web`. We have replaced the usages with the utility exported from `frontend-js-web`, but this could require additional changes from your team:
1. We have assumed the consent type for your use case is `NECESSARY`, but that could be wrong. Please check that this is correct with the legal team.
2. If the consent type if different, **you must make additional changes** to make sure that the case where the **user hasn't accepted** that type of cookies is covered in the code. 

   If the user hasn't consented, when trying to set a value (`sessionStorage.setItem`) the method will return `false`, and when reading a value (`localStorage.getItem`) the method will return `undefined`. 
   
   You can check the consent status anywhere as follows:

   ```js
   // Where X ∈ {NECESSARY,FUNCTIONAL,PERFORMANCE,PERSONALIZATION}
   const hasConsent = Liferay.Util.Cookie.get(Liferay.Util.Cookie.TYPES.X, Liferay.Util.Cookie.TYPES.NECESSARY); 
   ```
   
   
### How to replicate
The cookie banner where you can set the consent preferences is currently behind a feature flag (`feature.flag.LPS-142518`), so to test this:
* Add `feature.flag.LPS-142518=true` to `portal-ext.properties`
* Restart portal
* Navigate to `Control Panel > System Settings > Cookies`
* Enable the cookie banner by checking the corresponding checkbox and click `Save`
* Cookie banner should now be visible

With this you should be able to check that everything is working as expected in all cases (with/without consent management enabled, with/without user consent).

Please let us know if you need any extra info for this.
