### PR TITLE
[TS] LPS-194839 

### DIFF
--- a/modules/apps/portal-security/portal-security-auto-login/src/main/java/com/liferay/portal/security/auto/login/remember/me/RememberMeAutoLogin.java
+++ b/modules/apps/portal-security/portal-security-auto-login/src/main/java/com/liferay/portal/security/auto/login/remember/me/RememberMeAutoLogin.java
@@ -106,7 +106,11 @@ public class RememberMeAutoLogin extends BaseAutoLogin {
 
 			long userId = GetterUtil.getLong(credentials[0]);
 
-			if (guestUser.getUserId() == userId) {
+			User user = _userLocalService.fetchUserById(userId);
+
+			if ((user == null) || (guestUser.getUserId() == userId) ||
+				!user.isActive()) {
+
 				removeCookies(httpServletRequest, httpServletResponse);
 
 				return null;

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/servlet/taglib/util/UserActionDropdownItems.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/servlet/taglib/util/UserActionDropdownItems.java
@@ -106,7 +106,7 @@ public class UserActionDropdownItems {
 						!PropsValues.PORTAL_JAAS_ENABLE &&
 						PropsValues.PORTAL_IMPERSONATION_ENABLE &&
 						(_user.getUserId() != _themeDisplay.getUserId()) &&
-						!_themeDisplay.isImpersonated() &&
+						_user.isActive() && !_themeDisplay.isImpersonated() &&
 						UserPermissionUtil.contains(
 							_themeDisplay.getPermissionChecker(),
 							_user.getUserId(), ActionKeys.IMPERSONATE),

--- a/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
+++ b/portal-impl/src/com/liferay/portal/events/ServicePreAction.java
@@ -907,12 +907,8 @@ public class ServicePreAction extends Action {
 			realUser = UserLocalServiceUtil.getUserById(realUserId.longValue());
 		}
 
-		if (!user.isActive()) {
-			user = company.getGuestUser();
-
-			if (realUser == null) {
-				httpSession.invalidate();
-			}
+		if (!user.isActive() && (realUserId == user.getUserId())) {
+			httpSession.invalidate();
 		}
 
 		boolean signedIn = !user.isGuestUser();

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -7117,6 +7117,16 @@ public class PortalImpl implements Portal {
 
 		User doAsUser = UserLocalServiceUtil.getUserById(doAsUserId);
 
+		if (!doAsUser.isActive()) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to impersonate " + doAsUserIdString +
+						" because the user is not active");
+			}
+
+			return 0;
+		}
+
 		User realUser = UserLocalServiceUtil.getUserById(
 			realUserIdObj.longValue());
 


### PR DESCRIPTION
For steps to reproduce and implementation details, please check: https://github.com/liferay-appsec/liferay-portal/pull/1343

-  LPS-194839 Avoid setting user as guest user and check if user is active and not impersonated instead
- LPS-194839 If the user is not active when remember me is marked then do automatically remove cookie so the error message is not looped in menu area
- LPS-194839 Remove impersonation if the value of the doAsUserId parameter is from an inactive user
- LPS-194839 Remove the impersonate option from the actions menu of an inactive user
