### PR TITLE
LPS-179091 If the user's screen name is autogenerated then do not allow updates to it

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -5182,16 +5182,23 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			emailAddress = StringPool.BLANK;
 		}
 
+		User user = userPersistence.findByPrimaryKey(userId);
+
+		Company company = _companyPersistence.findByPrimaryKey(
+			user.getCompanyId());
+
+		if (PrefsPropsUtil.getBoolean(
+				company.getCompanyId(),
+				PropsKeys.USERS_SCREEN_NAME_ALWAYS_AUTOGENERATE)) {
+
+			screenName = user.getScreenName();
+		}
+
 		Locale locale = LocaleUtil.fromLanguageId(languageId);
 
 		validate(
 			userId, screenName, emailAddress, null, firstName, middleName,
 			lastName, smsSn, locale);
-
-		User user = userPersistence.findByPrimaryKey(userId);
-
-		Company company = _companyPersistence.findByPrimaryKey(
-			user.getCompanyId());
 
 		if (!PropsValues.USERS_EMAIL_ADDRESS_REQUIRED &&
 			Validator.isNull(emailAddress)) {


### PR DESCRIPTION
This was previously sent to the USM team but it seems that AppSec is now in charge of User Management. If this is incorrect please let me know.

If there's a reason why we want to leave this API available to update the user's screen name please let me know and I can document it on the LPS. Please let me know if there are any other questions.