### PR TITLE
LPS-175232 Support parametarized algorithms in CompositePasswordEncryptor

### DIFF
--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/CompositePasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/CompositePasswordEncryptor.java
@@ -196,6 +196,10 @@ public class CompositePasswordEncryptor
 		else if (algorithm.startsWith(TYPE_PBKDF2)) {
 			passwordEncryptor = _serviceTrackerMap.getService(TYPE_PBKDF2);
 		}
+		else if (algorithm.indexOf(CharPool.SLASH) > 0) {
+			passwordEncryptor = _serviceTrackerMap.getService(
+				algorithm.substring(0, algorithm.indexOf(CharPool.SLASH)));
+		}
 		else {
 			passwordEncryptor = _serviceTrackerMap.getService(algorithm);
 		}


### PR DESCRIPTION
LPS-175232 This change updates the CompositePasswordEncryptor to ignore optional parameters (separated by slashes) when looking up encryption algorithms. This will allow for a custom PasswordEncryptor implementation that supports parameterizing key size and rounds just like the PBKDF2 encryptor supports. There is only a small change to the _select() method to strip parameters off of the algorithm prior to lookup.