### PR TITLE
[TS] LPP-48522>LPS-182407 Prevent xss in liferay-asset:select-asset-display-page

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/init.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/init.jsp
@@ -28,6 +28,7 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 page import="com.liferay.asset.taglib.internal.display.context.SelectAssetDisplayPageDisplayContext" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
+page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %>
 
 <liferay-frontend:defineObjects />

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
@@ -147,7 +147,7 @@
 			Liferay.Util.openModal({
 				title: '<liferay-ui:message key="preview" />',
 				url:
-					'<%= selectAssetDisplayPageDisplayContext.getURLViewInContext() %>',
+					'<%= HtmlUtil.escapeJS(selectAssetDisplayPageDisplayContext.getURLViewInContext()) %>',
 			});
 		});
 	}
@@ -157,7 +157,7 @@
 			Liferay.Util.openModal({
 				title: '<liferay-ui:message key="preview" />',
 				url:
-					'<%= selectAssetDisplayPageDisplayContext.getURLViewInContext() %>',
+					'<%= HtmlUtil.escapeJS(selectAssetDisplayPageDisplayContext.getURLViewInContext()) %>',
 			});
 		});
 	}


### PR DESCRIPTION
Hi team,
This PR is for fixing [LPS-182407](https://issues.liferay.com/browse/LPS-182407)

As Minhchau recommend
>It is able to reproduce the issue in master using blogs by setting a breakpoint here:
>
>https://github.com/liferay/liferay-portal/blob/7.4.3.75-ga75/modules/apps/asset/asset->taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/SelectAssetDisplayPageDisplayContext.java#L276
>
>And setting the viewInContextURL to themeDisplay.getURLCurrent() the way that https://github.com/liferay/liferay->portal/blob/7.4.3.75-ga75/modules/apps/journal/journal->web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java#L418 does.
So that we should fix on master as well. 
This is the previous discussion with Minhchau about this issue https://github.com/holatuwol/liferay-portal-ee/pull/156

The [original PR](https://github.com/ces-quanhuynh/liferay-portal/pull/27) was passed my review 
Please review and leave your comment.
Thanks,
Quan
cc @locpham97 @holatuwol
