### PR TITLE
[TS] LPS-174987

### DIFF
--- a/modules/dxp/apps/saml/saml-persistence-service/bnd.bnd
+++ b/modules/dxp/apps/saml/saml-persistence-service/bnd.bnd
@@ -28,6 +28,6 @@ Import-Package:\
 	\
 	*
 Liferay-Releng-Module-Group-Title: SAML
-Liferay-Require-SchemaVersion: 3.0.2
+Liferay-Require-SchemaVersion: 3.0.3
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/registry/SamlServiceUpgradeStepRegistrator.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/registry/SamlServiceUpgradeStepRegistrator.java
@@ -144,6 +144,11 @@ public class SamlServiceUpgradeStepRegistrator
 				"SamlPeerBinding", "samlNameIdFormat", "VARCHAR(128) null"),
 			UpgradeProcessFactory.alterColumnType(
 				"SamlPeerBinding", "samlNameIdValue", "VARCHAR(1024) null"));
+
+		registry.register(
+			"3.0.2", "3.0.3",
+			UpgradeProcessFactory.alterColumnType(
+				"SamlSpSession", "sessionIndex", "VARCHAR(200) null"));
 	}
 
 	@Reference

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/model/impl/SamlSpSessionModelImpl.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/model/impl/SamlSpSessionModelImpl.java
@@ -96,7 +96,7 @@ public class SamlSpSessionModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table SamlSpSession (samlSpSessionId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,samlPeerBindingId LONG,assertionXml TEXT null,jSessionId VARCHAR(200) null,samlSpSessionKey VARCHAR(75) null,sessionIndex VARCHAR(75) null,terminated_ BOOLEAN)";
+		"create table SamlSpSession (samlSpSessionId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,samlPeerBindingId LONG,assertionXml TEXT null,jSessionId VARCHAR(200) null,samlSpSessionKey VARCHAR(75) null,sessionIndex VARCHAR(200) null,terminated_ BOOLEAN)";
 
 	public static final String TABLE_SQL_DROP = "drop table SamlSpSession";
 

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -145,7 +145,9 @@
 			<hint name="max-length">200</hint>
 		</field>
 		<field name="samlSpSessionKey" type="String" />
-		<field name="sessionIndex" type="String" />
+		<field name="sessionIndex" type="String">
+			<hint name="max-length">200</hint>
+		</field>
 		<field name="terminated" type="boolean" />
 	</model>
 </model-hints>

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/indexes.sql
@@ -17,8 +17,8 @@ create index IX_61204DD on SamlSpIdpConnection (companyId, samlIdpEntityId[$COLU
 create index IX_31762094 on SamlSpMessage (expirationDate);
 create index IX_5615F9DD on SamlSpMessage (samlIdpEntityId[$COLUMN_LENGTH:1024$], samlIdpResponseKey[$COLUMN_LENGTH:75$]);
 
-create index IX_C052F506 on SamlSpSession (companyId, sessionIndex[$COLUMN_LENGTH:75$]);
+create index IX_C052F506 on SamlSpSession (companyId, sessionIndex[$COLUMN_LENGTH:200$]);
 create index IX_85F532ED on SamlSpSession (jSessionId[$COLUMN_LENGTH:200$]);
 create index IX_5C25BCF on SamlSpSession (samlPeerBindingId);
 create unique index IX_C66E4319 on SamlSpSession (samlSpSessionKey[$COLUMN_LENGTH:75$]);
-create index IX_2001B382 on SamlSpSession (sessionIndex[$COLUMN_LENGTH:75$]);
+create index IX_2001B382 on SamlSpSession (sessionIndex[$COLUMN_LENGTH:200$]);

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/tables.sql
@@ -108,6 +108,6 @@ create table SamlSpSession (
 	assertionXml TEXT null,
 	jSessionId VARCHAR(200) null,
 	samlSpSessionKey VARCHAR(75) null,
-	sessionIndex VARCHAR(75) null,
+	sessionIndex VARCHAR(200) null,
 	terminated_ BOOLEAN
 );


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-174987

IBM Security Verify can produce session indexes that exceed the current 75 character limit. I'm unsure of the best size but thought 200 would be sufficient.

If there are any questions or concerns please let me know.