### PR TITLE
LPS-76246 Fix "Relay state exceeds 80 bytes" error

### DIFF
--- a/modules/dxp/apps/saml/saml-api/build.gradle
+++ b/modules/dxp/apps/saml/saml-api/build.gradle
@@ -3,6 +3,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.opensaml", name: "opensaml-saml-api", version: "3.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.metatype", version: "1.3.0"

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelper.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelper.java
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.saml.opensaml.integration.internal.helper;
+
+import org.opensaml.saml.common.messaging.context.SAMLBindingContext;
+
+/**
+ * @author Michael Bowerman
+ */
+public interface RelayStateHelper {
+
+	public String getRelayState(SAMLBindingContext samlBindingContext);
+
+	public void setRelayState(
+		SAMLBindingContext samlBindingContext, String relayState);
+
+}

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
@@ -26,9 +26,9 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.helper.SamlHttpRequestHelper;
 import com.liferay.saml.opensaml.integration.internal.binding.SamlBinding;
+import com.liferay.saml.opensaml.integration.internal.helper.RelayStateHelper;
 import com.liferay.saml.opensaml.integration.internal.transport.HttpClientFactory;
 import com.liferay.saml.opensaml.integration.internal.util.OpenSamlUtil;
-import com.liferay.saml.opensaml.integration.internal.util.RelayStateUtil;
 import com.liferay.saml.opensaml.integration.internal.util.SamlUtil;
 import com.liferay.saml.persistence.model.SamlIdpSpSession;
 import com.liferay.saml.persistence.model.SamlIdpSsoSession;
@@ -607,7 +607,7 @@ public class SingleLogoutProfileImpl
 			outboundMessageContext.getSubcontext(
 				SAMLBindingContext.class, true);
 
-		RelayStateUtil.setRelayState(
+		_relayStateHelper.setRelayState(
 			samlBindingContext, portal.getPortalURL(httpServletRequest));
 
 		outboundMessageContext.setMessage(logoutRequest);
@@ -737,7 +737,7 @@ public class SingleLogoutProfileImpl
 						messageContext.getSubcontext(SAMLBindingContext.class);
 
 					samlSloContext.setRelayState(
-						RelayStateUtil.getRelayState(samlBindingContext));
+						_relayStateHelper.getRelayState(samlBindingContext));
 				}
 
 				samlSloContext.setUserId(portal.getUserId(httpServletRequest));
@@ -1225,7 +1225,7 @@ public class SingleLogoutProfileImpl
 		samlBindingContext = outboundMessageContext.getSubcontext(
 			SAMLBindingContext.class, true);
 
-		RelayStateUtil.setRelayState(
+		_relayStateHelper.setRelayState(
 			samlBindingContext, samlSloContext.getRelayState());
 
 		SecurityParametersContext securityParametersContext =
@@ -1443,6 +1443,9 @@ public class SingleLogoutProfileImpl
 
 	@Reference
 	private HttpClientFactory _httpClientFactory;
+
+	@Reference
+	private RelayStateHelper _relayStateHelper;
 
 	@Reference
 	private SamlHttpRequestHelper _samlHttpRequestHelper;

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
@@ -28,6 +28,7 @@ import com.liferay.saml.helper.SamlHttpRequestHelper;
 import com.liferay.saml.opensaml.integration.internal.binding.SamlBinding;
 import com.liferay.saml.opensaml.integration.internal.transport.HttpClientFactory;
 import com.liferay.saml.opensaml.integration.internal.util.OpenSamlUtil;
+import com.liferay.saml.opensaml.integration.internal.util.RelayStateUtil;
 import com.liferay.saml.opensaml.integration.internal.util.SamlUtil;
 import com.liferay.saml.persistence.model.SamlIdpSpSession;
 import com.liferay.saml.persistence.model.SamlIdpSsoSession;
@@ -606,8 +607,8 @@ public class SingleLogoutProfileImpl
 			outboundMessageContext.getSubcontext(
 				SAMLBindingContext.class, true);
 
-		samlBindingContext.setRelayState(
-			portal.getPortalURL(httpServletRequest));
+		RelayStateUtil.setRelayState(
+			samlBindingContext, portal.getPortalURL(httpServletRequest));
 
 		outboundMessageContext.setMessage(logoutRequest);
 
@@ -736,7 +737,7 @@ public class SingleLogoutProfileImpl
 						messageContext.getSubcontext(SAMLBindingContext.class);
 
 					samlSloContext.setRelayState(
-						samlBindingContext.getRelayState());
+						RelayStateUtil.getRelayState(samlBindingContext));
 				}
 
 				samlSloContext.setUserId(portal.getUserId(httpServletRequest));
