### PR TITLE
[TS] LPS-169318 Reverting usage of DLFileVersion.userId back to ResourcePermission.ownerId in dslQuery due to performance issues

### DIFF
--- a/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
+++ b/modules/apps/portal-security/portal-security-permission-impl/src/main/java/com/liferay/portal/security/permission/internal/InlineSQLHelperImpl.java
@@ -418,10 +418,8 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 
 		T table = classPKColumn.getTable();
 
-		Column<T, Long> userIdColumn = table.getColumn("userId", Long.class);
-
 		DSLQuery resourcePermissionDSLQuery = _getResourcePermissionQuery(
-			permissionChecker, modelClassName, userIdColumn, groupIds);
+			permissionChecker, modelClassName, groupIds);
 
 		Predicate permissionPredicate = classPKColumn.in(
 			resourcePermissionDSLQuery);
@@ -485,7 +483,7 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 
 	private DSLQuery _getResourcePermissionQuery(
 		PermissionChecker permissionChecker, String modelClassName,
-		Column<?, Long> userIdColumn, long[] groupIds) {
+		long[] groupIds) {
 
 		Predicate roleIdsOrOwnerIdsPredicate = null;
 
@@ -500,10 +498,6 @@ public class InlineSQLHelperImpl implements InlineSQLHelper {
 		if (permissionChecker.isSignedIn()) {
 			Expression<Long> ownerIdExpression =
 				ResourcePermissionTable.INSTANCE.ownerId;
-
-			if (userIdColumn != null) {
-				ownerIdExpression = userIdColumn;
-			}
 
 			Predicate ownerIdPredicate = ownerIdExpression.eq(
 				permissionChecker.getUserId());


### PR DESCRIPTION
Hi Team,

https://issues.liferay.com/browse/LPS-169318

**Issue**:
Customer reported that dlapp/get-file-entries API call is significantly slower for non-admin users.
The cause of the performance issue is the change of the userId check in the query.
ResourcePermission.ownerId = {userId} was replaced by DLFileVersion.userId = {userId} in [LPS-136334](https://issues.liferay.com/browse/LPS-136334) when the new DSL queries were introduced.

**Solution**:
On [PTR-3453](https://issues.liferay.com/browse/PTR-3453) it was determined that since the results of the two queries are the same, the current implementation can be changed back to the original query.
I removed the logic that replaced ResourcePermission.ownerId with DLFileVersion.userId, and I also removed "userIdColumn" from the method signature due to SF failure.

Please review my PR!

Best regards,
Évi