### PR TITLE
[TS] LPS-169817 

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/AuthVerifierServletRequest.java
+++ b/portal-impl/src/com/liferay/portal/servlet/AuthVerifierServletRequest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.servlet;
 
+import com.liferay.portal.kernel.audit.AuditRequestThreadLocal;
 import com.liferay.portal.kernel.servlet.HttpSessionWrapper;
 import com.liferay.portal.kernel.servlet.ProtectedServletRequest;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -26,6 +27,13 @@ public class AuthVerifierServletRequest extends ProtectedServletRequest {
 		super(httpServletRequest, String.valueOf(userId), authType);
 
 		_userId = userId;
+
+		if (_userId != null) {
+			AuditRequestThreadLocal auditRequestThreadLocal =
+				AuditRequestThreadLocal.getAuditThreadLocal();
+
+			auditRequestThreadLocal.setRealUserId(_userId);
+		}
 
 		httpServletRequest.removeAttribute(WebKeys.USER);
 		httpServletRequest.setAttribute(WebKeys.USER_ID, userId);


### PR DESCRIPTION
**Steps to reproduce:**
1. Create an organization through the API via this command:
`curl -X 'POST' 'http://localhost:8080/o/headless-admin-user/v1.0/organizations' -H 'accept: application/json' -H 'Content-Type: application/json' -u 'test@liferay.com:test' -d '{"comment": "Org created from API","name": "orgfromAPI"}'`

2. Check the Audit logs in Control Panel -> Security -> Audit

_Expected behavior:_ User Id and User Name filled in correctly
_Actual behavior:_ User Id is 0 and User Name is empty

**Implementation details:**

The class responsible for add the AuditEvent object is the AuditEventLocalServiceImpl.java, which uses AuditMessage object as a parameter that contains the informations in the [addAuditEvent](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventLocalServiceImpl.java#L40) method (including userId and userName) 

There is a class named OrganizationModelListener.java that is called when we use the terminal command to add a new organization. It uses a class called AuditMessageBuilder [to fetch the information defined by the local thread](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management/src/main/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/OrganizationModelListener.java#L128) in the [buildAuditMessage](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/java/com/liferay/portal/security/audit/event/generators/util/AuditMessageBuilder.java#L53) method.

However, a class named [AuditFilter.java needs to be called so that the system has this information from the local thread in a AuditRequestThreadLocal object](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-security-audit/portal-security-audit-wiring/src/main/java/com/liferay/portal/security/audit/wiring/internal/servlet/filter/AuditFilter.java#L108). It was verified by debug that the AuditFilter class is not being called during this process, so the userID and userName will always be null.

[In the past, I had made a modification to set this information in OrganizationModelListener.java](https://github.com/liferay-appsec/liferay-portal/pull/970), but it was rejected and a generic solution was implemented instead. [This generic solution added a new class called AuthVerifierServletRequest.java to set the user attributes in the request and after that calls the AuditFilter in the class AuditVerifierFilter.java ](https://github.com/liferay-appsec/liferay-portal/pull/1010/files#diff-e1692f1027634ccb56c2ac0cb6aba3a7e6b96ff0c381ff3ced8a65ed57189ccf). But [this last part was reverted](https://github.com/liferay/liferay-portal/commit/2f5134fd195720104e876f377055cc87fea8167c) because some regressions were found.

With that in mind, I modified the AuthVerifierServletRequest.java class that was created in the generic solution to add the missing realIdUser attribute.

**Commits included:**
- LPS-169817 Set the realUserId of AuditRequestThreadLocal before build AuditMessage