### PR TITLE
LPS-190666 - display all roles in site membership if the user has the Assign User Roles permission

### DIFF
--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectRolesDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SelectRolesDisplayContext.java
@@ -14,9 +14,12 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.SearchDisplayStyleUtil;
 import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
+import com.liferay.portal.kernel.service.permission.UserPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -26,6 +29,7 @@ import com.liferay.site.memberships.constants.SiteMembershipsPortletKeys;
 import com.liferay.site.memberships.web.internal.util.DepotRolesUtil;
 import com.liferay.users.admin.kernel.util.UsersAdminUtil;
 
+import java.util.Iterator;
 import java.util.List;
 
 import javax.portlet.PortletURL;
@@ -205,16 +209,41 @@ public class SelectRolesDisplayContext {
 
 		Group group = GroupLocalServiceUtil.fetchGroup(getGroupId());
 
-		if (group.isDepot()) {
+		if (UserPermissionUtil.contains(themeDisplay.getPermissionChecker(),
+			themeDisplay.getUserId(), ActionKeys.ASSIGN_USER_ROLES)) {
+
+
+			List<Role> filteredGroupRoles = ListUtil.copy(roles);
+
+			Iterator<Role> iterator = filteredGroupRoles.iterator();
+
+			while (iterator.hasNext()) {
+				Role groupRole = iterator.next();
+
+				String roleName = groupRole.getName();
+
+				if (roleName.equals(RoleConstants.ORGANIZATION_USER) ||
+					roleName.equals(RoleConstants.SITE_MEMBER)) {
+
+					iterator.remove();
+				}
+			}
+
+			roleSearch.setResultsAndTotal(filteredGroupRoles);
+
+			
+		} else 	if (group.isDepot()) {
 			roles = DepotRolesUtil.filterGroupRoles(
 				themeDisplay.getPermissionChecker(), getGroupId(), roles);
+			roleSearch.setResultsAndTotal(roles);
 		}
 		else {
 			roles = UsersAdminUtil.filterGroupRoles(
 				themeDisplay.getPermissionChecker(), getGroupId(), roles);
+			roleSearch.setResultsAndTotal(roles);
 		}
 
-		roleSearch.setResultsAndTotal(roles);
+
 
 		_roleSearch = roleSearch;
 


### PR DESCRIPTION
Ticket [LPS-190666](https://liferay.atlassian.net/browse/LPS-190666)

### Problem to  be solved
Proposed change to resolve the bug where a user with permissions cannot see all roles when filtering users by roles (in the portal membership option).

### Code changes
The proposal completes the solution proposed by @ChrisKian in the pr https://github.com/liferay-appsec/liferay-portal/pull/1240 by adding a validation in the backend to not delegate security exclusively to the UI. 

In order to find the validation to be performed, the operation of role retrieval was checked and it was found that the UsersAdminImpl class (in the filterGroupRoles method) is where the list of roles is returned. 

Looking at the history of changes, it was seen that in this [LPSA-21087](https://liferay.atlassian.net/browse/LPSA-21087) ticket it is indicated that if the user has the permission "Assign User Roles" the user can see all the roles, so this is the check that has been added to the solution.

In this case, to avoid modifying the behavior of the rest of the portal, the modification has been added only when filtering users by role in the website membership (where the bug has been detected).
