### PR TITLE
[TS] LPS-185578 

### DIFF
--- a/modules/apps/portal-security/portal-security-service-access-policy-api/src/main/java/com/liferay/portal/security/service/access/policy/configuration/HeadlessDiscoveryConfiguration.java
+++ b/modules/apps/portal-security/portal-security-service-access-policy-api/src/main/java/com/liferay/portal/security/service/access/policy/configuration/HeadlessDiscoveryConfiguration.java
@@ -1,16 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.security.service.access.policy.configuration;
 
 import aQute.bnd.annotation.metatype.Meta;
 
+/**
+ * @author Mika Koivisto
+ */
 @Meta.OCD(
-		description = "headless-discovery-description",
-		id = "com.liferay.portal.security.service.access.policy.configuration.HeadlessDiscoveryConfiguration",
-		localization = "content/Language",
-		name = "headless-discovery-configuration-name"
-	)
-	public interface HeadlessDiscoveryConfiguration {
+	description = "headless-discovery-description",
+	id = "com.liferay.portal.security.service.access.policy.configuration.HeadlessDiscoveryConfiguration",
+	localization = "content/Language",
+	name = "headless-discovery-configuration-name"
+)
+public interface HeadlessDiscoveryConfiguration {
 
-		@Meta.AD(deflt = "true", name = "enable-api-explorer", required = false)
-		public boolean enableAPIExplorer();
+	@Meta.AD(deflt = "true", name = "enable-api-explorer", required = false)
+	public boolean enableAPIExplorer();
 
-	}
+}

--- a/modules/apps/portal-security/portal-security-service-access-policy-api/src/main/java/com/liferay/portal/security/service/access/policy/configuration/HeadlessDiscoveryConfiguration.java
+++ b/modules/apps/portal-security/portal-security-service-access-policy-api/src/main/java/com/liferay/portal/security/service/access/policy/configuration/HeadlessDiscoveryConfiguration.java
@@ -1,0 +1,16 @@
+package com.liferay.portal.security.service.access.policy.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+@Meta.OCD(
+		description = "headless-discovery-description",
+		id = "com.liferay.portal.security.service.access.policy.configuration.HeadlessDiscoveryConfiguration",
+		localization = "content/Language",
+		name = "headless-discovery-configuration-name"
+	)
+	public interface HeadlessDiscoveryConfiguration {
+
+		@Meta.AD(deflt = "true", name = "enable-api-explorer", required = false)
+		public boolean enableAPIExplorer();
+
+	}

--- a/modules/apps/portal-security/portal-security-service-access-policy-api/src/main/java/com/liferay/portal/security/service/access/policy/exception/HeadlessNotEnabledException.java
+++ b/modules/apps/portal-security/portal-security-service-access-policy-api/src/main/java/com/liferay/portal/security/service/access/policy/exception/HeadlessNotEnabledException.java
@@ -1,0 +1,20 @@
+package com.liferay.portal.security.service.access.policy.exception;
+
+
+public class HeadlessNotEnabledException extends SecurityException {
+
+	public HeadlessNotEnabledException() {
+	}
+
+	public HeadlessNotEnabledException(String msg) {
+		super(msg);
+	}
+
+	public HeadlessNotEnabledException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public HeadlessNotEnabledException(Throwable throwable) {
+		super(throwable);
+	}
+}

--- a/modules/apps/portal-security/portal-security-service-access-policy-api/src/main/java/com/liferay/portal/security/service/access/policy/exception/HeadlessNotEnabledException.java
+++ b/modules/apps/portal-security/portal-security-service-access-policy-api/src/main/java/com/liferay/portal/security/service/access/policy/exception/HeadlessNotEnabledException.java
@@ -1,6 +1,22 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.security.service.access.policy.exception;
 
