### PR TITLE
[TS] LPS-177580 Update oauth2-oidc-sdk dependency

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -2316,7 +2316,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.oauth.client.persistence.service.jar!oauth2-oidc-sdk.jar</file-name>
-				<version>8.4.3</version>
+				<version>8.11</version>
 				<project-name>OAuth 2.0 SDK with OpenID Connect extensions</project-name>
 				<project-url>https://connect2id.com</project-url>
 				<licenses>
@@ -2325,7 +2325,7 @@
 						<license-url>http://www.apache.org/licenses/LICENSE-2.0.html‎</license-url>
 					</license>
 				</licenses>
-				<current-version-publish-date>2020-05-31 11:45:35</current-version-publish-date>
+				<current-version-publish-date>2020-06-28 11:51:04</current-version-publish-date>
 				<latest-version-publish-date>2023-02-16 11:03:26</latest-version-publish-date>
 			</library>
 			<library>
@@ -3949,7 +3949,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.security.sso.openid.connect.impl.jar!oauth2-oidc-sdk.jar</file-name>
-				<version>8.4.3</version>
+				<version>8.11</version>
 				<project-name>OAuth 2.0 SDK with OpenID Connect extensions</project-name>
 				<project-url>https://connect2id.com</project-url>
 				<licenses>
@@ -3958,7 +3958,7 @@
 						<license-url>http://www.apache.org/licenses/LICENSE-2.0.html‎</license-url>
 					</license>
 				</licenses>
-				<current-version-publish-date>2020-05-31 11:45:35</current-version-publish-date>
+				<current-version-publish-date>2020-06-28 11:51:04</current-version-publish-date>
 				<latest-version-publish-date>2023-02-16 11:03:26</latest-version-publish-date>
 			</library>
 			<library>
@@ -4047,7 +4047,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.security.sso.openid.connect.persistence.service.jar!oauth2-oidc-sdk.jar</file-name>
-				<version>8.4.3</version>
+				<version>8.11</version>
 				<project-name>OAuth 2.0 SDK with OpenID Connect extensions</project-name>
 				<project-url>https://connect2id.com</project-url>
 				<licenses>
@@ -4056,7 +4056,7 @@
 						<license-url>http://www.apache.org/licenses/LICENSE-2.0.html‎</license-url>
 					</license>
 				</licenses>
-				<current-version-publish-date>2020-05-31 11:45:35</current-version-publish-date>
+				<current-version-publish-date>2020-06-28 11:51:04</current-version-publish-date>
 				<latest-version-publish-date>2023-02-16 11:03:26</latest-version-publish-date>
 			</library>
 			<library>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -1058,7 +1058,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.oauth.client.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.oauth.client.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1772,7 +1772,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.impl.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.impl.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1814,7 +1814,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -1058,7 +1058,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.oauth.client.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.4.3</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.oauth.client.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1772,7 +1772,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.impl.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.4.3</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.impl.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1814,7 +1814,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.4.3</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>

--- a/modules/apps/oauth-client/oauth-client-persistence-service/build.gradle
+++ b/modules/apps/oauth-client/oauth-client-persistence-service/build.gradle
@@ -8,7 +8,7 @@ dependencies {
 	compileInclude group: "com.nimbusds", name: "content-type", version: "2.0"
 	compileInclude group: "com.nimbusds", name: "lang-tag", version: "1.4.4"
 	compileInclude group: "com.nimbusds", name: "nimbus-jose-jwt", version: "8.14.1"
-	compileInclude group: "com.nimbusds", name: "oauth2-oidc-sdk", version: "8.4.3"
+	compileInclude group: "com.nimbusds", name: "oauth2-oidc-sdk", version: "8.11"
 	compileInclude group: "com.sun.mail", name: "jakarta.mail", version: "1.6.6"
 	compileInclude group: "javax.activation", name: "activation", version: "1.1.1"
 	compileInclude group: "net.minidev", name: "accessors-smart", version: "2.4.2"

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/build.gradle
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/build.gradle
@@ -3,7 +3,7 @@ dependencies {
 	compileInclude group: "com.nimbusds", name: "content-type", version: "2.0"
 	compileInclude group: "com.nimbusds", name: "lang-tag", version: "1.4.4"
 	compileInclude group: "com.nimbusds", name: "nimbus-jose-jwt", version: "8.14.1"
-	compileInclude group: "com.nimbusds", name: "oauth2-oidc-sdk", version: "8.4.3"
+	compileInclude group: "com.nimbusds", name: "oauth2-oidc-sdk", version: "8.11"
 	compileInclude group: "com.sun.mail", name: "jakarta.mail", version: "1.6.6"
 	compileInclude group: "javax.activation", name: "activation", version: "1.1.1"
 	compileInclude group: "net.minidev", name: "accessors-smart", version: "2.4.2"

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/build.gradle
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 	compileInclude group: "com.nimbusds", name: "content-type", version: "2.0"
 	compileInclude group: "com.nimbusds", name: "lang-tag", version: "1.4.4"
 	compileInclude group: "com.nimbusds", name: "nimbus-jose-jwt", version: "8.14.1"
-	compileInclude group: "com.nimbusds", name: "oauth2-oidc-sdk", version: "8.4.3"
+	compileInclude group: "com.nimbusds", name: "oauth2-oidc-sdk", version: "8.11"
 	compileInclude group: "net.minidev", name: "accessors-smart", version: "2.4.2"
 	compileInclude group: "net.minidev", name: "json-smart", version: "2.4.5"
 


### PR DESCRIPTION
Hi Team,

https://issues.liferay.com/browse/LPS-167751 introduced the usage of CodeVerifier in OpenIdConnectAuthenticationSession, but CodeVerifier is not Serializable until "oauth2-oidc-sdk", version: "8.11"

Can you please review?
https://issues.liferay.com/browse/LPS-177580

Cheers,
Balázs