### PR TITLE
 [TS] LPS-188149 | Master - App Security 

### DIFF
--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -372,8 +372,10 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			liferayPortletURL.setWindowState(WindowState.MAXIMIZED);
 		}
 
+		String redirect = ParamUtil.getString(actionRequest, "redirect");
+		
 		actionRequest.setAttribute(
-			WebKeys.REDIRECT, liferayPortletURL.toString());
+				WebKeys.REDIRECT, liferayPortletURL.toString());
 
 		HttpSession httpSession = httpServletRequest.getSession();
 
@@ -382,6 +384,7 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			MFAWebKeys.MFA_WEB_DIGEST,
 			DigesterUtil.digest(encryptedStateMapJSON));
 		httpSession.setAttribute(MFAWebKeys.MFA_WEB_KEY, key);
+		httpSession.setAttribute(WebKeys.REDIRECT, redirect);
 	}
 
 	private static final Accessor<Object, String> _STRING_ACCESSOR =

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -55,6 +55,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.security.Key;
 
@@ -123,8 +124,12 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 					AuthenticatedSessionManagerUtil.getAuthenticatedUserId(
 						httpServletRequest, login, password, null);
 
+				long mfaUserId = _getMFAUserId(actionRequest);
+
 				if (_mfaPolicy.isSatisfied(
-						companyId, httpServletRequest, userId)) {
+						companyId, httpServletRequest, userId) ||
+					_mfaPolicy.isSatisfied(
+						companyId, httpServletRequest, mfaUserId)) {
 
 					_loginMVCActionCommand.processAction(
 						actionRequest, actionResponse);
@@ -270,6 +275,24 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			"returnToFullPageURL", returnToFullPageURL);
 
 		return liferayPortletURL;
+	}
+
+	private long _getMFAUserId(PortletRequest portletRequest) {
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		if (themeDisplay.isSignedIn()) {
+			return themeDisplay.getUserId();
+		}
+
+		HttpServletRequest httpServletRequest =
+			_portal.getOriginalServletRequest(
+				_portal.getHttpServletRequest(portletRequest));
+
+		HttpSession httpSession = httpServletRequest.getSession();
+
+		return GetterUtil.getLong(
+			httpSession.getAttribute(MFAWebKeys.MFA_USER_ID));
 	}
 
 	private void _postProcessAuthFailure(

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -47,6 +47,7 @@ import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Accessor;
 import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -55,7 +56,6 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.security.Key;
 
@@ -124,12 +124,11 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 					AuthenticatedSessionManagerUtil.getAuthenticatedUserId(
 						httpServletRequest, login, password, null);
 
-				long mfaUserId = _getMFAUserId(actionRequest);
-
 				if (_mfaPolicy.isSatisfied(
 						companyId, httpServletRequest, userId) ||
 					_mfaPolicy.isSatisfied(
-						companyId, httpServletRequest, mfaUserId)) {
+						companyId, httpServletRequest,
+						_getMFAUserId(actionRequest))) {
 
 					_loginMVCActionCommand.processAction(
 						actionRequest, actionResponse);
@@ -398,9 +397,9 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 		String redirect = ParamUtil.getString(actionRequest, "redirect");
 		String login = ParamUtil.getString(actionRequest, "login");
 		String password = ParamUtil.getString(actionRequest, "password");
-		
+
 		actionRequest.setAttribute(
-				WebKeys.REDIRECT, liferayPortletURL.toString());
+			WebKeys.REDIRECT, liferayPortletURL.toString());
 
 		HttpSession httpSession = httpServletRequest.getSession();
 
@@ -410,10 +409,9 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			DigesterUtil.digest(encryptedStateMapJSON));
 		httpSession.setAttribute(MFAWebKeys.MFA_WEB_KEY, key);
 		httpSession.setAttribute(WebKeys.REDIRECT, redirect);
-		
+
 		httpSession.setAttribute("login", login);
 		httpSession.setAttribute("password", password);
-		
 	}
 
 	private static final Accessor<Object, String> _STRING_ACCESSOR =

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -373,6 +373,8 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 		}
 
 		String redirect = ParamUtil.getString(actionRequest, "redirect");
+		String login = ParamUtil.getString(actionRequest, "login");
+		String password = ParamUtil.getString(actionRequest, "password");
 		
 		actionRequest.setAttribute(
 				WebKeys.REDIRECT, liferayPortletURL.toString());
