### PR TITLE
[TS] LPS-184788 - country dynamic selector needs to check for a non-undefined value before attempting to access a field

### DIFF
--- a/modules/apps/address/address-web/src/main/resources/META-INF/resources/js/CountryRegionDynamicSelect.js
+++ b/modules/apps/address/address-web/src/main/resources/META-INF/resources/js/CountryRegionDynamicSelect.js
@@ -32,7 +32,9 @@ function CountryRegionDynamicSelect({
 						(country) => country.a2 === 'JP'
 					);
 
-					japanCountryId = countryJP.countryId;
+					if (countryJP !== undefined) {
+						japanCountryId = countryJP.countryId;
+					}
 
 					callback(countries);
 				});


### PR DESCRIPTION
Hi AppSec team!

I've sent this here since this was initially the work of the USM team, but please let me know if this should be sent elsewhere.

The issue being solved here is that the selector present in the Organizations and Account screens can run into JS undefined function errors if the country of Japan is deactivated in the Countries Management menu. The selector itself checks explicitly for the country of Japan in its logic (see lines 31-32: https://github.com/wanderlast/liferay-portal/blob/2f2f4e46d328c76ac6d0d1dd2dc66e29e05a7fc5/modules/apps/address/address-web/src/main/resources/META-INF/resources/js/CountryRegionDynamicSelect.js#L31-L32). This can cause issues if it's removed from the list since it can no longer find it and therefore attempts to access a field of an undefined value in line 35. I've solved it simply by adding a check for a non-undefined value before attempting to use it.

Please let me know if you have any questions. THanks!