### PR TITLE
LPS-159334 Add audit message for a failed authentication when the user does not exist

### DIFF
--- a/modules/apps/user/user-test/build.gradle
+++ b/modules/apps/user/user-test/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	testIntegrationCompile project(":apps:change-tracking:change-tracking-test-util")
+	testIntegrationCompile project(":apps:portal-security-audit:portal-security-audit-api")
 	testIntegrationCompile project(":apps:ratings:ratings-test-util")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
@@ -18,12 +18,14 @@ import com.liferay.announcements.kernel.service.AnnouncementsDeliveryLocalServic
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.audit.AuditMessage;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PasswordExpiredException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.RequiredRoleException;
 import com.liferay.portal.kernel.exception.UserLockoutException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Organization;
@@ -68,11 +70,13 @@ import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -83,12 +87,21 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Michael C. Han
@@ -101,6 +114,24 @@ public class UserLocalServiceTest {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_auditMessageProcessor = new TestAuditMessageProcessor();
+
+		_bundleActivator = new UserLocalServiceTestBundleActivator();
+
+		Bundle bundle = FrameworkUtil.getBundle(UserLocalServiceTest.class);
+
+		_bundleContext = bundle.getBundleContext();
+
+		_bundleActivator.start(_bundleContext);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_bundleActivator.stop(_bundleContext);
+	}
 
 	@Test
 	public void testAuthenticateByEmailAddress() throws Exception {
@@ -151,6 +182,16 @@ public class UserLocalServiceTest {
 			_userLocalService.authenticateByEmailAddress(
 				user.getCompanyId(), user.getEmailAddress(), password, null,
 				null, null));
+	}
+
+	@Test
+	public void testAuthenticationWhenUserDoesNotExist() throws Exception {
+		_eventType = "LOGIN_DNE";
+		Assert.assertEquals(
+			Authenticator.DNE,
+			_userLocalService.authenticateByEmailAddress(
+				RandomTestUtil.randomLong(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), null, null, null));
 	}
 
 	@Test
@@ -836,6 +877,11 @@ public class UserLocalServiceTest {
 	private AnnouncementsDeliveryLocalService
 		_announcementsDeliveryLocalService;
 
+	private TestAuditMessageProcessor _auditMessageProcessor;
+	private BundleActivator _bundleActivator;
+	private BundleContext _bundleContext;
+	private String _eventType;
+
 	@Inject
 	private GroupLocalService _groupLocalService;
 
@@ -851,6 +897,8 @@ public class UserLocalServiceTest {
 	@Inject
 	private RoleLocalService _roleLocalService;
 
+	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
+
 	@Inject
 	private TicketLocalService _ticketLocalService;
 
@@ -863,5 +911,55 @@ public class UserLocalServiceTest {
 	@Inject
 	private UserNotificationEventLocalService
 		_userNotificationEventLocalService;
+
+	private class TestAuditMessageProcessor implements AuditMessageProcessor {
+
+		@Override
+		public void process(AuditMessage auditMessage) {
+			if (_eventType != null) {
+				Assert.assertNotNull(auditMessage);
+
+				if (!Objects.equals(_eventType, "LOGIN_DNE")) {
+					return;
+				}
+
+				Assert.assertEquals("LOGIN_DNE", auditMessage.getEventType());
+
+				JSONObject additionalInfoJSONObject =
+					auditMessage.getAdditionalInfo();
+
+				String reason = String.valueOf(
+					additionalInfoJSONObject.get("reason"));
+
+				Assert.assertEquals(
+					"Failed to authenticate - User Does Not Exist", reason);
+
+				String authType = String.valueOf(
+					additionalInfoJSONObject.get("authType"));
+
+				Assert.assertEquals("emailAddress", authType);
+			}
+		}
+
+	}
+
+	private class UserLocalServiceTestBundleActivator
+		implements BundleActivator {
+
+		@Override
+		public void start(BundleContext bundleContext) {
+			_serviceRegistration = _bundleContext.registerService(
+				AuditMessageProcessor.class, _auditMessageProcessor,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"eventTypes", "*"
+				).build());
+		}
+
+		@Override
+		public void stop(BundleContext bundleContext) {
+			_serviceRegistration.unregister();
+		}
+
+	}
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -26,6 +26,9 @@ import com.liferay.mail.kernel.template.MailTemplateFactoryUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.audit.AuditException;
+import com.liferay.portal.kernel.audit.AuditMessage;
+import com.liferay.portal.kernel.audit.AuditRouterUtil;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.cache.PortalCacheHelperUtil;
@@ -60,6 +63,8 @@ import com.liferay.portal.kernel.exception.UserPasswordException;
 import com.liferay.portal.kernel.exception.UserReminderQueryException;
 import com.liferay.portal.kernel.exception.UserScreenNameException;
 import com.liferay.portal.kernel.exception.UserSmsException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -1561,7 +1566,8 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		}
 
 		handleAuthenticationFailure(
-			login, authType, user, Collections.<String, String[]>emptyMap(),
+			login, authType, companyId, user,
+			Collections.<String, String[]>emptyMap(),
 			Collections.<String, String[]>emptyMap());
 
 		return 0;
@@ -1640,7 +1646,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		Company company = _companyPersistence.findByPrimaryKey(companyId);
 
 		handleAuthenticationFailure(
-			userName, company.getAuthType(), user,
+			userName, company.getAuthType(), companyId, user,
 			new HashMap<String, String[]>(), new HashMap<String, String[]>());
 
 		return 0;
@@ -5683,6 +5689,8 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 				PwdAuthenticator.pretendToAuthenticate();
 			}
 
+			_onUserDoesNotExist(authType, companyId, login, headerMap);
+
 			return Authenticator.DNE;
 		}
 
