### PR TITLE
[TS] LPS-196784 Redirect back to the Sign In widget instead of continuing to display the Forgot Password or Create Account screens

### DIFF
--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/CreateAccountNavigationPostPageInclude.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/CreateAccountNavigationPostPageInclude.java
@@ -73,6 +73,9 @@ public class CreateAccountNavigationPostPageInclude implements PageInclude {
 		iconTag.setCssClass("text-4");
 		iconTag.setMessage("create-account");
 
+		httpServletRequest.setAttribute(
+			"redirect", _portal.getCurrentURL(httpServletRequest));
+
 		try {
 			iconTag.setUrl(
 				_portal.getCreateAccountURL(httpServletRequest, themeDisplay));

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/ForgetPasswordNavigationPostPageInclude.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/ForgetPasswordNavigationPostPageInclude.java
@@ -7,6 +7,7 @@ package com.liferay.login.web.internal.servlet.taglib.include;
 
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.include.PageInclude;
 import com.liferay.taglib.portlet.RenderURLTag;
@@ -21,6 +22,7 @@ import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.PageContext;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Shuyang Zhou
@@ -61,6 +63,8 @@ public class ForgetPasswordNavigationPostPageInclude implements PageInclude {
 
 		renderURLTag.addParam("saveLastPath", Boolean.FALSE.toString());
 		renderURLTag.addParam("mvcRenderCommandName", "/login/forgot_password");
+		renderURLTag.addParam(
+			"redirect", _portal.getCurrentURL(httpServletRequest));
 		renderURLTag.setVar("forgotPasswordURL");
 		renderURLTag.setWindowState(WindowState.MAXIMIZED.toString());
 
@@ -77,5 +81,8 @@ public class ForgetPasswordNavigationPostPageInclude implements PageInclude {
 
 		iconTag.doTag(pageContext);
 	}
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/create_account.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/create_account.jsp
@@ -10,6 +10,10 @@
 <%
 String redirect = ParamUtil.getString(request, "redirect");
 
+if (Validator.isNotNull(redirect)) {
+	portletDisplay.setURLBack(redirect);
+}
+
 boolean male = ParamUtil.getBoolean(request, "male", true);
 
 Calendar birthdayCalendar = CalendarFactoryUtil.getCalendar();

--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/forgot_password.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/forgot_password.jsp
@@ -8,6 +8,12 @@
 <%@ include file="/init.jsp" %>
 
 <%
+String redirect = ParamUtil.getString(request, "redirect");
+
+if (Validator.isNotNull(redirect)) {
+	portletDisplay.setURLBack(redirect);
+}
+
 User user2 = (User)request.getAttribute(WebKeys.FORGOT_PASSWORD_REMINDER_USER);
 
 if (Validator.isNull(authType)) {

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1920,6 +1920,8 @@ public class PortalImpl implements Portal {
 					PortletRequest.RENDER_PHASE)
 			).setMVCRenderCommandName(
 				"/login/create_account"
+			).setRedirect(
+				httpServletRequest.getAttribute("redirect")
 			).setParameter(
 				"saveLastPath", false
 			).setPortletMode(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-196784

When switching from the maximized screens of the Forgot Password or Create Account pages the Sign In widget continues to render those screens. By setting the back URL it will now switch back to the regular Sign In fields.

If there are any issues or concerns please let me know.