### PR TITLE
 [TS] - LPS-190758 Set the correct remove icon value in organization roles container

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp
@@ -343,7 +343,7 @@ currentURLObj.setParameter("historyKey", liferayPortletResponse.getNamespace() +
 							data-groupId="<%= userGroupRole.getGroupId() %>"
 							data-rowId="<%= userGroupRole.getRoleId() %>"
 							displayType="null"
-							icon="remove"
+							icon="times-circle"
 							small="<%= true %>"
 							title='<%= LanguageUtil.format(request, "remove-x", HtmlUtil.escape(userGroupRole.getGroup().getDescriptiveName(locale))) %>'
 						/>


### PR DESCRIPTION
**Steps to reproduce:**
1. Log in as admin user
2. Control Panel → Users & Organizations → Users, Create a test user
3. Control Panel → Users & Organizations → Organizations, Create a test organization
4. Control Panel → Users & Organizations → Organizations, Assign the user to the test organization
5. Control Panel → Users & Organizations → Users → Edit test user → Roles, Add any organizational role to the user
6. Save & Reload the page

 _Expected result:_ There is a remove icon next to the assigned role
 _Actual result:_ The remove icon disappears, but it is still clickable and functional
 
 **Commit included:**
-  LPS-190758 Set the correct remove icon value in organization roles container