@@ -385,6 +387,10 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			DigesterUtil.digest(encryptedStateMapJSON));
 		httpSession.setAttribute(MFAWebKeys.MFA_WEB_KEY, key);
 		httpSession.setAttribute(WebKeys.REDIRECT, redirect);
+		
+		httpSession.setAttribute("login", login);
+		httpSession.setAttribute("password", password);
+		
 	}
 
 	private static final Accessor<Object, String> _STRING_ACCESSOR =

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/VerifyMVCActionCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/VerifyMVCActionCommand.java
@@ -95,10 +95,10 @@ public class VerifyMVCActionCommand extends BaseMVCActionCommand {
 				hideDefaultErrorMessage(actionRequest);
 
 				SessionErrors.add(actionRequest, "mfaVerificationFailed");
-			}  else {
-				_loginMVCActionCommand.processAction(actionRequest, actionResponse);
-
-				return;
+			}
+			else {
+				_loginMVCActionCommand.processAction(
+					actionRequest, actionResponse);
 			}
 		}
 		catch (Exception exception) {
@@ -124,16 +124,15 @@ public class VerifyMVCActionCommand extends BaseMVCActionCommand {
 			httpSession.getAttribute(MFAWebKeys.MFA_USER_ID));
 	}
 
+	@Reference(
+		target = "(component.name=com.liferay.multi.factor.authentication.web.internal.portlet.action.LoginMVCActionCommand)"
+	)
+	private MVCActionCommand _loginMVCActionCommand;
+
 	@Reference
 	private MFAPolicy _mfaPolicy;
 
 	@Reference
 	private Portal _portal;
-	
-	@Reference(
-			target = "(component.name=com.liferay.multi.factor.authentication.web.internal.portlet.action.LoginMVCActionCommand)"
-		)
-		private MVCActionCommand _loginMVCActionCommand;
-	
 
 }

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/VerifyMVCActionCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/VerifyMVCActionCommand.java
@@ -95,6 +95,10 @@ public class VerifyMVCActionCommand extends BaseMVCActionCommand {
 				hideDefaultErrorMessage(actionRequest);
 
 				SessionErrors.add(actionRequest, "mfaVerificationFailed");
+			}  else {
+				_loginMVCActionCommand.processAction(actionRequest, actionResponse);
+
+				return;
 			}
 		}
 		catch (Exception exception) {
@@ -125,5 +129,11 @@ public class VerifyMVCActionCommand extends BaseMVCActionCommand {
 
 	@Reference
 	private Portal _portal;
+	
+	@Reference(
+			target = "(component.name=com.liferay.multi.factor.authentication.web.internal.portlet.action.LoginMVCActionCommand)"
+		)
+		private MVCActionCommand _loginMVCActionCommand;
+	
 
 }

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -112,6 +112,12 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 			MFAWebKeys.BROWSER_MFA_CHECKERS, browserMFACheckers);
 		renderRequest.setAttribute(MFAWebKeys.MFA_USER_ID, mfaUserId);
 
+		String redirect = _getRedirectURL(renderRequest);
+
+		if (!redirect.isEmpty()) {
+			renderRequest.setAttribute(WebKeys.REDIRECT, redirect);
+		}
+
 		return "/mfa_verify/view.jsp";
 	}
 
@@ -155,6 +161,16 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 
 		return GetterUtil.getLong(
 			httpSession.getAttribute(MFAWebKeys.MFA_USER_ID));
+	}
+
+	private String _getRedirectURL(PortletRequest portletRequest) {
+		HttpServletRequest httpServletRequest =
+			_portal.getOriginalServletRequest(
+				_portal.getHttpServletRequest(portletRequest));
+
+		HttpSession httpSession = httpServletRequest.getSession();
+
+		return (String)httpSession.getAttribute(WebKeys.REDIRECT);
 	}
 
 	@Reference

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -112,11 +112,18 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 			MFAWebKeys.BROWSER_MFA_CHECKERS, browserMFACheckers);
 		renderRequest.setAttribute(MFAWebKeys.MFA_USER_ID, mfaUserId);
 
+		HttpSession httpSession = _getHttpSession(renderRequest);
 		String redirect = _getRedirectURL(renderRequest);
+		
+		String login = (String) httpSession.getAttribute("login");
+		String password =  (String) httpSession.getAttribute("password");
 
 		if (!redirect.isEmpty()) {
 			renderRequest.setAttribute(WebKeys.REDIRECT, redirect);
 		}
+		
+		renderRequest.setAttribute("login", login);
+		renderRequest.setAttribute("password", password);
 
 		return "/mfa_verify/view.jsp";
 	}
