### PR TITLE
LPS-169817 - User data does not display properly in Audit using OAuth2 & headless API

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java
@@ -9,11 +9,13 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.access.control.AccessControlUtil;
 import com.liferay.portal.kernel.security.auth.AccessControlContext;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierConfiguration;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierResult;
 import com.liferay.portal.kernel.servlet.ServletContextPool;
+import com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterChain;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -35,11 +37,14 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * <p>
@@ -124,6 +129,8 @@ public class AuthVerifierFilter extends BasePortalFilter {
 					_buildAuthVerifierConfigurations(_initParametersMap),
 					servletContext.getContextPath()));
 		}
+
+		_serviceTracker.open();
 	}
 
 	@Override
@@ -197,6 +204,19 @@ public class AuthVerifierFilter extends BasePortalFilter {
 					httpServletRequest, userId, authType);
 
 			accessControlContext.setRequest(authVerifierServletRequest);
+
+			Filter filter = _serviceTracker.getService();
+
+			if (filter != null) {
+				InvokerFilterChain invokerFilterChain = new InvokerFilterChain(
+					(servletRequest, servletResponse) -> {
+					});
+
+				invokerFilterChain.addFilter(filter);
+
+				invokerFilterChain.doFilter(
+					authVerifierServletRequest, httpServletResponse);
+			}
 
 			Class<?> clazz = getClass();
 
@@ -345,6 +365,14 @@ public class AuthVerifierFilter extends BasePortalFilter {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AuthVerifierFilter.class.getName());
+
+	private static final ServiceTracker<Filter, Filter> _serviceTracker =
+		new ServiceTracker<>(
+			SystemBundleUtil.getBundleContext(),
+			SystemBundleUtil.createFilter(
+				"(component.name=com.liferay.portal.security.audit.wiring." +
+					"internal.servlet.filter.AuditFilter)"),
+			null);
 
 	private boolean _guestAllowed = true;
 	private final Set<String> _hostsAllowed = new HashSet<>();


### PR DESCRIPTION
[LPS-169817](https://liferay.atlassian.net/browse/LPS-169817)

Re-invoke the AuditFilter after authenticating a request with AuthVerifierFilter

### Changes
The functionality was already done but reverted due to being [blocker](https://github.com/brianchandotcom/liferay-portal/pull/131045). 

The deleted commit has been re-added and the tickets that were indicated as failing have been tested. 

The reverted solution achieved keeping the AuditRequestThreadLocal mutations in the AuditFilter which is nice for maintainability.

### Tests
Tests performed successfully:

- The steps indicated in the ticket have been followed.
- The steps indicated in [LPS-176993](https://issues.liferay.com/browse/LPS-176993) and [LPS-177057](https://issues.liferay.com/browse/LPS-177057) have been followed. 