### PR TITLE
LPS-159334 Add audit message for a failed authentication when the user does not exist and refactor AuthFailure

### DIFF
--- a/modules/apps/login/login-authentication/bnd.bnd
+++ b/modules/apps/login/login-authentication/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Login Authentication
+Bundle-SymbolicName: com.liferay.login.authentication
+Bundle-Version: 1.0.0

--- a/modules/apps/login/login-authentication/build.gradle
+++ b/modules/apps/login/login-authentication/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+}

--- a/modules/apps/login/login-authentication/src/main/java/com/liferay/login/authentication/internal/security/auth/LoginAuthFailure.java
+++ b/modules/apps/login/login-authentication/src/main/java/com/liferay/login/authentication/internal/security/auth/LoginAuthFailure.java
@@ -12,21 +12,23 @@
  * details.
  */
 
-package com.liferay.portal.security.auth;
+package com.liferay.login.authentication.internal.security.auth;
 
 import com.liferay.portal.kernel.security.auth.AuthException;
 import com.liferay.portal.kernel.security.auth.AuthFailure;
-import com.liferay.portal.kernel.service.UserLocalServiceUtil;
-import com.liferay.portal.kernel.spring.osgi.OSGiBeanProperties;
+import com.liferay.portal.kernel.service.UserLocalService;
 
 import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Brian Wing Shun Chan
  * @author Scott Lee
  */
