### PR TITLE
LPS-76246 RelayState exceeds 80 bytes - Attempt #2

### DIFF
--- a/modules/dxp/apps/saml/saml-api/bnd.bnd
+++ b/modules/dxp/apps/saml/saml-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay SAML API
 Bundle-SymbolicName: com.liferay.saml.api
-Bundle-Version: 8.0.3
+Bundle-Version: 8.1.0
 Export-Package:\
 	com.liferay.saml.constants,\
 	com.liferay.saml.helper,\

--- a/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/helper/RelayStateHelper.java
+++ b/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/helper/RelayStateHelper.java
@@ -1,0 +1,17 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.saml.helper;
+
+/**
+ * @author Michael Bowerman
+ */
+public interface RelayStateHelper {
+
+	public String getRedirectFromRelayStateToken(String relayStateToken);
+
+	public String getRelayStateTokenFromRedirect(String redirect);
+
+}

--- a/modules/dxp/apps/saml/saml-api/src/main/resources/com/liferay/saml/helper/packageinfo
+++ b/modules/dxp/apps/saml/saml-api/src/main/resources/com/liferay/saml/helper/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelperImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelperImpl.java
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.saml.opensaml.integration.internal.helper;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import com.liferay.portal.kernel.uuid.PortalUUID;
+import com.liferay.saml.helper.RelayStateHelper;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Michael Bowerman
+ */
+@Component(service = RelayStateHelper.class)
+public class RelayStateHelperImpl implements RelayStateHelper {
+
+	public String getRedirectFromRelayStateToken(String relayStateToken) {
+		return _relayStateTokensToRedirects.get(relayStateToken);
+	}
+
+	public String getRelayStateTokenFromRedirect(String redirect) {
+		String relayStateToken = _redirectsToRelayStateTokens.get(redirect);
+
+		if (relayStateToken != null) {
+			String mappedRedirect = _relayStateTokensToRedirects.get(
+				relayStateToken);
+
+			if (Objects.equals(redirect, mappedRedirect)) {
+				return relayStateToken;
+			}
+
+			_redirectsToRelayStateTokens.remove(redirect);
+			_relayStateTokensToRedirects.remove(relayStateToken);
+		}
+
+		relayStateToken = _portalUUID.generate();
+
+		_redirectsToRelayStateTokens.put(redirect, relayStateToken);
+
+		_relayStateTokensToRedirects.put(relayStateToken, redirect);
+
+		return relayStateToken;
+	}
+
+	@Activate
+	protected void activate() {
+		CacheBuilder<Object, Object> cacheBuilder = CacheBuilder.newBuilder();
+
+		cacheBuilder.expireAfterAccess(10, TimeUnit.MINUTES);
+
+		Cache<String, String> redirectsToRelayStateTokensCache =
+			cacheBuilder.build();
+		Cache<String, String> relayStateTokensToRedirectsCache =
+			cacheBuilder.build();
+
+		_redirectsToRelayStateTokens = redirectsToRelayStateTokensCache.asMap();
+		_relayStateTokensToRedirects = relayStateTokensToRedirectsCache.asMap();
+	}
+
+	@Reference
+	private PortalUUID _portalUUID;
+
+	private ConcurrentMap<String, String> _redirectsToRelayStateTokens;
+	private ConcurrentMap<String, String> _relayStateTokensToRedirects;
+
+}

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileImpl.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.saml.constants.SamlWebKeys;
+import com.liferay.saml.helper.RelayStateHelper;
 import com.liferay.saml.helper.SamlHttpRequestHelper;
 import com.liferay.saml.opensaml.integration.internal.binding.SamlBinding;
 import com.liferay.saml.opensaml.integration.internal.transport.HttpClientFactory;
@@ -607,7 +608,8 @@ public class SingleLogoutProfileImpl
 				SAMLBindingContext.class, true);
 
 		samlBindingContext.setRelayState(
-			portal.getPortalURL(httpServletRequest));
+			_relayStateHelper.getRelayStateTokenFromRedirect(
+				portal.getPortalURL(httpServletRequest)));
 
 		outboundMessageContext.setMessage(logoutRequest);
 
@@ -1063,8 +1065,8 @@ public class SingleLogoutProfileImpl
 			terminateSsoSession(httpServletRequest, httpServletResponse);
 		}
 
