### PR TITLE
LPS-192547 Regression of LPS-155692 - Users cannot access their own personal pages on WebLogic

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -995,7 +995,9 @@ public class ServicePreAction extends Action {
 		if (layout != null) {
 			Group layoutGroup = layout.getGroup();
 
-			if (layoutGroup.isUser()) {
+			if (layoutGroup.isUser() &&
+				(layoutGroup.getClassPK() != user.getUserId())) {
+
 				if (!GetterUtil.getBoolean(
 						PropsUtil.get(
 							PropsKeys.LAYOUT_USER_ACCESS_VIA_PLID_ENABLED))) {


### PR DESCRIPTION
Ticket: [LPS-192547](https://liferay.atlassian.net/browse/LPS-192547)

The logic from [LPS-155692](https://liferay.atlassian.net/browse/LPS-155692) did not play nicely with WebLogic. The "getOriginalServletRequest" call was still returning the "actual" p_l_id-based URL, even though the user navigated to the friendl URL in their browser.

For now, I'm sending a quick fix to make it so that the user can always view _their own_ pages, even if using a p_l_id-based URL to do so. I believe that this would be the intended behavior anyway, that a user could always see their own page regardless of what type of URL they use.

However, this fix doesn't yet address the case of allowing users to see each other's pages by friendly URLs (which I believe is the intended behavior from my reading of [LPS-155692](https://liferay.atlassian.net/browse/LPS-155692), that they could see each other's pages by their friendly URLs, just not by p_l_id-based URLs). Since this case seems less problematic and more difficult to fix, I think we can fix it in a separate ticket.