@@ -171,6 +178,14 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 		HttpSession httpSession = httpServletRequest.getSession();
 
 		return (String)httpSession.getAttribute(WebKeys.REDIRECT);
+	}
+	
+	private HttpSession _getHttpSession(PortletRequest portletRequest) {
+		HttpServletRequest httpServletRequest =
+				_portal.getOriginalServletRequest(
+					_portal.getHttpServletRequest(portletRequest));
+
+			return httpServletRequest.getSession();
 	}
 
 	@Reference

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -114,18 +114,26 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 
 		HttpSession httpSession = _getHttpSession(renderRequest);
 		String redirect = _getRedirectURL(renderRequest);
-		
-		String login = (String) httpSession.getAttribute("login");
-		String password =  (String) httpSession.getAttribute("password");
+
+		String login = (String)httpSession.getAttribute("login");
+		String password = (String)httpSession.getAttribute("password");
 
 		if (!redirect.isEmpty()) {
 			renderRequest.setAttribute(WebKeys.REDIRECT, redirect);
 		}
-		
+
 		renderRequest.setAttribute("login", login);
 		renderRequest.setAttribute("password", password);
 
 		return "/mfa_verify/view.jsp";
+	}
+
+	private HttpSession _getHttpSession(PortletRequest portletRequest) {
+		HttpServletRequest httpServletRequest =
+			_portal.getOriginalServletRequest(
+				_portal.getHttpServletRequest(portletRequest));
+
+		return httpServletRequest.getSession();
 	}
 
 	private String _getMFACheckerName(
@@ -178,14 +186,6 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 		HttpSession httpSession = httpServletRequest.getSession();
 
 		return (String)httpSession.getAttribute(WebKeys.REDIRECT);
-	}
-	
-	private HttpSession _getHttpSession(PortletRequest portletRequest) {
-		HttpServletRequest httpServletRequest =
-				_portal.getOriginalServletRequest(
-					_portal.getHttpServletRequest(portletRequest));
-
-			return httpServletRequest.getSession();
 	}
 
 	@Reference

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/ViewMVCRenderCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/ViewMVCRenderCommand.java
@@ -168,22 +168,14 @@ public class ViewMVCRenderCommand implements MVCRenderCommand {
 			return themeDisplay.getUserId();
 		}
 
-		HttpServletRequest httpServletRequest =
-			_portal.getOriginalServletRequest(
-				_portal.getHttpServletRequest(portletRequest));
-
-		HttpSession httpSession = httpServletRequest.getSession();
+		HttpSession httpSession = _getHttpSession(portletRequest);
 
 		return GetterUtil.getLong(
 			httpSession.getAttribute(MFAWebKeys.MFA_USER_ID));
 	}
 
 	private String _getRedirectURL(PortletRequest portletRequest) {
-		HttpServletRequest httpServletRequest =
-			_portal.getOriginalServletRequest(
-				_portal.getHttpServletRequest(portletRequest));
-
-		HttpSession httpSession = httpServletRequest.getSession();
+		HttpSession httpSession = _getHttpSession(portletRequest);
 
 		return (String)httpSession.getAttribute(WebKeys.REDIRECT);
 	}

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/resources/META-INF/resources/init.jsp
@@ -32,6 +32,7 @@ page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
+page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.taglib.servlet.PipingServletResponseFactory" %>
 
 <%@ page import="java.util.List" %>

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/resources/META-INF/resources/mfa_verify/view.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/resources/META-INF/resources/mfa_verify/view.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-String redirect = ParamUtil.getString(request, "redirect");
+String redirect = (String)request.getAttribute(WebKeys.REDIRECT);
 
 BrowserMFAChecker browserMFAChecker = (BrowserMFAChecker)request.getAttribute(MFAWebKeys.BROWSER_MFA_CHECKER);
 String browserMFACheckerName = (String)request.getAttribute(MFAWebKeys.BROWSER_MFA_CHECKER_NAME);
@@ -46,7 +46,7 @@ int mfaCheckerIndex = ParamUtil.getInteger(request, "mfaCheckerIndex");
 		<portlet:renderURL copyCurrentRenderParameters="<%= false %>" var="useAnotherBrowserMFAChecker">
 			<portlet:param name="saveLastPath" value="<%= Boolean.FALSE.toString() %>" />
 			<portlet:param name="mvcRenderCommandName" value="/mfa_verify/view" />
