### PR TITLE
[TS] [Urgent] LPS-187864 Administrators were no longer able to update other users' screen names or email addresses

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditUserMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditUserMVCActionCommand.java
@@ -363,7 +363,7 @@ public class EditUserMVCActionCommand
 			!emailAddress.equals(oldEmailAddress)) {
 
 			int authResult = _userLocalService.authenticateByUserId(
-				themeDisplay.getCompanyId(), user.getUserId(),
+				themeDisplay.getCompanyId(), portal.getUserId(actionRequest),
 				ParamUtil.getString(actionRequest, "password"), new HashMap<>(),
 				new HashMap<>(), new HashMap<>());
 


### PR DESCRIPTION
Ticket: [LPS-187864](https://issues.liferay.com/browse/LPS-187864)

I tested the steps on [LPS-182685](https://issues.liferay.com/browse/LPS-182685) against this change and I wasn't able to reproduce the issue there. It seems that the permissions framework was preventing the requester from updating that user if the userId of the request was modified (even after I gave them VIEW permissions on the user but not UPDATE permissions). However, I wasn't 100% sure if I tested that ticket correctly because it didn't fully make sense to me. It seemed like "User A" needed "User B"'s password in order to pull off the attack. But if they had "User B"'s password already, then couldn't they just log in as "User B" and make whatever changes they wanted to their account that way?