-		String relayState = ParamUtil.getString(
-			httpServletRequest, "RelayState");
+		String relayState = _relayStateHelper.getRedirectFromRelayStateToken(
+			ParamUtil.getString(httpServletRequest, "RelayState"));
 
 		if (Validator.isNotNull(relayState)) {
 			httpServletResponse.sendRedirect(
@@ -1441,6 +1443,9 @@ public class SingleLogoutProfileImpl
 
 	@Reference
 	private HttpClientFactory _httpClientFactory;
+
+	@Reference
+	private RelayStateHelper _relayStateHelper;
 
 	@Reference
 	private SamlHttpRequestHelper _samlHttpRequestHelper;

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.util.URLCodec;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.saml.constants.SamlWebKeys;
+import com.liferay.saml.helper.RelayStateHelper;
 import com.liferay.saml.opensaml.integration.internal.binding.SamlBinding;
 import com.liferay.saml.opensaml.integration.internal.bootstrap.ParserPoolUtil;
 import com.liferay.saml.opensaml.integration.internal.metadata.MetadataManager;
@@ -492,7 +493,8 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			outboundMessageContext.getSubcontext(
 				SAMLBindingContext.class, true);
 
-		samlBindingContext.setRelayState(relayState);
+		samlBindingContext.setRelayState(
+			_relayStateHelper.getRelayStateTokenFromRedirect(relayState));
 
 		SAMLSelfEntityContext samlSelfEntityContext =
 			messageContext.getSubcontext(SAMLSelfEntityContext.class);
@@ -1259,7 +1261,8 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			SAMLBindingContext.class);
 
 		String relayState = portal.escapeRedirect(
-			samlBindingContext.getRelayState());
+			_relayStateHelper.getRedirectFromRelayStateToken(
+				samlBindingContext.getRelayState()));
 
 		if (Validator.isNull(relayState)) {
 			relayState = portal.getHomeURL(httpServletRequest);
@@ -2115,6 +2118,9 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 
 	@Reference
 	private NameIdResolverRegistry _nameIdResolverRegistry;
+
+	@Reference
+	private RelayStateHelper _relayStateHelper;
 
 	private SamlConfiguration _samlConfiguration;
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/SingleLogoutProfileIntegrationTest.java
@@ -12,8 +12,10 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.struts.Definition;
 import com.liferay.portal.struts.TilesUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.uuid.PortalUUIDImpl;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.opensaml.integration.internal.BaseSamlTestCase;
+import com.liferay.saml.opensaml.integration.internal.helper.RelayStateHelperImpl;
 import com.liferay.saml.persistence.model.SamlIdpSpSession;
 import com.liferay.saml.persistence.model.SamlSpSession;
 import com.liferay.saml.persistence.model.impl.SamlIdpSpConnectionImpl;
@@ -69,6 +71,9 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 
 		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
 
+		ReflectionTestUtil.setFieldValue(
+			_relayStateHelperImpl, "_portalUUID", new PortalUUIDImpl());
+
 		_samlIdpSpConnectionLocalService = getMockPortletService(
 			SamlIdpSpConnectionLocalServiceUtil.class,
 			SamlIdpSpConnectionLocalService.class);
@@ -81,6 +86,9 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 
 		_singleLogoutProfileImpl = new SingleLogoutProfileImpl();
 
+		ReflectionTestUtil.setFieldValue(
+			_singleLogoutProfileImpl, "_relayStateHelper",
+			_relayStateHelperImpl);
 		ReflectionTestUtil.setFieldValue(
 			_singleLogoutProfileImpl, "identifierGenerationStrategyFactory",
 			identifierGenerationStrategyFactory);
@@ -100,6 +108,9 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 		ReflectionTestUtil.setFieldValue(
 			_singleLogoutProfileImpl, "samlSpSessionLocalService",
 			_samlSpSessionLocalService);
+
+		ReflectionTestUtil.invoke(
+			_relayStateHelperImpl, "activate", new Class<?>[0]);
 
 		prepareServiceProvider(SP_ENTITY_ID);
 	}
@@ -332,6 +343,8 @@ public class SingleLogoutProfileIntegrationTest extends BaseSamlTestCase {
 		Assert.assertEquals("test@liferay.com", nameID.getValue());
 	}
 
+	private final RelayStateHelperImpl _relayStateHelperImpl =
+		new RelayStateHelperImpl();
 	private SamlIdpSpConnectionLocalService _samlIdpSpConnectionLocalService;
 	private SamlIdpSpSessionLocalService _samlIdpSpSessionLocalService;
 	private SamlSpSessionLocalService _samlSpSessionLocalService;

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
@@ -8,8 +8,10 @@ package com.liferay.saml.opensaml.integration.internal.servlet.profile;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.uuid.PortalUUIDImpl;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.opensaml.integration.internal.BaseSamlTestCase;
+import com.liferay.saml.opensaml.integration.internal.helper.RelayStateHelperImpl;
 import com.liferay.saml.opensaml.integration.internal.util.OpenSamlUtil;
 import com.liferay.saml.persistence.model.SamlSpIdpConnection;
 import com.liferay.saml.persistence.model.impl.SamlSpIdpConnectionImpl;