@@ -1224,7 +1225,8 @@ public class SingleLogoutProfileImpl
 		samlBindingContext = outboundMessageContext.getSubcontext(
 			SAMLBindingContext.class, true);
 
-		samlBindingContext.setRelayState(samlSloContext.getRelayState());
+		RelayStateUtil.setRelayState(
+			samlBindingContext, samlSloContext.getRelayState());
 
 		SecurityParametersContext securityParametersContext =
 			outboundMessageContext.getSubcontext(

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -40,6 +40,7 @@ import com.liferay.saml.opensaml.integration.internal.resolver.SubjectAssertionC
 import com.liferay.saml.opensaml.integration.internal.resolver.UserResolverSAMLContextImpl;
 import com.liferay.saml.opensaml.integration.internal.util.ConfigurationServiceBootstrapUtil;
 import com.liferay.saml.opensaml.integration.internal.util.OpenSamlUtil;
+import com.liferay.saml.opensaml.integration.internal.util.RelayStateUtil;
 import com.liferay.saml.opensaml.integration.internal.util.SamlUtil;
 import com.liferay.saml.opensaml.integration.resolver.AttributeResolver;
 import com.liferay.saml.opensaml.integration.resolver.NameIdResolver;
@@ -400,7 +401,7 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			String relayState = ParamUtil.getString(
 				httpServletRequest, "RelayState");
 
-			samlBindingContext.setRelayState(relayState);
+			RelayStateUtil.setRelayState(samlBindingContext, relayState);
 
 			SAMLPeerEntityContext samlPeerEntityContext =
 				messageContext.getSubcontext(SAMLPeerEntityContext.class);
@@ -441,8 +442,8 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 
 			samlSsoRequestContext = new SamlSsoRequestContext(
 				authnRequestXml, samlPeerEntityContext.getEntityId(),
-				samlBindingContext.getRelayState(), messageContext,
-				_userLocalService);
+				RelayStateUtil.getRelayState(samlBindingContext),
+				messageContext, _userLocalService);
 		}
 
 		String samlSsoSessionId = getSamlSsoSessionId(httpServletRequest);
@@ -492,7 +493,7 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			outboundMessageContext.getSubcontext(
 				SAMLBindingContext.class, true);
 
-		samlBindingContext.setRelayState(relayState);
+		RelayStateUtil.setRelayState(samlBindingContext, relayState);
 
 		SAMLSelfEntityContext samlSelfEntityContext =
 			messageContext.getSubcontext(SAMLSelfEntityContext.class);
@@ -1112,7 +1113,7 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			SAMLBindingContext samlBindingContext =
 				messageContext.getSubcontext(SAMLBindingContext.class, true);
 
-			samlBindingContext.setRelayState(relayState);
+			RelayStateUtil.setRelayState(samlBindingContext, relayState);
 
 			String samlSsoSessionId = getSamlSsoSessionId(httpServletRequest);
 
