### PR TITLE
[TS] LPS-181707 Non-ROOT context of SAML SP not considered when trying to sign back in with a different user

### DIFF
--- a/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal/saml_error.jsp
+++ b/modules/dxp/apps/saml/saml-web/src/main/resources/META-INF/resources/dynamic_include/com.liferay.portal/saml_error.jsp
@@ -23,7 +23,7 @@ String samlSubjectScreenName = (String)request.getAttribute(SamlWebKeys.SAML_SUB
 <liferay-util:buffer
 	var="msg"
 >
-	<aui:form action='<%= PortalUtil.getPortalURL(request) + "/c/portal/login" %>' method="post" name="fm">
+	<aui:form action='<%= PortalUtil.getPortalURL(request) + PortalUtil.getPathMain() + "/portal/login" %>' method="post" name="fm">
 		<aui:input name="p_auth" type="hidden" value="<%= AuthTokenUtil.getToken(request) %>" />
 		<aui:input name="saveLastPath" type="hidden" value="<%= false %>" />
 		<aui:input name="redirect" type="hidden" value="<%= PortalUtil.getCurrentURL(request) %>" />


### PR DESCRIPTION
Hi @liferay-appsec,

This is a fix for the issue [LPS-181707](https://issues.liferay.com/browse/LPS-181707) about not taking non-ROOT context into account. The same solution was used [LPS-155687](https://issues.liferay.com/browse/LPS-155687) and it works here as well.

Let me know if you have any questions.

Thanks!