### PR TITLE
[TS] LPS-196356 

### DIFF
--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminDisplayContext.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminDisplayContext.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.SearchDisplayStyleUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupServiceUtil;
 import com.liferay.portal.kernel.service.MembershipRequestLocalServiceUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
@@ -289,12 +288,10 @@ public class SiteAdminDisplayContext {
 			(ThemeDisplay)_httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		PermissionChecker permissionChecker =
-			themeDisplay.getPermissionChecker();
-
 		if (!group.isCompany() &&
 			PortalPermissionUtil.contains(
-				permissionChecker, ActionKeys.ADD_COMMUNITY)) {
+				themeDisplay.getPermissionChecker(),
+				ActionKeys.ADD_COMMUNITY)) {
 
 			return true;
 		}

--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminDisplayContext.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminDisplayContext.java
@@ -27,7 +27,6 @@ import com.liferay.portal.kernel.service.MembershipRequestLocalServiceUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserGroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
 import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -294,10 +293,8 @@ public class SiteAdminDisplayContext {
 			themeDisplay.getPermissionChecker();
 
 		if (!group.isCompany() &&
-			(PortalPermissionUtil.contains(
-				permissionChecker, ActionKeys.ADD_COMMUNITY) ||
-			 GroupPermissionUtil.contains(
-				 permissionChecker, group, ActionKeys.ADD_COMMUNITY))) {
+			PortalPermissionUtil.contains(
+				permissionChecker, ActionKeys.ADD_COMMUNITY)) {
 
 			return true;
 		}


### PR DESCRIPTION
### Steps to reproduce:

1. Start the bundle and log in as admin
2. Control Panel > Users and Organisations, create a new user
3. Add the new user as a member of Liferay DXP site on the Membership tab
4. At the Roles tab, add the new user as Site administrator of Liferay DXP site
5. Control Panel > Roles, Select User role, Define permissions tab > Control Panel > Sites > Sites
6. Add 'Access in Control Panel' and 'View' APPLICATION PERMISSIONS
7. Impersonate the user and navigate to Control Panel > Sites
8. At the kebab menu of Liferay DXP site, click on Add child site



✅ _Expected result:_ there is no Add child site button for the user, since it has only Access and View permission
❌ _Actual result:_ button is there, but when clicked, error message appears showing, that there is no permission

### Results of investigation
I was investigating the class that renders the dropdown items for the site and it calls the method [hasAddChildSitePermission](https://github.com/liferay/liferay-portal/blob/master/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/servlet/taglib/util/SiteActionDropdownItemsProvider.java#L93) to check the permission related to adding the child page. This method is from the SiteAdminDisplayContext class. It will check[ if the permission is contained in PortalPermissionUtil or GroupPermissionUtil](https://github.com/liferay/liferay-portal/blob/master/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminDisplayContext.java#L297).

Furthermore I investigated the render class for the child page (SelectSiteInitializerMVCRenderCommand) since the permission error message appears there after we click the button. It has a similar verification, but [only checks inside the PortalPermission class](https://github.com/liferay/liferay-portal/blob/master/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/action/SelectSiteInitializerMVCRenderCommand.java#L42).

It turns out that PortalPermissionUtil verification returns false as it should, but it is accompanied by GroupPermissionUtil.contains(permissionChecker, group, ActionKeys.ADD_COMMUNITY), which returns true. This is why this item would always appear in the dropdown. To match the permission logic that renders the child site, it was necessary to remove the verification by group permission.

### Commits included:
- LPS-196356 Remove verification by group permission
- LPS-196356 SF
