### PR TITLE
[TS] LPS-173082

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1822,7 +1822,7 @@ public class ServicePreAction extends Action {
 
 		if (requestURI.startsWith(mainPath) &&
 			(requestURI.startsWith(_PATH_PORTAL_LOGIN, mainPath.length()) ||
-			 requestURI.startsWith("/portal/saml", mainPath.length()))) {
+			 requestURI.startsWith(_PATH_PORTAL_SAML, mainPath.length()))) {
 
 			return true;
 		}
@@ -2113,6 +2113,8 @@ public class ServicePreAction extends Action {
 	private static final String _PATH_PORTAL_LOGIN = "/portal/login";
 
 	private static final String _PATH_PORTAL_LOGOUT = "/portal/logout";
+
+	private static final String _PATH_PORTAL_SAML = "/portal/saml";
 
 	private static final String _PATH_PROXY;
 

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -1821,7 +1821,8 @@ public class ServicePreAction extends Action {
 		}
 
 		if (requestURI.startsWith(mainPath) &&
-			requestURI.startsWith(_PATH_PORTAL_LOGIN, mainPath.length())) {
+			(requestURI.startsWith(_PATH_PORTAL_LOGIN, mainPath.length()) ||
+			 requestURI.startsWith("/portal/saml", mainPath.length()))) {
 
 			return true;
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-173082

SAML URLs (`/portal/saml/acs` and `/portal/saml/auth_redirect` at least in my testing) should be counted as login requests, otherwise it's possible for the portal to redirect to the login portlet if the "Prompt Enabled" is checked for guest user authentication during SAML auth.

Please let me know if you have any questions, thanks!