### PR TITLE
LPS-157194 Add upgrade process for 7.3 to clear out expired OAuth2Authorizations

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
@@ -16,10 +16,12 @@ package com.liferay.oauth2.provider.internal.upgrade.registry;
 
 import com.liferay.oauth2.provider.internal.upgrade.v2_0_0.OAuth2ApplicationScopeAliasesUpgradeProcess;
 import com.liferay.oauth2.provider.internal.upgrade.v3_0_0.OAuth2ApplicationClientCredentialUserUpgradeUser;
+import com.liferay.oauth2.provider.internal.upgrade.v3_0_1.OAuth2AuthorizationUpgradeProcess;
 import com.liferay.oauth2.provider.internal.upgrade.v3_2_0.OAuth2ApplicationFeatureUpgradeProcess;
 import com.liferay.oauth2.provider.internal.upgrade.v4_1_0.OAuth2ApplicationClientAuthenticationMethodUpgradeProcess;
 import com.liferay.oauth2.provider.internal.upgrade.v4_2_1.OAuth2ScopeGrantRemoveCompanyIdFromObjectsRelatedUpgradeProcess;
 import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
+import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.upgrade.BaseExternalReferenceCodeUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.BaseUuidUpgradeProcess;
@@ -71,7 +73,11 @@ public class OAuth2ServiceUpgradeStepRegistrator
 			new OAuth2ApplicationClientCredentialUserUpgradeUser());
 
 		registry.register(
-			"3.0.0", "3.1.0",
+			"3.0.0", "3.0.1",
+			new OAuth2AuthorizationUpgradeProcess(_configurationProvider));
+
+		registry.register(
+			"3.0.1", "3.1.0",
 			UpgradeProcessFactory.addColumns(
 				"OAuth2Application", "rememberDevice BOOLEAN"),
 			UpgradeProcessFactory.addColumns(
@@ -125,6 +131,9 @@ public class OAuth2ServiceUpgradeStepRegistrator
 
 	@Reference
 	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private ConfigurationProvider _configurationProvider;
 
 	@Reference
 	private ScopeLocator _scopeLocator;

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/v3_0_1/OAuth2AuthorizationUpgradeProcess.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/v3_0_1/OAuth2AuthorizationUpgradeProcess.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.internal.upgrade.v3_0_1;
+
+import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.Time;
+
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+
+/**
+ * @author Jonathan McCann
+ */
+public class OAuth2AuthorizationUpgradeProcess extends UpgradeProcess {
+
+	public OAuth2AuthorizationUpgradeProcess(
+		ConfigurationProvider configurationProvider) {
+
+		_configurationProvider = configurationProvider;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		OAuth2ProviderConfiguration oAuth2ProviderConfiguration =
+			_configurationProvider.getSystemConfiguration(
+				OAuth2ProviderConfiguration.class);
+
+		int expiredAuthorizationsAfterlifeDuration = Math.max(
+			oAuth2ProviderConfiguration.
+				expiredAuthorizationsAfterlifeDuration(),
+			0);
+
+		long expiredAuthorizationsAfterlifeDurationMillis =
+			expiredAuthorizationsAfterlifeDuration * Time.SECOND;
+
+		Timestamp purgeDate = new Timestamp(System.currentTimeMillis());
+
+		purgeDate.setTime(
+			purgeDate.getTime() - expiredAuthorizationsAfterlifeDurationMillis);
+
+		String sql = StringBundler.concat(
+			"create table TEMP_TABLE as (",
+			"select * from OAuth2Authorization where ",
+			"(accessTokenExpirationDate >= ?) or ((refreshTokenExpirationDate ",
+			"is not null) and (refreshTokenExpirationDate >= ?)))");
+
+		try (PreparedStatement preparedStatement = connection.prepareStatement(
+				sql)) {
+
+			preparedStatement.setTimestamp(1, purgeDate);
+			preparedStatement.setTimestamp(2, purgeDate);
+
+			preparedStatement.execute();
+		}
+
+		runSQL(
+			StringBundler.concat(
+				"create table TEMP_TABLE2 as (",
+				"select * from OA2Auths_OA2ScopeGrants where ",
+				"oAuth2AuthorizationId in (select oAuth2AuthorizationId from ",
+				"TEMP_TABLE))"));
+
+		runSQL("drop table OAuth2Authorization");
+		runSQL("drop table OA2Auths_OA2ScopeGrants");
+
+		runSQL("rename table TEMP_TABLE to OAuth2Authorization");
+		runSQL("rename table TEMP_TABLE2 to OA2Auths_OA2ScopeGrants");
+	}
+
+	private final ConfigurationProvider _configurationProvider;
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/build.gradle
@@ -22,5 +22,7 @@ dependencies {
 	testIntegrationCompile group: "org.mockito", name: "mockito-core", version: "1.10.8"
 	testIntegrationCompile project(":apps:document-library:document-library-api")
 	testIntegrationCompile project(":apps:portal-configuration:portal-configuration-test-util")
+	testIntegrationCompile project(":apps:portal:portal-upgrade-test-util")
+	testIntegrationCompile project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/upgrade/v3_0_1/test/UpgradeOAuth2AuthorizationTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/upgrade/v3_0_1/test/UpgradeOAuth2AuthorizationTest.java
@@ -1,0 +1,198 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.oauth2.provider.upgrade.v3_0_1.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.model.OAuth2Authorization;
+import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jonathan McCann
+ */
+@RunWith(Arquillian.class)
+public class UpgradeOAuth2AuthorizationTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator,
+			"com.liferay.oauth2.provider.internal.upgrade.v3_0_1." +
+				"OAuth2AuthorizationUpgradeProcess");
+
+		_oAuth2ScopeGrantId = RandomTestUtil.randomLong();
+	}
+
+	@Test
+	public void testUpgradeOAuth2Authorizations() throws Exception {
+		long now = System.currentTimeMillis();
+
+		_addOAuth2Authorization(new Date(now - Time.DAY), null);
+
+		_addOAuth2Authorization(new Date(), null);
+
+		_addOAuth2Authorization(null, new Date(now - Time.DAY));
+
+		_addOAuth2Authorization(null, new Date());
+
+		_upgradeProcess.upgrade();
+
+		Assert.assertEquals(
+			2, _oAuth2AuthorizationLocalService.getOAuth2AuthorizationsCount());
+
+		Assert.assertEquals(
+			2,
+			_oAuth2AuthorizationLocalService.
+				getOAuth2ScopeGrantOAuth2AuthorizationsCount(
+					_oAuth2ScopeGrantId));
+	}
+
+	@Test
+	public void testUpgradeOAuth2AuthorizationWithExpiredAccessToken()
+		throws Exception {
+
+		long now = System.currentTimeMillis();
+
+		_addOAuth2Authorization(new Date(now - Time.DAY), null);
+
+		_upgradeProcess.upgrade();
+
+		Assert.assertEquals(
+			0, _oAuth2AuthorizationLocalService.getOAuth2AuthorizationsCount());
+
+		Assert.assertEquals(
+			0,
+			_oAuth2AuthorizationLocalService.
+				getOAuth2ScopeGrantOAuth2AuthorizationsCount(
+					_oAuth2ScopeGrantId));
+	}
+
+	@Test
+	public void testUpgradeOAuth2AuthorizationWithExpiredRefreshToken()
+		throws Exception {
+
+		long now = System.currentTimeMillis();
+
+		_addOAuth2Authorization(null, new Date(now - Time.DAY));
+
+		_upgradeProcess.upgrade();
+
+		Assert.assertEquals(
+			0, _oAuth2AuthorizationLocalService.getOAuth2AuthorizationsCount());
+
+		Assert.assertEquals(
+			0,
+			_oAuth2AuthorizationLocalService.
+				getOAuth2ScopeGrantOAuth2AuthorizationsCount(
+					_oAuth2ScopeGrantId));
+	}
+
+	@Test
+	public void testUpgradeOAuth2AuthorizationWithValidAccessToken()
+		throws Exception {
+
+		_addOAuth2Authorization(new Date(), null);
+
+		_upgradeProcess.upgrade();
+
+		Assert.assertEquals(
+			1, _oAuth2AuthorizationLocalService.getOAuth2AuthorizationsCount());
+
+		Assert.assertEquals(
+			1,
+			_oAuth2AuthorizationLocalService.
+				getOAuth2ScopeGrantOAuth2AuthorizationsCount(
+					_oAuth2ScopeGrantId));
+	}
+
+	@Test
+	public void testUpgradeOAuth2AuthorizationWithValidRefreshToken()
+		throws Exception {
+
+		_addOAuth2Authorization(null, new Date());
+
+		_upgradeProcess.upgrade();
+
+		Assert.assertEquals(
+			1, _oAuth2AuthorizationLocalService.getOAuth2AuthorizationsCount());
+
+		Assert.assertEquals(
+			1,
+			_oAuth2AuthorizationLocalService.
+				getOAuth2ScopeGrantOAuth2AuthorizationsCount(
+					_oAuth2ScopeGrantId));
+	}
+
+	private void _addOAuth2Authorization(
+		Date accessTokenExpirationDate, Date refreshTokenExpirationDate) {
+
+		OAuth2Authorization oAuth2Authorization =
+			_oAuth2AuthorizationLocalService.createOAuth2Authorization(
+				RandomTestUtil.randomLong());
+
+		oAuth2Authorization.setAccessTokenExpirationDate(
+			accessTokenExpirationDate);
+		oAuth2Authorization.setRefreshTokenExpirationDate(
+			refreshTokenExpirationDate);
+
+		_oAuth2Authorizations.add(oAuth2Authorization);
+
+		_oAuth2AuthorizationLocalService.addOAuth2Authorization(
+			oAuth2Authorization);
+
+		_oAuth2AuthorizationLocalService.addOAuth2ScopeGrantOAuth2Authorization(
+			_oAuth2ScopeGrantId,
+			oAuth2Authorization.getOAuth2AuthorizationId());
+	}
+
+	private static long _oAuth2ScopeGrantId;
+	private static UpgradeProcess _upgradeProcess;
+
+	@Inject(
+		filter = "component.name=com.liferay.oauth2.provider.internal.upgrade.registry.OAuth2ServiceUpgradeStepRegistrator"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private OAuth2AuthorizationLocalService _oAuth2AuthorizationLocalService;
+
+	@DeleteAfterTestRun
+	private List<OAuth2Authorization> _oAuth2Authorizations = new ArrayList<>();
+
+}


### PR DESCRIPTION
@oliverkecskemety 

This is a follow up to the idea presented here - https://github.com/liferay-uniform/liferay-portal/pull/996#issuecomment-1449696082

If you wouldn't mind double checking the SQL logic I would appreciate it. It has switched from deleting to saving entries so I had to inverse the logic and want to make sure everything is correct.

I've also included five test cases which cover:
- A valid access token
- An invalid access token
- A valid refresh token
- An invalid refresh token
- A mix of the previous four to ensure it can handle mixed results

If there are any questions or concerns please let me know.