### PR TITLE
[TS] LPS-190666

### DIFF
--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectRolesDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectRolesDisplayContext.java
@@ -17,24 +17,22 @@ package com.liferay.site.memberships.web.internal.display.context;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.SearchDisplayStyleUtil;
 import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
-import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portlet.rolesadmin.search.RoleSearch;
 import com.liferay.portlet.rolesadmin.search.RoleSearchTerms;
 import com.liferay.site.memberships.constants.SiteMembershipsPortletKeys;
-import com.liferay.site.memberships.web.internal.util.DepotRolesUtil;
-import com.liferay.users.admin.kernel.util.UsersAdminUtil;
 
+import java.util.Iterator;
 import java.util.List;
 
 import javax.portlet.PortletURL;
@@ -212,18 +210,23 @@ public class SelectRolesDisplayContext {
 			new Integer[] {getRoleType()}, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
 			roleSearch.getOrderByComparator());
 
-		Group group = GroupLocalServiceUtil.fetchGroup(getGroupId());
+		List<Role> filteredGroupRoles = ListUtil.copy(roles);
 
-		if (group.isDepot()) {
-			roles = DepotRolesUtil.filterGroupRoles(
-				themeDisplay.getPermissionChecker(), getGroupId(), roles);
-		}
-		else {
-			roles = UsersAdminUtil.filterGroupRoles(
-				themeDisplay.getPermissionChecker(), getGroupId(), roles);
+		Iterator<Role> iterator = filteredGroupRoles.iterator();
+
+		while (iterator.hasNext()) {
+			Role groupRole = iterator.next();
+
+			String roleName = groupRole.getName();
+
+			if (roleName.equals(RoleConstants.ORGANIZATION_USER) ||
+				roleName.equals(RoleConstants.SITE_MEMBER)) {
+
+				iterator.remove();
+			}
 		}
 
-		roleSearch.setResultsAndTotal(roles);
+		roleSearch.setResultsAndTotal(filteredGroupRoles);
 
 		_roleSearch = roleSearch;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-190666

This pull changes which role(s) are returned when filtering in **People** > **Memberships** > **Filter and Order**.  Instead of just returning role(s) which the user has VIEW permission on, we now return all roles aside from Site Member and Org Member (these are implied, so no need to show them).

Although this change seems to be a security concern since the user can now view role(s) without VIEW access, there are a few things to keep in mind:
1. This display context is only used for visually filtering users based off their roles.  It does not grant additional access, but rather provides a sub-set of users the current user can already view.
2. In order for the current user to access this page, they need **Site Settings** > **Site: View Members** permission, so this is a pretty powerful permission they must first have. 
3. In the Table view of this page, there is a "Roles and Teams" column which displays every user's roles (and teams), regardless of the current user's privileges of their roles.  Therefore the current user can already derive all other user roles based off this column, so we aren't exposing anything more than what is already provided.

If this behavior is incorrect, and only roles with VIEW access should be visible, then we must also adjust the "Roles and Teams" to this same behavior.  Please let me know if you have any questions, thanks!