### PR TITLE
LPS-184771 Scope the ScopeFinders to the companyId of the configuration

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-service/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compileOnly group: "org.apache.cxf", name: "cxf-rt-rs-security-oauth2", version: "3.4.10"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/BaseConfigurationFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/BaseConfigurationFactory.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.util.Validator;
 import java.util.Collection;
 import java.util.Map;
 
+import org.osgi.service.cm.ConfigurationPlugin;
 import org.osgi.service.component.ComponentConstants;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
@@ -145,6 +146,11 @@ public abstract class BaseConfigurationFactory {
 
 	@Reference
 	protected CompanyLocalService companyLocalService;
+
+	@Reference(
+		target = "(config.plugin.id=org.apache.felix.configadmin.plugin.interpolation)"
+	)
+	protected ConfigurationPlugin configurationPlugin;
 
 	@Reference(target = ModuleServiceLifecycle.PORTAL_INITIALIZED)
 	protected ModuleServiceLifecycle moduleServiceLifecycle;

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
@@ -49,7 +49,11 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 @Component(
 	configurationPid = "com.liferay.oauth2.provider.configuration.OAuth2ProviderApplicationHeadlessServerConfiguration",
 	configurationPolicy = ConfigurationPolicy.REQUIRE,
-	property = "_portalK8sConfigMapModifier.cardinality.minimum=1", service = {}
+	property = {
+		"_portalK8sConfigMapModifier.cardinality.minimum=1",
+		"scopeFinders.target=(companyId=$[conf:companyId])"
+	},
+	service = {}
 )
 public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 	extends BaseConfigurationFactory {

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationUserAgentConfigurationFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationUserAgentConfigurationFactory.java
@@ -49,7 +49,11 @@ import org.osgi.service.component.annotations.ConfigurationPolicy;
 @Component(
 	configurationPid = "com.liferay.oauth2.provider.configuration.OAuth2ProviderApplicationUserAgentConfiguration",
 	configurationPolicy = ConfigurationPolicy.REQUIRE,
-	property = "_portalK8sConfigMapModifier.cardinality.minimum=1", service = {}
+	property = {
+		"_portalK8sConfigMapModifier.cardinality.minimum=1",
+		"scopeFinders.target=(companyId=$[conf:companyId])"
+	},
+	service = {}
 )
 public class OAuth2ProviderApplicationUserAgentConfigurationFactory
 	extends BaseConfigurationFactory {


### PR DESCRIPTION
This fixes a bug in partitioned environments, where the deletion of a SAPEntry on one partition can trigger ScopeFinders to become registered/unregistered in a different partition. This can also cause the original SAPEntry deletion to fail since Liferay may switch to the ScopeFinder's partition before the transaction gets committed.

Ticket: [LPS-184771](https://issues.liferay.com/browse/LPS-184771)