### PR TITLE
[TS] LPS-178212 Resource permissions popup should search for roles by visible information only

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/display/context/PortletConfigurationPermissionsDisplayContext.java
@@ -477,34 +477,34 @@ public class PortletConfigurationPermissionsDisplayContext {
 				RoleVisibilityConfiguration.class,
 				_themeDisplay.getCompanyId());
 
-		if (Validator.isNull(searchTerms.getKeywords())) {
+		String keywords = searchTerms.getKeywords();
+
+		if (Validator.isNull(keywords)) {
 			if (stricterRoleVisibilityConfiguration.
 					restrictPermissionSelectorRoleVisibility()) {
 
 				roleSearchContainer.setResultsAndTotal(
 					() -> RoleServiceUtil.getGroupRolesAndTeamRoles(
-						_themeDisplay.getCompanyId(), searchTerms.getKeywords(),
-						excludedRoleNames, getRoleTypes(),
-						roleModelResourceRoleId, roleTeamGroupId,
-						roleSearchContainer.getStart(),
+						_themeDisplay.getCompanyId(), null, excludedRoleNames,
+						null, null, getRoleTypes(), roleModelResourceRoleId,
+						roleTeamGroupId, roleSearchContainer.getStart(),
 						roleSearchContainer.getEnd()),
 					RoleServiceUtil.getGroupRolesAndTeamRolesCount(
-						_themeDisplay.getCompanyId(), searchTerms.getKeywords(),
-						excludedRoleNames, getRoleTypes(),
-						roleModelResourceRoleId, roleTeamGroupId));
+						_themeDisplay.getCompanyId(), null, excludedRoleNames,
+						null, null, getRoleTypes(), roleModelResourceRoleId,
+						roleTeamGroupId));
 			}
 			else {
 				roleSearchContainer.setResultsAndTotal(
 					() -> RoleLocalServiceUtil.getGroupRolesAndTeamRoles(
-						_themeDisplay.getCompanyId(), searchTerms.getKeywords(),
-						excludedRoleNames, getRoleTypes(),
-						roleModelResourceRoleId, roleTeamGroupId,
-						roleSearchContainer.getStart(),
+						_themeDisplay.getCompanyId(), null, excludedRoleNames,
+						null, null, getRoleTypes(), roleModelResourceRoleId,
+						roleTeamGroupId, roleSearchContainer.getStart(),
 						roleSearchContainer.getEnd()),
 					RoleLocalServiceUtil.getGroupRolesAndTeamRolesCount(
-						_themeDisplay.getCompanyId(), searchTerms.getKeywords(),
-						excludedRoleNames, getRoleTypes(),
-						roleModelResourceRoleId, roleTeamGroupId));
+						_themeDisplay.getCompanyId(), null, excludedRoleNames,
+						null, null, getRoleTypes(), roleModelResourceRoleId,
+						roleTeamGroupId));
 			}
 		}
 		else {
@@ -513,16 +513,18 @@ public class PortletConfigurationPermissionsDisplayContext {
 
 				roleSearchContainer.setResultsAndTotal(
 					RoleServiceUtil.getGroupRolesAndTeamRoles(
-						_themeDisplay.getCompanyId(), searchTerms.getKeywords(),
-						excludedRoleNames, getRoleTypes(), modelResourceRoleId,
-						teamGroupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS));
+						_themeDisplay.getCompanyId(), keywords,
+						excludedRoleNames, keywords, null, getRoleTypes(),
+						modelResourceRoleId, teamGroupId, QueryUtil.ALL_POS,
+						QueryUtil.ALL_POS));
 			}
 			else {
 				roleSearchContainer.setResultsAndTotal(
 					RoleLocalServiceUtil.getGroupRolesAndTeamRoles(
-						_themeDisplay.getCompanyId(), searchTerms.getKeywords(),
-						excludedRoleNames, getRoleTypes(), modelResourceRoleId,
-						teamGroupId, QueryUtil.ALL_POS, QueryUtil.ALL_POS));
+						_themeDisplay.getCompanyId(), keywords,
+						excludedRoleNames, keywords, null, getRoleTypes(),
+						modelResourceRoleId, teamGroupId, QueryUtil.ALL_POS,
+						QueryUtil.ALL_POS));
 			}
 		}
 

