### PR TITLE
LPS 163950 - 

### DIFF
--- a/modules/apps/login/login-web-test/bnd.bnd
+++ b/modules/apps/login/login-web-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Login Web Test
+Bundle-SymbolicName: com.liferay.login.web.test
+Bundle-Version: 1.0.0

--- a/modules/apps/login/login-web-test/build.gradle
+++ b/modules/apps/login/login-web-test/build.gradle
@@ -1,0 +1,8 @@
+dependencies {
+	testIntegrationCompile group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	testIntegrationCompile group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
+	testIntegrationCompile group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	testIntegrationCompile project(":apps:login:login-web")
+	testIntegrationCompile project(":core:osgi-service-tracker-collections")
+	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/login/login-web-test/src/testIntegration/java/com/liferay/login/web/internal/portlet/action/test/ForgotPasswordMVCActionCommandTest.java
+++ b/modules/apps/login/login-web-test/src/testIntegration/java/com/liferay/login/web/internal/portlet/action/test/ForgotPasswordMVCActionCommandTest.java
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.login.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.PasswordPolicy;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.PasswordPolicyLocalServiceUtil;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Date;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Alvaro Saugar
+ */
+@RunWith(Arquillian.class)
+public class ForgotPasswordMVCActionCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_companyId = TestPropsValues.getCompanyId();
+		_setUser();
+		_setMockLiferayPortletActionRequest();
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		UserLocalServiceUtil.deleteUser(_forgotPasswordUser);
+	}
+
+	@Test
+	public void testLockoutNotAdminUser() throws Exception {
+		_mvcActionCommand.processAction(
+			_mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		User userReturn = (User)_mockLiferayPortletActionRequest.getAttribute(
+			WebKeys.FORGOT_PASSWORD_REMINDER_USER);
+
+		Company company = CompanyLocalServiceUtil.getCompany(_companyId);
+
+		String mailDefaultUser = "default@" + company.getMx();
+
+		Assert.assertEquals(mailDefaultUser, userReturn.getEmailAddress());
+	}
+
+	@Test
+	public void testLockoutYesAdminUser() throws Exception {
+		Role role = _roleLocalService.getRole(
+			_companyId, RoleConstants.ADMINISTRATOR);
+
+		_userLocalService.addRoleUser(
+			role.getRoleId(), _forgotPasswordUser.getUserId());
+
+		_mvcActionCommand.processAction(
+			_mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		User userReturn = (User)_mockLiferayPortletActionRequest.getAttribute(
+			WebKeys.FORGOT_PASSWORD_REMINDER_USER);
+
+		Assert.assertEquals(
+			userReturn.getEmailAddress(),
+			_forgotPasswordUser.getEmailAddress());
+	}
+
+	private static ThemeDisplay _getThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			CompanyLocalServiceUtil.fetchCompany(_companyId));
+
+		return themeDisplay;
+	}
+
+	private static void _setMockLiferayPortletActionRequest() throws Exception {
+		_mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		_mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		HttpServletRequest httpServletRequest =
+			_mockLiferayPortletActionRequest.getHttpServletRequest();
+
+		httpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_CONFIG, null);
+
+		HttpSession httpSession = httpServletRequest.getSession();
+
+		httpSession.setAttribute(WebKeys.CAPTCHA_TEXT, _CAPTCHA_TEXT);
+
+		_mockLiferayPortletActionRequest.addParameter(
+			"captchaText", _CAPTCHA_TEXT);
+
+		_mockLiferayPortletActionRequest.addParameter(
+			"login", _forgotPasswordUser.getEmailAddress());
+	}
+
+	private static void _setUser() throws Exception {
+		_forgotPasswordUser = UserTestUtil.addUser();
+
+		_forgotPasswordUser.setLockout(true);
+
+		_forgotPasswordUser.setLockoutDate(new Date());
+
+		PasswordPolicy passwordPolicy = _forgotPasswordUser.getPasswordPolicy();
+
+		passwordPolicy.setLockout(true);
+		passwordPolicy.setLockoutDuration(0);
+
+		PasswordPolicyLocalServiceUtil.updatePasswordPolicy(passwordPolicy);
+
+		UserLocalServiceUtil.updateUser(_forgotPasswordUser);
+	}
+
+	private static final String _CAPTCHA_TEXT = StringUtil.toLowerCase(
+		RandomTestUtil.randomString());
+
+	private static long _companyId;
+	private static User _forgotPasswordUser;
+	private static MockLiferayPortletActionRequest
+		_mockLiferayPortletActionRequest;
+
+	@Inject(
+		filter = "mvc.command.name=/login/forgot_password",
+		type = MVCActionCommand.class
+	)
+	private MVCActionCommand _mvcActionCommand;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/login/login-web-test/src/testIntegration/java/com/liferay/login/web/internal/portlet/action/test/ForgotPasswordMVCActionCommandTest.java
+++ b/modules/apps/login/login-web-test/src/testIntegration/java/com/liferay/login/web/internal/portlet/action/test/ForgotPasswordMVCActionCommandTest.java
@@ -15,11 +15,8 @@
 package com.liferay.login.web.internal.portlet.action.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.PasswordPolicy;
