### PR TITLE
LPS-76246 Fix "Relay state exceeds 80 bytes" error

### DIFF
--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
@@ -28,6 +28,7 @@ import com.liferay.saml.helper.SamlHttpRequestHelper;
 import com.liferay.saml.opensaml.integration.internal.binding.SamlBinding;
 import com.liferay.saml.opensaml.integration.internal.transport.HttpClientFactory;
 import com.liferay.saml.opensaml.integration.internal.util.OpenSamlUtil;
+import com.liferay.saml.opensaml.integration.internal.util.RelayStateUtil;
 import com.liferay.saml.opensaml.integration.internal.util.SamlUtil;
 import com.liferay.saml.persistence.model.SamlIdpSpSession;
 import com.liferay.saml.persistence.model.SamlIdpSsoSession;
@@ -606,8 +607,8 @@ public class SingleLogoutProfileImpl
 			outboundMessageContext.getSubcontext(
 				SAMLBindingContext.class, true);
 
-		samlBindingContext.setRelayState(
-			portal.getPortalURL(httpServletRequest));
+		RelayStateUtil.setRelayState(
+			samlBindingContext, portal.getPortalURL(httpServletRequest));
 
 		outboundMessageContext.setMessage(logoutRequest);
 
@@ -736,7 +737,7 @@ public class SingleLogoutProfileImpl
 						messageContext.getSubcontext(SAMLBindingContext.class);
 
 					samlSloContext.setRelayState(
-						samlBindingContext.getRelayState());
+						RelayStateUtil.getRelayState(samlBindingContext));
 				}
 
 				samlSloContext.setUserId(portal.getUserId(httpServletRequest));
@@ -1224,7 +1225,8 @@ public class SingleLogoutProfileImpl
 		samlBindingContext = outboundMessageContext.getSubcontext(
 			SAMLBindingContext.class, true);
 
-		samlBindingContext.setRelayState(samlSloContext.getRelayState());
+		RelayStateUtil.setRelayState(
+			samlBindingContext, samlSloContext.getRelayState());
 
 		SecurityParametersContext securityParametersContext =
 			outboundMessageContext.getSubcontext(

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -40,6 +40,7 @@ import com.liferay.saml.opensaml.integration.internal.resolver.SubjectAssertionC
 import com.liferay.saml.opensaml.integration.internal.resolver.UserResolverSAMLContextImpl;
 import com.liferay.saml.opensaml.integration.internal.util.ConfigurationServiceBootstrapUtil;
 import com.liferay.saml.opensaml.integration.internal.util.OpenSamlUtil;
+import com.liferay.saml.opensaml.integration.internal.util.RelayStateUtil;
 import com.liferay.saml.opensaml.integration.internal.util.SamlUtil;
 import com.liferay.saml.opensaml.integration.resolver.AttributeResolver;
 import com.liferay.saml.opensaml.integration.resolver.NameIdResolver;
@@ -400,7 +401,7 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			String relayState = ParamUtil.getString(
 				httpServletRequest, "RelayState");
 
-			samlBindingContext.setRelayState(relayState);
+			RelayStateUtil.setRelayState(samlBindingContext, relayState);
 
 			SAMLPeerEntityContext samlPeerEntityContext =
 				messageContext.getSubcontext(SAMLPeerEntityContext.class);
@@ -441,8 +442,8 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 
 			samlSsoRequestContext = new SamlSsoRequestContext(
 				authnRequestXml, samlPeerEntityContext.getEntityId(),
-				samlBindingContext.getRelayState(), messageContext,
-				_userLocalService);
+				RelayStateUtil.getRelayState(samlBindingContext),
+				messageContext, _userLocalService);
 		}
 
 		String samlSsoSessionId = getSamlSsoSessionId(httpServletRequest);
@@ -492,7 +493,7 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			outboundMessageContext.getSubcontext(
 				SAMLBindingContext.class, true);
 
