### PR TITLE
LPS-183707 Fix infinite redirects on SAML logout - move code

### DIFF
--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSsoSamlPortalFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSsoSamlPortalFilter.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.saml.constants.SamlWebKeys;
+import com.liferay.saml.persistence.model.SamlSpSession;
 import com.liferay.saml.runtime.configuration.SamlProviderConfiguration;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
 import com.liferay.saml.runtime.servlet.profile.SingleLogoutProfile;
@@ -142,9 +143,20 @@ public class SpSsoSamlPortalFilter extends BaseSamlPortalFilter {
 			}
 		}
 		else if (requestPath.equals("/c/portal/logout")) {
+			boolean processSpLogout = false;
+
 			if (_singleLogoutProfile.isSingleLogoutSupported(
 					httpServletRequest)) {
 
+				SamlSpSession samlSpSession =
+					_singleLogoutProfile.getSamlSpSession(httpServletRequest);
+
+				if ((samlSpSession != null) && !samlSpSession.isTerminated()) {
+					processSpLogout = true;
+				}
+			}
+
+			if (processSpLogout) {
 				_singleLogoutProfile.processSpLogout(
 					httpServletRequest, httpServletResponse);
 			}

--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSsoSamlPortalFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSsoSamlPortalFilter.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.saml.constants.SamlWebKeys;
-import com.liferay.saml.persistence.model.SamlSpSession;
 import com.liferay.saml.runtime.configuration.SamlProviderConfiguration;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
 import com.liferay.saml.runtime.servlet.profile.SingleLogoutProfile;
@@ -143,20 +142,9 @@ public class SpSsoSamlPortalFilter extends BaseSamlPortalFilter {
 			}
 		}
 		else if (requestPath.equals("/c/portal/logout")) {
-			boolean processSpLogout = false;
-
 			if (_singleLogoutProfile.isSingleLogoutSupported(
 					httpServletRequest)) {
 
-				SamlSpSession samlSpSession =
-					_singleLogoutProfile.getSamlSpSession(httpServletRequest);
-
-				if ((samlSpSession != null) && !samlSpSession.isTerminated()) {
-					processSpLogout = true;
-				}
-			}
-
-			if (processSpLogout) {
 				_singleLogoutProfile.processSpLogout(
 					httpServletRequest, httpServletResponse);
 			}

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
@@ -124,7 +124,7 @@ public class SingleLogoutProfileImpl
 		try {
 			SamlSpSession samlSpSession = getSamlSpSession(httpServletRequest);
 
-			if (samlSpSession == null) {
+			if ((samlSpSession == null) || samlSpSession.isTerminated()) {
 				return false;
 			}
 


### PR DESCRIPTION
This condition makes sense to move into `SingleLogoutProfileImpl#isSingleLogoutSupported` because there we are already checking the `SamlSpSession == null` which is similar. Because in both cases the request/session is not able to participate in SLO.

> Only process the logout when we need to (i.e. if the SAML session is not yet terminated). If we try to process the logout when the session is already terminated, then we will just redirect the user to /c/portal/logout, which will result in an infinite redirect.
> 
> Relevant code: https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java#L574-L585
> 
> Ticket: [LPS-183707](https://issues.liferay.com/browse/LPS-183707)