-import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.PasswordPolicyLocalServiceUtil;
@@ -76,29 +73,7 @@ public class ForgotPasswordMVCActionCommandTest {
 	}
 
 	@Test
-	public void testLockoutNotAdminUser() throws Exception {
-		_mvcActionCommand.processAction(
-			_mockLiferayPortletActionRequest,
-			new MockLiferayPortletActionResponse());
-
-		User userReturn = (User)_mockLiferayPortletActionRequest.getAttribute(
-			WebKeys.FORGOT_PASSWORD_REMINDER_USER);
-
-		Company company = CompanyLocalServiceUtil.getCompany(_companyId);
-
-		String mailDefaultUser = "default@" + company.getMx();
-
-		Assert.assertEquals(mailDefaultUser, userReturn.getEmailAddress());
-	}
-
-	@Test
-	public void testLockoutYesAdminUser() throws Exception {
-		Role role = _roleLocalService.getRole(
-			_companyId, RoleConstants.ADMINISTRATOR);
-
-		_userLocalService.addRoleUser(
-			role.getRoleId(), _forgotPasswordUser.getUserId());
-
+	public void testLockoutAnyUser() throws Exception {
 		_mvcActionCommand.processAction(
 			_mockLiferayPortletActionRequest,
 			new MockLiferayPortletActionResponse());

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/ForgotPasswordMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/ForgotPasswordMVCActionCommand.java
@@ -267,9 +267,6 @@ public class ForgotPasswordMVCActionCommand extends BaseMVCActionCommand {
 					"Inactive user " + user.getUuid());
 			}
 
-			if (!_omniadmin.isOmniadmin(user)) {
-				_userLocalService.checkLockout(user);
-			}
 
 			return user;
 		}

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/ForgotPasswordMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/ForgotPasswordMVCActionCommand.java
@@ -399,12 +399,12 @@ public class ForgotPasswordMVCActionCommand extends BaseMVCActionCommand {
 	private Language _language;
 
 	@Reference
+	private Omniadmin _omniadmin;
+
+	@Reference
 	private Portal _portal;
 
 	@Reference
 	private UserLocalService _userLocalService;
-
-	@Reference
-	private Omniadmin _omniadmin;
 
 }

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/ForgotPasswordMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/ForgotPasswordMVCActionCommand.java
@@ -14,6 +14,7 @@
 
 package com.liferay.login.web.internal.portlet.action;
 
+import com.liferay.admin.kernel.util.Omniadmin;
 import com.liferay.captcha.configuration.CaptchaConfiguration;
 import com.liferay.captcha.util.CaptchaUtil;
 import com.liferay.login.web.constants.LoginPortletKeys;
@@ -266,7 +267,9 @@ public class ForgotPasswordMVCActionCommand extends BaseMVCActionCommand {
 					"Inactive user " + user.getUuid());
 			}
 
-			_userLocalService.checkLockout(user);
+			if (!_omniadmin.isOmniadmin(user)) {
+				_userLocalService.checkLockout(user);
+			}
 
 			return user;
 		}
@@ -400,5 +403,8 @@ public class ForgotPasswordMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private UserLocalService _userLocalService;
+
+	@Reference
+	private Omniadmin _omniadmin;
 
 }


### PR DESCRIPTION
[LPS-163950](https://issues.liferay.com/browse/LPS-163950)

### Problem
If the Lockout mechanism is used in a denial of service attack, the administrator user cannot recover the account using the Forgot Password functionality because it is locked

### Solution
Any user will be able to recover the password.

### Tests
An integration test (_ForgotPasswordMVCActionCommandTest_) has been created with one test. 

- _testLockoutAnyUser_: A lockout user is created and run the functionality Forgot Password. In this case the functionality can be executed. The way to check it is that the user himself is returned. 

