### PR TITLE
[TS] LPS-188149 Stateless redirection fix

### DIFF
--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -256,7 +256,7 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			"saveLastPath", Boolean.FALSE.toString());
 		liferayPortletURL.setParameter(
 			"mvcRenderCommandName", "/mfa_verify/view");
-		liferayPortletURL.setParameter("redirect", redirectURL);
+		liferayPortletURL.setParameter("process", redirectURL);
 		liferayPortletURL.setParameter(
 			"returnToFullPageURL", returnToFullPageURL);
 
@@ -330,29 +330,29 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			_portal.getOriginalServletRequest(
 				_portal.getHttpServletRequest(actionRequest));
 
-		LiferayPortletURL liferayPortletURL = _getLiferayPortletURL(
-			httpServletRequest,
-			PortletURLBuilder.createActionURL(
-				liferayPortletResponse
-			).setActionName(
-				"/login/login"
-			).setParameter(
-				"state", encryptedStateMapJSON
-			).buildString(),
-			PortletURLBuilder.createRenderURL(
-				liferayPortletResponse
-			).setRedirect(
-				() -> {
-					String redirect = ParamUtil.getString(
-						actionRequest, "redirect");
 
-					if (Validator.isNotNull(redirect)) {
-						return redirect;
-					}
+		httpServletRequest = _portal.getOriginalServletRequest(
+			httpServletRequest);
 
-					return null;
-				}
-			).buildString());
+		long plid = 0;
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		if (themeDisplay != null) {
+			plid = themeDisplay.getPlid();
+		}
+
+		LiferayPortletURL liferayPortletURL = _portletURLFactory.create(
+			httpServletRequest, MFAPortletKeys.MFA_VERIFY, plid,
+			PortletRequest.RENDER_PHASE);
+
+		liferayPortletURL.setParameter(
+			"saveLastPath", Boolean.FALSE.toString());
+		liferayPortletURL.setParameter(
+			"mvcRenderCommandName", "/mfa_verify/view");
+		liferayPortletURL.setParameter("state", encryptedStateMapJSON);
 
 		String portletId = ParamUtil.getString(httpServletRequest, "p_p_id");
 

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -323,7 +323,12 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			key,
 			_jsonFactory.looseSerializeDeep(
 				HashMapBuilder.<String, Object>put(
-					"requestParameters", actionRequest.getParameterMap()
+					"requestParameters",
+					() -> HashMapBuilder.putAll(
+						actionRequest.getParameterMap()
+					).remove(
+						"redirect"
+					).build()
 				).build()));
 
 		HttpServletRequest httpServletRequest =
@@ -352,6 +357,8 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 			"saveLastPath", Boolean.FALSE.toString());
 		liferayPortletURL.setParameter(
 			"mvcRenderCommandName", "/mfa_verify/view");
+		liferayPortletURL.setParameter(
+			"redirect", ParamUtil.getString(actionRequest, "redirect"));
 		liferayPortletURL.setParameter("state", encryptedStateMapJSON);
 
 		String portletId = ParamUtil.getString(httpServletRequest, "p_p_id");

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -24,7 +24,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
-import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.PortletURLFactory;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
@@ -124,7 +123,7 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 				}
 
 				if (userId > 0) {
-					_redirectToVerify(actionRequest, actionResponse, userId);
+					_redirectToVerify(actionRequest, userId);
 				}
 			}
 			catch (Exception exception) {
@@ -231,38 +230,6 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 		};
 	}
 