-		samlBindingContext.setRelayState(relayState);
+		RelayStateUtil.setRelayState(samlBindingContext, relayState);
 
 		SAMLSelfEntityContext samlSelfEntityContext =
 			messageContext.getSubcontext(SAMLSelfEntityContext.class);
@@ -1112,7 +1113,7 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			SAMLBindingContext samlBindingContext =
 				messageContext.getSubcontext(SAMLBindingContext.class, true);
 
-			samlBindingContext.setRelayState(relayState);
+			RelayStateUtil.setRelayState(samlBindingContext, relayState);
 
 			String samlSsoSessionId = getSamlSsoSessionId(httpServletRequest);
 
@@ -1259,7 +1260,7 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			SAMLBindingContext.class);
 
 		String relayState = portal.escapeRedirect(
-			samlBindingContext.getRelayState());
+			RelayStateUtil.getRelayState(samlBindingContext));
 
 		if (Validator.isNull(relayState)) {
 			relayState = portal.getHomeURL(httpServletRequest);

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/util/RelayStateUtil.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/util/RelayStateUtil.java
@@ -5,12 +5,16 @@
 
 package com.liferay.saml.opensaml.integration.internal.util;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 
 import org.opensaml.saml.common.messaging.context.SAMLBindingContext;
 
@@ -35,6 +39,15 @@ public class RelayStateUtil {
 	public static void setRelayState(
 		SAMLBindingContext samlBindingContext, String relayState) {
 
+		if (relayState == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Relay state is null. Setting blank relay state instead.");
+
+				relayState = StringPool.BLANK;
+			}
+		}
+
 		String uuid = PortalUUIDUtil.generate();
 
 		_relayStates.put(uuid, relayState);
@@ -44,7 +57,16 @@ public class RelayStateUtil {
 
 	private static final Log _log = LogFactoryUtil.getLog(RelayStateUtil.class);
 
-	private static final ConcurrentMap<String, String> _relayStates =
-		new ConcurrentHashMap<>();
+	private static final ConcurrentMap<String, String> _relayStates;
+
+	static {
+		CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+
+		cacheBuilder.expireAfterWrite(10, TimeUnit.MINUTES);
+
+		Cache<String, String> cache = cacheBuilder.build();
+
+		_relayStates = cache.asMap();
+	}
 
 }

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/util/RelayStateUtil.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/util/RelayStateUtil.java
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.saml.opensaml.integration.internal.util;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.opensaml.saml.common.messaging.context.SAMLBindingContext;
+
+/**
+ * @author Michael Bowerman
+ */
+public class RelayStateUtil {
+
+	public static String getRelayState(SAMLBindingContext samlBindingContext) {
+		String relayState = _relayStates.remove(
+			samlBindingContext.getRelayState());
+
+		if ((relayState == null) && _log.isWarnEnabled()) {
+			_log.warn(
+				"Unable to get relay state for key " +
+					samlBindingContext.getRelayState());
+		}
+
+		return relayState;
+	}
+
+	public static void setRelayState(
+		SAMLBindingContext samlBindingContext, String relayState) {
+
+		String uuid = PortalUUIDUtil.generate();
+
+		_relayStates.put(uuid, relayState);
+
+		samlBindingContext.setRelayState(uuid);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(RelayStateUtil.class);
+
+	private static final ConcurrentMap<String, String> _relayStates =
+		new ConcurrentHashMap<>();
+
+}

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
@@ -15,6 +15,7 @@ import com.liferay.saml.opensaml.integration.internal.bootstrap.SecurityConfigur
 import com.liferay.saml.opensaml.integration.internal.metadata.MetadataManagerImpl;
 import com.liferay.saml.opensaml.integration.internal.provider.CachingChainingMetadataResolver;
 import com.liferay.saml.opensaml.integration.internal.util.OpenSamlUtil;
+import com.liferay.saml.opensaml.integration.internal.util.RelayStateUtil;
 import com.liferay.saml.opensaml.integration.internal.util.SamlUtil;
 import com.liferay.saml.persistence.model.SamlSpAuthRequest;
 import com.liferay.saml.persistence.model.SamlSpIdpConnection;
@@ -301,7 +302,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 		SAMLBindingContext samlBindingContext = messageContext.getSubcontext(
 			SAMLBindingContext.class);
 
-		Assert.assertEquals(RELAY_STATE, samlBindingContext.getRelayState());
+		Assert.assertEquals(
+			RELAY_STATE, RelayStateUtil.getRelayState(samlBindingContext));
 
 		Assert.assertTrue(samlSsoRequestContext.isNewSession());
 	}
@@ -361,7 +363,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 		SAMLBindingContext samlBindingContext = messageContext.getSubcontext(
 			SAMLBindingContext.class);
 
-		Assert.assertEquals(RELAY_STATE, samlBindingContext.getRelayState());
+		Assert.assertEquals(
+			RELAY_STATE, RelayStateUtil.getRelayState(samlBindingContext));
 
 		Assert.assertTrue(samlSsoRequestContext.isNewSession());
 	}
@@ -470,7 +473,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 		SAMLBindingContext samlBindingContext = messageContext.getSubcontext(
 			SAMLBindingContext.class);
 
-		Assert.assertEquals(RELAY_STATE, samlBindingContext.getRelayState());
+		Assert.assertEquals(
+			RELAY_STATE, RelayStateUtil.getRelayState(samlBindingContext));
 
 		Assert.assertNull(
 			mockHttpSession.getAttribute(SamlWebKeys.SAML_SSO_REQUEST_CONTEXT));
@@ -560,7 +564,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 		SAMLBindingContext samlBindingContext = messageContext.getSubcontext(
 			SAMLBindingContext.class);
 
-		Assert.assertEquals(RELAY_STATE, samlBindingContext.getRelayState());
+		Assert.assertEquals(
+			RELAY_STATE, RelayStateUtil.getRelayState(samlBindingContext));
 
 		InOutOperationContext<?, ?> inOutOperationContext =
 			messageContext.getSubcontext(InOutOperationContext.class);
@@ -1209,7 +1214,7 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 
 		SamlSsoRequestContext samlSsoRequestContext = new SamlSsoRequestContext(
 			samlPeerEntityContext.getEntityId(),
-			samlBindingContext.getRelayState(), messageContext,
+			RelayStateUtil.getRelayState(samlBindingContext), messageContext,
 			userLocalService);
 
 		SAMLSelfEntityContext samlSelfEntityContext =


### PR DESCRIPTION
Not sure if this is the best way to do this, but it seemed to work well in my testing.

For the third commit, I'm not sure if there is a better/more "recommended" way to create a `ConcurrentMap` with a time-based expiration mechanism in Liferay code. The closest thing I could find was `ConcurrentReferenceKeyHashMap`, but this is a reference-based expiration mechanism, not a time-based one. I don't think a reference-based mechanism will work since there seems to be the potential for there to be a brief moment between `set` and `get` where no one has a reference to the UUID, as `set` and `get` happen in different threads. So in a reference-based expiration mechanism, the map entry could expire before we call `get`.

I'm not sure if we want to make the "10 Minutes" configurable, but I imagine the vast majority of clients aren't going to care about such a thing. They may only care about it if they find that this map is consuming an excessive amount of memory. If we do decide to make it configurable, we'd need a way to recreate the Map when the configuration has changed, or else we'd need to warn the user that they need to restart the portal after updating the configuration.

I tested the third commit by altering the expiration time to 1 minute, putting a "Suspend Thread" breakpoint after the entry was placed in the Map, and waiting over a minute. When it got to the `get` method, sure enough, the entry was not present in the Map and it got a null value. If it gets a null value, it's not really a big deal. The user just gets redirected to the home page on login instead of where they were logging in from previously. And with a 10-minute expiration time, it's hard to imagine this ever happening unless SAML is being extraordinarily slow (in which case, you've got way bigger problems).