### PR TITLE
[TS] LPS-191497 Updating spring-boot-starter-oauth2-resource-server to 2.7.11

### DIFF
--- a/modules/util/client-extension-util-spring-boot/build.gradle
+++ b/modules/util/client-extension-util-spring-boot/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
 	compile group: "org.springframework.boot", name: "spring-boot-starter-oauth2-client", version: "2.7.9"
-	compile group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.9"
+	compile group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.11"
 	compile group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.9"
 }

--- a/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-jethr0-workspace/client-extensions/liferay-jethr0-etc-spring-boot/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 	compile group: "com.liferay", name: "com.liferay.client.extension.util.spring.boot", version: "1.0.9"
 	compile group: "org.json", name: "json", version: "20230227"
 	compile group: "org.springframework.boot", name: "spring-boot-starter-activemq", version: "2.7.9"
-	compile group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.9"
+	compile group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.11"
 	compile group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.9"
 	compile group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.9"
 }

--- a/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/build.gradle
+++ b/workspaces/liferay-sample-workspace/client-extensions/liferay-sample-etc-spring-boot/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 	compile group: "commons-logging", name: "commons-logging", version: "1.2"
 	compile group: "net.datafaker", name: "datafaker", version: "1.9.0"
 	compile group: "org.json", name: "json", version: "20230227"
-	compile group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.9"
+	compile group: "org.springframework.boot", name: "spring-boot-starter-oauth2-resource-server", version: "2.7.11"
 	compile group: "org.springframework.boot", name: "spring-boot-starter-web", version: "2.7.9"
 	compile group: "org.springframework.boot", name: "spring-boot-starter-webflux", version: "2.7.9"
 }


### PR DESCRIPTION
Updating spring-boot-starter-oauth2-resource-server to 2.7.11 in order to fix vulnerability CVE-2023-20862.