-@OSGiBeanProperties(property = "key=auth.failure")
-public class LoginFailure implements AuthFailure {
+@Component(property = "key=auth.failure", service = AuthFailure.class)
+public class LoginAuthFailure implements AuthFailure {
 
 	@Override
 	public void onFailureByEmailAddress(
@@ -35,7 +37,7 @@ public class LoginFailure implements AuthFailure {
 		throws AuthException {
 
 		try {
-			UserLocalServiceUtil.checkLoginFailureByEmailAddress(
+			_userLocalService.checkLoginFailureByEmailAddress(
 				companyId, emailAddress);
 		}
 		catch (Exception exception) {
@@ -50,7 +52,7 @@ public class LoginFailure implements AuthFailure {
 		throws AuthException {
 
 		try {
-			UserLocalServiceUtil.checkLoginFailureByScreenName(
+			_userLocalService.checkLoginFailureByScreenName(
 				companyId, screenName);
 		}
 		catch (Exception exception) {
@@ -65,11 +67,14 @@ public class LoginFailure implements AuthFailure {
 		throws AuthException {
 
 		try {
-			UserLocalServiceUtil.checkLoginFailureById(userId);
+			_userLocalService.checkLoginFailureById(userId);
 		}
 		catch (Exception exception) {
 			throw new AuthException(exception);
 		}
 	}
+
+	@Reference
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/login/login-authentication/src/main/java/com/liferay/login/authentication/internal/security/auth/LoginMaxAuthFailure.java
+++ b/modules/apps/login/login-authentication/src/main/java/com/liferay/login/authentication/internal/security/auth/LoginMaxAuthFailure.java
@@ -12,21 +12,23 @@
  * details.
  */
 
-package com.liferay.portal.security.auth;
+package com.liferay.login.authentication.internal.security.auth;
 
 import com.liferay.portal.kernel.security.auth.AuthException;
 import com.liferay.portal.kernel.security.auth.AuthFailure;
-import com.liferay.portal.kernel.service.UserLocalServiceUtil;
-import com.liferay.portal.kernel.spring.osgi.OSGiBeanProperties;
+import com.liferay.portal.kernel.service.UserLocalService;
 
 import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Brian Wing Shun Chan
  * @author Scott Lee
  */
-@OSGiBeanProperties(property = "key=auth.max.failures")
-public class LoginMaxFailures implements AuthFailure {
+@Component(property = "key=auth.max.failures", service = AuthFailure.class)
+public class LoginMaxAuthFailure implements AuthFailure {
 
 	@Override
 	public void onFailureByEmailAddress(
@@ -35,7 +37,7 @@ public class LoginMaxFailures implements AuthFailure {
 		throws AuthException {
 
 		try {
-			UserLocalServiceUtil.updateLockoutByEmailAddress(
+			_userLocalService.updateLockoutByEmailAddress(
 				companyId, emailAddress, true);
 		}
 		catch (Exception exception) {
@@ -50,7 +52,7 @@ public class LoginMaxFailures implements AuthFailure {
 		throws AuthException {
 
 		try {
-			UserLocalServiceUtil.updateLockoutByScreenName(
+			_userLocalService.updateLockoutByScreenName(
 				companyId, screenName, true);
 		}
 		catch (Exception exception) {
@@ -65,11 +67,14 @@ public class LoginMaxFailures implements AuthFailure {
 		throws AuthException {
 
 		try {
-			UserLocalServiceUtil.updateLockoutById(userId, true);
+			_userLocalService.updateLockoutById(userId, true);
 		}
 		catch (Exception exception) {
 			throw new AuthException(exception);
 		}
 	}
+
+	@Reference
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/bnd.bnd
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Security Audit Event Generators API
 Bundle-SymbolicName: com.liferay.portal.security.audit.event.generators.api
-Bundle-Version: 6.1.1
+Bundle-Version: 6.2.0
 Export-Package:\
 	com.liferay.portal.security.audit.event.generators.constants,\
 	com.liferay.portal.security.audit.event.generators.util

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/java/com/liferay/portal/security/audit/event/generators/constants/EventTypes.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/java/com/liferay/portal/security/audit/event/generators/constants/EventTypes.java
@@ -32,6 +32,8 @@ public interface EventTypes {
 
 	public static final String LOGIN = "LOGIN";
 
+	public static final String LOGIN_DNE = "LOGIN_DNE";
+
 	public static final String LOGIN_FAILURE = "LOGIN_FAILURE";
 
 	public static final String LOGOUT = "LOGOUT";

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/resources/com/liferay/portal/security/audit/event/generators/constants/packageinfo
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/resources/com/liferay/portal/security/audit/event/generators/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.1
+version 1.1.0

--- a/modules/apps/portal-security/portal-security-auth-test/src/testIntegration/java/com/liferay/portal/security/auth/test/AuthPipelineTest.java
+++ b/modules/apps/portal-security/portal-security-auth-test/src/testIntegration/java/com/liferay/portal/security/auth/test/AuthPipelineTest.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.security.auth.AuthFailure;
 import com.liferay.portal.kernel.security.auth.Authenticator;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.security.auth.AuthPipeline;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -68,7 +69,10 @@ public class AuthPipelineTest {
 					return null;
 				}),
 			HashMapDictionaryBuilder.<String, Object>put(
-				"key", new String[] {"auth.failure", "auth.max.failures"}
+				"key",
+				new String[] {
+					PropsKeys.AUTH_FAILURE, PropsKeys.AUTH_MAX_FAILURES
+				}
 			).put(
 				"service.ranking", Integer.MAX_VALUE
 			).build());
@@ -84,7 +88,7 @@ public class AuthPipelineTest {
 					return Authenticator.SUCCESS;
 				}),
 			HashMapDictionaryBuilder.<String, Object>put(
-				"key", "auth.pipeline.pre"
+				"key", PropsKeys.AUTH_PIPELINE_PRE
 			).put(
 				"service.ranking", Integer.MAX_VALUE
 			).build());
@@ -105,7 +109,7 @@ public class AuthPipelineTest {
 	@Test
 	public void testAuthenticateByEmailAddress() throws AuthException {
 		AuthPipeline.authenticateByEmailAddress(
-			"auth.pipeline.pre", 0, RandomTestUtil.randomString(),
+			PropsKeys.AUTH_PIPELINE_PRE, 0, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), null, null);
 
 		Assert.assertTrue(_calledAuthenticator);
@@ -114,7 +118,7 @@ public class AuthPipelineTest {
 	@Test
 	public void testAuthenticateByScreenName() throws AuthException {
 		AuthPipeline.authenticateByScreenName(
-			"auth.pipeline.pre", 0, RandomTestUtil.randomString(),
+			PropsKeys.AUTH_PIPELINE_PRE, 0, RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), null, null);
 
 		Assert.assertTrue(_calledAuthenticator);
@@ -123,7 +127,7 @@ public class AuthPipelineTest {
 	@Test
 	public void testAuthenticateByUserId() throws AuthException {
 		AuthPipeline.authenticateByUserId(
-			"auth.pipeline.pre", 0, RandomTestUtil.randomLong(),
+			PropsKeys.AUTH_PIPELINE_PRE, 0, RandomTestUtil.randomLong(),
 			RandomTestUtil.randomString(), null, null);
 
 		Assert.assertTrue(_calledAuthenticator);
@@ -133,7 +137,8 @@ public class AuthPipelineTest {
 	public void testOnFailureByScreenName() {
 		try {
 			AuthPipeline.onFailureByScreenName(
-				"auth.failure", 0, RandomTestUtil.randomString(), null, null);
+				PropsKeys.AUTH_FAILURE, 0, RandomTestUtil.randomString(), null,
+				null);
 		}
 		catch (AuthException authException) {
 			if (_log.isDebugEnabled()) {
@@ -148,7 +153,8 @@ public class AuthPipelineTest {
 	public void testOnFailureByUserId() {
 		try {
 			AuthPipeline.onFailureByUserId(
-				"auth.failure", 0, RandomTestUtil.randomLong(), null, null);
+				PropsKeys.AUTH_FAILURE, 0, RandomTestUtil.randomLong(), null,
+				null);
 		}
 		catch (AuthException authException) {
 			if (_log.isDebugEnabled()) {
@@ -163,8 +169,8 @@ public class AuthPipelineTest {
 	public void testOnMaxFailuresByEmailAddress() {
 		try {
 			AuthPipeline.onMaxFailuresByEmailAddress(
-				"auth.max.failures", 0, RandomTestUtil.randomString(), null,
-				null);
+				PropsKeys.AUTH_MAX_FAILURES, 0, RandomTestUtil.randomString(),
+				null, null);
 		}
 		catch (AuthException authException) {
 			if (_log.isDebugEnabled()) {
@@ -179,8 +185,8 @@ public class AuthPipelineTest {
 	public void testOnMaxFailuresByScreenName() {
 		try {
 			AuthPipeline.onMaxFailuresByScreenName(
-				"auth.max.failures", 0, RandomTestUtil.randomString(), null,
-				null);
+				PropsKeys.AUTH_MAX_FAILURES, 0, RandomTestUtil.randomString(),
+				null, null);
 		}
 		catch (AuthException authException) {
 			if (_log.isDebugEnabled()) {
@@ -195,8 +201,8 @@ public class AuthPipelineTest {
 	public void testOnMaxFailuresByUserId() {
 		try {
 			AuthPipeline.onMaxFailuresByUserId(
-				"auth.max.failures", 0, RandomTestUtil.randomLong(), null,
-				null);
+				PropsKeys.AUTH_MAX_FAILURES, 0, RandomTestUtil.randomLong(),
+				null, null);
 		}
 		catch (AuthException authException) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/user/user-test/build.gradle
+++ b/modules/apps/user/user-test/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	testIntegrationCompile project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationCompile project(":apps:portal-security-audit:portal-security-audit-api")
+	testIntegrationCompile project(":apps:portal-security-audit:portal-security-audit-event-generators-api")
 	testIntegrationCompile project(":apps:ratings:ratings-test-util")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/user/user-test/build.gradle
+++ b/modules/apps/user/user-test/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	testIntegrationCompile group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testIntegrationCompile group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	testIntegrationCompile project(":apps:change-tracking:change-tracking-test-util")
+	testIntegrationCompile project(":apps:portal-security-audit:portal-security-audit-api")
 	testIntegrationCompile project(":apps:ratings:ratings-test-util")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
@@ -77,6 +77,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.security.audit.AuditMessageProcessor;
+import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PropsValues;
@@ -871,8 +872,6 @@ public class UserLocalServiceTest {
 		return userIds;
 	}
 
-	private static final String _LOGIN_DNE = "LOGIN_DNE";
-
 	@Inject
 	private AnnouncementsDeliveryLocalService
 		_announcementsDeliveryLocalService;
@@ -917,7 +916,8 @@ public class UserLocalServiceTest {
 		public void process(AuditMessage auditMessage) {
 			Assert.assertNotNull(auditMessage);
 
-			Assert.assertEquals(_LOGIN_DNE, auditMessage.getEventType());
+			Assert.assertEquals(
+				EventTypes.LOGIN_DNE, auditMessage.getEventType());
 
 			JSONObject additionalInfoJSONObject =
 				auditMessage.getAdditionalInfo();
@@ -944,7 +944,7 @@ public class UserLocalServiceTest {
 			_serviceRegistration = _bundleContext.registerService(
 				AuditMessageProcessor.class, _auditMessageProcessor,
 				HashMapDictionaryBuilder.<String, Object>put(
-					"eventTypes", _LOGIN_DNE
+					"eventTypes", EventTypes.LOGIN_DNE
 				).build());
 		}
 

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/security/auth/LoginAuthDNE.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/security/auth/LoginAuthDNE.java
@@ -34,11 +34,11 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Nikoletta Buza
  */
-@Component(property = "key=auth.dne", service = AuthDNE.class)
-public class LoginDNE implements AuthDNE {
+@Component(service = AuthDNE.class)
+public class LoginAuthDNE implements AuthDNE {
 
 	@Override
-	public void onUserDoesNotExist(
+	public void onDoesNotExist(
 		String authType, long companyId, String login,
 		Map<String, String[]> headerMap, Map<String, String[]> parameterMap) {
 
@@ -84,7 +84,7 @@ public class LoginDNE implements AuthDNE {
 		}
 	}
 
-	private static final Log _log = LogFactoryUtil.getLog(LoginDNE.class);
+	private static final Log _log = LogFactoryUtil.getLog(LoginAuthDNE.class);
 
 	@Reference
 	private AuditRouter _auditRouter;

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/security/auth/LoginAuthFailure.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/security/auth/LoginAuthFailure.java
@@ -38,7 +38,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Stian Sigvartsen
  */
 @Component(property = "key=auth.failure", service = AuthFailure.class)
-public class LoginFailure implements AuthFailure {
+public class LoginAuthFailure implements AuthFailure {
 
 	@Override
 	public void onFailureByEmailAddress(
@@ -143,7 +143,8 @@ public class LoginFailure implements AuthFailure {
 		return auditMessage;
 	}
 
-	private static final Log _log = LogFactoryUtil.getLog(LoginFailure.class);
+	private static final Log _log = LogFactoryUtil.getLog(
+		LoginAuthFailure.class);
 
 	@Reference
 	private AuditRouter _auditRouter;

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/security/auth/LoginDNE.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/security/auth/LoginDNE.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of the Liferay Enterprise
+ * Subscription License ("License"). You may not use this file except in
+ * compliance with the License. You can obtain a copy of the License by
+ * contacting Liferay, Inc. See the License for the specific language governing
+ * permissions and limitations under the License, including but not limited to
+ * distribution rights of the Software.
+ *
+ *
+ *
+ */
+
+package com.liferay.portal.security.audit.event.generators.internal.security.auth;
+
+import com.liferay.portal.kernel.audit.AuditException;
+import com.liferay.portal.kernel.audit.AuditMessage;
+import com.liferay.portal.kernel.audit.AuditRouter;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.AuthDNE;
+import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Nikoletta Buza
+ */
+@Component(property = "key=auth.dne", service = AuthDNE.class)
+public class LoginDNE implements AuthDNE {
+
+	@Override
+	public void onUserDoesNotExist(
+		String authType, long companyId, String login,
+		Map<String, String[]> headerMap, Map<String, String[]> parameterMap) {
+
+		try {
+			AuditMessage auditMessage = null;
+
+			if (authType.equals(CompanyConstants.AUTH_TYPE_EA) ||
+				authType.equals(CompanyConstants.AUTH_TYPE_ID) ||
+				authType.equals(CompanyConstants.AUTH_TYPE_SN)) {
+
+				JSONObject additionalInfoJSONObject =
+					_jsonFactory.createJSONObject();
+
+				auditMessage = new AuditMessage(
+					EventTypes.LOGIN_DNE, companyId, 0, null,
+					User.class.getName(), "0", null,
+					additionalInfoJSONObject.put(
+						"authType", authType
+					).put(
+						"headers", _jsonFactory.serialize(headerMap)
+					).put(
+						"reason", "Failed to authenticate - User Does Not Exist"
+					));
+
+				auditMessage.setUserLogin(login);
+			}
+
+			if (auditMessage == null) {
+				return;
+			}
+
+			_auditRouter.route(auditMessage);
+		}
+		catch (AuditException auditException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to route audit message", auditException);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(LoginDNE.class);
+
+	@Reference
+	private AuditRouter _auditRouter;
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+}

--- a/portal-impl/src/META-INF/security-spring.xml
+++ b/portal-impl/src/META-INF/security-spring.xml
@@ -4,9 +4,8 @@
 	default-destroy-method="destroy"
 	default-init-method="afterPropertiesSet"
 	xmlns="http://www.springframework.org/schema/beans"
-	xmlns:util="http://www.springframework.org/schema/util"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd http://www.springframework.org/schema/util http://www.springframework.org/schema/util/spring-util-3.0.xsd"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd"
 >
 	<bean class="com.liferay.portal.kernel.internal.security.permission.resource.ModelResourcePermissionDefinitionTracker" id="com.liferay.portal.kernel.internal.security.permission.resource.ModelResourcePermissionDefinitionTracker" />
 	<bean class="com.liferay.portal.kernel.internal.security.permission.resource.PortletResourcePermissionDefinitionTracker" id="com.liferay.portal.kernel.internal.security.permission.resource.PortletResourcePermissionDefinitionTracker" />
@@ -100,8 +99,6 @@
 	<bean class="com.liferay.portal.security.auth.EmailAddressGeneratorFactory" id="com.liferay.portal.security.auth.EmailAddressGeneratorFactory" />
 	<bean class="com.liferay.portal.security.auth.EmailAddressValidatorFactory" id="com.liferay.portal.security.auth.EmailAddressValidatorFactory" />
 	<bean class="com.liferay.portal.security.auth.FullNameValidatorFactory" id="com.liferay.portal.security.auth.FullNameValidatorFactory" />
-	<bean class="com.liferay.portal.security.auth.LoginFailure" id="com.liferay.portal.security.auth.LoginFailure" />
-	<bean class="com.liferay.portal.security.auth.LoginMaxFailures" id="com.liferay.portal.security.auth.LoginMaxFailures" />
 	<bean class="com.liferay.portal.security.auth.MVCPortletAuthTokenWhitelist" id="com.liferay.portal.security.auth.MVCPortletAuthTokenWhitelist" />
 	<bean class="com.liferay.portal.security.auth.ScreenNameGeneratorFactory" id="com.liferay.portal.security.auth.ScreenNameGeneratorFactory" />
 	<bean class="com.liferay.portal.security.auth.ScreenNameValidatorFactory" id="com.liferay.portal.security.auth.ScreenNameValidatorFactory" />

--- a/portal-impl/src/com/liferay/portal/security/auth/packageinfo
+++ b/portal-impl/src/com/liferay/portal/security/auth/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 6.0.0

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -5682,7 +5682,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			}
 
 			try {
-				AuthPipeline.onUserDoesNotExist(
+				AuthPipeline.onDoesNotExist(
 					authType, companyId, login, headerMap, parameterMap);
 			}
 			catch (Exception exception) {
@@ -6027,7 +6027,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		if (user == null) {
 			try {
-				AuthPipeline.onUserDoesNotExist(
+				AuthPipeline.onDoesNotExist(
 					authType, companyId, login, headerMap, parameterMap);
 			}
 			catch (Exception exception) {
@@ -6058,7 +6058,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 			if (user == null) {
 				try {
-					AuthPipeline.onUserDoesNotExist(
+					AuthPipeline.onDoesNotExist(
 						authType, companyId, login, headerMap, parameterMap);
 				}
 				catch (Exception exception) {

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3498,8 +3498,8 @@
     # Env: LIFERAY_AUTH_PERIOD_FAILURE
     # Env: LIFERAY_AUTH_PERIOD_MAX_PERIOD_FAILURES
     #
-    #auth.failure=com.liferay.portal.security.auth.LoginFailure
-    #auth.max.failures=com.liferay.portal.security.auth.LoginMaxFailures
+    #auth.failure=com.liferay.portal.security.auth.LoginAuthFailure
+    #auth.max.failures=com.liferay.portal.security.auth.LoginMaxAuthFailure
 
     #
     # Set the following to true if users are allowed to have simultaneous logins

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/AuthDNE.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/AuthDNE.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.security.auth;
+
+import java.util.Map;
+
+/**
+ * @author Nikoletta Buza
+ */
+public interface AuthDNE {
+
+	public void onUserDoesNotExist(
+			String authType, long companyId, String login,
+			Map<String, String[]> headerMap, Map<String, String[]> parameterMap)
+		throws AuthException;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/AuthDNE.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/AuthDNE.java
@@ -21,7 +21,7 @@ import java.util.Map;
  */
 public interface AuthDNE {
 
-	public void onUserDoesNotExist(
+	public void onDoesNotExist(
 			String authType, long companyId, String login,
 			Map<String, String[]> headerMap, Map<String, String[]> parameterMap)
 		throws AuthException;

--- a/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/auth/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0


### PR DESCRIPTION
[LPS-159334](https://issues.liferay.com/browse/LPS-159334)
A previous PR was already reviewed and forwarded. This PR only contains additional refactoring.

------
Reviewed [PR](https://github.com/liferay-appsec/liferay-portal/pull/1133)
Next [PR](https://github.com/liferay-appsec/liferay-portal/pull/1156)
Forwarded [PR and notes](https://github.com/brianchandotcom/liferay-portal/pull/136182#issuecomment-1588732735) on refactoring

----
Note:
The keys (`auth.failure`,`auth.max.failures`) of all the `AuthFailure` implementations are required because of `AuthPipeline._onFailure` as this method can be called in `UserLocalServiceImpl.handleAuthenticationFailure` with any of the keys. So we need to be able to select specific services by their respective keys otherwise we end up executing all three implementations of `AuthFailure.onFailureByEmailAddress` when in reality only the ones related to `auth.failure` or the one related to `auth.max.failures` should be called, resulting in unwanted behaviour.