### PR TITLE
LPS-188257 - NullPointerException is thrown when LDAP password policy is enabled when user has no password policy set

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/frontend/taglib/servlet/taglib/UserPasswordScreenNavigationEntry.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/frontend/taglib/servlet/taglib/UserPasswordScreenNavigationEntry.java
@@ -72,7 +72,7 @@ public class UserPasswordScreenNavigationEntry
 		catch (PortalException portalException) {
 			_log.error(portalException);
 
-			return false;
+			return true;
 		}
 	}
 

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/frontend/taglib/servlet/taglib/UserPasswordScreenNavigationEntry.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/frontend/taglib/servlet/taglib/UserPasswordScreenNavigationEntry.java
@@ -63,6 +63,10 @@ public class UserPasswordScreenNavigationEntry
 		try {
 			PasswordPolicy passwordPolicy = selUser.getPasswordPolicy();
 
+			if (passwordPolicy == null) {
+				return true;
+			}
+
 			return passwordPolicy.isChangeable();
 		}
 		catch (PortalException portalException) {


### PR DESCRIPTION
### _Context:_  [LPS-188257](https://liferay.atlassian.net/browse/LPS-188257) 


_Regression bug caused by_: [LPS-179689](https://liferay.atlassian.net/browse/LPS-179689)

### **Reproduction steps:**

1. Go to Control Panel -> Instance Settings -> LDAP -> General and enable 'Use LDAP Password Policy'. You don't need to connect Liferay with an LDAP-server for this reproduction.
3. Go to Control Panel -> Users and Organizations. Try to edit the test user.

**_Expected Behavior:_** User edit page is displayed

**_Current Behavior:_** You will get the message “Users and Organizations is temporarily unavailable” and this exception displayed in the log console:
```
2023-06-12 13:40:28.172 ERROR [http-nio-8080-exec-8][render_portlet_jsp:131] null
java.lang.NullPointerException: null
        at com.liferay.users.admin.web.internal.frontend.taglib.servlet.taglib.UserPasswordScreenNavigationEntry.isVisible(UserPasswordScreenNavigationEntry.java:66) ~[?:?]
```

