### PR TITLE
[TS] LPS-193127 | master

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OrganizationResourceImpl.java
@@ -567,6 +567,9 @@ public class OrganizationResourceImpl extends BaseOrganizationResourceImpl {
 				contextCompany.getCompanyId(), organization.getCustomFields(),
 				contextAcceptLanguage.getPreferredLocale()));
 
+		serviceContext.setExternalReferenceCode(
+			organization.getExternalReferenceCode());
+
 		return serviceContext;
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -294,6 +294,8 @@ public class OrganizationLocalServiceImpl
 
 		if (serviceContext != null) {
 			organization.setUuid(serviceContext.getUuid());
+			organization.setExternalReferenceCode(
+				serviceContext.getExternalReferenceCode());
 		}
 
 		organization.setCompanyId(user.getCompanyId());
@@ -2093,6 +2095,11 @@ public class OrganizationLocalServiceImpl
 			_userFileUploadsSettings.getImageMaxWidth());
 
 		organization.setExpandoBridgeAttributes(serviceContext);
+
+		if (serviceContext != null) {
+			organization.setExternalReferenceCode(
+				serviceContext.getExternalReferenceCode());
+		}
 
 		organization = organizationPersistence.update(organization);
 

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 121.0.1
+Bundle-Version: 121.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContext.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContext.java
@@ -337,6 +337,15 @@ public class ServiceContext implements Cloneable, Serializable {
 	}
 
 	/**
+	 * Returns the externalReferenceCode of an entity
+	 *
+	 * @return externalReferenceCode of an entity
+	 */
+	public String getExternalReferenceCode() {
+		return _externalReferenceCode;
+	}
+
+	/**
 	 * Returns the date when an <code>aui:form</code> was generated in this
 	 * service context. The form date can be used in detecting situations in
 	 * which an entity has been modified while another client was editing that
@@ -1225,6 +1234,15 @@ public class ServiceContext implements Cloneable, Serializable {
 	}
 
 	/**
+	 * Sets the externalReferenceCode of an entity
+	 *
+	 * @param externalReferenceCode the externalReferenceCode of an entity
+	 */
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		_externalReferenceCode = externalReferenceCode;
+	}
+
+	/**
 	 * Sets whether portal exceptions should be handled as failures, possibly
 	 * halting processing, or if exceptions should be handled differently,
 	 * possibly allowing processing to continue in some manner.
@@ -1545,6 +1563,7 @@ public class ServiceContext implements Cloneable, Serializable {
 	private boolean _deriveDefaultPermissions;
 	private Map<String, Serializable> _expandoBridgeAttributes =
 		new LinkedHashMap<>();
+	private String _externalReferenceCode;
 	private boolean _failOnPortalException = true;
 	private Date _formDate;
 	private transient Map<String, String> _headers;

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 25.1.0
+version 25.2.0


### PR DESCRIPTION
Hi team,

A customer reported it is not possible to update `externalReferenceCode` (`ERC`) in `Organization` entities using headless API through POST and PUT methods.

Analysis showed me that `ERC` field was not 'implemented' to be managed. 

Thus, the fix strategy is to use `ServiceContext` object to pass the `ERC` to insert/update impl methods.

Best regards.

References:
https://liferay.atlassian.net/browse/LPS-193127