### PR TITLE
[TS] LPS-173722 - StaleObjectStateExceptions can occur during digest update

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -5695,6 +5695,8 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 				String newDigest = user.getDigest(password);
 
 				if (!newDigest.equals(digest)) {
+					user = userPersistence.fetchByPrimaryKey(user.getUserId());
+
 					user.setDigest(newDigest);
 
 					user = userPersistence.update(user);


### PR DESCRIPTION
Hi @liferay-appsec !

https://issues.liferay.com/browse/LPP-47761

This is an attempt to address a potential StaleObjectStateException that can occur during the login authentication process which prevents users from logging in. We've been able to trace the error to when we update the digest where the only change shown when comparing the two objects (the stale one and the new one) is to the MVCC. We've theorized that it's due to a null/empty digest, but even with that information haven't found a way to reproduce at all unfortunately so I'm not really aware of a way to test this. Please see PTR-3549 for additional information and context for why this approach was taken.

I'm sending this to your team since this is technically authentication related, but let me know if you want me to send this elsewhere and I can. Thanks!