### PR TITLE
[TS] LPS-193151 | AppSec

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/UserDisplayContext.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/UserDisplayContext.java
@@ -46,6 +46,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.user.groups.admin.item.selector.UserGroupItemSelectorCriterion;
 import com.liferay.users.admin.kernel.util.UsersAdminUtil;
 
@@ -157,17 +158,18 @@ public class UserDisplayContext {
 
 	public List<Organization> getOrganizations() throws PortalException {
 		if (_selUser != null) {
-			if (!_initDisplayContext.isFilterManageableOrganizations()) {
-				List<Organization> organizations = _selUser.getOrganizations();
+			List<Organization> organizations = _selUser.getOrganizations();
 
+			if (!PropsValues.ORGANIZATIONS_MEMBERSHIP_STRICT) {
 				organizations.addAll(_getParentOrganizations(organizations));
+			}
 
+			if (!_initDisplayContext.isFilterManageableOrganizations()) {
 				return organizations;
 			}
 
 			return UsersAdminUtil.filterOrganizations(
-				_themeDisplay.getPermissionChecker(),
-				_selUser.getOrganizations());
+				_themeDisplay.getPermissionChecker(), organizations);
 		}
 
 		String organizationIds = ParamUtil.getString(

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/UserDisplayContext.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/UserDisplayContext.java
@@ -158,7 +158,11 @@ public class UserDisplayContext {
 	public List<Organization> getOrganizations() throws PortalException {
 		if (_selUser != null) {
 			if (!_initDisplayContext.isFilterManageableOrganizations()) {
-				return _selUser.getOrganizations();
+				List<Organization> organizations = _selUser.getOrganizations();
+
+				organizations.addAll(_getParentOrganizations(organizations));
+
+				return organizations;
 			}
 
 			return UsersAdminUtil.filterOrganizations(
@@ -314,8 +318,10 @@ public class UserDisplayContext {
 
 		allGroups.addAll(getGroups());
 		allGroups.addAll(getInheritedSiteGroups());
+
 		allGroups.addAll(
 			GroupLocalServiceUtil.getOrganizationsGroups(getOrganizations()));
+
 		allGroups.addAll(
 			GroupLocalServiceUtil.getUserGroupsGroups(getUserGroups()));
 
@@ -331,6 +337,26 @@ public class UserDisplayContext {
 
 		return GroupLocalServiceUtil.getOrganizationsRelatedGroups(
 			organizations);
+	}
+
+	private List<Organization> _getParentOrganizations(
+			List<Organization> organizations)
+		throws PortalException {
+
+		List<Organization> parentOrganizations = new ArrayList<>();
+
+		for (Organization organization : organizations) {
+			Organization parentOrganization =
+				organization.getParentOrganization();
+
+			if ((parentOrganization != null) &&
+				!organizations.contains(parentOrganization)) {
+
+				parentOrganizations.add(parentOrganization);
+			}
+		}
+
+		return parentOrganizations;
 	}
 
 	private long[] _getSelectedOrganizationIds() throws PortalException {


### PR DESCRIPTION
**Steps to reproduce:**
1. Create a user [dummy@whatever.com](mailto:dummy@whatever.com).
2. Create an organization "parent organization" and its child organization "child organization".
3. Assing the dummy user to the child organization.
4. Create a regular role "father role" and assing it to the "parent organization" (father role -> Assignees -> Organizations -> '+' -> "parent organization").
5. Create a regular role "child role" and assing it to the "child organization" (child role -> Assignees -> Organizations -> '+' -> "child organization").
6. Go to the dummy user and check the organizations and roles
- The user only belongs to the child organization: should it not appear the father organization too?
- The dummy user only has the child role. But if we add more permissions to the father role (i.e father role->Define Permissions ->Control Panel ->Users ad Organizations ->Application Permissions -> Access in Control Panel & View) the dummy user has the permissions to access the users and organizations in the control panel.

_Actual Behavior:_ The user only belongs to the child organization and see only the child role, but has both. 
_Expected Behavior:_ The user belongs to the father and child organization and see the father and child role.


**Implementation details:**

The jsp file that [renders the user's organizations list uses a class called UserDisplayContext](https://github.com/liferay/liferay-portal/blob/master/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/organizations.jsp#L13C55-L13C71) to fetch the organizations in the [getOrganizations](https://github.com/liferay/liferay-portal/blob/master/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/UserDisplayContext.java#L158) method. This method currently returns only the organizations that are directly associated with the user. 

It is also called in the [_getAllGroups](https://github.com/liferay/liferay-portal/blob/master/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/UserDisplayContext.java#L318) method, which is used in the [getRoleGroups](https://github.com/liferay/liferay-portal/blob/master/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/display/context/UserDisplayContext.java#L191) method defined in the jsp file that [renders the user's regular roles list](https://github.com/liferay/liferay-portal/blob/master/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/roles.jsp#L26). 

With that in mind, the getOrganization method was modified to also include the inherited parent organizations when fetching user organizations.


**Commits included:**
- LPS-193151 Fetch parent organizations for inherited organizations and regular roles listing