### PR TITLE
[TS] LPS-193158

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -1330,7 +1330,9 @@ public class LiferayOAuthDataProvider
 				oAuth2Application.getClientCredentialUserId(),
 				oAuth2Application.getClientCredentialUserName()));
 
-		if (!clientAuthenticationMethod.equals("client_secret_basic_or_post")) {
+		List<String> features = oAuth2Application.getFeaturesList();
+
+		if (features.contains("force.authentication.type.check")) {
 			client.setTokenEndpointAuthMethod(clientAuthenticationMethod);
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -1329,7 +1329,10 @@ public class LiferayOAuthDataProvider
 				oAuth2Application.getCompanyId(),
 				oAuth2Application.getClientCredentialUserId(),
 				oAuth2Application.getClientCredentialUserName()));
-		client.setTokenEndpointAuthMethod(clientAuthenticationMethod);
+
+		if (!clientAuthenticationMethod.equals("client_secret_basic_or_post")) {
+			client.setTokenEndpointAuthMethod(clientAuthenticationMethod);
+		}
 
 		Map<String, String> properties = client.getProperties();
 

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -769,9 +769,7 @@ public class OAuth2ApplicationLocalServiceImpl
 					OAuthConstants.TOKEN_ENDPOINT_AUTH_BASIC) ||
 				 clientAuthenticationMethod.equals(
 					 OAuthConstants.TOKEN_ENDPOINT_AUTH_POST) ||
-				 clientAuthenticationMethod.equals("client_secret_jwt") ||
-				 clientAuthenticationMethod.equals(
-					 "client_secret_basic_or_post")) {
+				 clientAuthenticationMethod.equals("client_secret_jwt")) {
 
 			// Confidential client with client secret
 

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -769,7 +769,9 @@ public class OAuth2ApplicationLocalServiceImpl
 					OAuthConstants.TOKEN_ENDPOINT_AUTH_BASIC) ||
 				 clientAuthenticationMethod.equals(
 					 OAuthConstants.TOKEN_ENDPOINT_AUTH_POST) ||
-				 clientAuthenticationMethod.equals("client_secret_jwt")) {
+				 clientAuthenticationMethod.equals("client_secret_jwt") ||
+				 clientAuthenticationMethod.equals(
+					 "client_secret_basic_or_post")) {
 
 			// Confidential client with client secret
 

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/display/context/OAuth2AdminPortletDisplayContext.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/display/context/OAuth2AdminPortletDisplayContext.java
@@ -124,8 +124,7 @@ public class OAuth2AdminPortletDisplayContext
 	}
 
 	public String[] getOAuth2Features(PortletPreferences portletPreferences) {
-		return StringUtil.split(
-			portletPreferences.getValue("oAuth2Features", StringPool.BLANK));
+		return portletPreferences.getValues("oAuth2Features", new String[0]);
 	}
 
 	public ClientProfile[] getSortedClientProfiles() {

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/portlet-preferences/default-portlet-preferences.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/portlet-preferences/default-portlet-preferences.xml
@@ -4,6 +4,7 @@
 	<preference>
 		<name>oAuth2Features</name>
 		<value>token.introspection</value>
+		<value>force.authentication.type.check</value>
 	</preference>
 	<preference>
 		<name>oAuth2Grants</name>

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_left_column.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_left_column.jsp
@@ -30,6 +30,7 @@ OAuth2Application oAuth2Application = oAuth2AdminPortletDisplayContext.getOAuth2
 
 	<aui:select helpMessage="client-authentication-method-help" label="Client Authentication Method" name="clientAuthenticationMethod" required="<%= true %>">
 		<aui:option label="Client Secret Basic" value="client_secret_basic" />
+		<aui:option label="Client Secret Basic or Post" value="client_secret_basic_or_post" />
 		<aui:option label="Client Secret Post" value="client_secret_post" />
 		<aui:option label="None" value="none" />
 		<aui:option label="Client Secret JWT" value="client_secret_jwt" />

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_left_column.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_left_column.jsp
@@ -30,7 +30,6 @@ OAuth2Application oAuth2Application = oAuth2AdminPortletDisplayContext.getOAuth2
 
 	<aui:select helpMessage="client-authentication-method-help" label="Client Authentication Method" name="clientAuthenticationMethod" required="<%= true %>">
 		<aui:option label="Client Secret Basic" value="client_secret_basic" />
-		<aui:option label="Client Secret Basic or Post" value="client_secret_basic_or_post" />
 		<aui:option label="Client Secret Post" value="client_secret_post" />
 		<aui:option label="None" value="none" />
 		<aui:option label="Client Secret JWT" value="client_secret_jwt" />
@@ -281,10 +280,12 @@ OAuth2Application oAuth2Application = oAuth2AdminPortletDisplayContext.getOAuth2
 				String name = "feature-" + oAuth2Feature;
 
 				checked = ParamUtil.getBoolean(request, name, checked);
+
+				oAuth2Feature = StringUtil.replace(oAuth2Feature, CharPool.PERIOD, CharPool.DASH);
 			%>
 
 				<div class="supportedFeature">
-					<aui:input checked="<%= checked %>" label='<%= oAuth2Feature.equals("token.introspection") ? "token-introspection" : HtmlUtil.escape(oAuth2Feature) %>' name="<%= name %>" type="checkbox" />
+					<aui:input checked="<%= checked %>" label="<%= HtmlUtil.escape(oAuth2Feature) %>" name="<%= name %>" type="checkbox" />
 				</div>
 
 			<%

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/init.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/init.jsp
@@ -35,6 +35,7 @@ page import="com.liferay.oauth2.provider.web.internal.display.context.OAuth2Admi
 page import="com.liferay.oauth2.provider.web.internal.display.context.OAuth2ApplicationsManagementToolbarDisplayContext" %><%@
 page import="com.liferay.oauth2.provider.web.internal.display.context.OAuth2AuthorizationsManagementToolbarDisplayContext" %><%@
 page import="com.liferay.oauth2.provider.web.internal.tree.Tree" %><%@
+page import="com.liferay.petra.string.CharPool" %><%@
 page import="com.liferay.petra.string.StringBundler" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker" %><%@

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -7394,6 +7394,7 @@ for-security-reasons-upload-field-repeatability-is-limited-the-limit-is-defined-
 for-x-y=For {0}, {1}.
 forbidden=Forbidden
 force-approve=Force Approve
+force-authentication-type-check=Force Authentication Type Check
 force-authn=Force Authn
 force-authn-help=Force identity provider to reauthenticate user regardless of existing security context.
 force-basic-auth=Force Basic Authentication


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-193158

Please select one of two possible solutions:
1. Adds a new `Client Authentication Method` called "Client Secret Basic or Post".  Allows Basic or Post auth types to be used with the same client-id and secret.  Drop the second commit if you like this solution.
2. Add a new portlet preference "force.authentication.type.check" which gets populated as an OAuth2Application "feature".  When enabled, we pass along the authentication type to the client, forcing only that type to be used.  When disabled, the client will determine the type upon request.  This value is empty/false by default.  Please squash the two commits, retaining the second commit's message if you prefer this solution.

If neither of these solutions is ideal, please let me know how we should proceed, thanks!