### PR TITLE
[TS] LPS-194839 

### DIFF
--- a/modules/apps/portal-security/portal-security-auto-login/src/main/java/com/liferay/portal/security/auto/login/remember/me/RememberMeAutoLogin.java
+++ b/modules/apps/portal-security/portal-security-auto-login/src/main/java/com/liferay/portal/security/auto/login/remember/me/RememberMeAutoLogin.java
@@ -106,9 +106,9 @@ public class RememberMeAutoLogin extends BaseAutoLogin {
 
 			long userId = GetterUtil.getLong(credentials[0]);
 
-			User realUser = _userLocalService.getUserById(userId);
+			User user = _userLocalService.getUserById(userId);
 
-			if ((guestUser.getUserId() == userId) || !realUser.isActive()) {
+			if ((guestUser.getUserId() == userId) || !user.isActive()) {
 				removeCookies(httpServletRequest, httpServletResponse);
 
 				return null;

--- a/modules/apps/portal-security/portal-security-auto-login/src/main/java/com/liferay/portal/security/auto/login/remember/me/RememberMeAutoLogin.java
+++ b/modules/apps/portal-security/portal-security-auto-login/src/main/java/com/liferay/portal/security/auto/login/remember/me/RememberMeAutoLogin.java
@@ -106,7 +106,9 @@ public class RememberMeAutoLogin extends BaseAutoLogin {
 
 			long userId = GetterUtil.getLong(credentials[0]);
 
-			if (guestUser.getUserId() == userId) {
+			User realUser = _userLocalService.getUserById(userId);
+
+			if ((guestUser.getUserId() == userId) || !realUser.isActive()) {
 				removeCookies(httpServletRequest, httpServletResponse);
 
 				return null;

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -907,7 +907,7 @@ public class ServicePreAction extends Action {
 			realUser = UserLocalServiceUtil.getUserById(realUserId.longValue());
 		}
 
-		if (realUser == null || !realUser.isActive()) {
+		if ((realUser == null) || !realUser.isActive()) {
 			httpSession.invalidate();
 		}
 

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -907,12 +907,8 @@ public class ServicePreAction extends Action {
 			realUser = UserLocalServiceUtil.getUserById(realUserId.longValue());
 		}
 
-		if (!user.isActive()) {
-			user = company.getGuestUser();
-
-			if (realUser == null) {
-				httpSession.invalidate();
-			}
+		if (realUser == null || !realUser.isActive()) {
+			httpSession.invalidate();
 		}
 
 		boolean signedIn = !user.isGuestUser();


### PR DESCRIPTION
### Steps to reproduce:
1. Sign in as Admin
2. Go to Control Panel > Users and Organizations > Users > Create a new user account with a password
3. Log in with that user in another browser
4. In the browser where you're logged in as administrator, deactivate the user
5. Refresh the browser in the other browser where the deactivated user's session is still active

✅ _Expected Results:_
The message “ "If you are not Firstname Lastname, log out and try again.” is displayed and  the user should be able to click on the Sign Out option in the User menu.

❌ _Actual Results:_
The message “ "If you are not Firstname Lastname, log out and try again.” is displayed, but even if the user appears to be "signed out", clicking in "Sign In" will result in a loop of messages indicating that the account is not active.

### Implementation details:
It was discovered that the section was not invalidated because this condition in [ServicePreAction](https://github.com/liferay-appsec/liferay-portal/commit/e49c2ccdc75604093832353f82ac2a965fb2de09#diff-03ac8ecc61ae0f9801e24816245e0916338c7c03a677ed976e65bc90f6ba3178L913) doesn't seem to be correct, as realUser is not null. To fix this, a verification has been added to check if the user is active. if it isn't, then the session will be invalidated.

Along with that, even if the condition around the invalidation call is removed, when "remember me" is active, RememberMeAutoLogin [logs the user in automatically](https://github.com/liferay-appsec/liferay-portal/blob/master/modules/apps/portal-security/portal-security-auto-login/src/main/java/com/liferay/portal/security/auto/login/remember/me/RememberMeAutoLogin.java#L101), so the error message keeps appearing. To avoid this issue, another verification was added so that remember me cookies can be removed if the user with the forwarded credentials is not active anymore. (https://github.com/liferay-appsec/liferay-portal/commit/0e21ff36ff60ae429f57f866f4f5b0f14d47c7ee)

### Commits included:
- LPS-194839 Avoid setting real user as guest user and check if real user is active instead
- LPS-194839 If the user is not active when remember me is marked then do automatically remove cookie so the error message is not looped in menu area
- LPS-194839 SF