-	private LiferayPortletURL _getLiferayPortletURL(
-		HttpServletRequest httpServletRequest, String redirectURL,
-		String returnToFullPageURL) {
-
-		httpServletRequest = _portal.getOriginalServletRequest(
-			httpServletRequest);
-
-		long plid = 0;
-
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		if (themeDisplay != null) {
-			plid = themeDisplay.getPlid();
-		}
-
-		LiferayPortletURL liferayPortletURL = _portletURLFactory.create(
-			httpServletRequest, MFAPortletKeys.MFA_VERIFY, plid,
-			PortletRequest.RENDER_PHASE);
-
-		liferayPortletURL.setParameter(
-			"saveLastPath", Boolean.FALSE.toString());
-		liferayPortletURL.setParameter(
-			"mvcRenderCommandName", "/mfa_verify/view");
-		liferayPortletURL.setParameter("process", redirectURL);
-		liferayPortletURL.setParameter(
-			"returnToFullPageURL", returnToFullPageURL);
-
-		return liferayPortletURL;
-	}
-
 	private void _postProcessAuthFailure(
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
@@ -309,13 +276,8 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 		actionResponse.sendRedirect(portletURL.toString());
 	}
 
-	private void _redirectToVerify(
-			ActionRequest actionRequest, ActionResponse actionResponse,
-			long userId)
+	private void _redirectToVerify(ActionRequest actionRequest, long userId)
 		throws Exception {
-
-		LiferayPortletResponse liferayPortletResponse =
-			_portal.getLiferayPortletResponse(actionResponse);
 
 		Key key = _encryptor.generateKey();
 
@@ -334,7 +296,6 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 		HttpServletRequest httpServletRequest =
 			_portal.getOriginalServletRequest(
 				_portal.getHttpServletRequest(actionRequest));
-
 
 		httpServletRequest = _portal.getOriginalServletRequest(
 			httpServletRequest);

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/VerifyMVCActionCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/VerifyMVCActionCommand.java
@@ -97,6 +97,8 @@ public class VerifyMVCActionCommand extends BaseMVCActionCommand {
 						LoginPortletKeys.LOGIN
 					).setActionName(
 						"/login/login"
+					).setRedirect(
+						ParamUtil.getString(actionRequest, "redirect")
 					).setParameter(
 						"saveLastPath", Boolean.FALSE
 					).setParameter(

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/VerifyMVCActionCommand.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/action/VerifyMVCActionCommand.java
@@ -5,12 +5,14 @@
 
 package com.liferay.multi.factor.authentication.web.internal.portlet.action;
 
+import com.liferay.login.web.constants.LoginPortletKeys;
 import com.liferay.multi.factor.authentication.spi.checker.browser.BrowserMFAChecker;
 import com.liferay.multi.factor.authentication.web.internal.constants.MFAPortletKeys;
 import com.liferay.multi.factor.authentication.web.internal.constants.MFAWebKeys;
 import com.liferay.multi.factor.authentication.web.internal.policy.MFAPolicy;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -86,6 +88,20 @@ public class VerifyMVCActionCommand extends BaseMVCActionCommand {
 				hideDefaultErrorMessage(actionRequest);
 
 				SessionErrors.add(actionRequest, "mfaVerificationFailed");
+			}
+			else {
+				actionRequest.setAttribute(
+					WebKeys.REDIRECT,
+					PortletURLBuilder.createActionURL(
+						_portal.getLiferayPortletResponse(actionResponse),
+						LoginPortletKeys.LOGIN
+					).setActionName(
+						"/login/login"
+					).setParameter(
+						"saveLastPath", Boolean.FALSE
+					).setParameter(
+						"state", ParamUtil.getString(actionRequest, "state")
+					).buildString());
 			}
 		}
 		catch (Exception exception) {

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/resources/META-INF/resources/init.jsp
@@ -11,10 +11,12 @@
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
-<%@ page import="com.liferay.multi.factor.authentication.spi.checker.browser.BrowserMFAChecker" %><%@
+<%@ page import="com.liferay.login.web.constants.LoginPortletKeys" %><%@
+page import="com.liferay.multi.factor.authentication.spi.checker.browser.BrowserMFAChecker" %><%@
 page import="com.liferay.multi.factor.authentication.spi.checker.setup.SetupMFAChecker" %><%@
 page import="com.liferay.multi.factor.authentication.web.internal.constants.MFAWebKeys" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/resources/META-INF/resources/mfa_verify/view.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/resources/META-INF/resources/mfa_verify/view.jsp
@@ -9,6 +9,7 @@
 
 <%
 String redirect = ParamUtil.getString(request, "redirect");
+String state = ParamUtil.getString(request, "state");
 
 BrowserMFAChecker browserMFAChecker = (BrowserMFAChecker)request.getAttribute(MFAWebKeys.BROWSER_MFA_CHECKER);
 String browserMFACheckerName = (String)request.getAttribute(MFAWebKeys.BROWSER_MFA_CHECKER_NAME);
@@ -25,6 +26,7 @@ int mfaCheckerIndex = ParamUtil.getInteger(request, "mfaCheckerIndex");
 <aui:form action="<%= verifyURL %>" cssClass="container-fluid container-fluid-max-xl sign-in-form" data-senna-off="true" method="post" name="fm">
 	<aui:input name="saveLastPath" type="hidden" value="<%= false %>" />
 	<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
+	<aui:input name="state" type="hidden" value="<%= state %>" />
 	<aui:input name="mfaCheckerIndex" type="hidden" value="<%= mfaCheckerIndex %>" />
 
 	<liferay-ui:error key="mfaVerificationFailed" message="multi-factor-authentication-has-failed" />
@@ -37,7 +39,8 @@ int mfaCheckerIndex = ParamUtil.getInteger(request, "mfaCheckerIndex");
 		<portlet:renderURL copyCurrentRenderParameters="<%= false %>" var="useAnotherBrowserMFAChecker">
 			<portlet:param name="saveLastPath" value="<%= Boolean.FALSE.toString() %>" />
 			<portlet:param name="mvcRenderCommandName" value="/mfa_verify/view" />
-			<portlet:param name="redirect" value='<%= ParamUtil.getString(request, "redirect") %>' />
+			<portlet:param name="redirect" value="<%= redirect %>" />
+			<portlet:param name="state" value="<%= state %>" />
 			<portlet:param name="mfaCheckerIndex" value='<%= ((mfaCheckerIndex + 1) < browserMFACheckers.size()) ? String.valueOf(mfaCheckerIndex + 1) : "0" %>' />
 		</portlet:renderURL>
 

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/resources/META-INF/resources/mfa_verify/view.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/resources/META-INF/resources/mfa_verify/view.jsp
@@ -19,6 +19,15 @@ long mfaUserId = (Long)request.getAttribute(MFAWebKeys.MFA_USER_ID);
 int mfaCheckerIndex = ParamUtil.getInteger(request, "mfaCheckerIndex");
 %>
 
+<liferay-portlet:renderURL portletName="<%= LoginPortletKeys.LOGIN %>" var="loginURL">
+	<portlet:param name="redirect" value="<%= redirect %>" />
+</liferay-portlet:renderURL>
+
+<%
+portletDisplay.setShowBackIcon(true);
+portletDisplay.setURLBack(ParamUtil.getString(request, "backURL", loginURL));
+%>
+
 <portlet:actionURL name="/mfa_verify/verify" var="verifyURL">
 	<portlet:param name="mvcRenderCommandName" value="/mfa_verify/view" />
 </portlet:actionURL>


### PR DESCRIPTION
**Steps to reproduce:**
1. Set up SMTP
2. Log in as admin user
3. Control panel → Instance settings → Login → Prompt Enabled →  
4. Product menu → Content & Data → Documents and Media → open tree.png → bookmark the page
5. Control panel → Instance settings → Multi-Factor Authentication → Enabled   
6. Log out
7. Open the bookmarked link
8. Log in & insert OTP

_Expected Behavior:_ Get redirected to the bookmarked page
_Actual Behavior:_ A green confirmation banner shows that the process was successful, but the page does not redirect anywhere

**Implementation Details:**

The problem was that with a page like the tree image render in DL, the combination of "state" and "redirect" parameters quickly approached 4000 characters. At that limit parameters can get dropped.

The redirect parameter that is provided to /c/portal/login (and the login portlet) was encoded into the state parameter and hence could not be accessed when building the "return to full page" link. Hence it was sent separately in another parameter. So I extracted it from state and sent it separately, removing the need to send a second parameter altogether. Resulting in a considerably shorter request URL length.