### PR TITLE
LPS-197277

### DIFF
--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/CountryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/CountryResourceImpl.java
@@ -118,8 +118,10 @@ public class CountryResourceImpl extends BaseCountryResourceImpl {
 				ServiceContextFactory.getInstance(
 					Country.class.getName(), contextHttpServletRequest));
 
-		_countryLocalService.updateCountryLocalizations(
-			serviceBuilderCountry, country.getTitle_i18n());
+		if (country.getTitle_i18n() != null) {
+			_countryLocalService.updateCountryLocalizations(
+				serviceBuilderCountry, country.getTitle_i18n());
+		}
 
 		return _toCountry(
 			_countryLocalService.updateGroupFilterEnabled(
@@ -141,8 +143,10 @@ public class CountryResourceImpl extends BaseCountryResourceImpl {
 				GetterUtil.getBoolean(country.getShippingAllowed(), true),
 				GetterUtil.getBoolean(country.getSubjectToVAT()));
 
-		_countryLocalService.updateCountryLocalizations(
-			serviceBuilderCountry, country.getTitle_i18n());
+		if (country.getTitle_i18n() != null) {
+			_countryLocalService.updateCountryLocalizations(
+				serviceBuilderCountry, country.getTitle_i18n());
+		}
 
 		return _toCountry(
 			_countryService.updateGroupFilterEnabled(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-197277

Changes from [LPS-191338](https://liferay.atlassian.net/browse/LPS-191338) cause a test failure and potential regression.  When using headless API POST or PUT methods for the Country object, if we remove the `title_i18n` field, we will throw a NPE.

I chose to not update country localizations with a `null` title because we allow for empty titles in countries.  Further, if we want to update some parts of a country without changing the title, excluding the `title_i18n` field will provide that functionality.

Please let me know if you have any questions, thanks!