### PR TITLE
[TS] LPS-184912 Only count approved users to be consistent with the behavior of the User count in the User Groups portlet itself

### DIFF
--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/edit_team_assignments_user_groups.jsp
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/edit_team_assignments_user_groups.jsp
@@ -50,7 +50,7 @@ EditSiteTeamAssignmentsUserGroupsDisplayContext editSiteTeamAssignmentsUserGroup
 
 			<%
 			int usersCount = UserLocalServiceUtil.searchCount(
-				company.getCompanyId(), StringPool.BLANK, WorkflowConstants.STATUS_ANY,
+				company.getCompanyId(), StringPool.BLANK, WorkflowConstants.STATUS_APPROVED,
 				LinkedHashMapBuilder.<String, Object>put(
 					"usersUserGroups", Long.valueOf(userGroup.getUserGroupId())
 				).build());


### PR DESCRIPTION
This is how the User Groups portlet gets the User count: https://github.com/liferay/liferay-portal/blob/aec692ba4cebf1288fbf7dc6f93f1abc160d2d23/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/view_flat_user_groups.jspf#L39. It only counts approved users.

Ticket: [LPS-184912](https://issues.liferay.com/browse/LPS-184912)