### PR TITLE
[TS] LPS-191496 Updating spring-boot-starter-oauth2-client to 2.7.11

### DIFF
--- a/modules/util/client-extension-util-spring-boot/build.gradle
+++ b/modules/util/client-extension-util-spring-boot/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-	compile group: "org.springframework.boot", name: "spring-boot-starter-oauth2-client", version: "2.7.9"
+	compile group: "org.springframework.boot", name: "spring-boot-starter-oauth2-client", version: "2.7.11"
 	compile group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.9"
 	compile group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.9"
 }

--- a/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-etc-cron/build.gradle
+++ b/workspaces/liferay-partner-workspace/client-extensions/liferay-partner-etc-cron/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 	compile group: "com.liferay", name: "com.liferay.petra.string", version: "5.2.0"
 	compile group: "org.json", name: "json", version: "20220320"
 	compile group: "org.springframework.boot", name: "spring-boot", version: "2.7.9"
-	compile group: "org.springframework.boot", name: "spring-boot-starter-oauth2-client", version: "2.7.9"
+	compile group: "org.springframework.boot", name: "spring-boot-starter-oauth2-client", version: "2.7.11"
 	compile group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.9"
 }
 

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/build.gradle
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-cron/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 	compile group: "com.liferay", name: "com.liferay.headless.delivery.client", version: "latest.release"
 	compile group: "commons-logging", name: "commons-logging", version: "1.2"
 	compile group: "org.springframework.boot", name: "spring-boot", version: "2.7.9"
-	compile group: "org.springframework.boot", name: "spring-boot-starter-oauth2-client", version: "2.7.9"
+	compile group: "org.springframework.boot", name: "spring-boot-starter-oauth2-client", version: "2.7.11"
 	compile group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.9"
 }
 


### PR DESCRIPTION
Updating spring-boot-starter-oauth2-client to 2.7.11 in order to fix vulnerability CVE-2023-20862.