### PR TITLE
[TS] LPS-196784 Do not restore current view to avoid showing the forgot pass or create account screens when navigating back

### DIFF
--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/LoginPortlet.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/LoginPortlet.java
@@ -27,6 +27,7 @@ import org.osgi.service.component.annotations.Reference;
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",
 		"com.liferay.portlet.render-weight=50",
+		"com.liferay.portlet.restore-current-view=false",
 		"com.liferay.portlet.single-page-application=false",
 		"com.liferay.portlet.use-default-template=true",
 		"javax.portlet.display-name=Sign In",


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-196784

Previous fix reviewed under https://github.com/liferay-appsec/liferay-portal/pull/1401
Previous fix reverted under https://github.com/liferay-appsec/liferay-portal/pull/1419 due to https://liferay.atlassian.net/browse/LPS-197914

This fix instead of trying to maintain the redirect simply disables the _Restore Current View_ functionality. This makes it so that when going from a maximized Sign In widget back to the normal sized widget it renders the sign in fields instead of the Forgot Password or Create Account fields.

Please let me know if there are any concerns with this change. Based on the previous fix causing a regression for Commerce it seems this flow is rather fragile so I want to make sure nothing else is depending on the current view being maintained.