@@ -1259,7 +1260,7 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			SAMLBindingContext.class);
 
 		String relayState = portal.escapeRedirect(
-			samlBindingContext.getRelayState());
+			RelayStateUtil.getRelayState(samlBindingContext));
 
 		if (Validator.isNull(relayState)) {
 			relayState = portal.getHomeURL(httpServletRequest);

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.opensaml.integration.internal.binding.SamlBinding;
 import com.liferay.saml.opensaml.integration.internal.bootstrap.ParserPoolUtil;
+import com.liferay.saml.opensaml.integration.internal.helper.RelayStateHelper;
 import com.liferay.saml.opensaml.integration.internal.metadata.MetadataManager;
 import com.liferay.saml.opensaml.integration.internal.resolver.AttributePublisherImpl;
 import com.liferay.saml.opensaml.integration.internal.resolver.AttributeResolverRegistry;
@@ -40,7 +41,6 @@ import com.liferay.saml.opensaml.integration.internal.resolver.SubjectAssertionC
 import com.liferay.saml.opensaml.integration.internal.resolver.UserResolverSAMLContextImpl;
 import com.liferay.saml.opensaml.integration.internal.util.ConfigurationServiceBootstrapUtil;
 import com.liferay.saml.opensaml.integration.internal.util.OpenSamlUtil;
-import com.liferay.saml.opensaml.integration.internal.util.RelayStateUtil;
 import com.liferay.saml.opensaml.integration.internal.util.SamlUtil;
 import com.liferay.saml.opensaml.integration.resolver.AttributeResolver;
 import com.liferay.saml.opensaml.integration.resolver.NameIdResolver;
@@ -401,7 +401,7 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			String relayState = ParamUtil.getString(
 				httpServletRequest, "RelayState");
 
-			RelayStateUtil.setRelayState(samlBindingContext, relayState);
+			_relayStateHelper.setRelayState(samlBindingContext, relayState);
 
 			SAMLPeerEntityContext samlPeerEntityContext =
 				messageContext.getSubcontext(SAMLPeerEntityContext.class);
@@ -442,7 +442,7 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 
 			samlSsoRequestContext = new SamlSsoRequestContext(
 				authnRequestXml, samlPeerEntityContext.getEntityId(),
-				RelayStateUtil.getRelayState(samlBindingContext),
+				_relayStateHelper.getRelayState(samlBindingContext),
 				messageContext, _userLocalService);
 		}
 
@@ -493,7 +493,7 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			outboundMessageContext.getSubcontext(
 				SAMLBindingContext.class, true);
 
-		RelayStateUtil.setRelayState(samlBindingContext, relayState);
+		_relayStateHelper.setRelayState(samlBindingContext, relayState);
 
 		SAMLSelfEntityContext samlSelfEntityContext =
 			messageContext.getSubcontext(SAMLSelfEntityContext.class);
@@ -1113,7 +1113,7 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			SAMLBindingContext samlBindingContext =
 				messageContext.getSubcontext(SAMLBindingContext.class, true);
 
-			RelayStateUtil.setRelayState(samlBindingContext, relayState);
+			_relayStateHelper.setRelayState(samlBindingContext, relayState);
 
 			String samlSsoSessionId = getSamlSsoSessionId(httpServletRequest);
 