@@ -60,6 +62,9 @@ public class XMLSecurityTest extends BaseSamlTestCase {
 	public void setUp() throws Exception {
 		super.setUp();
 
+		ReflectionTestUtil.setFieldValue(
+			_relayStateHelperImpl, "_portalUUID", new PortalUUIDImpl());
+
 		SamlSpAuthRequestLocalService samlSpAuthRequestLocalService =
 			getMockPortletService(
 				SamlSpAuthRequestLocalServiceUtil.class,
@@ -90,6 +95,8 @@ public class XMLSecurityTest extends BaseSamlTestCase {
 			_webSsoProfileImpl, "metadataManager", metadataManagerImpl);
 		ReflectionTestUtil.setFieldValue(_webSsoProfileImpl, "portal", portal);
 		ReflectionTestUtil.setFieldValue(
+			_webSsoProfileImpl, "_relayStateHelper", _relayStateHelperImpl);
+		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "samlBindingProvider", samlBindingProvider);
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "samlProviderConfigurationHelper",
@@ -103,6 +110,9 @@ public class XMLSecurityTest extends BaseSamlTestCase {
 		ReflectionTestUtil.setFieldValue(
 			_webSsoProfileImpl, "samlSpSessionLocalService",
 			samlSpSessionLocalService);
+
+		ReflectionTestUtil.invoke(
+			_relayStateHelperImpl, "activate", new Class<?>[0]);
 
 		prepareServiceProvider(SP_ENTITY_ID);
 	}
@@ -346,6 +356,8 @@ public class XMLSecurityTest extends BaseSamlTestCase {
 		return encoder.withoutPadding();
 	}
 
+	private final RelayStateHelperImpl _relayStateHelperImpl =
+		new RelayStateHelperImpl();
 	private final WebSsoProfileImpl _webSsoProfileImpl =
 		new WebSsoProfileImpl();
 

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/AssertionConsumerServiceAction.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/AssertionConsumerServiceAction.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.saml.constants.SamlWebKeys;
+import com.liferay.saml.helper.RelayStateHelper;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
 import com.liferay.saml.runtime.exception.AuthnAgeException;
 import com.liferay.saml.runtime.exception.EntityInteractionException;
@@ -102,8 +103,8 @@ public class AssertionConsumerServiceAction extends BaseSamlStrutsAction {
 
 			httpSession.setAttribute(SamlWebKeys.SAML_SSO_ERROR, error);
 
-			String redirect = ParamUtil.getString(
-				httpServletRequest, "RelayState");
+			String redirect = _relayStateHelper.getRedirectFromRelayStateToken(
+				ParamUtil.getString(httpServletRequest, "RelayState"));
 
 			redirect = _portal.escapeRedirect(redirect);
 
@@ -126,6 +127,9 @@ public class AssertionConsumerServiceAction extends BaseSamlStrutsAction {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private RelayStateHelper _relayStateHelper;
 
 	@Reference
 	private SamlProviderConfigurationHelper _samlProviderConfigurationHelper;


### PR DESCRIPTION
Ticket: [LPS-76246](https://liferay.atlassian.net/browse/LPS-76246).

The [first attempt](https://github.com/brianchandotcom/liferay-portal/pull/139720) at this fix caused a regression reported at [LPS-194604](https://liferay.atlassian.net/browse/LPS-194604). The reason for the regression is that I didn't realize that there is a "RelayState" request parameter that automatically gets set (I assume by the third-party OpenSAML code) that Liferay reads in some cases to try to grab the redirect URL. These cases had not been handled by my previous fix.

The new fix handles these cases by calling the new RelayStateHelper code only when we need to convert between the RelayState token and URL. In all other cases, it just allows the RelayState token to be passed rather than converting back and forth between the token and the URL.

I realize that the new `RelayStateHelperImpl` component probably looks very overengineered, since it includes two maps (one in each direction), with an access-time-based expiration mechanism for each. Let me explain
why I designed it this way.

First, we can't "pop" from the Map that is mapping RelayState tokens toredirects, because there are some cases when we need to retrieve from the map multiple times, and we don't know at runtime when the last time is (so we can't simply separate it into "peek" and "pop"). For example, we have a call to get the RelayState inside of a `try`, and then another call to get the RelayState inside the corresponding `catch`. We don't know whether the `try` will error out, so we don't know when the "last" time we'll need to get that RelayState will be.

Therefore, the entries will need to stay in the Map, at least for a while. I imagine that in the most common case, there will only be a handful of disctinct URLs that users are logging in from, meaning that the number of distinct redirects will be relatively small. Therefore, I made the logic bidirectional by including maps in both directions. That way, we can retrieve the existing RelayState tokens rather than generating new ones over and over and storing the same URL over and over, which would be memory-inefficient.

However, it's possible that on some users' systems, they've set things up in such a way where each user is likely to have their own distinct redirect URL (for example, maybe there's some userId-related parameter in the URL that they access the login from). For these cases, it's important to have the entries expire from the map after a while so that the size of the map doesn't grow indefinitely. Therefore, I set both maps to have their entries expire after 10 minutes of having not been accessed (i.e. 10 mintues after the last read or write operation on the entry).

Let me know if you have any ideas in how to improve on this or do it in a more elegant way.