### PR TITLE
LPS-177021 Modify implementation of GraphQLRequestContextValidator to improve the corner cases

### DIFF
--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/vulcan/graphql/contributor/v1_0/StructuredContentGraphQLContributor.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/vulcan/graphql/contributor/v1_0/StructuredContentGraphQLContributor.java
@@ -39,6 +39,11 @@ public class StructuredContentGraphQLContributor implements GraphQLContributor {
 		return new StructuredContentQuery();
 	}
 
+	@Override
+	public boolean isJaxRsResourceInvocation() {
+		return false;
+	}
+
 	public static class StructuredContentQuery {
 
 		@GraphQLTypeExtension(StructuredContent.class)

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/vulcan/graphql/validation/OAuth2GraphQLRequestContextValidator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/vulcan/graphql/validation/OAuth2GraphQLRequestContextValidator.java
@@ -62,7 +62,7 @@ public class OAuth2GraphQLRequestContextValidator
 	public void validate(GraphQLRequestContext graphQLRequestContext)
 		throws Exception {
 
-		if (!graphQLRequestContext.isValidationRequired()) {
+		if (!graphQLRequestContext.isJaxRsResourceInvocation()) {
 			return;
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/vulcan/graphql/validation/OAuth2GraphQLRequestContextValidator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/vulcan/graphql/validation/OAuth2GraphQLRequestContextValidator.java
@@ -32,7 +32,6 @@ import com.liferay.portal.vulcan.graphql.validation.GraphQLRequestContext;
 import com.liferay.portal.vulcan.graphql.validation.GraphQLRequestContextValidator;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -82,14 +81,11 @@ public class OAuth2GraphQLRequestContextValidator
 			_checkScope(graphQLRequestContext, serviceReference);
 		}
 
-		Method method = graphQLRequestContext.getResourceMethod();
+		_setServiceDepth();
 
-		if (method != null) {
-			_setServiceDepth();
-
-			_accessControlAdvisor.accept(
-				method, new Object[0], _NULL_ACCESS_CONTROLLED);
-		}
+		_accessControlAdvisor.accept(
+			graphQLRequestContext.getResourceMethod(), new Object[0],
+			_NULL_ACCESS_CONTROLLED);
 	}
 
 	@Activate
@@ -123,6 +119,10 @@ public class OAuth2GraphQLRequestContextValidator
 		_scopeContext.setCompanyId(graphQLRequestContext.getCompanyId());
 
 		try {
+			if (serviceReferences.isEmpty()) {
+				throw new ForbiddenException();
+			}
+
 			for (ServiceReference<ScopeLogic> serviceReference :
 					serviceReferences) {
 
@@ -138,6 +138,10 @@ public class OAuth2GraphQLRequestContextValidator
 					throw new ForbiddenException();
 				}
 			}
+		}
+		catch (Exception exception) {
+			throw new ForbiddenException(
+				"Forbidden operation: " + exception.getMessage(), exception);
 		}
 		finally {
 			_scopeContext.setApplicationName(null);

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/contributor/GraphQLContributor.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/contributor/GraphQLContributor.java
@@ -33,4 +33,8 @@ public interface GraphQLContributor {
 		return null;
 	}
 
+	public default boolean isJaxRsResourceInvocation() {
+		return true;
+	}
+
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/servlet/ServletData.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/servlet/ServletData.java
@@ -41,4 +41,8 @@ public interface ServletData {
 		return null;
 	}
 
+	public default boolean isJaxRsResourceInvocation() {
+		return true;
+	}
+
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/validation/GraphQLRequestContext.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/graphql/validation/GraphQLRequestContext.java
@@ -31,6 +31,6 @@ public interface GraphQLRequestContext {
 
 	public Method getResourceMethod();
 
-	public boolean isValidationRequired();
+	public boolean isJaxRsResourceInvocation();
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/contributor/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/contributor/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/servlet/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/servlet/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/validation/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/graphql/validation/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/fetcher/BaseDataFetcher.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/data/fetcher/BaseDataFetcher.java
@@ -47,14 +47,10 @@ public abstract class BaseDataFetcher implements DataFetcher<Object> {
 		throws Exception {
 
 		try {
-			if (_graphQLRequestContext != null) {
-				for (GraphQLRequestContextValidator
-						graphQLRequestContextValidator :
-							_graphQLRequestContextValidators) {
+			for (GraphQLRequestContextValidator graphQLRequestContextValidator :
+					_graphQLRequestContextValidators) {
 
-					graphQLRequestContextValidator.validate(
-						_graphQLRequestContext);
-				}
+				graphQLRequestContextValidator.validate(_graphQLRequestContext);
 			}
 
 			return get(

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/ServletDataAdapter.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/servlet/ServletDataAdapter.java
@@ -46,6 +46,11 @@ public class ServletDataAdapter implements ServletData {
 		return _graphQLContributor.getQuery();
 	}
 
+	@Override
+	public boolean isJaxRsResourceInvocation() {
+		return _graphQLContributor.isJaxRsResourceInvocation();
+	}
+
 	private ServletDataAdapter(GraphQLContributor graphQLContributor) {
 		_graphQLContributor = graphQLContributor;
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/validation/GraphQLDTOContributorRequestContext.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/validation/GraphQLDTOContributorRequestContext.java
@@ -60,7 +60,7 @@ public class GraphQLDTOContributorRequestContext
 	}
 
 	@Override
-	public boolean isValidationRequired() {
+	public boolean isJaxRsResourceInvocation() {
 		return true;
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/validation/ServletDataRequestContext.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/graphql/validation/ServletDataRequestContext.java
@@ -18,7 +18,6 @@ import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.graphql.servlet.ServletData;
 import com.liferay.portal.vulcan.graphql.validation.GraphQLRequestContext;
-import com.liferay.portal.vulcan.internal.graphql.servlet.ServletDataAdapter;
 
 import java.lang.reflect.Method;
 
@@ -67,14 +66,8 @@ public class ServletDataRequestContext implements GraphQLRequestContext {
 	}
 
 	@Override
-	public boolean isValidationRequired() {
-		if ((_servletData == null) ||
-			(_servletData instanceof ServletDataAdapter)) {
-
-			return false;
-		}
-
-		return true;
+	public boolean isJaxRsResourceInvocation() {
+		return _servletData.isJaxRsResourceInvocation();
 	}
 
 	private String _getNamespace(ServletData servletData) {

--- a/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/BaseGraphQLServlet.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-test/src/testIntegration/java/com/liferay/portal/vulcan/internal/graphql/servlet/test/BaseGraphQLServlet.java
@@ -101,6 +101,11 @@ public class BaseGraphQLServlet {
 			return _testQuery;
 		}
 
+		@Override
+		public boolean isJaxRsResourceInvocation() {
+			return false;
+		}
+
 		private final TestQuery _testQuery = new TestQuery();
 
 	}


### PR DESCRIPTION
This PR contains the code to improve some corner cases in which a request could be returned with a HTTP code different from 403 Forbidden.

The method `isValidationRequired` has been replaced with `isJaxRsResourceInvocation`, and the implementation of that method, by default returning `true`, is delegated to the developer that creates the implementation of the `ServletData` interface. By now, in Liferay there are two different implementation types of that interface:

- `StructuredContentGraphQLContributor`: Implementation of the `GraphQLContributor` interface that is adapted to the `ServletData` interface by the `ServletDataAdapter` registered. The implementation just returns an implementation that provides a new field `version` for the extended element `StructuredContent`. It is not invoking any JAX-RS resource, that is why the value of the `isJaxRsResourceInvocation` method returns false.
- `ServletDataImpl`: Auto-generated by REST Builder for all the REST APIs of Liferay created with REST Builder. It will not change the returned value, so it will be returned the default value : true. The default value is that because it is not allowed to include a breaking change for the customers that use REST Builder with previous versions.

How to test the `StructuredContentGraphQLContributor`:

For example with the following body:

```
query {
    admin {
        structuredContents(
            siteKey: "20121"
        )
        {
            items {
                title
                version {
                    number
                    status {
                        code
                    }
                }
            }
        }
    }
}

```