-
+/**
+ * @author Mirna Gama
+ */
 public class HeadlessNotEnabledException extends SecurityException {
 
 	public HeadlessNotEnabledException() {
@@ -17,4 +33,5 @@ public class HeadlessNotEnabledException extends SecurityException {
 	public HeadlessNotEnabledException(Throwable throwable) {
 		super(throwable);
 	}
+
 }

--- a/modules/apps/portal-security/portal-security-service-access-policy-service/src/main/java/com/liferay/portal/security/service/access/policy/internal/SAPAccessControlPolicy.java
+++ b/modules/apps/portal-security/portal-security-service-access-policy-service/src/main/java/com/liferay/portal/security/service/access/policy/internal/SAPAccessControlPolicy.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.security.service.access.policy.ServiceAccessPol
 import com.liferay.portal.kernel.security.service.access.policy.ServiceAccessPolicyThreadLocal;
 import com.liferay.portal.kernel.settings.CompanyServiceSettingsLocator;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.security.service.access.policy.configuration.HeadlessDiscoveryConfiguration;
 import com.liferay.portal.security.service.access.policy.configuration.SAPConfiguration;
 import com.liferay.portal.security.service.access.policy.constants.SAPConstants;
 import com.liferay.portal.security.service.access.policy.model.SAPEntry;
@@ -40,6 +41,7 @@ import com.liferay.portal.security.service.access.policy.service.SAPEntryLocalSe
 import java.lang.reflect.Method;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -184,6 +186,15 @@ public class SAPAccessControlPolicy extends BaseAccessControlPolicy {
 		if (allowedServiceSignatures.contains(StringPool.STAR) ||
 			allowedServiceSignatures.contains(className)) {
 
+			if (className.contains("HeadlessDiscoveryAPIApplication")) {
+				HeadlessDiscoveryConfiguration _headlessDiscoveryConfiguration = 
+						_getHeadlessDiscoveryConfiguration(CompanyThreadLocal.getCompanyId());
+				
+				if (!_headlessDiscoveryConfiguration.enableAPIExplorer()) {
+					throw new SecurityException("Access denied. "+className + " not enabled");
+				}
+			}
+			
 			return;
 		}
 
@@ -343,6 +354,19 @@ public class SAPAccessControlPolicy extends BaseAccessControlPolicy {
 		}
 
 		return allowedServiceSignatures;
+	}
+	
+	private HeadlessDiscoveryConfiguration
+	_getHeadlessDiscoveryConfiguration(long companyId) {
+
+	try {
+		return _configurationProvider.getCompanyConfiguration(
+				HeadlessDiscoveryConfiguration.class, companyId);
+	}
+	catch (ConfigurationException configurationException) {
+		//_log.error(configurationException);
+		}
+		return null;
 	}
 
 	@Reference

--- a/modules/apps/portal-security/portal-security-service-access-policy-service/src/main/java/com/liferay/portal/security/service/access/policy/internal/SAPAccessControlPolicy.java
+++ b/modules/apps/portal-security/portal-security-service-access-policy-service/src/main/java/com/liferay/portal/security/service/access/policy/internal/SAPAccessControlPolicy.java
@@ -19,6 +19,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
@@ -40,12 +41,9 @@ import com.liferay.portal.security.service.access.policy.exception.HeadlessNotEn
 import com.liferay.portal.security.service.access.policy.model.SAPEntry;
 import com.liferay.portal.security.service.access.policy.service.SAPEntryLocalService;
 
-import com.liferay.portal.kernel.log.Log;
-
 import java.lang.reflect.Method;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -191,14 +189,16 @@ public class SAPAccessControlPolicy extends BaseAccessControlPolicy {
 			allowedServiceSignatures.contains(className)) {
 
 			if (className.contains("HeadlessDiscoveryAPIApplication")) {
-				HeadlessDiscoveryConfiguration _headlessDiscoveryConfiguration = 
-						_getHeadlessDiscoveryConfiguration(CompanyThreadLocal.getCompanyId());
-				
-				if (!_headlessDiscoveryConfiguration.enableAPIExplorer()) {
-					throw new HeadlessNotEnabledException("API Explorer not enabled");
+				HeadlessDiscoveryConfiguration headlessDiscoveryConfiguration =
+					_getHeadlessDiscoveryConfiguration(
+						CompanyThreadLocal.getCompanyId());
+
+				if (!headlessDiscoveryConfiguration.enableAPIExplorer()) {
+					throw new HeadlessNotEnabledException(
+						"API Explorer not enabled");
 				}
 			}
-			
+
 			return;
 		}
 
@@ -268,6 +268,20 @@ public class SAPAccessControlPolicy extends BaseAccessControlPolicy {
 		}
 
 		return defaultServiceAccessPolicyNames;
+	}
+
+	private HeadlessDiscoveryConfiguration _getHeadlessDiscoveryConfiguration(
+		long companyId) {
+
+		try {
+			return _configurationProvider.getCompanyConfiguration(
+				HeadlessDiscoveryConfiguration.class, companyId);
+		}
+		catch (ConfigurationException configurationException) {
+			_log.error(configurationException);
+		}
+
+		return null;
 	}
 
 	private List<String> _getSystemServiceAccessPolicyNames(long companyId) {
@@ -359,23 +373,10 @@ public class SAPAccessControlPolicy extends BaseAccessControlPolicy {
 
 		return allowedServiceSignatures;
 	}
-	
-	private HeadlessDiscoveryConfiguration
-	_getHeadlessDiscoveryConfiguration(long companyId) {
-
-	try {
-		return _configurationProvider.getCompanyConfiguration(
-				HeadlessDiscoveryConfiguration.class, companyId);
-	}
-	catch (ConfigurationException configurationException) {
-		      _log.error(configurationException);
-		}
-		return null;
-	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
-			SAPAccessControlPolicy.class.getName());
-			
+		SAPAccessControlPolicy.class.getName());
+
 	@Reference
 	private ConfigurationProvider _configurationProvider;
 

--- a/modules/apps/portal-security/portal-security-service-access-policy-service/src/main/java/com/liferay/portal/security/service/access/policy/internal/SAPAccessControlPolicy.java
+++ b/modules/apps/portal-security/portal-security-service-access-policy-service/src/main/java/com/liferay/portal/security/service/access/policy/internal/SAPAccessControlPolicy.java
@@ -19,6 +19,7 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.security.access.control.AccessControlPolicy;
@@ -35,8 +36,11 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.service.access.policy.configuration.HeadlessDiscoveryConfiguration;
 import com.liferay.portal.security.service.access.policy.configuration.SAPConfiguration;
 import com.liferay.portal.security.service.access.policy.constants.SAPConstants;
+import com.liferay.portal.security.service.access.policy.exception.HeadlessNotEnabledException;
 import com.liferay.portal.security.service.access.policy.model.SAPEntry;
 import com.liferay.portal.security.service.access.policy.service.SAPEntryLocalService;
+
+import com.liferay.portal.kernel.log.Log;
 
 import java.lang.reflect.Method;
 
@@ -191,7 +195,7 @@ public class SAPAccessControlPolicy extends BaseAccessControlPolicy {
 						_getHeadlessDiscoveryConfiguration(CompanyThreadLocal.getCompanyId());
 				
 				if (!_headlessDiscoveryConfiguration.enableAPIExplorer()) {
-					throw new SecurityException("Access denied. "+className + " not enabled");
+					throw new HeadlessNotEnabledException("API Explorer not enabled");
 				}
 			}
 			
@@ -364,11 +368,14 @@ public class SAPAccessControlPolicy extends BaseAccessControlPolicy {
 				HeadlessDiscoveryConfiguration.class, companyId);
 	}
 	catch (ConfigurationException configurationException) {
-		//_log.error(configurationException);
+		      _log.error(configurationException);
 		}
 		return null;
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+			SAPAccessControlPolicy.class.getName());
+			
 	@Reference
 	private ConfigurationProvider _configurationProvider;
 