--- a/modules/apps/roles/roles-test/src/testIntegration/java/com/liferay/roles/service/persistence/test/RoleFinderTest.java
+++ b/modules/apps/roles/roles-test/src/testIntegration/java/com/liferay/roles/service/persistence/test/RoleFinderTest.java
@@ -87,8 +87,9 @@ public class RoleFinderTest {
 				_user, permissionChecker)) {
 
 			List<Role> roles = _roleFinder.filterFindByGroupRoleAndTeamRole(
-				TestPropsValues.getCompanyId(), null, existingRoleNames, _TYPES,
-				0, _user.getGroupId(), QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+				TestPropsValues.getCompanyId(), null, existingRoleNames, null,
+				null, _TYPES, 0, _user.getGroupId(), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS);
 
 			Assert.assertEquals(roles.toString(), 1, roles.size());
 

--- a/portal-impl/src/com/liferay/portal/service/http/RoleServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/RoleServiceHttp.java
@@ -244,9 +244,10 @@ public class RoleServiceHttp {
 
 	public static java.util.List<com.liferay.portal.kernel.model.Role>
 		getGroupRolesAndTeamRoles(
-			HttpPrincipal httpPrincipal, long companyId, String keywords,
-			java.util.List<String> excludedNames, int[] types,
-			long excludedTeamRoleId, long teamGroupId, int start, int end) {
+			HttpPrincipal httpPrincipal, long companyId, String name,
+			java.util.List<String> excludedNames, String title,
+			String description, int[] types, long excludedTeamRoleId,
+			long teamGroupId, int start, int end) {
 
 		try {
 			MethodKey methodKey = new MethodKey(
@@ -254,8 +255,8 @@ public class RoleServiceHttp {
 				_getGroupRolesAndTeamRolesParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, companyId, keywords, excludedNames, types,
-				excludedTeamRoleId, teamGroupId, start, end);
+				methodKey, companyId, name, excludedNames, title, description,
+				types, excludedTeamRoleId, teamGroupId, start, end);
 
 			Object returnObj = null;
 
@@ -280,9 +281,9 @@ public class RoleServiceHttp {
 	}
 
 	public static int getGroupRolesAndTeamRolesCount(
-		HttpPrincipal httpPrincipal, long companyId, String keywords,
-		java.util.List<String> excludedNames, int[] types,
-		long excludedTeamRoleId, long teamGroupId) {
+		HttpPrincipal httpPrincipal, long companyId, String name,
+		java.util.List<String> excludedNames, String title, String description,
+		int[] types, long excludedTeamRoleId, long teamGroupId) {
 
 		try {
 			MethodKey methodKey = new MethodKey(
@@ -290,8 +291,8 @@ public class RoleServiceHttp {
 				_getGroupRolesAndTeamRolesCountParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, companyId, keywords, excludedNames, types,
-				excludedTeamRoleId, teamGroupId);
+				methodKey, companyId, name, excludedNames, title, description,
+				types, excludedTeamRoleId, teamGroupId);
 
 			Object returnObj = null;
 
@@ -891,13 +892,14 @@ public class RoleServiceHttp {
 		new Class[] {long.class};
 	private static final Class<?>[] _getGroupRolesAndTeamRolesParameterTypes5 =
 		new Class[] {
-			long.class, String.class, java.util.List.class, int[].class,
-			long.class, long.class, int.class, int.class
+			long.class, String.class, java.util.List.class, String.class,
+			String.class, int[].class, long.class, long.class, int.class,
+			int.class
 		};
 	private static final Class<?>[]
 		_getGroupRolesAndTeamRolesCountParameterTypes6 = new Class[] {
-			long.class, String.class, java.util.List.class, int[].class,
-			long.class, long.class
+			long.class, String.class, java.util.List.class, String.class,
+			String.class, int[].class, long.class, long.class
 		};
 	private static final Class<?>[] _getRoleParameterTypes7 = new Class[] {
 		long.class

--- a/portal-impl/src/com/liferay/portal/service/http/packageinfo
+++ b/portal-impl/src/com/liferay/portal/service/http/packageinfo
@@ -1,1 +1,1 @@
-version 10.4.0
+version 11.0.0

--- a/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleLocalServiceImpl.java
@@ -767,23 +767,24 @@ public class RoleLocalServiceImpl extends RoleLocalServiceBaseImpl {
 
 	@Override
 	public List<Role> getGroupRolesAndTeamRoles(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end) {
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end) {
 
 		return roleFinder.findByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId, start, end);
 	}
 
 	@Override
 	public int getGroupRolesAndTeamRolesCount(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId) {
 
 		return roleFinder.countByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/RoleServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/RoleServiceImpl.java
@@ -158,23 +158,24 @@ public class RoleServiceImpl extends RoleServiceBaseImpl {
 
 	@Override
 	public List<Role> getGroupRolesAndTeamRoles(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end) {
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end) {
 
 		return roleFinder.filterFindByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId, start, end);
 	}
 
 	@Override
 	public int getGroupRolesAndTeamRolesCount(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId) {
 
 		return roleFinder.filterCountByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId);
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/RoleFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/RoleFinderImpl.java
@@ -75,12 +75,13 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 
 	@Override
 	public int countByGroupRoleAndTeamRole(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId) {
 
 		return doCountByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, false);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId, false);
 	}
 
 	@Override
@@ -162,12 +163,13 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 
 	@Override
 	public int filterCountByGroupRoleAndTeamRole(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId) {
 
 		return doCountByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, true);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId, true);
 	}
 
 	@Override
@@ -241,13 +243,13 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 
 	@Override
 	public List<Role> filterFindByGroupRoleAndTeamRole(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end) {
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end) {
 
 		return doFindByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end, true);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId, start, end, true);
 	}
 
 	@Override
@@ -330,13 +332,13 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 
 	@Override
 	public List<Role> findByGroupRoleAndTeamRole(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end) {
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end) {
 
 		return doFindByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end, false);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId, start, end, false);
 	}
 
 	@Override
@@ -428,9 +430,9 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 	}
 
 	protected int doCountByGroupRoleAndTeamRole(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId,
-		boolean inlineSQLHelper) {
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId, boolean inlineSQLHelper) {
 
 		if ((types == null) || (types.length == 0)) {
 			return 0;
@@ -449,7 +451,7 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 						).as(
 							COUNT_COLUMN_NAME
 						)),
