### PR TITLE
LPS-186583 Country becomes null after calling Headless API

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/ServiceBuilderCountryUtil.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/util/ServiceBuilderCountryUtil.java
@@ -14,10 +14,18 @@
 
 package com.liferay.headless.admin.user.internal.dto.v1_0.util;
 
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Country;
+import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.service.CountryServiceUtil;
+import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
+import com.liferay.portal.model.impl.CountryImpl;
+
+import java.util.List;
 
 /**
  * @author Drew Brokke
@@ -40,6 +48,23 @@ public class ServiceBuilderCountryUtil {
 
 			if (country != null) {
 				return country;
+			}
+
+			String addressCountryKeyWord =
+				StringPool.QUOTE + addressCountry + StringPool.QUOTE;
+
+			OrderByComparator comparator = OrderByComparatorFactoryUtil.create(
+				CountryImpl.TABLE_NAME, "name", true);
+
+			BaseModelSearchResult<Country> baseModelSearchResult =
+				CountryServiceUtil.searchCountries(
+					companyId, true, addressCountryKeyWord, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, comparator);
+
+			List<Country> countries = baseModelSearchResult.getBaseModels();
+
+			if (countries != null) {
+				return countries.get(0);
 			}
 
 			return CountryServiceUtil.getCountryByName(


### PR DESCRIPTION
Hi Team,

https://issues.liferay.com/browse/LPS-186583.

The issue is when changing the attributes of a user with headless api and the ServiceBuilderCountryUtil is looking for the country name to add the country value for the new user, it can't find it, because it is saved with dashes instead of space.

Solution: 
Using the CountryServiceUtil.searchCountries() method to search for the country with the country name. This method can find the title even when we patch the user with a country name in another language.

I considered other solution:
-changed spaces to dash: this worked only in english.
-searched for title in country localization. This solution worked, but at the source format got the : Illegal call to class 'com.liferay.portal.kernel.service.persistence.CountryLocalizationUtil

Tested it locally, and it fixed the problem.

Thank you in advance,
Gege