### PR TITLE
[TS] LPS-185167

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -904,6 +904,26 @@ public class ServicePreAction extends Action {
 			return null;
 		}
 
+		HttpSession httpSession = httpServletRequest.getSession();
+
+		User realUser = user;
+
+		Long realUserId = (Long)httpSession.getAttribute(WebKeys.USER_ID);
+
+		if ((realUserId != null) &&
+			(user.getUserId() != realUserId.longValue())) {
+
+			realUser = UserLocalServiceUtil.getUserById(realUserId.longValue());
+		}
+
+		if (!user.isActive()) {
+			user = company.getGuestUser();
+
+			if (realUser == null) {
+				httpSession.invalidate();
+			}
+		}
+
 		boolean signedIn = !user.isGuestUser();
 
 		if (PropsValues.BROWSER_CACHE_DISABLED ||
@@ -915,18 +935,6 @@ public class ServicePreAction extends Action {
 				HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE);
 			httpServletResponse.setHeader(
 				HttpHeaders.PRAGMA, HttpHeaders.PRAGMA_NO_CACHE_VALUE);
-		}
-
-		HttpSession httpSession = httpServletRequest.getSession();
-
-		User realUser = user;
-
-		Long realUserId = (Long)httpSession.getAttribute(WebKeys.USER_ID);
-
-		if ((realUserId != null) &&
-			(user.getUserId() != realUserId.longValue())) {
-
-			realUser = UserLocalServiceUtil.getUserById(realUserId.longValue());
 		}
 
 		long refererPlid = ParamUtil.getLong(httpServletRequest, "refererPlid");


### PR DESCRIPTION
Hi team,

This is a PR that aims to fix the scenario of an active user making use of an active session being able to see and interact with portlets in an inconsistent state.

The fix is based on the approach suggested in the comments of LPS-185167 and PTR-3858, that is, invalidating the session if the user is inactive.

Could you please review it? Please, let me know if further clarifications are needed for this review. 

Thanks!