### PR TITLE
[TS] LPS-186972

### DIFF
--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/configuration/admin/service/OpenIdConnectProviderManagedServiceFactory.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/configuration/admin/service/OpenIdConnectProviderManagedServiceFactory.java
@@ -163,7 +163,7 @@ public class OpenIdConnectProviderManagedServiceFactory
 			String clientName = jsonObject.getString("client_name", null);
 
 			if (clientName != null) {
-				clientName = clientName.substring(10);
+				clientName = clientName.substring(_CLIENT_TO.length());
 			}
 
 			oAuthClientEntryIds.put(
@@ -297,7 +297,7 @@ public class OpenIdConnectProviderManagedServiceFactory
 			return null;
 		}
 
-		return "Client to " + providerName;
+		return _CLIENT_TO + providerName;
 	}
 
 	private String _generateInfoJSON(Dictionary<String, ?> properties) {
@@ -589,6 +589,8 @@ public class OpenIdConnectProviderManagedServiceFactory
 			}
 		}
 	}
+
+	private static final String _CLIENT_TO = "Client to ";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		OpenIdConnectProviderManagedServiceFactory.class);

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/configuration/admin/service/OpenIdConnectProviderManagedServiceFactory.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/configuration/admin/service/OpenIdConnectProviderManagedServiceFactory.java
@@ -47,6 +47,7 @@ import java.security.MessageDigest;
 
 import java.util.Dictionary;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -140,6 +141,34 @@ public class OpenIdConnectProviderManagedServiceFactory
 						company.getCompanyId(), null, "", properties);
 				}
 			});
+
+		List<OAuthClientEntry> oAuthClientEntries =
+			_oAuthClientEntryLocalService.getCompanyOAuthClientEntries(
+				company.getCompanyId());
+
+		for (OAuthClientEntry oAuthClientEntry : oAuthClientEntries) {
+			Map<String, Long> oAuthClientEntryIds = _oAuthClientEntryIds.get(
+				company.getCompanyId());
+
+			if (oAuthClientEntryIds == null) {
+				oAuthClientEntryIds = new HashMap<>();
+
+				_oAuthClientEntryIds.put(
+					company.getCompanyId(), oAuthClientEntryIds);
+			}
+
+			JSONObject jsonObject = _jsonFactory.createJSONObject(
+				oAuthClientEntry.getInfoJSON());
+
+			String clientName = jsonObject.getString("client_name", null);
+
+			if (clientName != null) {
+				clientName = clientName.substring(10);
+			}
+
+			oAuthClientEntryIds.put(
+				clientName, oAuthClientEntry.getOAuthClientEntryId());
+		}
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-186972

When utilizing the [getOAuthClientEntryId](https://github.com/liferay/liferay-portal/blob/b087f97f26aa2da3113f15a376289ab890d12a90/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/configuration/admin/service/OpenIdConnectProviderManagedServiceFactory.java#L106-L126) method after a module/server restart, instance-level oAuth client's will not be included in the `_oAuthClientEntryIds` map, resulting in a `NoSuchOAuthClientEntryException`.

The solution is to make sure the `_oAuthClientEntryIds` map is properly reinitialized.

Please let me know if you have any questions, thanks!