### PR TITLE
LPS-197277

### DIFF
--- a/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/CountryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/CountryResourceImpl.java
@@ -7,6 +7,7 @@ package com.liferay.headless.admin.address.internal.resource.v1_0;
 
 import com.liferay.headless.admin.address.dto.v1_0.Country;
 import com.liferay.headless.admin.address.resource.v1_0.CountryResource;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.CountryTable;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
 import com.liferay.portal.kernel.search.Sort;
@@ -15,6 +16,7 @@ import com.liferay.portal.kernel.service.CountryService;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
 import com.liferay.portal.odata.entity.DoubleEntityField;
@@ -25,7 +27,10 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -118,6 +123,16 @@ public class CountryResourceImpl extends BaseCountryResourceImpl {
 				ServiceContextFactory.getInstance(
 					Country.class.getName(), contextHttpServletRequest));
 
+		if (country.getTitle_i18n() == null) {
+			Map<String, String> titleMap = new HashMap<>();
+
+			for (Locale locale : _language.getAvailableLocales()) {
+				titleMap.put(_language.getLanguageId(locale), null);
+			}
+
+			country.setTitle_i18n(titleMap);
+		}
+
 		_countryLocalService.updateCountryLocalizations(
 			serviceBuilderCountry, country.getTitle_i18n());
 
@@ -140,6 +155,16 @@ public class CountryResourceImpl extends BaseCountryResourceImpl {
 				GetterUtil.getDouble(country.getPosition()),
 				GetterUtil.getBoolean(country.getShippingAllowed(), true),
 				GetterUtil.getBoolean(country.getSubjectToVAT()));
+
+		if (country.getTitle_i18n() == null) {
+			Map<String, String> titleMap = new HashMap<>();
+
+			for (Locale locale : _language.getAvailableLocales()) {
+				titleMap.put(_language.getLanguageId(locale), null);
+			}
+
+			country.setTitle_i18n(titleMap);
+		}
 
 		_countryLocalService.updateCountryLocalizations(
 			serviceBuilderCountry, country.getTitle_i18n());
@@ -192,5 +217,11 @@ public class CountryResourceImpl extends BaseCountryResourceImpl {
 
 	@Reference
 	private CountryService _countryService;
+
+	@Reference
+	private Language _language;
+
+	@Reference
+	private Localization _localization;
 
 }


### PR DESCRIPTION
Resent from https://github.com/liferay-appsec/liferay-portal/pull/1406

My changes in the previous PR would result in no localization changes when not passed the title_i18n attribute.  This is incorrect, since POST should save blank localizations and PUT should overwrite existing localizations with blank ones.  The logic in this PR resolves the issue across all request types.

PATCH is not affected, since [passing in a null value results in the existing localizations being used instead](https://github.com/liferay/liferay-portal/blob/master/modules/apps/headless/headless-admin-address/headless-admin-address-impl/src/main/java/com/liferay/headless/admin/address/internal/resource/v1_0/BaseCountryResourceImpl.java#L558-L560).

Please let me know if you have any questions, thanks!