-			<portlet:param name="redirect" value='<%= ParamUtil.getString(request, "redirect") %>' />
+			<portlet:param name="redirect" value="<%= (String)request.getAttribute(WebKeys.REDIRECT) %>" />
 			<portlet:param name="mfaCheckerIndex" value='<%= ((mfaCheckerIndex + 1) < browserMFACheckers.size()) ? String.valueOf(mfaCheckerIndex + 1) : "0" %>' />
 		</portlet:renderURL>
 

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/resources/META-INF/resources/mfa_verify/view.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/resources/META-INF/resources/mfa_verify/view.jsp
@@ -18,6 +18,8 @@
 
 <%
 String redirect = (String)request.getAttribute(WebKeys.REDIRECT);
+String login = (String)request.getAttribute("login");
+String password = (String)request.getAttribute("password");
 
 BrowserMFAChecker browserMFAChecker = (BrowserMFAChecker)request.getAttribute(MFAWebKeys.BROWSER_MFA_CHECKER);
 String browserMFACheckerName = (String)request.getAttribute(MFAWebKeys.BROWSER_MFA_CHECKER_NAME);
@@ -35,6 +37,8 @@ int mfaCheckerIndex = ParamUtil.getInteger(request, "mfaCheckerIndex");
 	<aui:input name="saveLastPath" type="hidden" value="<%= false %>" />
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 	<aui:input name="mfaCheckerIndex" type="hidden" value="<%= mfaCheckerIndex %>" />
+	<aui:input name="login" type="hidden" value="<%= login %>" />
+	<aui:input name="password" type="hidden" value="<%= password %>" />
 
 	<liferay-ui:error key="mfaVerificationFailed" message="multi-factor-authentication-has-failed" />
 


### PR DESCRIPTION
**Steps to reproduce:**
1. Set up SMTP
2. Log in as admin user
3. Control panel → Instance settings → Login → Prompt Enabled →  
4. Product menu → Content & Data → Documents and Media → open tree.png → bookmark the page
5. Control panel → Instance settings → Multi-Factor Authentication → Enabled   
6. Log out
7. Open the bookmarked link
8. Log in & insert OTP

_Expected Behavior:_ Get redirected to the bookmarked page
_Actual Behavior:_ A green confirmation banner shows that the process was successful, but the page does not redirect anywhere

**Implementation Details:**

It was discovered that the redirect value [was missing in the view jsp file when the MFA is validated when the request redirect was overwritten](https://github.com/liferay-appsec/liferay-portal/pull/1229/commits/af7f859b32c5142d8e542f9175907b71a76600f4#diff-cd4794b72c830f978dafceedae2dc732fa81a3598ac2f9e5d3dd20a45b3da140R387).  

After it is filled in, the portal is redirected to the login page - This happens because the login is not resumed after MFA is validated, so [it was necessary to call the login mvc action class again to resume the flow](https://github.com/liferay-appsec/liferay-portal/pull/1229/commits/c735bc52eff9e4d1c5406690b9f4a3bc9edf4655#diff-099defccc6530fcce412e2dc404b84f487a97664e8579913a3c2baf77ab301eeR99).

Furthermore, it was observed that the user's credentials are not persisted in the request after the verify class is called, so it was necessary to [store them in the session in order to be able to fetch them and place them in the next render request](https://github.com/liferay-appsec/liferay-portal/pull/1229/commits/3e6c8bf67ae32bac58000c77612c3806bd8ab5d7#diff-285e713e6eff25805ea13b04446600b15c2450708fc12ca6b8066701a42f63e3R125) when the login flow is resumed.

And lastly, when the login flow is resumed, the user id is null because the user was not authenticated yet in the super login mvc action class, so it was not possible to fetch the id in the first place. To fix this, another verification was added to [check by the MFA user id](https://github.com/liferay-appsec/liferay-portal/pull/1229/commits/76a2418140a120690d0a5e251deb3db91d5aece8#diff-cd4794b72c830f978dafceedae2dc732fa81a3598ac2f9e5d3dd20a45b3da140R131) which was demonstrably fulfilled.


**Commits Included:**

- LPS-188149 Set value of redirect in the http session and portlet param in view file
- LPS-188149 Prevent redirect to auth screen by default and proceed to authenticate the user in mvc action class
- LPS-188149 Add user credentials on the request
- LPS-188149 Check if MFA User is satisfied when VerifyMVCActionCommand calls the super method
- LPS-188149 SF
- LPS-188149 Simplify
