### PR TITLE
LPS-198665 - AccountEntry permission validation 

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/AccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/AccountResourceImpl.java
@@ -271,8 +271,8 @@ public class AccountResourceImpl extends BaseAccountResourceImpl {
 				address.getStreet1(), address.getStreet2(),
 				address.getStreet3(), address.getCity(), address.getZip(),
 				address.getRegionId(), address.getCountryId(),
-				address.getListTypeId(), address.getMailing(),
-				address.getPrimary(), address.getPhoneNumber(),
+				address.getListTypeId(), address.isMailing(),
+				address.isPrimary(), address.getPhoneNumber(),
 				_createServiceContext(account));
 		}
 
@@ -324,8 +324,8 @@ public class AccountResourceImpl extends BaseAccountResourceImpl {
 				address.getDescription(), address.getStreet1(),
 				address.getStreet2(), address.getStreet3(), address.getCity(),
 				address.getZip(), address.getRegionId(), address.getCountryId(),
-				address.getListTypeId(), address.getMailing(),
-				address.getPrimary(), address.getPhoneNumber(),
+				address.getListTypeId(), address.isMailing(),
+				address.isPrimary(), address.getPhoneNumber(),
 				_createServiceContext(account));
 		}
 

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/PostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/PostalAddressResourceImpl.java
@@ -209,8 +209,8 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 		ListType listType = _getListType(postalAddress);
 
 		Address address = _addressService.addAddress(
-			null, contextUser.getUserId(), AccountEntry.class.getName(),
-			accountId, postalAddress.getName(), null,
+			null, AccountEntry.class.getName(), accountId,
+			postalAddress.getName(), null,
 			postalAddress.getStreetAddressLine1(),
 			postalAddress.getStreetAddressLine2(),
 			postalAddress.getStreetAddressLine3(),

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/PostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/PostalAddressResourceImpl.java
@@ -19,13 +19,10 @@ import com.liferay.portal.kernel.model.ListType;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.Region;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
-import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.AddressLocalService;
 import com.liferay.portal.kernel.service.AddressService;
-import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CountryService;
 import com.liferay.portal.kernel.service.ListTypeLocalService;
 import com.liferay.portal.kernel.service.RegionService;
@@ -42,8 +39,6 @@ import javax.ws.rs.BadRequestException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
@@ -57,18 +52,7 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 	@Override
 	public void deletePostalAddress(Long postalAddressId) throws Exception {
-		Address address = _addressLocalService.getAddress(postalAddressId);
-
-		String className = address.getClassName();
-
-		if (className.equals(AccountEntry.class.getName())) {
-			_check(address.getClassPK(), ActionKeys.UPDATE);
-
-			_addressLocalService.deleteAddress(postalAddressId);
-		}
-		else {
-			_addressService.deleteAddress(postalAddressId);
-		}
+		_addressLocalService.deleteAddress(postalAddressId);
 	}
 
 	@Override
@@ -111,19 +95,6 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 	@Override
 	public PostalAddress getPostalAddress(Long postalAddressId)
 		throws Exception {
-
-		Address address = _addressLocalService.getAddress(postalAddressId);
-
-		String className = address.getClassName();
-
-		if (className.equals(AccountEntry.class.getName())) {
-			_check(address.getClassPK(), ActionKeys.VIEW);
-
-			return PostalAddressUtil.toPostalAddress(
-				contextAcceptLanguage.isAcceptAllLanguages(), address,
-				contextCompany.getCompanyId(),
-				contextAcceptLanguage.getPreferredLocale());
-		}
 
 		return PostalAddressUtil.toPostalAddress(
 			contextAcceptLanguage.isAcceptAllLanguages(),
@@ -217,28 +188,12 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 			address.setStreet3(postalAddress.getStreetAddressLine3());
 		}
 
-		String className = address.getClassName();
-
-		if (className.equals(AccountEntry.class.getName())) {
-			_check(address.getClassPK(), ActionKeys.UPDATE);
-
-			address = _addressLocalService.updateAddress(
-				address.getAddressId(), address.getName(),
-				address.getDescription(), address.getStreet1(),
-				address.getStreet2(), address.getStreet3(), address.getCity(),
-				address.getZip(), address.getRegionId(), address.getCountryId(),
-				address.getListTypeId(), address.isMailing(),
-				address.isPrimary(), phoneNumber);
-		}
-		else {
-			address = _addressService.updateAddress(
-				address.getAddressId(), address.getName(),
-				address.getDescription(), address.getStreet1(),
-				address.getStreet2(), address.getStreet3(), address.getCity(),
-				address.getZip(), address.getRegionId(), address.getCountryId(),
-				address.getListTypeId(), address.isMailing(),
-				address.isPrimary(), phoneNumber);
-		}
+		address = _addressLocalService.updateAddress(
+			address.getAddressId(), address.getName(), address.getDescription(),
+			address.getStreet1(), address.getStreet2(), address.getStreet3(),
+			address.getCity(), address.getZip(), address.getRegionId(),
+			address.getCountryId(), address.getListTypeId(),
+			address.isMailing(), address.isPrimary(), phoneNumber);
 
 		return PostalAddressUtil.toPostalAddress(
 			contextAcceptLanguage.isAcceptAllLanguages(), address,
@@ -256,8 +211,6 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 		long regionId = _getRegionId(postalAddress, country);
 
 		ListType listType = _getListType(postalAddress);
-
-		_check(accountId, ActionKeys.UPDATE);
 
 		Address address = _addressLocalService.addAddress(
 			null, contextUser.getUserId(), AccountEntry.class.getName(),
@@ -289,42 +242,20 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 		ListType listType = _getListType(postalAddress);
 
-		String className = address.getClassName();
-
-		if (className.equals(AccountEntry.class.getName())) {
-			_check(address.getClassPK(), ActionKeys.UPDATE);
-
-			address = _addressLocalService.updateAddress(
-				address.getAddressId(), postalAddress.getName(),
-				address.getDescription(), postalAddress.getStreetAddressLine1(),
-				postalAddress.getStreetAddressLine2(),
-				postalAddress.getStreetAddressLine3(),
-				postalAddress.getAddressLocality(),
-				postalAddress.getPostalCode(), regionId, country.getCountryId(),
-				listType.getListTypeId(), address.isMailing(),
-				postalAddress.getPrimary(), postalAddress.getPhoneNumber());
-		}
-		else {
-			address = _addressService.updateAddress(
-				address.getAddressId(), postalAddress.getName(),
-				address.getDescription(), postalAddress.getStreetAddressLine1(),
-				postalAddress.getStreetAddressLine2(),
-				postalAddress.getStreetAddressLine3(),
-				postalAddress.getAddressLocality(),
-				postalAddress.getPostalCode(), regionId, country.getCountryId(),
-				listType.getListTypeId(), address.isMailing(),
-				postalAddress.getPrimary(), postalAddress.getPhoneNumber());
-		}
+		address = _addressLocalService.updateAddress(
+			address.getAddressId(), postalAddress.getName(),
+			address.getDescription(), postalAddress.getStreetAddressLine1(),
+			postalAddress.getStreetAddressLine2(),
+			postalAddress.getStreetAddressLine3(),
+			postalAddress.getAddressLocality(), postalAddress.getPostalCode(),
+			regionId, country.getCountryId(), listType.getListTypeId(),
+			address.isMailing(), postalAddress.getPrimary(),
+			postalAddress.getPhoneNumber());
 
 		return PostalAddressUtil.toPostalAddress(
 			contextAcceptLanguage.isAcceptAllLanguages(), address,
 			contextCompany.getCompanyId(),
 			contextAcceptLanguage.getPreferredLocale());
-	}
-
-	private void _check(long accountId, String action) throws Exception {
-		_accountEntryModelResourcePermission.check(
-			GuestOrUserUtil.getPermissionChecker(), accountId, action);
 	}
 
 	private Country _getCountryByTitle(PostalAddress postalAddress) {
@@ -406,14 +337,6 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 		return region.getRegionId();
 	}
 
-	@Reference(
-		policy = ReferencePolicy.DYNAMIC,
-		policyOption = ReferencePolicyOption.GREEDY,
-		target = "(model.class.name=com.liferay.account.model.AccountEntry)"
-	)
-	private volatile ModelResourcePermission<AccountEntry>
-		_accountEntryModelResourcePermission;
-
 	@Reference
 	private AccountEntryService _accountEntryService;
 
@@ -422,9 +345,6 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 	@Reference
 	private AddressService _addressService;
-
-	@Reference
-	private ClassNameLocalService _classNameLocalService;
 
 	@Reference
 	private CountryService _countryService;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/PostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/PostalAddressResourceImpl.java
@@ -21,7 +21,6 @@ import com.liferay.portal.kernel.model.Region;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
-import com.liferay.portal.kernel.service.AddressLocalService;
 import com.liferay.portal.kernel.service.AddressService;
 import com.liferay.portal.kernel.service.CountryService;
 import com.liferay.portal.kernel.service.ListTypeLocalService;
@@ -52,7 +51,7 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 	@Override
 	public void deletePostalAddress(Long postalAddressId) throws Exception {
-		_addressLocalService.deleteAddress(postalAddressId);
+		_addressService.deleteAddress(postalAddressId);
 	}
 
 	@Override
@@ -63,9 +62,8 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 		return Page.of(
 			transform(
-				_addressLocalService.getAddresses(
-					contextCompany.getCompanyId(), AccountEntry.class.getName(),
-					accountId),
+				_addressService.getAddresses(
+					AccountEntry.class.getName(), accountId),
 				address -> PostalAddressUtil.toPostalAddress(
 					contextAcceptLanguage.isAcceptAllLanguages(), address,
 					contextCompany.getCompanyId(),
@@ -82,8 +80,7 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 		return Page.of(
 			transform(
-				_addressLocalService.getAddresses(
-					contextCompany.getCompanyId(),
+				_addressService.getAddresses(
 					organization.getModelClassName(),
 					organization.getOrganizationId()),
 				address -> PostalAddressUtil.toPostalAddress(
@@ -116,9 +113,8 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 		return Page.of(
 			transform(
-				_addressLocalService.getAddresses(
-					user.getCompanyId(), Contact.class.getName(),
-					user.getContactId()),
+				_addressService.getAddresses(
+					Contact.class.getName(), user.getContactId()),
 				address -> PostalAddressUtil.toPostalAddress(
 					contextAcceptLanguage.isAcceptAllLanguages(), address,
 					contextCompany.getCompanyId(),
@@ -130,7 +126,7 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 			Long postalAddressId, PostalAddress postalAddress)
 		throws Exception {
 
-		Address address = _addressLocalService.getAddress(postalAddressId);
+		Address address = _addressService.getAddress(postalAddressId);
 
 		Country country = null;
 
@@ -188,7 +184,7 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 			address.setStreet3(postalAddress.getStreetAddressLine3());
 		}
 
-		address = _addressLocalService.updateAddress(
+		address = _addressService.updateAddress(
 			address.getAddressId(), address.getName(), address.getDescription(),
 			address.getStreet1(), address.getStreet2(), address.getStreet3(),
 			address.getCity(), address.getZip(), address.getRegionId(),
@@ -212,7 +208,7 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 		ListType listType = _getListType(postalAddress);
 
-		Address address = _addressLocalService.addAddress(
+		Address address = _addressService.addAddress(
 			null, contextUser.getUserId(), AccountEntry.class.getName(),
 			accountId, postalAddress.getName(), null,
 			postalAddress.getStreetAddressLine1(),
@@ -234,7 +230,7 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 			Long postalAddressId, PostalAddress postalAddress)
 		throws Exception {
 
-		Address address = _addressLocalService.getAddress(postalAddressId);
+		Address address = _addressService.getAddress(postalAddressId);
 
 		Country country = _getCountryByTitle(postalAddress);
 
@@ -242,7 +238,7 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 		ListType listType = _getListType(postalAddress);
 
-		address = _addressLocalService.updateAddress(
+		address = _addressService.updateAddress(
 			address.getAddressId(), postalAddress.getName(),
 			address.getDescription(), postalAddress.getStreetAddressLine1(),
 			postalAddress.getStreetAddressLine2(),
@@ -339,9 +335,6 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 	@Reference
 	private AccountEntryService _accountEntryService;
-
-	@Reference
-	private AddressLocalService _addressLocalService;
 
 	@Reference
 	private AddressService _addressService;

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/PostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/PostalAddressResourceImpl.java
@@ -11,6 +11,7 @@ import com.liferay.headless.admin.user.dto.v1_0.PostalAddress;
 import com.liferay.headless.admin.user.internal.dto.v1_0.converter.constants.DTOConverterConstants;
 import com.liferay.headless.admin.user.internal.dto.v1_0.util.PostalAddressUtil;
 import com.liferay.headless.admin.user.resource.v1_0.PostalAddressResource;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.Contact;
@@ -19,10 +20,15 @@ import com.liferay.portal.kernel.model.ListType;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.Region;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.AddressLocalService;
 import com.liferay.portal.kernel.service.AddressService;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CountryService;
 import com.liferay.portal.kernel.service.ListTypeLocalService;
 import com.liferay.portal.kernel.service.RegionService;
@@ -39,6 +45,8 @@ import javax.ws.rs.BadRequestException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 import org.osgi.service.component.annotations.ServiceScope;
 
 /**
@@ -52,7 +60,19 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 	@Override
 	public void deletePostalAddress(Long postalAddressId) throws Exception {
-		_addressLocalService.deleteAddress(postalAddressId);
+		Address address = _addressLocalService.getAddress(postalAddressId);
+
+		String className  = address.getClassName();
+		if (className.equals(AccountEntry.class.getName())) {
+			_check(address.getClassPK(), ActionKeys.UPDATE);
+
+			_addressLocalService.deleteAddress(postalAddressId);
+
+		} else {
+			_addressService.deleteAddress(postalAddressId);
+		}
+
+
 	}
 
 	@Override
@@ -95,6 +115,20 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 	@Override
 	public PostalAddress getPostalAddress(Long postalAddressId)
 		throws Exception {
+
+		Address address = _addressLocalService.getAddress(postalAddressId);
+
+		String className  = address.getClassName();
+		if (className.equals(AccountEntry.class.getName())) {
+			_check(address.getClassPK(), ActionKeys.VIEW);
+
+			return PostalAddressUtil.toPostalAddress(
+				contextAcceptLanguage.isAcceptAllLanguages(),
+				address,
+				contextCompany.getCompanyId(),
+				contextAcceptLanguage.getPreferredLocale());
+
+		}
 
 		return PostalAddressUtil.toPostalAddress(
 			contextAcceptLanguage.isAcceptAllLanguages(),
@@ -188,12 +222,25 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 			address.setStreet3(postalAddress.getStreetAddressLine3());
 		}
 
-		address = _addressLocalService.updateAddress(
-			address.getAddressId(), address.getName(), address.getDescription(),
-			address.getStreet1(), address.getStreet2(), address.getStreet3(),
-			address.getCity(), address.getZip(), address.getRegionId(),
-			address.getCountryId(), address.getListTypeId(),
-			address.isMailing(), address.isPrimary(), phoneNumber);
+		String className  = address.getClassName();
+		if (className.equals(AccountEntry.class.getName())) {
+			_check(address.getClassPK(), ActionKeys.UPDATE);
+
+			address = _addressLocalService.updateAddress(
+				address.getAddressId(), address.getName(), address.getDescription(),
+				address.getStreet1(), address.getStreet2(), address.getStreet3(),
+				address.getCity(), address.getZip(), address.getRegionId(),
+				address.getCountryId(), address.getListTypeId(),
+				address.isMailing(), address.isPrimary(), phoneNumber);
+
+		} else {
+			address = _addressService.updateAddress(
+				address.getAddressId(), address.getName(), address.getDescription(),
+				address.getStreet1(), address.getStreet2(), address.getStreet3(),
+				address.getCity(), address.getZip(), address.getRegionId(),
+				address.getCountryId(), address.getListTypeId(),
+				address.isMailing(), address.isPrimary(), phoneNumber);
+		}
 
 		return PostalAddressUtil.toPostalAddress(
 			contextAcceptLanguage.isAcceptAllLanguages(), address,
@@ -211,6 +258,8 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 		long regionId = _getRegionId(postalAddress, country);
 
 		ListType listType = _getListType(postalAddress);
+
+		_check(accountId, ActionKeys.UPDATE);
 
 		Address address = _addressLocalService.addAddress(
 			null, contextUser.getUserId(), AccountEntry.class.getName(),
@@ -242,15 +291,31 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 		ListType listType = _getListType(postalAddress);
 
-		address = _addressLocalService.updateAddress(
-			address.getAddressId(), postalAddress.getName(),
-			address.getDescription(), postalAddress.getStreetAddressLine1(),
-			postalAddress.getStreetAddressLine2(),
-			postalAddress.getStreetAddressLine3(),
-			postalAddress.getAddressLocality(), postalAddress.getPostalCode(),
-			regionId, country.getCountryId(), listType.getListTypeId(),
-			address.isMailing(), postalAddress.getPrimary(),
-			postalAddress.getPhoneNumber());
+		String className  = address.getClassName();
+		if (className.equals(AccountEntry.class.getName())) {
+			_check(address.getClassPK(), ActionKeys.UPDATE);
+
+			address = _addressLocalService.updateAddress(
+				address.getAddressId(), postalAddress.getName(),
+				address.getDescription(), postalAddress.getStreetAddressLine1(),
+				postalAddress.getStreetAddressLine2(),
+				postalAddress.getStreetAddressLine3(),
+				postalAddress.getAddressLocality(), postalAddress.getPostalCode(),
+				regionId, country.getCountryId(), listType.getListTypeId(),
+				address.isMailing(), postalAddress.getPrimary(),
+				postalAddress.getPhoneNumber());
+
+		} else {
+			address = _addressService.updateAddress(
+				address.getAddressId(), postalAddress.getName(),
+				address.getDescription(), postalAddress.getStreetAddressLine1(),
+				postalAddress.getStreetAddressLine2(),
+				postalAddress.getStreetAddressLine3(),
+				postalAddress.getAddressLocality(), postalAddress.getPostalCode(),
+				regionId, country.getCountryId(), listType.getListTypeId(),
+				address.isMailing(), postalAddress.getPrimary(),
+				postalAddress.getPhoneNumber());
+		}
 
 		return PostalAddressUtil.toPostalAddress(
 			contextAcceptLanguage.isAcceptAllLanguages(), address,
@@ -300,6 +365,14 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 		return listType;
 	}
 
+	private void _check(long accountId, String action) throws PortalException {
+
+		PermissionChecker permissionChecker = GuestOrUserUtil.getPermissionChecker();
+		_accountEntryModelResourcePermission.check(
+			permissionChecker, accountId, action);
+
+	}
+
 	private long _getRegionId(PostalAddress postalAddress, Country country) {
 		if (postalAddress.getAddressType() == null) {
 			return 0;
@@ -347,6 +420,9 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 	private AddressService _addressService;
 
 	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
 	private CountryService _countryService;
 
 	@Reference
@@ -354,6 +430,14 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 	@Reference
 	private ListTypeLocalService _listTypeLocalService;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(model.class.name=com.liferay.account.model.AccountEntry)"
+	)
+	private volatile ModelResourcePermission<AccountEntry>
+		_accountEntryModelResourcePermission;
+
 
 	@Reference(
 		target = DTOConverterConstants.ORGANIZATION_RESOURCE_DTO_CONVERTER

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/PostalAddressResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/PostalAddressResourceImpl.java
@@ -11,7 +11,6 @@ import com.liferay.headless.admin.user.dto.v1_0.PostalAddress;
 import com.liferay.headless.admin.user.internal.dto.v1_0.converter.constants.DTOConverterConstants;
 import com.liferay.headless.admin.user.internal.dto.v1_0.util.PostalAddressUtil;
 import com.liferay.headless.admin.user.resource.v1_0.PostalAddressResource;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.Contact;
@@ -21,9 +20,7 @@ import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.Region;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
-import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.AddressLocalService;
@@ -62,17 +59,16 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 	public void deletePostalAddress(Long postalAddressId) throws Exception {
 		Address address = _addressLocalService.getAddress(postalAddressId);
 
-		String className  = address.getClassName();
+		String className = address.getClassName();
+
 		if (className.equals(AccountEntry.class.getName())) {
 			_check(address.getClassPK(), ActionKeys.UPDATE);
 
 			_addressLocalService.deleteAddress(postalAddressId);
-
-		} else {
+		}
+		else {
 			_addressService.deleteAddress(postalAddressId);
 		}
-
-
 	}
 
 	@Override
@@ -118,16 +114,15 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 		Address address = _addressLocalService.getAddress(postalAddressId);
 
-		String className  = address.getClassName();
+		String className = address.getClassName();
+
 		if (className.equals(AccountEntry.class.getName())) {
 			_check(address.getClassPK(), ActionKeys.VIEW);
 
 			return PostalAddressUtil.toPostalAddress(
-				contextAcceptLanguage.isAcceptAllLanguages(),
-				address,
+				contextAcceptLanguage.isAcceptAllLanguages(), address,
 				contextCompany.getCompanyId(),
 				contextAcceptLanguage.getPreferredLocale());
-
 		}
 
 		return PostalAddressUtil.toPostalAddress(
@@ -222,24 +217,27 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 			address.setStreet3(postalAddress.getStreetAddressLine3());
 		}
 
-		String className  = address.getClassName();
+		String className = address.getClassName();
+
 		if (className.equals(AccountEntry.class.getName())) {
 			_check(address.getClassPK(), ActionKeys.UPDATE);
 
 			address = _addressLocalService.updateAddress(
-				address.getAddressId(), address.getName(), address.getDescription(),
-				address.getStreet1(), address.getStreet2(), address.getStreet3(),
-				address.getCity(), address.getZip(), address.getRegionId(),
-				address.getCountryId(), address.getListTypeId(),
-				address.isMailing(), address.isPrimary(), phoneNumber);
-
-		} else {
+				address.getAddressId(), address.getName(),
+				address.getDescription(), address.getStreet1(),
+				address.getStreet2(), address.getStreet3(), address.getCity(),
+				address.getZip(), address.getRegionId(), address.getCountryId(),
+				address.getListTypeId(), address.isMailing(),
+				address.isPrimary(), phoneNumber);
+		}
+		else {
 			address = _addressService.updateAddress(
-				address.getAddressId(), address.getName(), address.getDescription(),
-				address.getStreet1(), address.getStreet2(), address.getStreet3(),
-				address.getCity(), address.getZip(), address.getRegionId(),
-				address.getCountryId(), address.getListTypeId(),
-				address.isMailing(), address.isPrimary(), phoneNumber);
+				address.getAddressId(), address.getName(),
+				address.getDescription(), address.getStreet1(),
+				address.getStreet2(), address.getStreet3(), address.getCity(),
+				address.getZip(), address.getRegionId(), address.getCountryId(),
+				address.getListTypeId(), address.isMailing(),
+				address.isPrimary(), phoneNumber);
 		}
 
 		return PostalAddressUtil.toPostalAddress(
@@ -291,7 +289,8 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 		ListType listType = _getListType(postalAddress);
 
-		String className  = address.getClassName();
+		String className = address.getClassName();
+
 		if (className.equals(AccountEntry.class.getName())) {
 			_check(address.getClassPK(), ActionKeys.UPDATE);
 
@@ -300,27 +299,32 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 				address.getDescription(), postalAddress.getStreetAddressLine1(),
 				postalAddress.getStreetAddressLine2(),
 				postalAddress.getStreetAddressLine3(),
-				postalAddress.getAddressLocality(), postalAddress.getPostalCode(),
-				regionId, country.getCountryId(), listType.getListTypeId(),
-				address.isMailing(), postalAddress.getPrimary(),
-				postalAddress.getPhoneNumber());
-
-		} else {
+				postalAddress.getAddressLocality(),
+				postalAddress.getPostalCode(), regionId, country.getCountryId(),
+				listType.getListTypeId(), address.isMailing(),
+				postalAddress.getPrimary(), postalAddress.getPhoneNumber());
+		}
+		else {
 			address = _addressService.updateAddress(
 				address.getAddressId(), postalAddress.getName(),
 				address.getDescription(), postalAddress.getStreetAddressLine1(),
 				postalAddress.getStreetAddressLine2(),
 				postalAddress.getStreetAddressLine3(),
-				postalAddress.getAddressLocality(), postalAddress.getPostalCode(),
-				regionId, country.getCountryId(), listType.getListTypeId(),
-				address.isMailing(), postalAddress.getPrimary(),
-				postalAddress.getPhoneNumber());
+				postalAddress.getAddressLocality(),
+				postalAddress.getPostalCode(), regionId, country.getCountryId(),
+				listType.getListTypeId(), address.isMailing(),
+				postalAddress.getPrimary(), postalAddress.getPhoneNumber());
 		}
 
 		return PostalAddressUtil.toPostalAddress(
 			contextAcceptLanguage.isAcceptAllLanguages(), address,
 			contextCompany.getCompanyId(),
 			contextAcceptLanguage.getPreferredLocale());
+	}
+
+	private void _check(long accountId, String action) throws Exception {
+		_accountEntryModelResourcePermission.check(
+			GuestOrUserUtil.getPermissionChecker(), accountId, action);
 	}
 
 	private Country _getCountryByTitle(PostalAddress postalAddress) {
@@ -365,14 +369,6 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 		return listType;
 	}
 
-	private void _check(long accountId, String action) throws PortalException {
-
-		PermissionChecker permissionChecker = GuestOrUserUtil.getPermissionChecker();
-		_accountEntryModelResourcePermission.check(
-			permissionChecker, accountId, action);
-
-	}
-
 	private long _getRegionId(PostalAddress postalAddress, Country country) {
 		if (postalAddress.getAddressType() == null) {
 			return 0;
@@ -410,6 +406,14 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 		return region.getRegionId();
 	}
 
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY,
+		target = "(model.class.name=com.liferay.account.model.AccountEntry)"
+	)
+	private volatile ModelResourcePermission<AccountEntry>
+		_accountEntryModelResourcePermission;
+
 	@Reference
 	private AccountEntryService _accountEntryService;
 
@@ -430,14 +434,6 @@ public class PostalAddressResourceImpl extends BasePostalAddressResourceImpl {
 
 	@Reference
 	private ListTypeLocalService _listTypeLocalService;
-	@Reference(
-		policy = ReferencePolicy.DYNAMIC,
-		policyOption = ReferencePolicyOption.GREEDY,
-		target = "(model.class.name=com.liferay.account.model.AccountEntry)"
-	)
-	private volatile ModelResourcePermission<AccountEntry>
-		_accountEntryModelResourcePermission;
-
 
 	@Reference(
 		target = DTOConverterConstants.ORGANIZATION_RESOURCE_DTO_CONVERTER

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/manager/AddressContactInfoManager.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/manager/AddressContactInfoManager.java
@@ -72,11 +72,11 @@ public class AddressContactInfoManager extends BaseContactInfoManager<Address> {
 	@Override
 	protected Address doAdd(Address address) throws Exception {
 		return _addressService.addAddress(
-			_className, _classPK, address.getStreet1(), address.getStreet2(),
-			address.getStreet3(), address.getCity(), address.getZip(),
-			address.getRegionId(), address.getCountryId(),
+			null, _className, _classPK, null, null, address.getStreet1(),
+			address.getStreet2(), address.getStreet3(), address.getCity(),
+			address.getZip(), address.getRegionId(), address.getCountryId(),
 			address.getListTypeId(), address.isMailing(), address.isPrimary(),
-			new ServiceContext());
+			null, new ServiceContext());
 	}
 
 	@Override
@@ -87,10 +87,11 @@ public class AddressContactInfoManager extends BaseContactInfoManager<Address> {
 	@Override
 	protected void doUpdate(Address address) throws Exception {
 		_addressService.updateAddress(
-			address.getAddressId(), address.getStreet1(), address.getStreet2(),
-			address.getStreet3(), address.getCity(), address.getZip(),
-			address.getRegionId(), address.getCountryId(),
-			address.getListTypeId(), address.isMailing(), address.isPrimary());
+			address.getAddressId(), address.getName(), address.getDescription(),
+			address.getStreet1(), address.getStreet2(), address.getStreet3(),
+			address.getCity(), address.getZip(), address.getRegionId(),
+			address.getCountryId(), address.getListTypeId(),
+			address.isMailing(), address.isPrimary(), address.getPhoneNumber());
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/http/AddressServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/AddressServiceHttp.java
@@ -43,11 +43,10 @@ public class AddressServiceHttp {
 
 	public static com.liferay.portal.kernel.model.Address addAddress(
 			HttpPrincipal httpPrincipal, String externalReferenceCode,
-			long userId, String className, long classPK, String name,
-			String description, String street1, String street2, String street3,
-			String city, String zip, long regionId, long countryId,
-			long listTypeId, boolean mailing, boolean primary,
-			String phoneNumber,
+			String className, long classPK, String name, String description,
+			String street1, String street2, String street3, String city,
+			String zip, long regionId, long countryId, long listTypeId,
+			boolean mailing, boolean primary, String phoneNumber,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -57,55 +56,9 @@ public class AddressServiceHttp {
 				_addAddressParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, externalReferenceCode, userId, className, classPK,
-				name, description, street1, street2, street3, city, zip,
-				regionId, countryId, listTypeId, mailing, primary, phoneNumber,
-				serviceContext);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return (com.liferay.portal.kernel.model.Address)returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
-	public static com.liferay.portal.kernel.model.Address addAddress(
-			HttpPrincipal httpPrincipal, String className, long classPK,
-			String street1, String street2, String street3, String city,
-			String zip, long regionId, long countryId, long listTypeId,
-			boolean mailing, boolean primary,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				AddressServiceUtil.class, "addAddress",
-				_addAddressParameterTypes1);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, className, classPK, street1, street2, street3, city,
-				zip, regionId, countryId, listTypeId, mailing, primary,
+				methodKey, externalReferenceCode, className, classPK, name,
+				description, street1, street2, street3, city, zip, regionId,
+				countryId, listTypeId, mailing, primary, phoneNumber,
 				serviceContext);
 
 			Object returnObj = null;
@@ -143,7 +96,7 @@ public class AddressServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AddressServiceUtil.class, "deleteAddress",
-				_deleteAddressParameterTypes2);
+				_deleteAddressParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, addressId);
@@ -179,7 +132,7 @@ public class AddressServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AddressServiceUtil.class, "getAddress",
-				_getAddressParameterTypes3);
+				_getAddressParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, addressId);
@@ -220,7 +173,7 @@ public class AddressServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AddressServiceUtil.class, "getAddresses",
-				_getAddressesParameterTypes4);
+				_getAddressesParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, className, classPK);
@@ -255,50 +208,6 @@ public class AddressServiceHttp {
 	}
 
 	public static com.liferay.portal.kernel.model.Address updateAddress(
-			HttpPrincipal httpPrincipal, long addressId, String street1,
-			String street2, String street3, String city, String zip,
-			long regionId, long countryId, long listTypeId, boolean mailing,
-			boolean primary)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				AddressServiceUtil.class, "updateAddress",
-				_updateAddressParameterTypes5);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, addressId, street1, street2, street3, city, zip,
-				regionId, countryId, listTypeId, mailing, primary);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return (com.liferay.portal.kernel.model.Address)returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
-	public static com.liferay.portal.kernel.model.Address updateAddress(
 			HttpPrincipal httpPrincipal, long addressId, String name,
 			String description, String street1, String street2, String street3,
 			String city, String zip, long regionId, long countryId,
@@ -309,7 +218,7 @@ public class AddressServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AddressServiceUtil.class, "updateAddress",
-				_updateAddressParameterTypes6);
+				_updateAddressParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, addressId, name, description, street1, street2,
@@ -347,33 +256,20 @@ public class AddressServiceHttp {
 	private static Log _log = LogFactoryUtil.getLog(AddressServiceHttp.class);
 
 	private static final Class<?>[] _addAddressParameterTypes0 = new Class[] {
-		String.class, long.class, String.class, long.class, String.class,
+		String.class, String.class, long.class, String.class, String.class,
 		String.class, String.class, String.class, String.class, String.class,
-		String.class, long.class, long.class, long.class, boolean.class,
-		boolean.class, String.class,
-		com.liferay.portal.kernel.service.ServiceContext.class
+		long.class, long.class, long.class, boolean.class, boolean.class,
+		String.class, com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _addAddressParameterTypes1 = new Class[] {
-		String.class, long.class, String.class, String.class, String.class,
-		String.class, String.class, long.class, long.class, long.class,
-		boolean.class, boolean.class,
-		com.liferay.portal.kernel.service.ServiceContext.class
-	};
-	private static final Class<?>[] _deleteAddressParameterTypes2 =
+	private static final Class<?>[] _deleteAddressParameterTypes1 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getAddressParameterTypes3 = new Class[] {
+	private static final Class<?>[] _getAddressParameterTypes2 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getAddressesParameterTypes4 = new Class[] {
+	private static final Class<?>[] _getAddressesParameterTypes3 = new Class[] {
 		String.class, long.class
 	};
-	private static final Class<?>[] _updateAddressParameterTypes5 =
-		new Class[] {
-			long.class, String.class, String.class, String.class, String.class,
-			String.class, long.class, long.class, long.class, boolean.class,
-			boolean.class
-		};
-	private static final Class<?>[] _updateAddressParameterTypes6 =
+	private static final Class<?>[] _updateAddressParameterTypes4 =
 		new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, String.class, String.class, long.class, long.class,

--- a/portal-impl/src/com/liferay/portal/service/http/AddressServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/AddressServiceHttp.java
@@ -42,6 +42,55 @@ import com.liferay.portal.kernel.util.MethodKey;
 public class AddressServiceHttp {
 
 	public static com.liferay.portal.kernel.model.Address addAddress(
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			long userId, String className, long classPK, String name,
+			String description, String street1, String street2, String street3,
+			String city, String zip, long regionId, long countryId,
+			long listTypeId, boolean mailing, boolean primary,
+			String phoneNumber,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				AddressServiceUtil.class, "addAddress",
+				_addAddressParameterTypes0);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, userId, className, classPK,
+				name, description, street1, street2, street3, city, zip,
+				regionId, countryId, listTypeId, mailing, primary, phoneNumber,
+				serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.kernel.model.Address)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.portal.kernel.model.Address addAddress(
 			HttpPrincipal httpPrincipal, String className, long classPK,
 			String street1, String street2, String street3, String city,
 			String zip, long regionId, long countryId, long listTypeId,
@@ -52,7 +101,7 @@ public class AddressServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AddressServiceUtil.class, "addAddress",
-				_addAddressParameterTypes0);
+				_addAddressParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, className, classPK, street1, street2, street3, city,
@@ -94,7 +143,7 @@ public class AddressServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AddressServiceUtil.class, "deleteAddress",
-				_deleteAddressParameterTypes1);
+				_deleteAddressParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, addressId);
@@ -130,7 +179,7 @@ public class AddressServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AddressServiceUtil.class, "getAddress",
-				_getAddressParameterTypes2);
+				_getAddressParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, addressId);
@@ -171,7 +220,7 @@ public class AddressServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AddressServiceUtil.class, "getAddresses",
-				_getAddressesParameterTypes3);
+				_getAddressesParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, className, classPK);
@@ -215,7 +264,7 @@ public class AddressServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				AddressServiceUtil.class, "updateAddress",
-				_updateAddressParameterTypes4);
+				_updateAddressParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, addressId, street1, street2, street3, city, zip,
@@ -249,27 +298,86 @@ public class AddressServiceHttp {
 		}
 	}
 
+	public static com.liferay.portal.kernel.model.Address updateAddress(
+			HttpPrincipal httpPrincipal, long addressId, String name,
+			String description, String street1, String street2, String street3,
+			String city, String zip, long regionId, long countryId,
+			long listTypeId, boolean mailing, boolean primary,
+			String phoneNumber)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				AddressServiceUtil.class, "updateAddress",
+				_updateAddressParameterTypes6);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, addressId, name, description, street1, street2,
+				street3, city, zip, regionId, countryId, listTypeId, mailing,
+				primary, phoneNumber);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.portal.kernel.model.Address)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	private static Log _log = LogFactoryUtil.getLog(AddressServiceHttp.class);
 
 	private static final Class<?>[] _addAddressParameterTypes0 = new Class[] {
+		String.class, long.class, String.class, long.class, String.class,
+		String.class, String.class, String.class, String.class, String.class,
+		String.class, long.class, long.class, long.class, boolean.class,
+		boolean.class, String.class,
+		com.liferay.portal.kernel.service.ServiceContext.class
+	};
+	private static final Class<?>[] _addAddressParameterTypes1 = new Class[] {
 		String.class, long.class, String.class, String.class, String.class,
 		String.class, String.class, long.class, long.class, long.class,
 		boolean.class, boolean.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _deleteAddressParameterTypes1 =
+	private static final Class<?>[] _deleteAddressParameterTypes2 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getAddressParameterTypes2 = new Class[] {
+	private static final Class<?>[] _getAddressParameterTypes3 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getAddressesParameterTypes3 = new Class[] {
+	private static final Class<?>[] _getAddressesParameterTypes4 = new Class[] {
 		String.class, long.class
 	};
-	private static final Class<?>[] _updateAddressParameterTypes4 =
+	private static final Class<?>[] _updateAddressParameterTypes5 =
 		new Class[] {
 			long.class, String.class, String.class, String.class, String.class,
 			String.class, long.class, long.class, long.class, boolean.class,
 			boolean.class
+		};
+	private static final Class<?>[] _updateAddressParameterTypes6 =
+		new Class[] {
+			long.class, String.class, String.class, String.class, String.class,
+			String.class, String.class, String.class, long.class, long.class,
+			long.class, boolean.class, boolean.class, String.class
 		};
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/AddressServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/AddressServiceImpl.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.service.base.AddressServiceBaseImpl;
 import com.liferay.portal.service.permission.CommonPermissionUtil;
@@ -23,20 +24,22 @@ public class AddressServiceImpl extends AddressServiceBaseImpl {
 
 	@Override
 	public Address addAddress(
-			String externalReferenceCode, long userId, String className,
-			long classPK, String name, String description, String street1,
-			String street2, String street3, String city, String zip,
-			long regionId, long countryId, long listTypeId, boolean mailing,
-			boolean primary, String phoneNumber, ServiceContext serviceContext)
+			String externalReferenceCode, String className, long classPK,
+			String name, String description, String street1, String street2,
+			String street3, String city, String zip, long regionId,
+			long countryId, long listTypeId, boolean mailing, boolean primary,
+			String phoneNumber, ServiceContext serviceContext)
 		throws PortalException {
 
+		PermissionChecker permissionChecker = getPermissionChecker();
+
 		CommonPermissionUtil.check(
-			getPermissionChecker(), className, classPK, ActionKeys.UPDATE);
+			permissionChecker, className, classPK, ActionKeys.UPDATE);
 
 		return addressLocalService.addAddress(
-			externalReferenceCode, userId, className, classPK, name,
-			description, street1, street2, street3, city, zip, regionId,
-			countryId, listTypeId, mailing, primary, phoneNumber,
+			externalReferenceCode, permissionChecker.getUserId(), className,
+			classPK, name, description, street1, street2, street3, city, zip,
+			regionId, countryId, listTypeId, mailing, primary, phoneNumber,
 			serviceContext);
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/AddressServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/AddressServiceImpl.java
@@ -44,23 +44,6 @@ public class AddressServiceImpl extends AddressServiceBaseImpl {
 	}
 
 	@Override
-	public Address addAddress(
-			String className, long classPK, String street1, String street2,
-			String street3, String city, String zip, long regionId,
-			long countryId, long listTypeId, boolean mailing, boolean primary,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		CommonPermissionUtil.check(
-			getPermissionChecker(), className, classPK, ActionKeys.UPDATE);
-
-		return addressLocalService.addAddress(
-			null, getUserId(), className, classPK, null, null, street1, street2,
-			street3, city, zip, regionId, countryId, listTypeId, mailing,
-			primary, null, serviceContext);
-	}
-
-	@Override
 	public void deleteAddress(long addressId) throws PortalException {
 		Address address = addressPersistence.findByPrimaryKey(addressId);
 
@@ -93,24 +76,6 @@ public class AddressServiceImpl extends AddressServiceBaseImpl {
 
 		return addressLocalService.getAddresses(
 			user.getCompanyId(), className, classPK);
-	}
-
-	@Override
-	public Address updateAddress(
-			long addressId, String street1, String street2, String street3,
-			String city, String zip, long regionId, long countryId,
-			long listTypeId, boolean mailing, boolean primary)
-		throws PortalException {
-
-		Address address = addressPersistence.findByPrimaryKey(addressId);
-
-		CommonPermissionUtil.check(
-			getPermissionChecker(), address.getClassNameId(),
-			address.getClassPK(), ActionKeys.UPDATE);
-
-		return addressLocalService.updateAddress(
-			addressId, street1, street2, street3, city, zip, regionId,
-			countryId, listTypeId, mailing, primary);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/AddressServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/AddressServiceImpl.java
@@ -9,10 +9,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
-import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.service.base.AddressServiceBaseImpl;
 import com.liferay.portal.service.permission.CommonPermissionUtil;
 

--- a/portal-impl/src/com/liferay/portal/service/impl/AddressServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/AddressServiceImpl.java
@@ -9,7 +9,10 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.service.base.AddressServiceBaseImpl;
 import com.liferay.portal.service.permission.CommonPermissionUtil;
 
@@ -20,6 +23,25 @@ import java.util.List;
  * @author Alexander Chow
  */
 public class AddressServiceImpl extends AddressServiceBaseImpl {
+
+	@Override
+	public Address addAddress(
+			String externalReferenceCode, long userId, String className,
+			long classPK, String name, String description, String street1,
+			String street2, String street3, String city, String zip,
+			long regionId, long countryId, long listTypeId, boolean mailing,
+			boolean primary, String phoneNumber, ServiceContext serviceContext)
+		throws PortalException {
+
+		CommonPermissionUtil.check(
+			getPermissionChecker(), className, classPK, ActionKeys.UPDATE);
+
+		return addressLocalService.addAddress(
+			externalReferenceCode, userId, className, classPK, name,
+			description, street1, street2, street3, city, zip, regionId,
+			countryId, listTypeId, mailing, primary, phoneNumber,
+			serviceContext);
+	}
 
 	@Override
 	public Address addAddress(
@@ -89,6 +111,25 @@ public class AddressServiceImpl extends AddressServiceBaseImpl {
 		return addressLocalService.updateAddress(
 			addressId, street1, street2, street3, city, zip, regionId,
 			countryId, listTypeId, mailing, primary);
+	}
+
+	@Override
+	public Address updateAddress(
+			long addressId, String name, String description, String street1,
+			String street2, String street3, String city, String zip,
+			long regionId, long countryId, long listTypeId, boolean mailing,
+			boolean primary, String phoneNumber)
+		throws PortalException {
+
+		Address address = addressPersistence.findByPrimaryKey(addressId);
+
+		CommonPermissionUtil.check(
+			getPermissionChecker(), address.getClassNameId(),
+			address.getClassPK(), ActionKeys.UPDATE);
+
+		return addressLocalService.updateAddress(
+			addressId, name, description, street1, street2, street3, city, zip,
+			regionId, countryId, listTypeId, mailing, primary, phoneNumber);
 	}
 
 }

--- a/portal-impl/src/com/liferay/portal/service/permission/CommonPermissionUtil.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/CommonPermissionUtil.java
@@ -8,6 +8,7 @@ package com.liferay.portal.service.permission;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ClassedModel;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.Organization;
@@ -15,6 +16,8 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionRegistryUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.OrganizationPermissionUtil;
@@ -70,12 +73,20 @@ public class CommonPermissionUtil {
 			UserPermissionUtil.check(permissionChecker, classPK, actionId);
 		}
 		else {
-			if (_log.isWarnEnabled()) {
-				_log.warn("Invalid class name " + className);
+			ModelResourcePermission<ClassedModel> modelResourcePermission =
+				ModelResourcePermissionRegistryUtil.getModelResourcePermission(
+					className);
+
+			if (modelResourcePermission == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("Invalid class name " + className);
+				}
+
+				throw new PrincipalException.MustHavePermission(
+					permissionChecker, className, classPK, actionId);
 			}
 
-			throw new PrincipalException.MustHavePermission(
-				permissionChecker, className, classPK, actionId);
+			modelResourcePermission.check(permissionChecker, classPK, actionId);
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portlet/usersadmin/util/UsersAdminUtil.java
+++ b/portal-impl/src/com/liferay/portlet/usersadmin/util/UsersAdminUtil.java
@@ -1399,6 +1399,9 @@ public class UsersAdminUtil {
 		for (Address address : addresses) {
 			long addressId = address.getAddressId();
 
+			String externalReferenceCode = address.getExternalReferenceCode();
+			String name = address.getName();
+			String description = address.getDescription();
 			String street1 = address.getStreet1();
 			String street2 = address.getStreet2();
 			String street3 = address.getStreet3();
@@ -1409,19 +1412,22 @@ public class UsersAdminUtil {
 			long listTypeId = address.getListTypeId();
 			boolean mailing = address.isMailing();
 			boolean primary = address.isPrimary();
+			String phoneNumber = address.getPhoneNumber();
 
 			if (addressId <= 0) {
 				address = AddressServiceUtil.addAddress(
-					className, classPK, street1, street2, street3, city, zip,
-					regionId, countryId, listTypeId, mailing, primary,
+					externalReferenceCode, className, classPK, name,
+					description, street1, street2, street3, city, zip, regionId,
+					countryId, listTypeId, mailing, primary, phoneNumber,
 					new ServiceContext());
 
 				addressId = address.getAddressId();
 			}
 			else {
 				AddressServiceUtil.updateAddress(
-					addressId, street1, street2, street3, city, zip, regionId,
-					countryId, listTypeId, mailing, primary);
+					addressId, name, description, street1, street2, street3,
+					city, zip, regionId, countryId, listTypeId, mailing,
+					primary, phoneNumber);
 			}
 
 			addressIds.add(addressId);

--- a/portal-kernel/src/com/liferay/portal/kernel/service/AddressService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/AddressService.java
@@ -44,18 +44,11 @@ public interface AddressService extends BaseService {
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.portal.service.impl.AddressServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the address remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link AddressServiceUtil} if injection and service tracking are not available.
 	 */
 	public Address addAddress(
-			String externalReferenceCode, long userId, String className,
-			long classPK, String name, String description, String street1,
-			String street2, String street3, String city, String zip,
-			long regionId, long countryId, long listTypeId, boolean mailing,
-			boolean primary, String phoneNumber, ServiceContext serviceContext)
-		throws PortalException;
-
-	public Address addAddress(
-			String className, long classPK, String street1, String street2,
+			String externalReferenceCode, String className, long classPK,
+			String name, String description, String street1, String street2,
 			String street3, String city, String zip, long regionId,
 			long countryId, long listTypeId, boolean mailing, boolean primary,
-			ServiceContext serviceContext)
+			String phoneNumber, ServiceContext serviceContext)
 		throws PortalException;
 
 	public void deleteAddress(long addressId) throws PortalException;
@@ -73,12 +66,6 @@ public interface AddressService extends BaseService {
 	 * @return the OSGi service identifier
 	 */
 	public String getOSGiServiceIdentifier();
-
-	public Address updateAddress(
-			long addressId, String street1, String street2, String street3,
-			String city, String zip, long regionId, long countryId,
-			long listTypeId, boolean mailing, boolean primary)
-		throws PortalException;
 
 	public Address updateAddress(
 			long addressId, String name, String description, String street1,

--- a/portal-kernel/src/com/liferay/portal/kernel/service/AddressService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/AddressService.java
@@ -44,6 +44,14 @@ public interface AddressService extends BaseService {
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.portal.service.impl.AddressServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the address remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link AddressServiceUtil} if injection and service tracking are not available.
 	 */
 	public Address addAddress(
+			String externalReferenceCode, long userId, String className,
+			long classPK, String name, String description, String street1,
+			String street2, String street3, String city, String zip,
+			long regionId, long countryId, long listTypeId, boolean mailing,
+			boolean primary, String phoneNumber, ServiceContext serviceContext)
+		throws PortalException;
+
+	public Address addAddress(
 			String className, long classPK, String street1, String street2,
 			String street3, String city, String zip, long regionId,
 			long countryId, long listTypeId, boolean mailing, boolean primary,
@@ -70,6 +78,13 @@ public interface AddressService extends BaseService {
 			long addressId, String street1, String street2, String street3,
 			String city, String zip, long regionId, long countryId,
 			long listTypeId, boolean mailing, boolean primary)
+		throws PortalException;
+
+	public Address updateAddress(
+			long addressId, String name, String description, String street1,
+			String street2, String street3, String city, String zip,
+			long regionId, long countryId, long listTypeId, boolean mailing,
+			boolean primary, String phoneNumber)
 		throws PortalException;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/service/AddressServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/AddressServiceUtil.java
@@ -30,6 +30,21 @@ public class AddressServiceUtil {
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.portal.service.impl.AddressServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
 	public static Address addAddress(
+			String externalReferenceCode, long userId, String className,
+			long classPK, String name, String description, String street1,
+			String street2, String street3, String city, String zip,
+			long regionId, long countryId, long listTypeId, boolean mailing,
+			boolean primary, String phoneNumber, ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addAddress(
+			externalReferenceCode, userId, className, classPK, name,
+			description, street1, street2, street3, city, zip, regionId,
+			countryId, listTypeId, mailing, primary, phoneNumber,
+			serviceContext);
+	}
+
+	public static Address addAddress(
 			String className, long classPK, String street1, String street2,
 			String street3, String city, String zip, long regionId,
 			long countryId, long listTypeId, boolean mailing, boolean primary,
@@ -73,6 +88,18 @@ public class AddressServiceUtil {
 		return getService().updateAddress(
 			addressId, street1, street2, street3, city, zip, regionId,
 			countryId, listTypeId, mailing, primary);
+	}
+
+	public static Address updateAddress(
+			long addressId, String name, String description, String street1,
+			String street2, String street3, String city, String zip,
+			long regionId, long countryId, long listTypeId, boolean mailing,
+			boolean primary, String phoneNumber)
+		throws PortalException {
+
+		return getService().updateAddress(
+			addressId, name, description, street1, street2, street3, city, zip,
+			regionId, countryId, listTypeId, mailing, primary, phoneNumber);
 	}
 
 	public static AddressService getService() {

--- a/portal-kernel/src/com/liferay/portal/kernel/service/AddressServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/AddressServiceUtil.java
@@ -30,30 +30,17 @@ public class AddressServiceUtil {
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.portal.service.impl.AddressServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
 	public static Address addAddress(
-			String externalReferenceCode, long userId, String className,
-			long classPK, String name, String description, String street1,
-			String street2, String street3, String city, String zip,
-			long regionId, long countryId, long listTypeId, boolean mailing,
-			boolean primary, String phoneNumber, ServiceContext serviceContext)
-		throws PortalException {
-
-		return getService().addAddress(
-			externalReferenceCode, userId, className, classPK, name,
-			description, street1, street2, street3, city, zip, regionId,
-			countryId, listTypeId, mailing, primary, phoneNumber,
-			serviceContext);
-	}
-
-	public static Address addAddress(
-			String className, long classPK, String street1, String street2,
+			String externalReferenceCode, String className, long classPK,
+			String name, String description, String street1, String street2,
 			String street3, String city, String zip, long regionId,
 			long countryId, long listTypeId, boolean mailing, boolean primary,
-			ServiceContext serviceContext)
+			String phoneNumber, ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addAddress(
-			className, classPK, street1, street2, street3, city, zip, regionId,
-			countryId, listTypeId, mailing, primary, serviceContext);
+			externalReferenceCode, className, classPK, name, description,
+			street1, street2, street3, city, zip, regionId, countryId,
+			listTypeId, mailing, primary, phoneNumber, serviceContext);
 	}
 
 	public static void deleteAddress(long addressId) throws PortalException {
@@ -77,17 +64,6 @@ public class AddressServiceUtil {
 	 */
 	public static String getOSGiServiceIdentifier() {
 		return getService().getOSGiServiceIdentifier();
-	}
-
-	public static Address updateAddress(
-			long addressId, String street1, String street2, String street3,
-			String city, String zip, long regionId, long countryId,
-			long listTypeId, boolean mailing, boolean primary)
-		throws PortalException {
-
-		return getService().updateAddress(
-			addressId, street1, street2, street3, city, zip, regionId,
-			countryId, listTypeId, mailing, primary);
 	}
 
 	public static Address updateAddress(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/AddressServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/AddressServiceWrapper.java
@@ -27,31 +27,17 @@ public class AddressServiceWrapper
 
 	@Override
 	public Address addAddress(
-			String externalReferenceCode, long userId, String className,
-			long classPK, String name, String description, String street1,
-			String street2, String street3, String city, String zip,
-			long regionId, long countryId, long listTypeId, boolean mailing,
-			boolean primary, String phoneNumber, ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _addressService.addAddress(
-			externalReferenceCode, userId, className, classPK, name,
-			description, street1, street2, street3, city, zip, regionId,
-			countryId, listTypeId, mailing, primary, phoneNumber,
-			serviceContext);
-	}
-
-	@Override
-	public Address addAddress(
-			String className, long classPK, String street1, String street2,
+			String externalReferenceCode, String className, long classPK,
+			String name, String description, String street1, String street2,
 			String street3, String city, String zip, long regionId,
 			long countryId, long listTypeId, boolean mailing, boolean primary,
-			ServiceContext serviceContext)
+			String phoneNumber, ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _addressService.addAddress(
-			className, classPK, street1, street2, street3, city, zip, regionId,
-			countryId, listTypeId, mailing, primary, serviceContext);
+			externalReferenceCode, className, classPK, name, description,
+			street1, street2, street3, city, zip, regionId, countryId,
+			listTypeId, mailing, primary, phoneNumber, serviceContext);
 	}
 
 	@Override
@@ -83,18 +69,6 @@ public class AddressServiceWrapper
 	@Override
 	public String getOSGiServiceIdentifier() {
 		return _addressService.getOSGiServiceIdentifier();
-	}
-
-	@Override
-	public Address updateAddress(
-			long addressId, String street1, String street2, String street3,
-			String city, String zip, long regionId, long countryId,
-			long listTypeId, boolean mailing, boolean primary)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _addressService.updateAddress(
-			addressId, street1, street2, street3, city, zip, regionId,
-			countryId, listTypeId, mailing, primary);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/service/AddressServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/AddressServiceWrapper.java
@@ -27,6 +27,22 @@ public class AddressServiceWrapper
 
 	@Override
 	public Address addAddress(
+			String externalReferenceCode, long userId, String className,
+			long classPK, String name, String description, String street1,
+			String street2, String street3, String city, String zip,
+			long regionId, long countryId, long listTypeId, boolean mailing,
+			boolean primary, String phoneNumber, ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _addressService.addAddress(
+			externalReferenceCode, userId, className, classPK, name,
+			description, street1, street2, street3, city, zip, regionId,
+			countryId, listTypeId, mailing, primary, phoneNumber,
+			serviceContext);
+	}
+
+	@Override
+	public Address addAddress(
 			String className, long classPK, String street1, String street2,
 			String street3, String city, String zip, long regionId,
 			long countryId, long listTypeId, boolean mailing, boolean primary,
@@ -79,6 +95,19 @@ public class AddressServiceWrapper
 		return _addressService.updateAddress(
 			addressId, street1, street2, street3, city, zip, regionId,
 			countryId, listTypeId, mailing, primary);
+	}
+
+	@Override
+	public Address updateAddress(
+			long addressId, String name, String description, String street1,
+			String street2, String street3, String city, String zip,
+			long regionId, long countryId, long listTypeId, boolean mailing,
+			boolean primary, String phoneNumber)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _addressService.updateAddress(
+			addressId, name, description, street1, street2, street3, city, zip,
+			regionId, countryId, listTypeId, mailing, primary, phoneNumber);
 	}
 
 	@Override


### PR DESCRIPTION
[LPS-198665](https://liferay.atlassian.net/browse/LPS-198665)

Changes to make the validation of permissions when making requests on the Addresses.

High level changes are:

- Create methods at RemoteService level to include necessary parameters. 
- Modification of the services used in _PostalAddressResourceImpl_ to include the validation of permissions.
- It was necessary to check if the address was linked to Account or not to know which permissions to validate (for more information on this point see _The solution_ section).

### The solution
The change for the validation of the permissions has not only consisted in changing the call from LocalService to RemoteService, but it has been necessary to include logic in the implementation of the Headless API since an Address can be related to different entities that makes its validation different:
* Account (as discussed in this ticket) validates against Account permissions and uses `AccountEntryModelResourcePermission`
* Company/Contact/Organization/User validates against the corresponding entity and uses `CommonPermissionUtil`

In all cases, the permissions to validate were the same, only the entity changed:

- GET (`getPostalAddress`) validating the `VIEW` permission 
- POST (`postAccountPostalAddress`), PUT (`putPostalAddress`) and PATCH (`patchPostalAddress`)  validating the `UPDATE` permission ##methods

Note, the GET method was not included in the original ticket but has been modified to correctly handle permissions. 

To fix this, methods with more parameters, needed for the Headless API have been added in the `AddressServiceImpl`, subsequently generating the service construct to extend it to the interface. 

Then, in the implementation of the endpoint _PostalAddressResourceImpl_ in each of the indicated methods the entity to which the Address was related has been checked (using the functions `getClassName` and `getClassPK` since the first one indicates the entity to which it is related and the second one the id of the same one). In this way it is possible to know which validations have to be performed:

- In case it is an Account, `AccountEntryModelResourcePermission` is used.
- In other case `CommonPermissionUtil` is used

### Tests
The tests are included in the ticket [comment](https://liferay.atlassian.net/browse/LPS-198665?focusedCommentId=2484903).