@@ -1260,7 +1260,7 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			SAMLBindingContext.class);
 
 		String relayState = portal.escapeRedirect(
-			RelayStateUtil.getRelayState(samlBindingContext));
+			_relayStateHelper.getRelayState(samlBindingContext));
 
 		if (Validator.isNull(relayState)) {
 			relayState = portal.getHomeURL(httpServletRequest);
@@ -2116,6 +2116,9 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 
 	@Reference
 	private NameIdResolverRegistry _nameIdResolverRegistry;
+
+	@Reference
+	private RelayStateHelper _relayStateHelper;
 
 	private SamlConfiguration _samlConfiguration;
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/util/RelayStateUtil.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/util/RelayStateUtil.java
@@ -5,12 +5,16 @@
 
 package com.liferay.saml.opensaml.integration.internal.util;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 
 import org.opensaml.saml.common.messaging.context.SAMLBindingContext;
 
@@ -35,6 +39,15 @@ public class RelayStateUtil {
 	public static void setRelayState(
 		SAMLBindingContext samlBindingContext, String relayState) {
 
+		if (relayState == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Relay state is null. Setting blank relay state instead.");
+
+				relayState = StringPool.BLANK;
+			}
+		}
+
 		String uuid = PortalUUIDUtil.generate();
 
 		_relayStates.put(uuid, relayState);
@@ -44,7 +57,16 @@ public class RelayStateUtil {
 
 	private static final Log _log = LogFactoryUtil.getLog(RelayStateUtil.class);
 
-	private static final ConcurrentMap<String, String> _relayStates =
-		new ConcurrentHashMap<>();
+	private static final ConcurrentMap<String, String> _relayStates;
+
+	static {
+		CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+
+		cacheBuilder.expireAfterWrite(10, TimeUnit.MINUTES);
+
+		Cache<String, String> cache = cacheBuilder.build();
+
+		_relayStates = cache.asMap();
+	}
 
 }

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/util/RelayStateUtil.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/util/RelayStateUtil.java
@@ -1,0 +1,50 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.saml.opensaml.integration.internal.util;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.opensaml.saml.common.messaging.context.SAMLBindingContext;
+
+/**
+ * @author Michael Bowerman
+ */
+public class RelayStateUtil {
+
+	public static String getRelayState(SAMLBindingContext samlBindingContext) {
+		String relayState = _relayStates.remove(
+			samlBindingContext.getRelayState());
+
+		if ((relayState == null) && _log.isWarnEnabled()) {
+			_log.warn(
+				"Unable to get relay state for key " +
+					samlBindingContext.getRelayState());
+		}
+
+		return relayState;
+	}
+
+	public static void setRelayState(
+		SAMLBindingContext samlBindingContext, String relayState) {
+
+		String uuid = PortalUUIDUtil.generate();
+
+		_relayStates.put(uuid, relayState);
+
+		samlBindingContext.setRelayState(uuid);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(RelayStateUtil.class);
+
+	private static final ConcurrentMap<String, String> _relayStates =
+		new ConcurrentHashMap<>();
+
+}

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
@@ -12,8 +12,10 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.struts.Definition;
 import com.liferay.portal.struts.TilesUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.uuid.PortalUUIDImpl;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.opensaml.integration.internal.BaseSamlTestCase;
+import com.liferay.saml.opensaml.integration.internal.helper.RelayStateHelperImpl;
 import com.liferay.saml.persistence.model.SamlIdpSpSession;
 import com.liferay.saml.persistence.model.SamlSpSession;
 import com.liferay.saml.persistence.model.impl.SamlIdpSpConnectionImpl;
@@ -82,12 +84,18 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 		_singleLogoutProfileImpl = new SingleLogoutProfileImpl();
 
 		ReflectionTestUtil.setFieldValue(
+			_relayStateHelperImpl, "_portalUUID", new PortalUUIDImpl());
+
+		ReflectionTestUtil.setFieldValue(
 			_singleLogoutProfileImpl, "identifierGenerationStrategyFactory",
 			identifierGenerationStrategyFactory);
 		ReflectionTestUtil.setFieldValue(
 			_singleLogoutProfileImpl, "metadataManager", metadataManagerImpl);
 		ReflectionTestUtil.setFieldValue(
 			_singleLogoutProfileImpl, "portal", portal);
+		ReflectionTestUtil.setFieldValue(
+			_singleLogoutProfileImpl, "_relayStateHelper",
+			_relayStateHelperImpl);
 		ReflectionTestUtil.setFieldValue(
 			_singleLogoutProfileImpl, "samlBindingProvider",
 			samlBindingProvider);
@@ -100,6 +108,9 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 		ReflectionTestUtil.setFieldValue(
 			_singleLogoutProfileImpl, "samlSpSessionLocalService",
 			_samlSpSessionLocalService);
+
+		ReflectionTestUtil.invoke(
+			_relayStateHelperImpl, "activate", new Class<?>[0]);
 
 		prepareServiceProvider(SP_ENTITY_ID);
 	}
@@ -332,6 +343,8 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 		Assert.assertEquals("test@liferay.com", nameID.getValue());
 	}
 
+	private final RelayStateHelperImpl _relayStateHelperImpl =
+		new RelayStateHelperImpl();
 	private SamlIdpSpConnectionLocalService _samlIdpSpConnectionLocalService;
 	private SamlIdpSpSessionLocalService _samlIdpSpSessionLocalService;
 	private SamlSpSessionLocalService _samlSpSessionLocalService;

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
@@ -573,12 +573,7 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 			samlPeerMetadataContext.getRoleDescriptor() instanceof
 				SPSSODescriptor);
 
