### PR TITLE
[TS] LPS-185536, 186263 - incorrect info in Countries Management menu

### DIFF
--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/osgi/commands/PortalAddressOSGiCommands.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/osgi/commands/PortalAddressOSGiCommands.java
@@ -65,24 +65,21 @@ public class PortalAddressOSGiCommands {
 	public void populateCompanyCountries(long companyId) throws Exception {
 		Company company = _companyLocalService.getCompany(companyId);
 
-		int count = _countryLocalService.getCompanyCountriesCount(
-			company.getCompanyId());
+		int count = _countryLocalService.getCompanyCountriesCount(companyId);
 
 		if (count > 0) {
 			if (_log.isDebugEnabled()) {
 				_log.debug(
 					StringBundler.concat(
 						"Skipping country initialization. Countries are ",
-						"already initialized for company ",
-						company.getCompanyId(), "."));
+						"already initialized for company ", companyId, "."));
 			}
 
 			return;
 		}
 
 		if (_log.isDebugEnabled()) {
-			_log.debug(
-				"Initializing countries for company " + company.getCompanyId());
+			_log.debug("Initializing countries for company " + companyId);
 		}
 
 		JSONArray countriesJSONArray = _getJSONArray(
@@ -96,7 +93,7 @@ public class PortalAddressOSGiCommands {
 
 				ServiceContext serviceContext = new ServiceContext();
 
-				serviceContext.setCompanyId(company.getCompanyId());
+				serviceContext.setCompanyId(companyId);
 
 				User guestUser = company.getGuestUser();
 
@@ -135,9 +132,7 @@ public class PortalAddressOSGiCommands {
 		Company company = _companyLocalService.getCompany(companyId);
 
 		if (_log.isDebugEnabled()) {
-			_log.debug(
-				"Reinitializing countries for company " +
-					company.getCompanyId());
+			_log.debug("Reinitializing countries for company " + companyId);
 		}
 
 		JSONArray countriesJSONArray = _getJSONArray(
@@ -168,7 +163,7 @@ public class PortalAddressOSGiCommands {
 				else {
 					ServiceContext serviceContext = new ServiceContext();
 
-					serviceContext.setCompanyId(company.getCompanyId());
+					serviceContext.setCompanyId(companyId);
 
 					User guestUser = company.getGuestUser();
 

--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/osgi/commands/PortalAddressOSGiCommands.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/osgi/commands/PortalAddressOSGiCommands.java
@@ -157,6 +157,16 @@ public class PortalAddressOSGiCommands {
 					Country country = _countryLocalService.getCountryByName(
 						companyId, name);
 
+					country = _countryLocalService.updateCountry(
+						country.getCountryId(),
+						countryJSONObject.getString("a2"),
+						countryJSONObject.getString("a3"), country.isActive(),
+						country.isBillingAllowed(),
+						countryJSONObject.getString("idd"), name,
+						countryJSONObject.getString("number"),
+						country.getPosition(), country.isShippingAllowed(),
+						country.isSubjectToVAT());
+
 					_processCountryRegions(country);
 				}
 				else {

--- a/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/osgi/commands/PortalAddressOSGiCommands.java
+++ b/modules/apps/address/address-impl/src/main/java/com/liferay/address/internal/osgi/commands/PortalAddressOSGiCommands.java
@@ -34,10 +34,10 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Stream;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -138,23 +138,22 @@ public class PortalAddressOSGiCommands {
 		JSONArray countriesJSONArray = _getJSONArray(
 			"com/liferay/address/dependencies/countries.json");
 
+		List<Country> countries = _countryLocalService.getCompanyCountries(
+			companyId);
+
+		HashSet<String> countryNames = new HashSet<>();
+
+		for (Country country : countries) {
+			countryNames.add(country.getName());
+		}
+
 		for (int i = 0; i < countriesJSONArray.length(); i++) {
 			JSONObject countryJSONObject = countriesJSONArray.getJSONObject(i);
 
 			try {
 				String name = countryJSONObject.getString("name");
 
-				List<Country> countries =
-					_countryLocalService.getCompanyCountries(companyId);
-
-				Stream<Country> countryStream = countries.stream();
-
-				if (countryStream.anyMatch(
-						country -> country.getName(
-						).equals(
-							name
-						))) {
-
+				if (countryNames.contains(name)) {
 					Country country = _countryLocalService.getCountryByName(
 						companyId, name);
 

--- a/modules/apps/address/address-impl/src/main/resources/com/liferay/address/dependencies/countries.json
+++ b/modules/apps/address/address-impl/src/main/resources/com/liferay/address/dependencies/countries.json
@@ -34,7 +34,7 @@
 	{
 		"a2": "AS",
 		"a3": "ASM",
-		"idd": 684,
+		"idd": 1,
 		"name": "american-samoa",
 		"number": 16,
 		"zipRequired": true
@@ -58,7 +58,7 @@
 	{
 		"a2": "AI",
 		"a3": "AIA",
-		"idd": 264,
+		"idd": 1,
 		"name": "anguilla",
 		"number": 660,
 		"zipRequired": true
@@ -74,7 +74,7 @@
 	{
 		"a2": "AG",
 		"a3": "ATG",
-		"idd": 268,
+		"idd": 1,
 		"name": "antigua-barbuda",
 		"number": 28,
 		"zipRequired": false
@@ -130,7 +130,7 @@
 	{
 		"a2": "BS",
 		"a3": "BHS",
-		"idd": 242,
+		"idd": 1,
 		"name": "bahamas",
 		"number": 44,
 		"zipRequired": false
@@ -154,7 +154,7 @@
 	{
 		"a2": "BB",
 		"a3": "BRB",
-		"idd": 246,
+		"idd": 1,
 		"name": "barbados",
 		"number": 52,
 		"zipRequired": true
@@ -194,7 +194,7 @@
 	{
 		"a2": "BM",
 		"a3": "BMU",
-		"idd": 441,
+		"idd": 1,
 		"name": "bermuda",
 		"number": 60,
 		"zipRequired": true
@@ -266,7 +266,7 @@
 	{
 		"a2": "VG",
 		"a3": "VGB",
-		"idd": 284,
+		"idd": 1,
 		"name": "british-virgin-islands",
 		"number": 92,
 		"zipRequired": true
@@ -338,7 +338,7 @@
 	{
 		"a2": "KY",
 		"a3": "CYM",
-		"idd": 345,
+		"idd": 1,
 		"name": "cayman-islands",
 		"number": 136,
 		"zipRequired": true
@@ -490,7 +490,7 @@
 	{
 		"a2": "DM",
 		"a3": "DMA",
-		"idd": 767,
+		"idd": 1,
 		"name": "dominica",
 		"number": 212,
 		"zipRequired": false
@@ -498,7 +498,7 @@
 	{
 		"a2": "DO",
 		"a3": "DOM",
-		"idd": 829,
+		"idd": 1,
 		"name": "dominican-republic",
 		"number": 214,
 		"zipRequired": true
@@ -698,7 +698,7 @@
 	{
 		"a2": "GD",
 		"a3": "GRD",
-		"idd": 473,
+		"idd": 1,
 		"name": "grenada",
 		"number": 308,
 		"zipRequired": true
@@ -714,7 +714,7 @@
 	{
 		"a2": "GU",
 		"a3": "GUM",
-		"idd": 671,
+		"idd": 1,
 		"name": "guam",
 		"number": 316,
 		"zipRequired": true
@@ -874,7 +874,7 @@
 	{
 		"a2": "JM",
 		"a3": "JAM",
-		"idd": 876,
+		"idd": 1,
 		"name": "jamaica",
 		"number": 388,
 		"zipRequired": false
@@ -1162,7 +1162,7 @@
 	{
 		"a2": "MS",
 		"a3": "MSR",
-		"idd": 664,
+		"idd": 1,
 		"name": "montserrat",
 		"number": 500,
 		"zipRequired": true
@@ -1282,7 +1282,7 @@
 	{
 		"a2": "MP",
 		"a3": "MNP",
-		"idd": 670,
+		"idd": 1,
 		"name": "northern-mariana-islands",
 		"number": 580,
 		"zipRequired": true
@@ -1394,7 +1394,7 @@
 	{
 		"a2": "PR",
 		"a3": "PRI",
-		"idd": 939,
+		"idd": 1,
 		"name": "puerto-rico",
 		"number": 630,
 		"zipRequired": true
@@ -1522,7 +1522,7 @@
 	{
 		"a2": "SX",
 		"a3": "SXM",
-		"idd": 721,
+		"idd": 1,
 		"name": "sint-maarten",
 		"number": 534,
 		"zipRequired": true
@@ -1626,7 +1626,7 @@
 	{
 		"a2": "KN",
 		"a3": "KNA",
-		"idd": 869,
+		"idd": 1,
 		"name": "st-kitts",
 		"number": 659,
 		"zipRequired": false
@@ -1634,7 +1634,7 @@
 	{
 		"a2": "LC",
 		"a3": "LCA",
-		"idd": 758,
+		"idd": 1,
 		"name": "st-lucia",
 		"number": 662,
 		"zipRequired": false
@@ -1658,7 +1658,7 @@
 	{
 		"a2": "VC",
 		"a3": "VCT",
-		"idd": 784,
+		"idd": 1,
 		"name": "st-vincent",
 		"number": 670,
 		"zipRequired": true
@@ -1778,7 +1778,7 @@
 	{
 		"a2": "TT",
 		"a3": "TTO",
-		"idd": 868,
+		"idd": 1,
 		"name": "trinidad-tobago",
 		"number": 780,
 		"zipRequired": false
@@ -1810,7 +1810,7 @@
 	{
 		"a2": "TC",
 		"a3": "TCA",
-		"idd": 649,
+		"idd": 1,
 		"name": "turks-caicos",
 		"number": 796,
 		"zipRequired": true
@@ -1874,7 +1874,7 @@
 	{
 		"a2": "VI",
 		"a3": "VIR",
-		"idd": 340,
+		"idd": 1,
 		"name": "united-states-virgin-islands",
 		"number": 850,
 		"zipRequired": true

--- a/modules/apps/address/address-impl/src/main/resources/com/liferay/address/dependencies/regions/BE.json
+++ b/modules/apps/address/address-impl/src/main/resources/com/liferay/address/dependencies/regions/BE.json
@@ -1,0 +1,54 @@
+[
+	{
+		"name": "Antwerpen",
+		"regionCode": "VAN"
+	},
+	{
+		"name": "Brabant wallon",
+		"regionCode": "WBR"
+	},
+	{
+		"name": "Brussels-Capital Region",
+		"regionCode": "BRU"
+	},
+	{
+		"name": "Hainaut",
+		"regionCode": "WHT"
+	},
+	{
+		"name": "Limburg",
+		"regionCode": "VLI"
+	},
+	{
+		"name": "Liège",
+		"regionCode": "WLG"
+	},
+	{
+		"name": "Luxembourg",
+		"regionCode": "WLX"
+	},
+	{
+		"name": "Namur",
+		"regionCode": "WNA"
+	},
+	{
+		"name": "Oost-Vlaanderen",
+		"regionCode": "VOV"
+	},
+	{
+		"name": "Vlaams Gewest",
+		"regionCode": "VLG"
+	},
+	{
+		"name": "Vlaams-Brabant",
+		"regionCode": "VBR"
+	},
+	{
+		"name": "Walloon Region",
+		"regionCode": "WAL"
+	},
+	{
+		"name": "West-Vlaanderen",
+		"regionCode": "VWV"
+	}
+]


### PR DESCRIPTION
Hi AppSec team! This is a resend of https://github.com/liferay-appsec/liferay-portal/pull/1137 with additional commits for LPS-186263 which requires the infrastructure put into place with LPS-185536 to allow us to update countries/regions in existing instances using the JSON files included.

This is a fix with two major parts. The first is to simply add/edit the JSON with the required information of Belgium's regions, per the list on https://www.iso.org/obp/ui/#search. This is the BE.json file and is mostly a 1:1 copy from the ISO 3166 standard except for the name "Brussels-Capital Region" which is presented in both Dutch and French versions on the site. I opted for the default to be the English name per [Belgium's website](https://www.belgium.be/en/about_belgium/government/regions/brussels_capital_region). There are also fixes made to the phone codes in countries.json, adjusting them to the correct value of "1" per [List of Country Calling Codes](https://en.wikipedia.org/wiki/List_of_country_calling_codes).

The second half is the trickier part which is that we don't really (from what I can tell) have a way for a user to 'refresh' the list of countries, let alone their regions, in an existing company. The two OSGI commands listed in PortalAddressOSGICommands either completely reinitializes the information (meaning custom companies/regions added through the UI would be lost) or doesn't do anything at all since it sees that there's already countries previously added. While a user could technically add each region manually through the UI, this allows both them (and us) to add them through simply adding a new compatible json file. The method itself is based on populateCompanyCountries() above it but modifies the logic to check if we already have a country name in our list of countries. If we do, we update the values and repopulate the regions. If not, we add it as normal.

The last commit is a minor refactor. I noticed in the logic for populateCompanyCountries (and therefore the method I was adding as well) that despite the argument being companyId and us grabbing company using it at the beginning of our method, we were consistently then calling company.getCompanyId() afterwards instead of just using the companyId we already had. Since company/companyIds are unique and unlikely to change, I couldn't think of a reason why we'd be making these calls, so I changed it, but if there's something I'm missing in this please let me know.

Thanks for taking the time to look at this!