### PR TITLE
[TS] LPS-180708 Custom field for "Page": Default value showing up, when field was saved with empty string

### DIFF
--- a/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
+++ b/modules/apps/expando/expando-taglib/src/main/resources/META-INF/resources/custom_attribute/page.jsp
@@ -75,10 +75,6 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 							<%
 							Boolean curValue = (Boolean)value;
 
-							if (curValue == null) {
-								curValue = (Boolean)defaultValue;
-							}
-
 							curValue = ParamUtil.getBoolean(request, "ExpandoAttribute--" + name + "--", curValue);
 							%>
 
@@ -97,12 +93,6 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 
 								if (value != null) {
 									valueDate.setTime((Date)value);
-								}
-								else if (defaultValue != null) {
-									valueDate.setTime((Date)defaultValue);
-								}
-								else {
-									valueDate.setTime(new Date());
 								}
 
 								String fieldParam = "ExpandoAttribute--" + name + "--";
@@ -657,10 +647,6 @@ ExpandoBridge expandoBridge = ExpandoBridgeFactoryUtil.getExpandoBridge(company.
 
 							<%
 							value = ParamUtil.getString(request, "ExpandoAttribute--" + name + "--", String.valueOf(value));
-
-							if (Validator.isNull(String.valueOf(value))) {
-								value = defaultValue;
-							}
 							%>
 
 							<c:choose>


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

I have sent this pull request to your Team as per [this suggestion](https://github.com/liferay-usm/liferay-portal/pull/1039#issuecomment-1533111742).

Motivation
=======
If an empty string (blank or whitespace(s)) is entered in a custom text field and then saved, it will be filled with the default value upon reload.

Proposed Solution
========
The `ExpandoValueLocalServiceImpl#getData()` method already provides the logic that checks for null value and provides the default value.
Removing the superfluous logic in the UI.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://issues.liferay.com/browse/LPS-180708

Thank you and best regards,
István