### PR TITLE
[TS] LPS-178212 Resource permissions popup should search for roles by visible information only

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java
@@ -484,26 +484,26 @@ public class PortletConfigurationPermissionsDisplayContext {
 				roleSearchContainer.setResultsAndTotal(
 					() -> RoleServiceUtil.getGroupRolesAndTeamRoles(
 						_themeDisplay.getCompanyId(), searchTerms.getKeywords(),
-						excludedRoleNames, getRoleTypes(),
+						false, excludedRoleNames, getRoleTypes(),
 						roleModelResourceRoleId, roleTeamGroupId,
 						roleSearchContainer.getStart(),
 						roleSearchContainer.getEnd()),
 					RoleServiceUtil.getGroupRolesAndTeamRolesCount(
 						_themeDisplay.getCompanyId(), searchTerms.getKeywords(),
-						excludedRoleNames, getRoleTypes(),
+						false, excludedRoleNames, getRoleTypes(),
 						roleModelResourceRoleId, roleTeamGroupId));
 			}
 			else {
 				roleSearchContainer.setResultsAndTotal(
 					() -> RoleLocalServiceUtil.getGroupRolesAndTeamRoles(
 						_themeDisplay.getCompanyId(), searchTerms.getKeywords(),
-						excludedRoleNames, getRoleTypes(),
+						false, excludedRoleNames, getRoleTypes(),
 						roleModelResourceRoleId, roleTeamGroupId,
 						roleSearchContainer.getStart(),
 						roleSearchContainer.getEnd()),
 					RoleLocalServiceUtil.getGroupRolesAndTeamRolesCount(
 						_themeDisplay.getCompanyId(), searchTerms.getKeywords(),
-						excludedRoleNames, getRoleTypes(),
+						false, excludedRoleNames, getRoleTypes(),
 						roleModelResourceRoleId, roleTeamGroupId));
 			}
 		}
@@ -514,15 +514,17 @@ public class PortletConfigurationPermissionsDisplayContext {
 				roleSearchContainer.setResultsAndTotal(
 					RoleServiceUtil.getGroupRolesAndTeamRoles(
 						_themeDisplay.getCompanyId(), searchTerms.getKeywords(),
-						excludedRoleNames, getRoleTypes(), modelResourceRoleId,
-						teamGroupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS));
+						false, excludedRoleNames, getRoleTypes(),
+						modelResourceRoleId, teamGroupId, QueryUtil.ALL_POS,
+						QueryUtil.ALL_POS));
 			}
 			else {
 				roleSearchContainer.setResultsAndTotal(
 					RoleLocalServiceUtil.getGroupRolesAndTeamRoles(
 						_themeDisplay.getCompanyId(), searchTerms.getKeywords(),
-						excludedRoleNames, getRoleTypes(), modelResourceRoleId,
-						teamGroupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS));
+						false, excludedRoleNames, getRoleTypes(),
+						modelResourceRoleId, teamGroupId, QueryUtil.ALL_POS,
+						QueryUtil.ALL_POS));
 			}
 		}
 

