### PR TITLE
[TS] LPS-188335 Removing additional quotes around emailAddress before preparing wildcard query with it to fix email search results

### DIFF
--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/query/contributor/UserKeywordQueryContributor.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/spi/model/query/contributor/UserKeywordQueryContributor.java
@@ -77,7 +77,8 @@ public class UserKeywordQueryContributor implements KeywordQueryContributor {
 				keywords = StringUtil.toLowerCase(keywords);
 
 				booleanQuery.add(
-					_getTrailingWildcardQuery("emailAddress", keywords),
+					_getTrailingWildcardQuery(
+						"emailAddress", StringUtil.unquote(keywords)),
 					BooleanClauseOccur.SHOULD);
 				booleanQuery.add(
 					_getTrailingWildcardQuery("emailAddressDomain", keywords),


### PR DESCRIPTION
Hi Team,

https://liferay.atlassian.net/browse/LPS-188335

The fix is CAS prio, so I'm sorry if this fix is a bit hasty.

Issue: 
The email search with quotes didn't return any results.
![search_with_dash_and_quotes](https://github.com/liferay-appsec/liferay-portal/assets/97447507/a46f9410-f492-49fe-b1b8-0209a5558683)
![search_with_dot_and_quotes](https://github.com/liferay-appsec/liferay-portal/assets/97447507/77b3124d-9928-4fc9-b6bc-2014b15942aa)


Solution:
The same search worked on 7.2 (the customers original version), so I took a look how the search query was put together. 
The way it was put together changed in that it is happening in a different class, but the essence is that the double quotes were removed, and then the wildcard was applied. 
I emulated the same on master and it produced the same behavior.

Please review my PR!

Thank you!

Évi