### PR TITLE
LPS-193862 - CAPTCHA verification is always failing 

### DIFF
--- a/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
+++ b/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
@@ -41,7 +41,10 @@ String url = (String)request.getAttribute("liferay-captcha:captcha:url");
 				<liferay-ui:message key="text-verification" />
 			</label>
 
-			<input aria-labelledby="<portlet:namespace />captchaLabel <portlet:namespace />captchaError" class="form-control" name="captchaText" required="<%= true %>" size="10" type="text" value="" />
+			<input
+				aria-labelledby="<portlet:namespace />captchaLabel <portlet:namespace />captchaError" class="form-control"
+				name="<portlet:namespace />captchaText" required="<%= true %>" size="10" type="text" value=""
+			/>
 
 			<c:if test="<%= Validator.isNotNull(errorMessage) %>">
 				<p class="font-weight-semi-bold mt-1 text-danger" id="<portlet:namespace />captchaError">


### PR DESCRIPTION
### Steps to Reproduce:

1. Go to Content&Data → Forms
2. Create a form with a text field
3. In the created Form screen, go to Settings → enable Require Captcha → Save
4. Copy the shared form link, and  go to the shared link
5. Input  captcha text corresponding with the image
6. Submit form

✅  Expected Result: The form is submitted successfully
 ❌  Actual Result: The form appears with the error: “Error: Text verification failed.”.
 
### Results of investigation: 
It was discovered the request parameter “captchaText” is null in the [validateChallenge method from the SimpleCaptchaImpl class](https://github.com/liferay/liferay-portal/blob/master/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/SimpleCaptchaImpl.java#L405). 
 
The cause commit: https://github.com/brianchandotcom/liferay-portal/pull/139100/commits/4e84bd5808d0071d02e5c3b7d0c6d12733b69144.

We can notice that the aui:input tag has been changed to the input tag. After inspecting the generated html on the browser page and comparing it to the older generated html, it was discovered that the "name" attribute was incomplete and did not include the portlet namespace in it.

### Commits included:

- LPS-193862 Add missing portlet namespace in input captcha text name attribute