--- a/modules/apps/roles/roles-test/src/testIntegration/java/com/liferay/roles/service/persistence/test/RoleFinderTest.java
+++ b/modules/apps/roles/roles-test/src/testIntegration/java/com/liferay/roles/service/persistence/test/RoleFinderTest.java
@@ -87,8 +87,9 @@ public class RoleFinderTest {
 				_user, permissionChecker)) {
 
 			List<Role> roles = _roleFinder.filterFindByGroupRoleAndTeamRole(
-				TestPropsValues.getCompanyId(), null, existingRoleNames, _TYPES,
-				0, _user.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+				TestPropsValues.getCompanyId(), null, true, existingRoleNames,
+				_TYPES, 0, _user.getGroupId(), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS);
 
 			Assert.assertEquals(roles.toString(), 1, roles.size());
 

--- a/modules/apps/roles/roles-test/src/testIntegration/java/com/liferay/roles/service/test/RoleLocalServiceTest.java
+++ b/modules/apps/roles/roles-test/src/testIntegration/java/com/liferay/roles/service/test/RoleLocalServiceTest.java
@@ -51,6 +51,7 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.comparator.RoleRoleIdComparator;
@@ -266,7 +267,7 @@ public class RoleLocalServiceTest {
 		excludedRoleNames.add(RoleConstants.GUEST);
 
 		List<Role> actualRoles = _roleLocalService.getGroupRolesAndTeamRoles(
-			companyId, null, excludedRoleNames, roleTypes, 0, groupId,
+			companyId, null, true, excludedRoleNames, roleTypes, 0, groupId,
 			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		List<Role> expectedRoles = ListUtil.filter(
@@ -300,7 +301,8 @@ public class RoleLocalServiceTest {
 		Assert.assertEquals(
 			expectedRoles.size(),
 			_roleLocalService.getGroupRolesAndTeamRolesCount(
-				companyId, null, excludedRoleNames, roleTypes, 0, groupId));
+				companyId, null, true, excludedRoleNames, roleTypes, 0,
+				groupId));
 
 		actualRoles = new ArrayList(actualRoles);
 		expectedRoles = new ArrayList(expectedRoles);
@@ -317,40 +319,96 @@ public class RoleLocalServiceTest {
 	public void testGetGroupRolesAndTeamRolesWithKeyword() throws Exception {
 		createOrganizationAndTeam();
 
+		long userId = TestPropsValues.getUserId();
+		String keywordRole = RandomTestUtil.randomString();
+
 		long companyId = _organization.getCompanyId();
 		long groupId = _organization.getGroupId();
+
+		Role role1 = _roleLocalService.addRole(
+			userId, null, 0, keywordRole,
+			Collections.singletonMap(LocaleUtil.getDefault(), keywordRole),
+			Collections.emptyMap(), RoleConstants.TYPE_SITE, StringPool.BLANK,
+			new ServiceContext());
+
+		Role role2 = _roleLocalService.addRole(
+			userId, null, 0, StringUtil.randomString(),
+			Collections.singletonMap(
+				LocaleUtil.getDefault(), StringUtil.randomString()),
+			Collections.singletonMap(LocaleUtil.getDefault(), keywordRole),
+			RoleConstants.TYPE_SITE, StringPool.BLANK, new ServiceContext());
 
 		int[] roleTypes = RoleConstants.TYPES_ORGANIZATION_AND_REGULAR_AND_SITE;
 
 		List<String> excludedRoleNames = new ArrayList<>();
 
-		excludedRoleNames.add(RoleConstants.GUEST);
+		excludedRoleNames.add(role1.getName());
 
 		Assert.assertEquals(
 			0,
 			_roleLocalService.getGroupRolesAndTeamRolesCount(
-				companyId, RoleConstants.GUEST, excludedRoleNames, roleTypes, 0,
+				companyId, keywordRole, false, excludedRoleNames, roleTypes, 0,
 				groupId));
-
-		List<Role> roles1 = _roleLocalService.getGroupRolesAndTeamRoles(
-			companyId, RoleConstants.GUEST, excludedRoleNames, roleTypes, 0,
-			groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
-
-		Assert.assertTrue(roles1.toString(), roles1.isEmpty());
 
 		Assert.assertEquals(
 			1,
 			_roleLocalService.getGroupRolesAndTeamRolesCount(
-				companyId, _team.getName(), excludedRoleNames, roleTypes, 0,
+				companyId, keywordRole, true, excludedRoleNames, roleTypes, 0,
 				groupId));
 
-		List<Role> roles2 = _roleLocalService.getGroupRolesAndTeamRoles(
-			companyId, _team.getName(), excludedRoleNames, roleTypes, 0,
+		List<Role> roles1 = _roleLocalService.getGroupRolesAndTeamRoles(
+			companyId, keywordRole, false, excludedRoleNames, roleTypes, 0,
 			groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
-		_role = roles2.get(0);
+		Assert.assertTrue(roles1.toString(), roles1.isEmpty());
 
-		Assert.assertEquals(_team.getTeamId(), _role.getClassPK());
+		List<Role> roles2 = _roleLocalService.getGroupRolesAndTeamRoles(
+			companyId, keywordRole, true, excludedRoleNames, roleTypes, 0,
+			groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		Assert.assertEquals(role2, roles2.get(0));
+
+		// change here for team
+
+		String keywordTeam = RandomTestUtil.randomString();
+
+		Team team1 = _teamLocalService.addTeam(
+			userId, groupId, keywordTeam, RandomTestUtil.randomString(),
+			new ServiceContext());
+		Team team2 = _teamLocalService.addTeam(
+			userId, groupId, RandomTestUtil.randomString(), keywordTeam,
+			new ServiceContext());
+
+		Assert.assertEquals(
+			1,
+			_roleLocalService.getGroupRolesAndTeamRolesCount(
+				companyId, keywordTeam, false, excludedRoleNames, roleTypes, 0,
+				groupId));
+		Assert.assertEquals(
+			2,
+			_roleLocalService.getGroupRolesAndTeamRolesCount(
+				companyId, keywordTeam, true, excludedRoleNames, roleTypes, 0,
+				groupId));
+
+		List<Role> roles3 = _roleLocalService.getGroupRolesAndTeamRoles(
+			companyId, keywordTeam, false, excludedRoleNames, roleTypes, 0,
+			groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		_role = roles3.get(0);
+
+		Assert.assertEquals(team1.getTeamId(), _role.getClassPK());
+
+		List<Role> roles4 = _roleLocalService.getGroupRolesAndTeamRoles(
+			companyId, keywordTeam, true, excludedRoleNames, roleTypes, 0,
+			groupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		_role = roles4.get(0);
+
+		Assert.assertEquals(team1.getTeamId(), _role.getClassPK());
+
+		_role = roles4.get(1);
+
+		Assert.assertEquals(team2.getTeamId(), _role.getClassPK());
 	}
 
 	@Test

--- a/portal-impl/src/com/liferay/portal/service/http/RoleServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/RoleServiceHttp.java
@@ -245,8 +245,9 @@ public class RoleServiceHttp {
 	public static java.util.List<com.liferay.portal.kernel.model.Role>
 		getGroupRolesAndTeamRoles(
 			HttpPrincipal httpPrincipal, long companyId, String keywords,
-			java.util.List<String> excludedNames, int[] types,
-			long excludedTeamRoleId, long teamGroupId, int start, int end) {
+			boolean searchDescription, java.util.List<String> excludedNames,
+			int[] types, long excludedTeamRoleId, long teamGroupId, int start,
+			int end) {
 
 		try {
 			MethodKey methodKey = new MethodKey(
@@ -254,8 +255,9 @@ public class RoleServiceHttp {
 				_getGroupRolesAndTeamRolesParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, companyId, keywords, excludedNames, types,
-				excludedTeamRoleId, teamGroupId, start, end);
+				methodKey, companyId, keywords, searchDescription,
+				excludedNames, types, excludedTeamRoleId, teamGroupId, start,
+				end);
 
 			Object returnObj = null;
 
@@ -281,8 +283,8 @@ public class RoleServiceHttp {
 
 	public static int getGroupRolesAndTeamRolesCount(
 		HttpPrincipal httpPrincipal, long companyId, String keywords,
-		java.util.List<String> excludedNames, int[] types,
-		long excludedTeamRoleId, long teamGroupId) {
+		boolean searchDescription, java.util.List<String> excludedNames,
+		int[] types, long excludedTeamRoleId, long teamGroupId) {
 
 		try {
 			MethodKey methodKey = new MethodKey(
@@ -290,8 +292,8 @@ public class RoleServiceHttp {
 				_getGroupRolesAndTeamRolesCountParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, companyId, keywords, excludedNames, types,
-				excludedTeamRoleId, teamGroupId);
+				methodKey, companyId, keywords, searchDescription,
+				excludedNames, types, excludedTeamRoleId, teamGroupId);
 
 			Object returnObj = null;
 
@@ -891,13 +893,13 @@ public class RoleServiceHttp {
 		new Class[] {long.class};
 	private static final Class<?>[] _getGroupRolesAndTeamRolesParameterTypes5 =
 		new Class[] {
-			long.class, String.class, java.util.List.class, int[].class,
-			long.class, long.class, int.class, int.class
+			long.class, String.class, boolean.class, java.util.List.class,
+			int[].class, long.class, long.class, int.class, int.class
 		};
 	private static final Class<?>[]
 		_getGroupRolesAndTeamRolesCountParameterTypes6 = new Class[] {
-			long.class, String.class, java.util.List.class, int[].class,
-			long.class, long.class
+			long.class, String.class, boolean.class, java.util.List.class,
+			int[].class, long.class, long.class
 		};
 	private static final Class<?>[] _getRoleParameterTypes7 = new Class[] {
 		long.class

--- a/portal-impl/src/com/liferay/portal/service/http/packageinfo
+++ b/portal-impl/src/com/liferay/portal/service/http/packageinfo
@@ -1,1 +1,1 @@
-version 10.3.0
+version 11.0.0

--- a/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
@@ -767,23 +767,24 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 
 	@Override
 	public List<Role> getGroupRolesAndTeamRoles(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end) {
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end) {
 
 		return roleFinder.findByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId, start, end);
 	}
 
 	@Override
 	public int getGroupRolesAndTeamRolesCount(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId) {
 
 		return roleFinder.countByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/RoleServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleServiceImpl.java
@@ -158,23 +158,24 @@ public class RoleServiceImpl extends RoleServiceBaseImpl {
 
 	@Override
 	public List<Role> getGroupRolesAndTeamRoles(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end) {
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end) {
 
 		return roleFinder.filterFindByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId, start, end);
 	}
 
 	@Override
 	public int getGroupRolesAndTeamRolesCount(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId) {
 
 		return roleFinder.filterCountByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/RoleFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/RoleFinderImpl.java
@@ -75,12 +75,13 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 
 	@Override
 	public int countByGroupRoleAndTeamRole(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId) {
 
 		return doCountByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, false);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId, false);
 	}
 
 	@Override
@@ -162,12 +163,13 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 
 	@Override
 	public int filterCountByGroupRoleAndTeamRole(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId) {
 
 		return doCountByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, true);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId, true);
 	}
 
 	@Override
@@ -241,13 +243,13 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 
 	@Override
 	public List<Role> filterFindByGroupRoleAndTeamRole(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end) {
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end) {
 
 		return doFindByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end, true);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId, start, end, true);
 	}
 
 	@Override
@@ -330,13 +332,13 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 
 	@Override
 	public List<Role> findByGroupRoleAndTeamRole(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end) {
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end) {
 
 		return doFindByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end, false);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId, start, end, false);
 	}
 
 	@Override
@@ -428,9 +430,9 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 	}
 
 	protected int doCountByGroupRoleAndTeamRole(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId,
-		boolean inlineSQLHelper) {
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId, boolean inlineSQLHelper) {
 
 		if ((types == null) || (types.length == 0)) {
 			return 0;
@@ -449,8 +451,8 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 						).as(
 							COUNT_COLUMN_NAME
 						)),
-					companyId, keywords, excludedNames, types,
-					excludedTeamRoleId, teamGroupId, inlineSQLHelper));
+					companyId, keywords, searchDescription, excludedNames,
+					types, excludedTeamRoleId, teamGroupId, inlineSQLHelper));
 
 			sqlQuery.addScalar(COUNT_COLUMN_NAME, Type.LONG);
 
@@ -641,9 +643,9 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 	}
 
 	protected List<Role> doFindByGroupRoleAndTeamRole(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end, boolean inlineSQLHelper) {
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end, boolean inlineSQLHelper) {
 
 		if ((types == null) || (types.length == 0)) {
 			return Collections.emptyList();
@@ -656,8 +658,8 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 
 			OrderByStep orderByStep = _getOrderByStep(
 				DSLQueryFactoryUtil.select(RoleTable.INSTANCE), companyId,
-				keywords, excludedNames, types, excludedTeamRoleId, teamGroupId,
-				inlineSQLHelper);
+				keywords, searchDescription, excludedNames, types,
+				excludedTeamRoleId, teamGroupId, inlineSQLHelper);
 
 			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(
 				orderByStep.orderBy(RoleTable.INSTANCE.name.ascending()));
@@ -994,8 +996,8 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 
 	private OrderByStep _getOrderByStep(
 		FromStep fromStep, long companyId, String keywords,
-		List<String> excludedNames, int[] types, long excludedTeamRoleId,
-		long teamGroupId, boolean inlineSQLHelper) {
+		boolean searchDescription, List<String> excludedNames, int[] types,
+		long excludedTeamRoleId, long teamGroupId, boolean inlineSQLHelper) {
 
 		Predicate wherePredicate = RoleTable.INSTANCE.companyId.eq(companyId);
 
@@ -1021,10 +1023,16 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 					_getKeywordsPredicate(
 						RoleTable.INSTANCE.title, keywordsArray)
 				).or(
-					_getKeywordsPredicate(
-						DSLFunctionFactoryUtil.castClobText(
-							RoleTable.INSTANCE.description),
-						keywordsArray)
+					() -> {
+						if (searchDescription) {
+							return _getKeywordsPredicate(
+								DSLFunctionFactoryUtil.castClobText(
+									RoleTable.INSTANCE.description),
+								keywordsArray);
+						}
+
+						return null;
+					}
 				));
 
 			teamsSubqueryPredicate = teamsSubqueryPredicate.and(
@@ -1032,8 +1040,15 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 					_getKeywordsPredicate(
 						TeamTable.INSTANCE.name, keywordsArray
 					).or(
-						_getKeywordsPredicate(
-							TeamTable.INSTANCE.description, keywordsArray)
+						() -> {
+							if (searchDescription) {
+								return _getKeywordsPredicate(
+									TeamTable.INSTANCE.description,
+									keywordsArray);
+							}
+
+							return null;
+						}
 					)));
 		}
 

--- a/portal-impl/test/unit/com/liferay/portal/action/JSONServiceActionTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/action/JSONServiceActionTest.java
@@ -43,8 +43,8 @@ public class JSONServiceActionTest {
 		JSONServiceAction jsonServiceAction = new JSONServiceAction();
 
 		String[] parameters = {
-			"companyId", "keywords", "excludedNames", "types",
-			"excludedTeamRoleId", "teamGroupId", "start", "end"
+			"companyId", "keywords", "searchDescription", "excludedNames",
+			"types", "excludedTeamRoleId", "teamGroupId", "start", "end"
 		};
 
 		Object[] methodAndParameterTypes =
@@ -62,7 +62,7 @@ public class JSONServiceActionTest {
 
 		Object value = jsonServiceAction.getArgValue(
 			mockHttpServletRequest, RoleServiceUtil.class, method.getName(),
-			parameters[2], parameterTypes[2]);
+			parameters[3], parameterTypes[3]);
 
 		Assert.assertEquals("[]", value.toString());
 
@@ -73,7 +73,7 @@ public class JSONServiceActionTest {
 
 		value = jsonServiceAction.getArgValue(
 			mockHttpServletRequest, RoleServiceUtil.class, method.getName(),
-			parameters[2], parameterTypes[2]);
+			parameters[3], parameterTypes[3]);
 
 		Assert.assertEquals(
 			"{class=com.liferay.portal.kernel.dao.orm.EntityCacheUtil}",

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RoleLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RoleLocalService.java
@@ -404,14 +404,15 @@ public interface RoleLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Role> getGroupRolesAndTeamRoles(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end);
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getGroupRolesAndTeamRolesCount(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId);
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getGroupRolesCount(long groupId);

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RoleLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RoleLocalServiceUtil.java
@@ -476,22 +476,23 @@ public class RoleLocalServiceUtil {
 	}
 
 	public static List<Role> getGroupRolesAndTeamRoles(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end) {
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end) {
 
 		return getService().getGroupRolesAndTeamRoles(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId, start, end);
 	}
 
 	public static int getGroupRolesAndTeamRolesCount(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId) {
 
 		return getService().getGroupRolesAndTeamRolesCount(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId);
 	}
 
 	public static int getGroupRolesCount(long groupId) {

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RoleLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RoleLocalServiceWrapper.java
@@ -537,23 +537,24 @@ public class RoleLocalServiceWrapper
 
 	@Override
 	public java.util.List<Role> getGroupRolesAndTeamRoles(
-		long companyId, String keywords, java.util.List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end) {
+		long companyId, String keywords, boolean searchDescription,
+		java.util.List<String> excludedNames, int[] types,
+		long excludedTeamRoleId, long teamGroupId, int start, int end) {
 
 		return _roleLocalService.getGroupRolesAndTeamRoles(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId, start, end);
 	}
 
 	@Override
 	public int getGroupRolesAndTeamRolesCount(
-		long companyId, String keywords, java.util.List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String keywords, boolean searchDescription,
+		java.util.List<String> excludedNames, int[] types,
+		long excludedTeamRoleId, long teamGroupId) {
 
 		return _roleLocalService.getGroupRolesAndTeamRolesCount(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RoleService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RoleService.java
@@ -113,14 +113,15 @@ public interface RoleService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Role> getGroupRolesAndTeamRoles(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end);
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getGroupRolesAndTeamRolesCount(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId);
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId);
 
 	/**
 	 * Returns the OSGi service identifier.

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RoleServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RoleServiceUtil.java
@@ -110,22 +110,23 @@ public class RoleServiceUtil {
 	}
 
 	public static List<Role> getGroupRolesAndTeamRoles(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end) {
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end) {
 
 		return getService().getGroupRolesAndTeamRoles(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId, start, end);
 	}
 
 	public static int getGroupRolesAndTeamRolesCount(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String keywords, boolean searchDescription,
+		List<String> excludedNames, int[] types, long excludedTeamRoleId,
+		long teamGroupId) {
 
 		return getService().getGroupRolesAndTeamRolesCount(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RoleServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RoleServiceWrapper.java
@@ -113,23 +113,24 @@ public class RoleServiceWrapper
 
 	@Override
 	public java.util.List<Role> getGroupRolesAndTeamRoles(
-		long companyId, String keywords, java.util.List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end) {
+		long companyId, String keywords, boolean searchDescription,
+		java.util.List<String> excludedNames, int[] types,
+		long excludedTeamRoleId, long teamGroupId, int start, int end) {
 
 		return _roleService.getGroupRolesAndTeamRoles(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId, start, end);
 	}
 
 	@Override
 	public int getGroupRolesAndTeamRolesCount(
-		long companyId, String keywords, java.util.List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String keywords, boolean searchDescription,
+		java.util.List<String> excludedNames, int[] types,
+		long excludedTeamRoleId, long teamGroupId) {
 
 		return _roleService.getGroupRolesAndTeamRolesCount(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 19.5.0
+version 20.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/RoleFinder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/RoleFinder.java
@@ -24,8 +24,9 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface RoleFinder {
 
 	public int countByGroupRoleAndTeamRole(
-		long companyId, String keywords, java.util.List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId);
+		long companyId, String keywords, boolean searchDescription,
+		java.util.List<String> excludedNames, int[] types,
+		long excludedTeamRoleId, long teamGroupId);
 
 	public int countByKeywords(
 		long companyId, String keywords, Integer[] types);
@@ -53,8 +54,9 @@ public interface RoleFinder {
 		boolean andOperator);
 
 	public int filterCountByGroupRoleAndTeamRole(
-		long companyId, String keywords, java.util.List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId);
+		long companyId, String keywords, boolean searchDescription,
+		java.util.List<String> excludedNames, int[] types,
+		long excludedTeamRoleId, long teamGroupId);
 
 	public int filterCountByKeywords(
 		long companyId, String keywords, Integer[] types,
@@ -80,7 +82,7 @@ public interface RoleFinder {
 
 	public java.util.List<com.liferay.portal.kernel.model.Role>
 		filterFindByGroupRoleAndTeamRole(
-			long companyId, String keywords,
+			long companyId, String keywords, boolean searchDescription,
 			java.util.List<String> excludedNames, int[] types,
 			long excludedTeamRoleId, long teamGroupId, int start, int end);
 
@@ -126,7 +128,7 @@ public interface RoleFinder {
 
 	public java.util.List<com.liferay.portal.kernel.model.Role>
 		findByGroupRoleAndTeamRole(
-			long companyId, String keywords,
+			long companyId, String keywords, boolean searchDescription,
 			java.util.List<String> excludedNames, int[] types,
 			long excludedTeamRoleId, long teamGroupId, int start, int end);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/RoleFinderUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/RoleFinderUtil.java
@@ -23,12 +23,13 @@ import com.liferay.portal.kernel.bean.PortalBeanLocatorUtil;
 public class RoleFinderUtil {
 
 	public static int countByGroupRoleAndTeamRole(
-		long companyId, String keywords, java.util.List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String keywords, boolean searchDescription,
+		java.util.List<String> excludedNames, int[] types,
+		long excludedTeamRoleId, long teamGroupId) {
 
 		return getFinder().countByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId);
 	}
 
 	public static int countByKeywords(
@@ -79,12 +80,13 @@ public class RoleFinderUtil {
 	}
 
 	public static int filterCountByGroupRoleAndTeamRole(
-		long companyId, String keywords, java.util.List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String keywords, boolean searchDescription,
+		java.util.List<String> excludedNames, int[] types,
+		long excludedTeamRoleId, long teamGroupId) {
 
 		return getFinder().filterCountByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId);
 	}
 
 	public static int filterCountByKeywords(
@@ -131,13 +133,13 @@ public class RoleFinderUtil {
 
 	public static java.util.List<com.liferay.portal.kernel.model.Role>
 		filterFindByGroupRoleAndTeamRole(
-			long companyId, String keywords,
+			long companyId, String keywords, boolean searchDescription,
 			java.util.List<String> excludedNames, int[] types,
 			long excludedTeamRoleId, long teamGroupId, int start, int end) {
 
 		return getFinder().filterFindByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId, start, end);
 	}
 
 	public static java.util.List<com.liferay.portal.kernel.model.Role>
@@ -206,13 +208,13 @@ public class RoleFinderUtil {
 
 	public static java.util.List<com.liferay.portal.kernel.model.Role>
 		findByGroupRoleAndTeamRole(
-			long companyId, String keywords,
+			long companyId, String keywords, boolean searchDescription,
 			java.util.List<String> excludedNames, int[] types,
 			long excludedTeamRoleId, long teamGroupId, int start, int end) {
 
 		return getFinder().findByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end);
+			companyId, keywords, searchDescription, excludedNames, types,
+			excludedTeamRoleId, teamGroupId, start, end);
 	}
 
 	public static java.util.List<com.liferay.portal.kernel.model.Role>

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 19.1.0
+version 20.0.0


### PR DESCRIPTION
Here is the PR for fixing https://issues.liferay.com/browse/LPS-178212.
Please help review this PR and leave your comments.
Thanks.

Notes:
As recommended in the ticket, overloading the finder method is preferred. However, I found that the current method is no longer used anywhere so I decided to refactor it by adding a boolean parameter. Because the added parameter is a boolean type, the refactoring method can cover the current method's logic. It also removes the redundant method.
So, I figured refactoring would be fine.
Previous PR:
https://github.com/liferay-appsec/liferay-portal/pull/1043