-		SAMLBindingContext samlBindingContext = messageContext.getSubcontext(
-			SAMLBindingContext.class);
-
-		Assert.assertEquals(
-			RELAY_STATE,
-			_relayStateHelperImpl.getRelayState(samlBindingContext));
+		Assert.assertEquals(RELAY_STATE, samlSsoRequestContext.getRelayState());
 
 		InOutOperationContext<?, ?> inOutOperationContext =
 			messageContext.getSubcontext(InOutOperationContext.class);

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
@@ -9,13 +9,14 @@ import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.uuid.PortalUUIDImpl;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.opensaml.integration.internal.BaseSamlTestCase;
 import com.liferay.saml.opensaml.integration.internal.bootstrap.SecurityConfigurationBootstrap;
+import com.liferay.saml.opensaml.integration.internal.helper.RelayStateHelperImpl;
 import com.liferay.saml.opensaml.integration.internal.metadata.MetadataManagerImpl;
 import com.liferay.saml.opensaml.integration.internal.provider.CachingChainingMetadataResolver;
 import com.liferay.saml.opensaml.integration.internal.util.OpenSamlUtil;
-import com.liferay.saml.opensaml.integration.internal.util.RelayStateUtil;
 import com.liferay.saml.opensaml.integration.internal.util.SamlUtil;
 import com.liferay.saml.persistence.model.SamlSpAuthRequest;
 import com.liferay.saml.persistence.model.SamlSpIdpConnection;
@@ -123,11 +124,16 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 			SamlSpSessionLocalService.class);
 
 		ReflectionTestUtil.setFieldValue(
+			_relayStateHelperImpl, "_portalUUID", new PortalUUIDImpl());
+
+		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "identifierGenerationStrategyFactory",
 			identifierGenerationStrategyFactory);
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "metadataManager", metadataManagerImpl);
 		ReflectionTestUtil.setFieldValue(_webSsoProfileImpl, "portal", portal);
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "_relayStateHelper", _relayStateHelperImpl);
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "samlBindingProvider", samlBindingProvider);
 		ReflectionTestUtil.setFieldValue(
@@ -149,6 +155,9 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 			getMockPortletService(
 				SamlSpIdpConnectionLocalServiceUtil.class,
 				SamlSpIdpConnectionLocalService.class));
+
+		ReflectionTestUtil.invoke(
+			_relayStateHelperImpl, "activate", new Class<?>[0]);
 
 		_webSsoProfileImpl.activate(new HashMap<String, Object>());
 
@@ -303,7 +312,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 			SAMLBindingContext.class);
 
 		Assert.assertEquals(
-			RELAY_STATE, RelayStateUtil.getRelayState(samlBindingContext));
+			RELAY_STATE,
+			_relayStateHelperImpl.getRelayState(samlBindingContext));
 
 		Assert.assertTrue(samlSsoRequestContext.isNewSession());
 	}