-					companyId, keywords, excludedNames, types,
+					companyId, name, excludedNames, title, description, types,
 					excludedTeamRoleId, teamGroupId, inlineSQLHelper));
 
 			sqlQuery.addScalar(COUNT_COLUMN_NAME, Type.LONG);
@@ -641,9 +643,9 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 	}
 
 	protected List<Role> doFindByGroupRoleAndTeamRole(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end, boolean inlineSQLHelper) {
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end, boolean inlineSQLHelper) {
 
 		if ((types == null) || (types.length == 0)) {
 			return Collections.emptyList();
@@ -655,9 +657,9 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 			session = openSession();
 
 			OrderByStep orderByStep = _getOrderByStep(
-				DSLQueryFactoryUtil.select(RoleTable.INSTANCE), companyId,
-				keywords, excludedNames, types, excludedTeamRoleId, teamGroupId,
-				inlineSQLHelper);
+				DSLQueryFactoryUtil.select(RoleTable.INSTANCE), companyId, name,
+				excludedNames, title, description, types, excludedTeamRoleId,
+				teamGroupId, inlineSQLHelper);
 
 			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(
 				orderByStep.orderBy(RoleTable.INSTANCE.name.ascending()));
@@ -993,9 +995,10 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 	}
 
 	private OrderByStep _getOrderByStep(
-		FromStep fromStep, long companyId, String keywords,
-		List<String> excludedNames, int[] types, long excludedTeamRoleId,
-		long teamGroupId, boolean inlineSQLHelper) {
+		FromStep fromStep, long companyId, String name,
+		List<String> excludedNames, String title, String description,
+		int[] types, long excludedTeamRoleId, long teamGroupId,
+		boolean inlineSQLHelper) {
 
 		Predicate wherePredicate = RoleTable.INSTANCE.companyId.eq(companyId);
 
@@ -1008,34 +1011,49 @@ public class RoleFinderImpl extends RoleFinderBaseImpl implements RoleFinder {
 		}
 
 		Predicate rolesWherePredicate = null;
-		Predicate teamsSubqueryPredicate = TeamTable.INSTANCE.groupId.eq(
-			teamGroupId);
+		Predicate teamsSubqueryPredicate = null;
 
-		if (Validator.isNotNull(keywords)) {
-			String[] keywordsArray = CustomSQLUtil.keywords(keywords, true);
+		if (Validator.isNotNull(name)) {
+			String[] names = CustomSQLUtil.keywords(name, true);
 
-			rolesWherePredicate = Predicate.withParentheses(
-				_getKeywordsPredicate(
-					RoleTable.INSTANCE.name, keywordsArray
-				).or(
-					_getKeywordsPredicate(
-						RoleTable.INSTANCE.title, keywordsArray)
-				).or(
-					_getKeywordsPredicate(
-						DSLFunctionFactoryUtil.castClobText(
-							RoleTable.INSTANCE.description),
-						keywordsArray)
-				));
+			rolesWherePredicate = _getKeywordsPredicate(
+				RoleTable.INSTANCE.name, names);
 
-			teamsSubqueryPredicate = teamsSubqueryPredicate.and(
-				Predicate.withParentheses(
-					_getKeywordsPredicate(
-						TeamTable.INSTANCE.name, keywordsArray
-					).or(
-						_getKeywordsPredicate(
-							TeamTable.INSTANCE.description, keywordsArray)
-					)));
+			teamsSubqueryPredicate = _getKeywordsPredicate(
+				TeamTable.INSTANCE.name, names);
 		}
+
+		if (Validator.isNotNull(title)) {
+			rolesWherePredicate = Predicate.or(
+				rolesWherePredicate,
+				_getKeywordsPredicate(
+					RoleTable.INSTANCE.title,
+					CustomSQLUtil.keywords(title, true)));
+		}
+
+		if (Validator.isNotNull(description)) {
+			String[] descriptions = CustomSQLUtil.keywords(description, true);
+
+			rolesWherePredicate = Predicate.or(
+				rolesWherePredicate,
+				_getKeywordsPredicate(
+					DSLFunctionFactoryUtil.castClobText(
+						RoleTable.INSTANCE.description),
+					descriptions));
+
+			teamsSubqueryPredicate = Predicate.or(
+				teamsSubqueryPredicate,
+				_getKeywordsPredicate(
+					TeamTable.INSTANCE.description, descriptions));
+		}
+
+		rolesWherePredicate = Predicate.withParentheses(rolesWherePredicate);
+
+		teamsSubqueryPredicate = TeamTable.INSTANCE.groupId.eq(
+			teamGroupId
+		).and(
+			Predicate.withParentheses(teamsSubqueryPredicate)
+		);
 
 		if (ListUtil.isNotEmpty(excludedNames)) {
 			Predicate excludedNamesWherePredicate = RoleTable.INSTANCE.name.neq(

--- a/portal-impl/test/unit/com/liferay/portal/action/JSONServiceActionTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/action/JSONServiceActionTest.java
@@ -43,8 +43,8 @@ public class JSONServiceActionTest {
 		JSONServiceAction jsonServiceAction = new JSONServiceAction();
 
 		String[] parameters = {
-			"companyId", "keywords", "excludedNames", "types",
-			"excludedTeamRoleId", "teamGroupId", "start", "end"
+			"companyId", "name", "excludedNames", "title", "description",
+			"types", "excludedTeamRoleId", "teamGroupId", "start", "end"
 		};
 
 		Object[] methodAndParameterTypes =

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RoleLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RoleLocalService.java
@@ -404,14 +404,15 @@ public interface RoleLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Role> getGroupRolesAndTeamRoles(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end);
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getGroupRolesAndTeamRolesCount(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId);
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getGroupRolesCount(long groupId);

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RoleLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RoleLocalServiceUtil.java
@@ -476,22 +476,23 @@ public class RoleLocalServiceUtil {
 	}
 
 	public static List<Role> getGroupRolesAndTeamRoles(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end) {
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end) {
 
 		return getService().getGroupRolesAndTeamRoles(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId, start, end);
 	}
 
 	public static int getGroupRolesAndTeamRolesCount(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId) {
 
 		return getService().getGroupRolesAndTeamRolesCount(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId);
 	}
 
 	public static int getGroupRolesCount(long groupId) {

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RoleLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RoleLocalServiceWrapper.java
@@ -537,23 +537,24 @@ public class RoleLocalServiceWrapper
 
 	@Override
 	public java.util.List<Role> getGroupRolesAndTeamRoles(
-		long companyId, String keywords, java.util.List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end) {
+		long companyId, String name, java.util.List<String> excludedNames,
+		String title, String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end) {
 
 		return _roleLocalService.getGroupRolesAndTeamRoles(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId, start, end);
 	}
 
 	@Override
 	public int getGroupRolesAndTeamRolesCount(
-		long companyId, String keywords, java.util.List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String name, java.util.List<String> excludedNames,
+		String title, String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId) {
 
 		return _roleLocalService.getGroupRolesAndTeamRolesCount(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RoleService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RoleService.java
@@ -113,14 +113,15 @@ public interface RoleService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<Role> getGroupRolesAndTeamRoles(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end);
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getGroupRolesAndTeamRolesCount(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId);
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId);
 
 	/**
 	 * Returns the OSGi service identifier.

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RoleServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RoleServiceUtil.java
@@ -110,22 +110,23 @@ public class RoleServiceUtil {
 	}
 
 	public static List<Role> getGroupRolesAndTeamRoles(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end) {
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end) {
 
 		return getService().getGroupRolesAndTeamRoles(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId, start, end);
 	}
 
 	public static int getGroupRolesAndTeamRolesCount(
-		long companyId, String keywords, List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String name, List<String> excludedNames, String title,
+		String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId) {
 
 		return getService().getGroupRolesAndTeamRolesCount(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/RoleServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/RoleServiceWrapper.java
@@ -113,23 +113,24 @@ public class RoleServiceWrapper
 
 	@Override
 	public java.util.List<Role> getGroupRolesAndTeamRoles(
-		long companyId, String keywords, java.util.List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId, int start,
-		int end) {
+		long companyId, String name, java.util.List<String> excludedNames,
+		String title, String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId, int start, int end) {
 
 		return _roleService.getGroupRolesAndTeamRoles(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId, start, end);
 	}
 
 	@Override
 	public int getGroupRolesAndTeamRolesCount(
-		long companyId, String keywords, java.util.List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String name, java.util.List<String> excludedNames,
+		String title, String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId) {
 
 		return _roleService.getGroupRolesAndTeamRolesCount(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId);
 	}
 
 	/**

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 20.2.0
+version 21.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/RoleFinder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/RoleFinder.java
@@ -24,8 +24,9 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface RoleFinder {
 
 	public int countByGroupRoleAndTeamRole(
-		long companyId, String keywords, java.util.List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId);
+		long companyId, String name, java.util.List<String> excludedNames,
+		String title, String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId);
 
 	public int countByKeywords(
 		long companyId, String keywords, Integer[] types);
@@ -53,8 +54,9 @@ public interface RoleFinder {
 		boolean andOperator);
 
 	public int filterCountByGroupRoleAndTeamRole(
-		long companyId, String keywords, java.util.List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId);
+		long companyId, String name, java.util.List<String> excludedNames,
+		String title, String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId);
 
 	public int filterCountByKeywords(
 		long companyId, String keywords, Integer[] types,
@@ -80,8 +82,8 @@ public interface RoleFinder {
 
 	public java.util.List<com.liferay.portal.kernel.model.Role>
 		filterFindByGroupRoleAndTeamRole(
-			long companyId, String keywords,
-			java.util.List<String> excludedNames, int[] types,
+			long companyId, String name, java.util.List<String> excludedNames,
+			String title, String description, int[] types,
 			long excludedTeamRoleId, long teamGroupId, int start, int end);
 
 	public java.util.List<com.liferay.portal.kernel.model.Role>
@@ -126,8 +128,8 @@ public interface RoleFinder {
 
 	public java.util.List<com.liferay.portal.kernel.model.Role>
 		findByGroupRoleAndTeamRole(
-			long companyId, String keywords,
-			java.util.List<String> excludedNames, int[] types,
+			long companyId, String name, java.util.List<String> excludedNames,
+			String title, String description, int[] types,
 			long excludedTeamRoleId, long teamGroupId, int start, int end);
 
 	public java.util.List<com.liferay.portal.kernel.model.Role> findByKeywords(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/RoleFinderUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/RoleFinderUtil.java
@@ -23,12 +23,13 @@ import com.liferay.portal.kernel.bean.PortalBeanLocatorUtil;
 public class RoleFinderUtil {
 
 	public static int countByGroupRoleAndTeamRole(
-		long companyId, String keywords, java.util.List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String name, java.util.List<String> excludedNames,
+		String title, String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId) {
 
 		return getFinder().countByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId);
 	}
 
 	public static int countByKeywords(
@@ -79,12 +80,13 @@ public class RoleFinderUtil {
 	}
 
 	public static int filterCountByGroupRoleAndTeamRole(
-		long companyId, String keywords, java.util.List<String> excludedNames,
-		int[] types, long excludedTeamRoleId, long teamGroupId) {
+		long companyId, String name, java.util.List<String> excludedNames,
+		String title, String description, int[] types, long excludedTeamRoleId,
+		long teamGroupId) {
 
 		return getFinder().filterCountByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId);
 	}
 
 	public static int filterCountByKeywords(
@@ -131,13 +133,13 @@ public class RoleFinderUtil {
 
 	public static java.util.List<com.liferay.portal.kernel.model.Role>
 		filterFindByGroupRoleAndTeamRole(
-			long companyId, String keywords,
-			java.util.List<String> excludedNames, int[] types,
+			long companyId, String name, java.util.List<String> excludedNames,
+			String title, String description, int[] types,
 			long excludedTeamRoleId, long teamGroupId, int start, int end) {
 
 		return getFinder().filterFindByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId, start, end);
 	}
 
 	public static java.util.List<com.liferay.portal.kernel.model.Role>
@@ -206,13 +208,13 @@ public class RoleFinderUtil {
 
 	public static java.util.List<com.liferay.portal.kernel.model.Role>
 		findByGroupRoleAndTeamRole(
-			long companyId, String keywords,
-			java.util.List<String> excludedNames, int[] types,
+			long companyId, String name, java.util.List<String> excludedNames,
+			String title, String description, int[] types,
 			long excludedTeamRoleId, long teamGroupId, int start, int end) {
 
 		return getFinder().findByGroupRoleAndTeamRole(
-			companyId, keywords, excludedNames, types, excludedTeamRoleId,
-			teamGroupId, start, end);
+			companyId, name, excludedNames, title, description, types,
+			excludedTeamRoleId, teamGroupId, start, end);
 	}
 
 	public static java.util.List<com.liferay.portal.kernel.model.Role>

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 20.0.0
+version 21.0.0


### PR DESCRIPTION
Hi guys,
I update the code based on https://github.com/brianchandotcom/liferay-portal/pull/133957#issuecomment-1523001182.
Look like he wants `name` and `excludedNames` together because they deal with the same parameter in the finder query.
Please help review this PR and leave your comments.
Ticket: https://issues.liferay.com/browse/LPS-178212
Thanks.