### PR TITLE
LPS-189621 Get users one by one instead of all at once because of argument number limitation

### DIFF
--- a/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/UserBulkReindexer.java
+++ b/modules/apps/users-admin/users-admin-impl/src/main/java/com/liferay/users/admin/internal/search/UserBulkReindexer.java
@@ -15,7 +15,6 @@
 package com.liferay.users.admin.internal.search;
 
 import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
-import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -43,32 +42,16 @@ public class UserBulkReindexer implements BulkReindexer {
 		IndexableActionableDynamicQuery indexableActionableDynamicQuery =
 			userLocalService.getIndexableActionableDynamicQuery();
 
-		indexableActionableDynamicQuery.setAddCriteriaMethod(
-			dynamicQuery -> dynamicQuery.add(
-				RestrictionsFactoryUtil.in("userId", classPKs)));
-		indexableActionableDynamicQuery.setCompanyId(companyId);
-		indexableActionableDynamicQuery.setPerformActionMethod(
-			(User user) -> {
-				if (!user.isGuestUser()) {
-					try {
-						indexableActionableDynamicQuery.addDocuments(
-							indexer.getDocument(user));
-					}
-					catch (PortalException portalException) {
-						if (_log.isWarnEnabled()) {
-							_log.warn(
-								"Unable to index user " + user.getUserId(),
-								portalException);
-						}
-					}
+		for (Long userId : classPKs) {
+			try {
+				_reindex(companyId, userId, indexableActionableDynamicQuery);
+			}
+			catch (PortalException portalException) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Unable to index user " + userId, portalException);
 				}
-			});
-
-		try {
-			indexableActionableDynamicQuery.performActions();
-		}
-		catch (PortalException portalException) {
-			throw new RuntimeException(portalException);
+			}
 		}
 	}
 
@@ -79,6 +62,19 @@ public class UserBulkReindexer implements BulkReindexer {
 
 	@Reference
 	protected UserLocalService userLocalService;
+
+	private void _reindex(
+			long companyId, Long userId,
+			IndexableActionableDynamicQuery indexableActionableDynamicQuery)
+		throws PortalException {
+
+		User user = userLocalService.getUserById(companyId, userId);
+
+		if (!user.isGuestUser()) {
+			indexableActionableDynamicQuery.addDocuments(
+				indexer.getDocument(user));
+		}
+	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		UserBulkReindexer.class);


### PR DESCRIPTION
Hi Team,

https://liferay.atlassian.net/browse/LPS-189621

Environment:
SQL Server 2017

Issue:
If a site got deactivated with more than 2100 users, then the console would show an error telling us that it can only handle 2100 arguments. This happened because in the reindex method, the query got a list of ids that went beyond 2100 in length.

Solution:
Saw lots of similar issues and I went with the same approach. Get the users that need to be reindexed one by one. Tried DSLQuery but the same error came up. 

Testing:
Tested it locally. The solution works. In regards of performance, well it took 26 seconds to reindex 2100 users. Tested it with the original code and 2070 users and the time was the same. Tested it with oracle server as well and took the same amount of time .
I used cloud db for the database.

Please review my PR!

Best regards,
Dani