--- a/portal-impl/src/com/liferay/portal/security/access/control/AccessControlAdvisorImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/access/control/AccessControlAdvisorImpl.java
@@ -54,6 +54,11 @@ public class AccessControlAdvisorImpl implements AccessControlAdvisor {
 					_log.debug(securityException);
 				}
 
+				if (securityException.getMessage()
+						.contains("API Explorer")) {
+					throw securityException;
+				}
+				
 				if (PropsValues.ACCESS_CONTROL_SANITIZE_SECURITY_EXCEPTION) {
 					throw new SecurityException();
 				}

--- a/portal-impl/src/com/liferay/portal/security/access/control/AccessControlAdvisorImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/access/control/AccessControlAdvisorImpl.java
@@ -54,11 +54,14 @@ public class AccessControlAdvisorImpl implements AccessControlAdvisor {
 					_log.debug(securityException);
 				}
 
-				if (securityException.getMessage()
-						.contains("API Explorer")) {
+				if (securityException.getMessage(
+					).contains(
+						"API Explorer"
+					)) {
+
 					throw securityException;
 				}
-				
+
 				if (PropsValues.ACCESS_CONTROL_SANITIZE_SECURITY_EXCEPTION) {
 					throw new SecurityException();
 				}


### PR DESCRIPTION
**Steps to reproduce:**

1. Navigate to Control Panel > Configuration > System Settings > Platform > Third Party > API Explorer
2. Disable the API Explorer
3. Access the o/api page

_Expected result:_ user-friendly page that suggest that the API Explorer page is disabled
_Actual result:_ showing internal details

_**Implementation details:**_

It has been found that [even if the api explorer is not enabled, partial information is still returned in the headless module](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/jaxrs/application/HeadlessDiscoveryAPIApplication.java#L95). 

To avoid this, a verification was created using a new configuration class [based on the one found in the headless module](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/headless/headless-discovery/headless-discovery-impl/src/main/java/com/liferay/headless/discovery/internal/configuration/HeadlessDiscoveryConfiguration.java) to [check if the enable-api-explorer property is set to false](https://github.com/liferay-appsec/liferay-portal/pull/1249/commits/a2c689e01b506fd3b18366531ba6cfc6d18d713c#diff-f8736ad6a90da33a912f598bfd616c4e6183a9726e9d0269d41a002838a2b5f3R193). If so, [an exception will be thrown to inform that API Explorer is not enabled](https://github.com/liferay-appsec/liferay-portal/pull/1249/files#diff-f8736ad6a90da33a912f598bfd616c4e6183a9726e9d0269d41a002838a2b5f3R197). 

After that, the exception is reinitialized and its message is erased. This happens so it can fix a discovered vulnerability that made the full name of the classes available, please check [LPS-133082](https://liferay.atlassian.net/browse/LPS-133082). But with that, the user cannot know if the api explorer is available, so it was necessary to add [another verification to not reinitialize the exception in case its message is related to the API explorer.](https://github.com/liferay-appsec/liferay-portal/pull/1249/files#diff-4a0223883d18edfdc0f6efc4c2f3e92435f01a4f62d4694ae2966dd9614be88aR57). 

_**Commits included:**_
- LPS-185578 If API Explorer is not enabled, deny access for HeadlessDiscoveryAPIApplication
- LPS-185578 Check if is headless exception message so the portal could inform the API Explorer is not enabled in the response
- LPS-185578 SF