@@ -364,7 +374,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 			SAMLBindingContext.class);
 
 		Assert.assertEquals(
-			RELAY_STATE, RelayStateUtil.getRelayState(samlBindingContext));
+			RELAY_STATE,
+			_relayStateHelperImpl.getRelayState(samlBindingContext));
 
 		Assert.assertTrue(samlSsoRequestContext.isNewSession());
 	}
@@ -474,7 +485,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 			SAMLBindingContext.class);
 
 		Assert.assertEquals(
-			RELAY_STATE, RelayStateUtil.getRelayState(samlBindingContext));
+			RELAY_STATE,
+			_relayStateHelperImpl.getRelayState(samlBindingContext));
 
 		Assert.assertNull(
 			mockHttpSession.getAttribute(SamlWebKeys.SAML_SSO_REQUEST_CONTEXT));
@@ -565,7 +577,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 			SAMLBindingContext.class);
 
 		Assert.assertEquals(
-			RELAY_STATE, RelayStateUtil.getRelayState(samlBindingContext));
+			RELAY_STATE,
+			_relayStateHelperImpl.getRelayState(samlBindingContext));
 
 		InOutOperationContext<?, ?> inOutOperationContext =
 			messageContext.getSubcontext(InOutOperationContext.class);
@@ -1214,8 +1227,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 
 		SamlSsoRequestContext samlSsoRequestContext = new SamlSsoRequestContext(
 			samlPeerEntityContext.getEntityId(),
-			RelayStateUtil.getRelayState(samlBindingContext), messageContext,
-			userLocalService);
+			_relayStateHelperImpl.getRelayState(samlBindingContext),
+			messageContext, userLocalService);
 
 		SAMLSelfEntityContext samlSelfEntityContext =
 			messageContext.getSubcontext(SAMLSelfEntityContext.class);
@@ -1258,6 +1271,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 			metadataManagerImpl.getSignatureTrustEngine());
 	}
 
+	private final RelayStateHelperImpl _relayStateHelperImpl =
+		new RelayStateHelperImpl();
 	private SamlSpAuthRequestLocalService _samlSpAuthRequestLocalService;
 	private SamlSpSessionLocalService _samlSpSessionLocalService;
 	private final WebSsoProfileImpl _webSsoProfileImpl =

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
@@ -15,6 +15,7 @@ import com.liferay.saml.opensaml.integration.internal.bootstrap.SecurityConfigur
 import com.liferay.saml.opensaml.integration.internal.metadata.MetadataManagerImpl;
 import com.liferay.saml.opensaml.integration.internal.provider.CachingChainingMetadataResolver;
 import com.liferay.saml.opensaml.integration.internal.util.OpenSamlUtil;
+import com.liferay.saml.opensaml.integration.internal.util.RelayStateUtil;
 import com.liferay.saml.opensaml.integration.internal.util.SamlUtil;
 import com.liferay.saml.persistence.model.SamlSpAuthRequest;
 import com.liferay.saml.persistence.model.SamlSpIdpConnection;
@@ -301,7 +302,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 		SAMLBindingContext samlBindingContext = messageContext.getSubcontext(
 			SAMLBindingContext.class);
 
-		Assert.assertEquals(RELAY_STATE, samlBindingContext.getRelayState());
+		Assert.assertEquals(
+			RELAY_STATE, RelayStateUtil.getRelayState(samlBindingContext));
 
 		Assert.assertTrue(samlSsoRequestContext.isNewSession());
 	}
@@ -361,7 +363,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 		SAMLBindingContext samlBindingContext = messageContext.getSubcontext(
 			SAMLBindingContext.class);
 
-		Assert.assertEquals(RELAY_STATE, samlBindingContext.getRelayState());
+		Assert.assertEquals(
+			RELAY_STATE, RelayStateUtil.getRelayState(samlBindingContext));
 
 		Assert.assertTrue(samlSsoRequestContext.isNewSession());
 	}
