### PR TITLE
[TS] LPS-173047 Anonymous users are exported to LDAP

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserExporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserExporterImpl.java
@@ -434,7 +434,7 @@ public class LDAPUserExporterImpl implements UserExporter {
 			String.format(
 				"(&(companyId=%s)(service.factoryPid=%s))", companyId,
 				"com.liferay.user.associated.data.web.internal.configuration." +
-					"AnonymousUserConfiguration"));
+					"AnonymousUserConfiguration.scoped"));
 
 		if (configurations == null) {
 			return null;

--- a/modules/apps/portal-security/portal-security-ldap-test/build.gradle
+++ b/modules/apps/portal-security/portal-security-ldap-test/build.gradle
@@ -4,8 +4,10 @@ dependencies {
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	testIntegrationImplementation project(":apps:portal-security:portal-security-export-import-api")
 	testIntegrationImplementation project(":apps:portal-security:portal-security-ldap-api")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
+	testIntegrationImplementation project(":apps:user-associated-data:user-associated-data-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/portal-security/portal-security-ldap-test/src/testIntegration/java/com/liferay/portal/security/ldap/internal/exportimport/test/LDAPUserExporterImplTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-test/src/testIntegration/java/com/liferay/portal/security/ldap/internal/exportimport/test/LDAPUserExporterImplTest.java
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.ldap.internal.exportimport.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.security.ldap.exportimport.LDAPUserImporter;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.user.associated.data.anonymizer.UADAnonymousUserProvider;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Istvan Sajtos
+ */
+@RunWith(Arquillian.class)
+public class LDAPUserExporterImplTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testAnonymousUserExport() throws Exception {
+		User user1 = _uadAnonymousUserProvider.getAnonymousUser(
+			TestPropsValues.getCompanyId());
+
+		Assert.assertNotNull(user1);
+
+		user1 = _userLocalService.updateUser(user1);
+
+		User user2 = _ldapUserImporter.importUser(
+			user1.getCompanyId(), user1.getEmailAddress(),
+			user1.getScreenName());
+
+		Assert.assertNull(user2);
+	}
+
+	@Inject
+	private LDAPUserImporter _ldapUserImporter;
+
+	@Inject
+	private UADAnonymousUserProvider _uadAnonymousUserProvider;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/anonymizer/UADAnonymousUserProviderImpl.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/anonymizer/UADAnonymousUserProviderImpl.java
@@ -75,7 +75,7 @@ public class UADAnonymousUserProviderImpl implements UADAnonymousUserProvider {
 		}
 	}
 
-	private User _createAnonymousUser(long companyId) throws Exception {
+	private User _addAnonymousUser(long companyId) throws Exception {
 		User user = _userLocalService.createUser(
 			_counterLocalService.increment());
 
@@ -163,7 +163,7 @@ public class UADAnonymousUserProviderImpl implements UADAnonymousUserProvider {
 			companyId);
 
 		if (configuration == null) {
-			User anonymousUser = _createAnonymousUser(companyId);
+			User anonymousUser = _addAnonymousUser(companyId);
 
 			_configurationProvider.saveCompanyConfiguration(
 				AnonymousUserConfiguration.class, companyId,
@@ -191,7 +191,7 @@ public class UADAnonymousUserProviderImpl implements UADAnonymousUserProvider {
 			return anonymousUser;
 		}
 
-		anonymousUser = _createAnonymousUser(companyId);
+		anonymousUser = _addAnonymousUser(companyId);
 
 		properties.put("userId", anonymousUser.getUserId());
 

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/anonymizer/UADAnonymousUserProviderImpl.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/anonymizer/UADAnonymousUserProviderImpl.java
@@ -173,9 +173,7 @@ public class UADAnonymousUserProviderImpl implements UADAnonymousUserProvider {
 					"userId", anonymousUser.getUserId()
 				).build());
 
-			_updateStatus(anonymousUser);
-
-			return anonymousUser;
+			return _updateStatus(anonymousUser);
 		}
 
 		Dictionary<String, Object> properties = configuration.getProperties();
@@ -197,13 +195,11 @@ public class UADAnonymousUserProviderImpl implements UADAnonymousUserProvider {
 
 		configuration.update(properties);
 
-		_updateStatus(anonymousUser);
-
-		return anonymousUser;
+		return _updateStatus(anonymousUser);
 	}
 
-	private void _updateStatus(User anonymousUser) throws Exception {
-		_userLocalService.updateStatus(
+	private User _updateStatus(User anonymousUser) throws Exception {
+		return _userLocalService.updateStatus(
 			anonymousUser.getUserId(), WorkflowConstants.STATUS_INACTIVE,
 			new ServiceContext());
 	}

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/anonymizer/UADAnonymousUserProviderImpl.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/anonymizer/UADAnonymousUserProviderImpl.java
@@ -13,6 +13,8 @@ import com.liferay.portal.configuration.module.configuration.ConfigurationProvid
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Contact;
+import com.liferay.portal.kernel.model.ContactConstants;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.PasswordPolicy;
 import com.liferay.portal.kernel.model.User;
@@ -105,6 +107,7 @@ public class UADAnonymousUserProviderImpl implements UADAnonymousUserProvider {
 		String jobTitle = StringPool.BLANK;
 
 		user.setCompanyId(companyId);
+		user.setContactId(_counterLocalService.increment());
 		user.setPassword(randomString);
 		user.setScreenName(screenName);
 		user.setEmailAddress(emailAddress);
@@ -130,6 +133,27 @@ public class UADAnonymousUserProviderImpl implements UADAnonymousUserProvider {
 			GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION,
 			StringPool.SLASH + screenName, false, true, null);
 
+		Contact contact = _contactLocalService.createContact(
+			user.getContactId());
+
+		contact.setCompanyId(companyId);
+		contact.setUserId(user.getUserId());
+		contact.setUserName(user.getFullName());
+		contact.setClassName(User.class.getName());
+		contact.setClassPK(user.getUserId());
+		contact.setParentContactId(ContactConstants.DEFAULT_PARENT_CONTACT_ID);
+		contact.setEmailAddress(user.getEmailAddress());
+		contact.setFirstName(firstName);
+		contact.setMiddleName(middleName);
+		contact.setLastName(lastName);
+		contact.setPrefixListTypeId(prefixListTypeId);
+		contact.setSuffixListTypeId(suffixListTypeId);
+		contact.setMale(true);
+		contact.setBirthday(
+			_portal.getDate(birthdayMonth, birthdayDay, birthdayYear));
+		contact.setJobTitle(jobTitle);
+
+		_contactLocalService.addContact(contact);
 
 		return user;
 	}

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/anonymizer/UADAnonymousUserProviderImpl.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/anonymizer/UADAnonymousUserProviderImpl.java
@@ -13,11 +13,13 @@ import com.liferay.portal.configuration.module.configuration.ConfigurationProvid
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.PasswordPolicy;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserConstants;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ContactLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.PasswordPolicyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -121,6 +123,13 @@ public class UADAnonymousUserProviderImpl implements UADAnonymousUserProvider {
 
 		_userLocalService.addUser(user);
 
+		_groupLocalService.addGroup(
+			user.getUserId(), GroupConstants.DEFAULT_PARENT_GROUP_ID,
+			User.class.getName(), user.getUserId(),
+			GroupConstants.DEFAULT_LIVE_GROUP_ID, null, null, 0, true,
+			GroupConstants.DEFAULT_MEMBERSHIP_RESTRICTION,
+			StringPool.SLASH + screenName, false, true, null);
+
 
 		return user;
 	}
@@ -193,6 +202,9 @@ public class UADAnonymousUserProviderImpl implements UADAnonymousUserProvider {
 
 	@Reference
 	private CounterLocalService _counterLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private PasswordPolicyLocalService _passwordPolicyLocalService;

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/anonymizer/UADAnonymousUserProviderImpl.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/anonymizer/UADAnonymousUserProviderImpl.java
@@ -17,11 +17,14 @@ import com.liferay.portal.kernel.model.PasswordPolicy;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserConstants;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ContactLocalService;
 import com.liferay.portal.kernel.service.PasswordPolicyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.security.pwd.PwdToolkitUtil;
 import com.liferay.user.associated.data.anonymizer.UADAnonymousUserProvider;
@@ -69,7 +72,8 @@ public class UADAnonymousUserProviderImpl implements UADAnonymousUserProvider {
 	}
 
 	private User _createAnonymousUser(long companyId) throws Exception {
-		long creatorUserId = 0;
+		User user = _userLocalService.createUser(
+			_counterLocalService.increment());
 
 		PasswordPolicy passwordPolicy =
 			_passwordPolicyLocalService.getDefaultPasswordPolicy(companyId);
@@ -98,26 +102,27 @@ public class UADAnonymousUserProviderImpl implements UADAnonymousUserProvider {
 		int birthdayYear = 1970;
 		String jobTitle = StringPool.BLANK;
 
-		User anonymousUser = _userLocalService.addUser(
-			creatorUserId, companyId, false, randomString, randomString, false,
-			screenName, emailAddress, locale, firstName, middleName, lastName,
-			prefixListTypeId, suffixListTypeId, true, birthdayMonth,
-			birthdayDay, birthdayYear, jobTitle, UserConstants.TYPE_REGULAR,
-			null, null, null, null, false, null);
-
-		anonymousUser.setComments(
+		user.setCompanyId(companyId);
+		user.setPassword(randomString);
+		user.setScreenName(screenName);
+		user.setEmailAddress(emailAddress);
+		user.setLanguageId(LocaleUtil.toLanguageId(locale));
+		user.setComments(
 			StringBundler.concat(
 				"This user is automatically created by the UAD application. ",
 				"Application data anonymized by Personal Data Erasure will be ",
 				"assigned to this user."));
+		user.setFirstName(firstName);
+		user.setMiddleName(middleName);
+		user.setLastName(lastName);
+		user.setJobTitle(jobTitle);
+		user.setType(UserConstants.TYPE_REGULAR);
+		user.setStatus(WorkflowConstants.STATUS_INCOMPLETE);
 
-		anonymousUser = _userLocalService.updateUser(anonymousUser);
+		_userLocalService.addUser(user);
 
-		_userLocalService.updateStatus(
-			anonymousUser.getUserId(), WorkflowConstants.STATUS_INACTIVE,
-			new ServiceContext());
 
-		return anonymousUser;
+		return user;
 	}
 
 	private User _getAnonymousUser(long companyId) throws Exception {
@@ -134,6 +139,8 @@ public class UADAnonymousUserProviderImpl implements UADAnonymousUserProvider {
 				).put(
 					"userId", anonymousUser.getUserId()
 				).build());
+
+			_updateStatus(anonymousUser);
 
 			return anonymousUser;
 		}
@@ -157,7 +164,15 @@ public class UADAnonymousUserProviderImpl implements UADAnonymousUserProvider {
 
 		configuration.update(properties);
 
+		_updateStatus(anonymousUser);
+
 		return anonymousUser;
+	}
+
+	private void _updateStatus(User anonymousUser) throws Exception {
+		_userLocalService.updateStatus(
+			anonymousUser.getUserId(), WorkflowConstants.STATUS_INACTIVE,
+			new ServiceContext());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
@@ -174,10 +189,16 @@ public class UADAnonymousUserProviderImpl implements UADAnonymousUserProvider {
 	private ConfigurationProvider _configurationProvider;
 
 	@Reference
+	private ContactLocalService _contactLocalService;
+
+	@Reference
 	private CounterLocalService _counterLocalService;
 
 	@Reference
 	private PasswordPolicyLocalService _passwordPolicyLocalService;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/configuration/persistence/listener/AnonymousUserConfigurationModelListener.java
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/java/com/liferay/user/associated/data/web/internal/configuration/persistence/listener/AnonymousUserConfigurationModelListener.java
@@ -16,6 +16,7 @@ import com.liferay.user.associated.data.web.internal.configuration.AnonymousUser
 import com.liferay.user.associated.data.web.internal.configuration.AnonymousUserConfigurationRetriever;
 
 import java.util.Dictionary;
+import java.util.Locale;
 import java.util.ResourceBundle;
 
 import org.osgi.service.cm.Configuration;
@@ -72,9 +73,14 @@ public class AnonymousUserConfigurationModelListener
 			return;
 		}
 
+		Locale locale = LocaleThreadLocal.getThemeDisplayLocale();
+
+		if (locale == null) {
+			locale = LocaleThreadLocal.getDefaultLocale();
+		}
+
 		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
-			"content.Language", LocaleThreadLocal.getThemeDisplayLocale(),
-			getClass());
+			"content.Language", locale, getClass());
 
 		String message = ResourceBundleUtil.getString(
 			resourceBundle,

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -335,6 +335,11 @@ public class PortalUpgradeProcessRegistryImpl
 			new GuestUnsupportedResourcePermissionsUpgradeProcess(
 				Group.class.getName(), ActionKeys.CONFIGURE_PORTLETS,
 				ActionKeys.VIEW_SITE_ADMINISTRATION));
+
+		upgradeVersionTreeMap.put(
+			new Version(28, 0, 2),
+			UpgradeModulesFactory.create(
+				new String[] {"com.liferay.user.associated.data.web"}, null));
 	}
 
 }


### PR DESCRIPTION
[LPS-173047](https://liferay.atlassian.net/browse/LPS-173047)
Hi,

This is the continuation of https://github.com/liferay-appsec/liferay-portal/pull/1376.

I removed the commit [15d4e9e](https://github.com/liferay-appsec/liferay-portal/pull/1376/commits/15d4e9e6226d74b6025f84ee762149e874e2ed08) which was responsible for the regression and the test change https://github.com/liferay-appsec/liferay-portal/pull/1376/commits/74c0265348d193d7257b9e0239eb3fde9cb4a416 which was necessary only for the removed commit.

The reason why [15d4e9e](https://github.com/liferay-appsec/liferay-portal/pull/1376/commits/15d4e9e6226d74b6025f84ee762149e874e2ed08) causes regression is coming from UADAnonymousUserProviderImpl.isAnonymousUser(user), which creates an anonymous user when none is found (i.e. no related configuration entry is found). At upgrade, when running at startup, creating an anonymous user (and related configuration) from LDAPUserExporterImpl will cause the failure of the upgrade of the old configuration entry. Therefore I need a check that doesn't create a new configuration entry. 

Please let me know if you have any questions.

Thank you,
Istvan

cc @zsigmondrab @gaborlovasdotcom 