### PR TITLE
LPS-76246 Remove unneeded dependency

### DIFF
--- a/modules/dxp/apps/saml/saml-api/build.gradle
+++ b/modules/dxp/apps/saml/saml-api/build.gradle
@@ -3,7 +3,6 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
-	compileOnly group: "org.opensaml", name: "opensaml-saml-api", version: "3.3.0"
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.metatype", version: "1.3.0"


### PR DESCRIPTION
I accidentally left in an unneeded dependency in my pull request for [LPS-76246](https://liferay.atlassian.net/browse/LPS-76246). Removing it here: https://github.com/liferay-appsec/liferay-portal/commit/017baca79aafedc5440e4007b3a2029499759245

Can you make sure the ci passes and then forward it straight to BChan?