### PR TITLE
LPS-182143 Make PasswordModifiedFilter smarter so that it doesn't always log the user out if session.enable.phishing.protection=false is set

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/UpdatePasswordAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdatePasswordAction.java
@@ -51,6 +51,7 @@ import com.liferay.portal.struts.model.ActionMapping;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+import java.util.Date;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
@@ -295,6 +296,14 @@ public class UpdatePasswordAction implements Action {
 
 				UserLocalServiceUtil.updateUser(user);
 			}
+
+			HttpSession httpSession = httpServletRequest.getSession();
+
+			Date passwordModifiedDate = user.getPasswordModifiedDate();
+
+			httpSession.setAttribute(
+				WebKeys.USER_PASSWORD_MODIFIED_TIME,
+				passwordModifiedDate.getTime());
 		}
 		finally {
 			PwdToolkitUtilThreadLocal.setValidate(previousValidate);

--- a/portal-impl/src/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilter.java
@@ -95,6 +95,16 @@ public class PasswordModifiedFilter extends BasePortalFilter {
 				return false;
 			}
 
+			Long sessionPasswordModifiedTime = (Long)httpSession.getAttribute(
+				WebKeys.USER_PASSWORD_MODIFIED_TIME);
+
+			if ((sessionPasswordModifiedTime != null) &&
+				(sessionPasswordModifiedTime >=
+					passwordModifiedDate.getTime())) {
+
+				return false;
+			}
+
 			if (!httpServletRequest.isRequestedSessionIdValid() ||
 				(httpSession.getCreationTime() <
 					passwordModifiedDate.getTime())) {

--- a/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
@@ -696,6 +696,9 @@ public interface WebKeys {
 
 	public static final String USER_PASSWORD = "USER_PASSWORD";
 
+	public static final String USER_PASSWORD_MODIFIED_TIME =
+		"USER_PASSWORD_MODIFIED_TIME";
+
 	public static final String USERS_NOTIFIED = "USERS_NOTIFIED";
 
 	public static final String VIRTUAL_HOST_LANGUAGE_ID =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 57.2.0
+version 57.3.0


### PR DESCRIPTION
Ticket: [LPS-182143](https://issues.liferay.com/browse/LPS-182143)

Currently, the PasswordModifiedFilter works by checking the user's passwordModifiedDate against the creation date of the current session. If the passwordModifiedDate is later than the session's create date, then we automatically invalidate the user's session.

This works fine under normal circumstances. However, the problem is that we have a portal property that allows the user to configure the portal to reuse the current session on login:
```
    #
    # Set this to true to invalidate the session when a user logs into the
    # portal. This helps prevent phishing. Set this to false if you need the
    # guest user and the authenticated user to have the same session.
    #
    # Set this to false if the property "company.security.auth.requires.https"
    # is set to true and you want to maintain the same credentials across HTTP
    # and HTTPS sessions.
    #
    # Env: LIFERAY_SESSION_PERIOD_ENABLE_PERIOD_PHISHING_PERIOD_PROTECTION
    #
    session.enable.phishing.protection=true
```
If this property is set to `false`, then we do not invalidate the session upon logging in, so modifying the password will _always_ result in the user's session being invalidated (since the session was created _before_ the user even logged in).

To solve this problem, I've added a new session attribute to track the latest time the user has updated their password within the session, and if it is equal to the user's passwordModifiedTime, then we avoid invalidating the session in the PasswordModifiedFilter.

Let me know if you have any concerns about this.

P.S. I bleeped out the word "password" in the commit messages since it seemed to be causing [this SF failure](https://github.com/liferay-appsec/liferay-portal/pull/1072#issuecomment-1513835885).