@@ -5746,7 +5754,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			}
 			catch (PortalException portalException) {
 				handleAuthenticationFailure(
-					login, authType, user, headerMap, parameterMap);
+					login, authType, companyId, user, headerMap, parameterMap);
 
 				throw portalException;
 			}
@@ -5777,7 +5785,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		if (authResult == Authenticator.FAILURE) {
 			authResult = handleAuthenticationFailure(
-				login, authType, user, headerMap, parameterMap);
+				login, authType, companyId, user, headerMap, parameterMap);
 
 			user = userPersistence.fetchByPrimaryKey(user.getUserId());
 		}
@@ -6016,41 +6024,43 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	}
 
 	protected int handleAuthenticationFailure(
-		String login, String authType, User user,
+		String login, String authType, long companyId, User user,
 		Map<String, String[]> headerMap, Map<String, String[]> parameterMap) {
 
 		if (user == null) {
+			_onUserDoesNotExist(authType, companyId, login, headerMap);
+
 			return Authenticator.DNE;
 		}
 
 		try {
 			if (authType.equals(CompanyConstants.AUTH_TYPE_EA)) {
 				AuthPipeline.onFailureByEmailAddress(
-					PropsKeys.AUTH_FAILURE, user.getCompanyId(),
-					user.getEmailAddress(), headerMap, parameterMap);
+					PropsKeys.AUTH_FAILURE, companyId, user.getEmailAddress(),
+					headerMap, parameterMap);
 			}
 			else if (authType.equals(CompanyConstants.AUTH_TYPE_SN)) {
 				AuthPipeline.onFailureByScreenName(
-					PropsKeys.AUTH_FAILURE, user.getCompanyId(),
-					user.getScreenName(), headerMap, parameterMap);
+					PropsKeys.AUTH_FAILURE, companyId, user.getScreenName(),
+					headerMap, parameterMap);
 			}
 			else if (authType.equals(CompanyConstants.AUTH_TYPE_ID)) {
 				AuthPipeline.onFailureByUserId(
-					PropsKeys.AUTH_FAILURE, user.getCompanyId(),
-					user.getUserId(), headerMap, parameterMap);
+					PropsKeys.AUTH_FAILURE, companyId, user.getUserId(),
+					headerMap, parameterMap);
 			}
 
 			user = userPersistence.fetchByPrimaryKey(user.getUserId());
 
 			if (user == null) {
+				_onUserDoesNotExist(authType, companyId, login, headerMap);
+
 				return Authenticator.DNE;
 			}
 
 			// Let LDAP handle max failure event
 
-			if (!LDAPSettingsUtil.isPasswordPolicyEnabled(
-					user.getCompanyId())) {
-
+			if (!LDAPSettingsUtil.isPasswordPolicyEnabled(companyId)) {
 				PasswordPolicy passwordPolicy = user.getPasswordPolicy();
 
 				user = userPersistence.fetchByPrimaryKey(user.getUserId());
@@ -6064,17 +6074,17 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 					if (authType.equals(CompanyConstants.AUTH_TYPE_EA)) {
 						AuthPipeline.onMaxFailuresByEmailAddress(
-							PropsKeys.AUTH_MAX_FAILURES, user.getCompanyId(),
+							PropsKeys.AUTH_MAX_FAILURES, companyId,
 							user.getEmailAddress(), headerMap, parameterMap);
 					}
 					else if (authType.equals(CompanyConstants.AUTH_TYPE_SN)) {
 						AuthPipeline.onMaxFailuresByScreenName(
-							PropsKeys.AUTH_MAX_FAILURES, user.getCompanyId(),
+							PropsKeys.AUTH_MAX_FAILURES, companyId,
 							user.getScreenName(), headerMap, parameterMap);
 					}
 					else if (authType.equals(CompanyConstants.AUTH_TYPE_ID)) {
 						AuthPipeline.onMaxFailuresByUserId(
-							PropsKeys.AUTH_MAX_FAILURES, user.getCompanyId(),
+							PropsKeys.AUTH_MAX_FAILURES, companyId,
 							user.getUserId(), headerMap, parameterMap);
 					}
 				}
@@ -7095,6 +7105,49 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		}
 
 		return newEncPwd.equals(user.getPassword());
+	}
+
+	private void _onUserDoesNotExist(
+		String authType, long companyId, String login,
+		Map<String, String[]> headerMap) {
+
+		try {
+			AuditMessage auditMessage = null;
+
+			if (authType.equals(CompanyConstants.AUTH_TYPE_EA) ||
+				authType.equals(CompanyConstants.AUTH_TYPE_ID) ||
+				authType.equals(CompanyConstants.AUTH_TYPE_SN)) {
+
+				auditMessage = new AuditMessage(
+					"LOGIN_DNE", companyId, 0, null, User.class.getName(), "0",
+					null,
+					JSONUtil.put(
+						"authType", authType
+					).put(
+						"headers", JSONFactoryUtil.serialize(headerMap)
+					).put(
+						"reason", "Failed to authenticate - User Does Not Exist"
+					));
+
+				auditMessage.setUserLogin(login);
+			}
+
+			if (auditMessage == null) {
+				return;
+			}
+
+			AuditRouterUtil.route(auditMessage);
+		}
+		catch (AuditException auditException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to route audit message", auditException);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
 	}
 
 	private void _sendNotificationEmail(


### PR DESCRIPTION
[LPS-159334](https://issues.liferay.com/browse/LPS-159334)
Audit message added for authentication failure when the provided login is incorrect.
Relevant test case added.

------------------------------------
Previous [PR](https://github.com/liferay-appsec/liferay-portal/pull/1130)