### PR TITLE
LPS-159271 Add the email address of the impersonated user

### DIFF
--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/java/com/liferay/portal/security/audit/event/generators/util/AuditMessageBuilder.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/java/com/liferay/portal/security/audit/event/generators/util/AuditMessageBuilder.java
@@ -60,6 +60,8 @@ public class AuditMessageBuilder {
 
 		if ((realUserId > 0) && (userId != realUserId)) {
 			additionalInfoJSONObject.put(
+				"doAsUserEmailAddress", PortalUtil.getUserEmailAddress(userId)
+			).put(
 				"doAsUserId", String.valueOf(userId)
 			).put(
 				"doAsUserName", PortalUtil.getUserName(userId, StringPool.BLANK)

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/events/ImpersonationAction.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/events/ImpersonationAction.java
@@ -82,6 +82,8 @@ public class ImpersonationAction extends Action {
 					_jsonFactory.createJSONObject();
 
 				additionalInfoJSONObject.put(
+					"userEmailAddress", user.getEmailAddress()
+				).put(
 					"userId", user.getUserId()
 				).put(
 					"userName", user.getFullName()

--- a/portal-impl/src/com/liferay/portal/action/LayoutAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LayoutAction.java
@@ -309,9 +309,11 @@ public class LayoutAction implements Action {
 						(realUser.getUserId() != user.getUserId())) {
 
 						additionalInfoJSONObject = JSONUtil.put(
-							"userId", user.getUserId()
+							"doAsUserId", user.getUserId()
 						).put(
-							"userName", user.getFullName()
+							"doAsUserName", user.getFullName()
+						).put(
+							"doAsUserEmailAddress", user.getEmailAddress()
 						);
 					}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessage.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessage.java
@@ -5,15 +5,18 @@
 
 package com.liferay.portal.kernel.audit;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalRunMode;
+import com.liferay.portal.kernel.util.PortalUtil;
 
 import java.io.Serializable;
 
@@ -99,6 +102,24 @@ public class AuditMessage implements Serializable {
 		_userEmailAddress = auditRequestThreadLocal.getRealUserEmailAddress();
 
 		long realUserId = auditRequestThreadLocal.getRealUserId();
+
+		long doAsUserId = 0;
+
+		if (PrincipalThreadLocal.getName() != null) {
+			doAsUserId = GetterUtil.getLong(PrincipalThreadLocal.getName());
+		}
+
+		if ((realUserId > 0) && (doAsUserId != realUserId) &&
+			!_additionalInfoJSONObject.has("doAsUserId")) {
+
+			_additionalInfoJSONObject.put(
+				"doAsUserEmailAddress", PortalUtil.getUserEmailAddress(doAsUserId)
+			).put(
+				"doAsUserId", String.valueOf(doAsUserId)
+			).put(
+				"doAsUserName", PortalUtil.getUserName(doAsUserId, StringPool.BLANK)
+			);
+		}
 
 		if (userId == realUserId) {
 			_userLogin = auditRequestThreadLocal.getRealUserLogin();


### PR DESCRIPTION
Only a WIP PR


`AuditMessageBuilder`, `LayoutAction`, `ImpersonationAction` pass in the `realUserId` and `realUserName` when creating the `AuditMessage`. Thus, the change in `AuditMessage` is supposed to cover the rest of the cases when impersonation is not handled separately. It is not confirmed at this point that in these remaining cases whether we actually use the ID and name of the impersonated user. If we do, the current changes in `AuditMessage` could handle those cases.
Questions open:
1. `AuditMessage`: how to access the `emailAddress` of the impersonated user (`AuditMsgBuilder` uses `PortalUtil`)
2. How can we determine we really do use the name and ID of the impersonated user when the `AuditMsg` is constructed directly (so not in `AuditMsgBuilder` and also excluding `LayoutAction`, `ImpersonationAction`, these are already covering the impersonation related checks).
3. Where and how would it be best to test the new field for all the different cases?