@@ -470,7 +473,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 		SAMLBindingContext samlBindingContext = messageContext.getSubcontext(
 			SAMLBindingContext.class);
 
-		Assert.assertEquals(RELAY_STATE, samlBindingContext.getRelayState());
+		Assert.assertEquals(
+			RELAY_STATE, RelayStateUtil.getRelayState(samlBindingContext));
 
 		Assert.assertNull(
 			mockHttpSession.getAttribute(SamlWebKeys.SAML_SSO_REQUEST_CONTEXT));
@@ -560,7 +564,8 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 		SAMLBindingContext samlBindingContext = messageContext.getSubcontext(
 			SAMLBindingContext.class);
 
-		Assert.assertEquals(RELAY_STATE, samlBindingContext.getRelayState());
+		Assert.assertEquals(
+			RELAY_STATE, RelayStateUtil.getRelayState(samlBindingContext));
 
 		InOutOperationContext<?, ?> inOutOperationContext =
 			messageContext.getSubcontext(InOutOperationContext.class);
@@ -1209,7 +1214,7 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 
 		SamlSsoRequestContext samlSsoRequestContext = new SamlSsoRequestContext(
 			samlPeerEntityContext.getEntityId(),
-			samlBindingContext.getRelayState(), messageContext,
+			RelayStateUtil.getRelayState(samlBindingContext), messageContext,
 			userLocalService);
 
 		SAMLSelfEntityContext samlSelfEntityContext =

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
@@ -8,8 +8,10 @@ package com.liferay.saml.opensaml.integration.internal.servlet.profile;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.uuid.PortalUUIDImpl;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.opensaml.integration.internal.BaseSamlTestCase;
+import com.liferay.saml.opensaml.integration.internal.helper.RelayStateHelperImpl;
 import com.liferay.saml.opensaml.integration.internal.util.OpenSamlUtil;
 import com.liferay.saml.persistence.model.SamlSpIdpConnection;
 import com.liferay.saml.persistence.model.impl.SamlSpIdpConnectionImpl;
@@ -84,10 +86,15 @@ public class XMLSecurityTest extends BaseSamlTestCase {
 		);
 
 		ReflectionTestUtil.setFieldValue(
+			_relayStateHelperImpl, "_portalUUID", new PortalUUIDImpl());
+
+		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "identifierGenerationStrategyFactory",
 			identifierGenerationStrategyFactory);
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "metadataManager", metadataManagerImpl);
+		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "_relayStateHelper", _relayStateHelperImpl);
 		ReflectionTestUtil.setFieldValue(_webSsoProfileImpl, "portal", portal);
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "samlBindingProvider", samlBindingProvider);
@@ -103,6 +110,9 @@ public class XMLSecurityTest extends BaseSamlTestCase {
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "samlSpSessionLocalService",
 			samlSpSessionLocalService);
+
+		ReflectionTestUtil.invoke(
+			_relayStateHelperImpl, "activate", new Class<?>[0]);
 
 		prepareServiceProvider(SP_ENTITY_ID);
 	}
@@ -346,6 +356,8 @@ public class XMLSecurityTest extends BaseSamlTestCase {
 		return encoder.withoutPadding();
 	}
 
+	private final RelayStateHelperImpl _relayStateHelperImpl =
+		new RelayStateHelperImpl();
 	private final WebSsoProfileImpl _webSsoProfileImpl =
 		new WebSsoProfileImpl();
 


### PR DESCRIPTION
I fixed the unit test failures at https://github.com/liferay-appsec/liferay-portal/pull/1273 and am re-sending this here.

At the outset, I mistakenly believed that it would be easier to fix the test failures if I converted the new class to an OSGi component. This turned out not to be true; however, I left the change in because I believe it's more in-line with the design of our codebase. Let me know if we should change it back to a static Util class.

Ticket: [LPS-76246](https://liferay.atlassian.net/browse/LPS-76246)