### PR TITLE
[TS] LPS-190605 Correct naming and empty option for status list.

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/details.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/details.jsp
@@ -55,7 +55,7 @@ if (organization != null) {
 	<c:when test="<%= PropsValues.FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS %>">
 		<liferay-ui:error key="<%= NoSuchListTypeException.class.getName() + Organization.class.getName() + ListTypeConstants.ORGANIZATION_STATUS %>" message="please-select-a-type" />
 
-		<aui:select label="status" listType="<%= ListTypeConstants.ORGANIZATION_STATUS %>" listTypeFieldName="statusListTypeId" name="statusListTypeId" showEmptyOption="<%= true %>" />
+		<aui:select label="status" listType="<%= ListTypeConstants.ORGANIZATION_STATUS %>" listTypeFieldName="statusListTypeId" name="statusId" showEmptyOption="<%= false %>" />
 	</c:when>
 	<c:otherwise>
 		<aui:input name="statusId" type="hidden" value="<%= (organization != null) ? organization.getStatusListTypeId() : ListTypeConstants.ORGANIZATION_STATUS_DEFAULT %>" />


### PR DESCRIPTION
Hi Team,

May I ask if you could check this PR?

based on https://liferay.atlassian.net/browse/LPS-190605.

Issue: 
when we set field.enable.com.liferay.portal.kernel.model.Organization.status=true in the portal-ext.properties, it is impossible to add a new organization.

Root cause: src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java in the addOrganization() method has 0 as value of statusId.

Solution:
modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/details.jsp the select field had wrong naming, changed it to "statusId" and set showEmptyOption to false.

--It could be a second validation in the OrganizationLocalServiceImpl to set a default value, if we let the select field to be empty.

Tested it locally and it solves the issue.

Thank you in advance!

BR,
Gege