### PR TITLE
LPS-176164 

### DIFF
--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/events/CookiesPreAction.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/events/CookiesPreAction.java
@@ -5,12 +5,15 @@
 
 package com.liferay.cookies.internal.events;
 
+import com.liferay.cookies.internal.manager.util.CookiesConsentTypesCaching;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
 import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
 import com.liferay.portal.kernel.events.Action;
 import com.liferay.portal.kernel.events.LifecycleAction;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.HashMap;
@@ -41,6 +44,23 @@ public class CookiesPreAction extends Action {
 		catch (Exception exception) {
 			_log.error(exception);
 		}
+	}
+
+	private String _getConsentTypeName(Integer consentType) {
+		String consentTypeName = StringPool.BLANK;
+
+		if (consentType == CookiesConstants.CONSENT_TYPE_FUNCTIONAL) {
+			consentTypeName = CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL;
+		}
+		else if (consentType == CookiesConstants.CONSENT_TYPE_PERFORMANCE) {
+			consentTypeName = CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE;
+		}
+		else if (consentType == CookiesConstants.CONSENT_TYPE_PERSONALIZATION) {
+			consentTypeName =
+				CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION;
+		}
+
+		return consentTypeName;
 	}
 
 	private Map<String, String> _getCookieValues(Cookie[] cookies) {
@@ -83,7 +103,25 @@ public class CookiesPreAction extends Action {
 		boolean optionalConsent = false;
 
 		if (performanceConsent && functionalConsent && personalizationConsent) {
+			Map<String, Integer> cookieConsentTypesCache =
+				CookiesConsentTypesCaching.getCookiesConsentTypesMapCache();
+
 			optionalConsent = true;
+
+			for (Map.Entry<String, Integer> cookieConsentType :
+					cookieConsentTypesCache.entrySet()) {
+
+				boolean consentTypeValue = GetterUtil.getBoolean(
+					cookieValues.get(
+						_getConsentTypeName(cookieConsentType.getValue())));
+
+				if (!consentTypeValue) {
+					CookiesManagerUtil.deleteCookies(
+						CookiesManagerUtil.getDomain(httpServletRequest),
+						httpServletRequest, httpServletResponse,
+						cookieConsentType.getKey());
+				}
+			}
 		}
 
 		boolean userConsent = Validator.isNotNull(

--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.cookies.internal.manager;
 
 import com.liferay.cookies.configuration.CookiesPreferenceHandlingConfiguration;
+import com.liferay.cookies.internal.manager.util.CookiesConsentTypesCaching;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
@@ -152,6 +153,8 @@ public class CookiesManagerImpl implements CookiesManager {
 				return false;
 			}
 		}
+
+		CookiesConsentTypesCaching.addCookie(cookie.getName(), consentType);
 
 		// LEP-5175
 

--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/util/CookiesConsentTypesCaching.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/util/CookiesConsentTypesCaching.java
@@ -1,0 +1,27 @@
+package com.liferay.cookies.internal.manager.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.liferay.portal.kernel.util.Validator;
+
+public class CookiesConsentTypesCaching {
+	 
+	private static Map<String, Integer> cookiesConsentTypesMapCache = 
+			new HashMap<String, Integer>();
+	
+	public static void addCookie(String cookieName, Integer cookieConsentType) {
+		if (!_isPresent(cookieName)) {
+			cookiesConsentTypesMapCache.put(cookieName, cookieConsentType);
+		}
+	}
+
+	private static boolean _isPresent(String cookieName) {
+		return !Validator.isNull(cookiesConsentTypesMapCache.get(cookieName));
+	}
+
+	public static Map<String, Integer> getCookiesConsentTypesMapCache() {
+		return cookiesConsentTypesMapCache;
+	}
+
+}

--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/util/CookiesConsentTypesCaching.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/util/CookiesConsentTypesCaching.java
@@ -1,3 +1,8 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+ 
 package com.liferay.cookies.internal.manager.util;
 
 import java.util.HashMap;
@@ -5,6 +10,9 @@ import java.util.Map;
 
 import com.liferay.portal.kernel.util.Validator;
 
+/**
+ * @author Mirna Gama
+ */
 public class CookiesConsentTypesCaching {
 	 
 	private static Map<String, Integer> cookiesConsentTypesMapCache = 

--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/util/CookiesConsentTypesCaching.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/util/CookiesConsentTypesCaching.java
@@ -2,34 +2,35 @@
  * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
- 
+
 package com.liferay.cookies.internal.manager.util;
+
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import com.liferay.portal.kernel.util.Validator;
 
 /**
  * @author Mirna Gama
  */
 public class CookiesConsentTypesCaching {
-	 
-	private static Map<String, Integer> cookiesConsentTypesMapCache = 
-			new HashMap<String, Integer>();
-	
+
 	public static void addCookie(String cookieName, Integer cookieConsentType) {
 		if (!_isPresent(cookieName)) {
-			cookiesConsentTypesMapCache.put(cookieName, cookieConsentType);
+			_cookiesConsentTypesMapCache.put(cookieName, cookieConsentType);
 		}
 	}
 
-	private static boolean _isPresent(String cookieName) {
-		return !Validator.isNull(cookiesConsentTypesMapCache.get(cookieName));
+	public static Map<String, Integer> getCookiesConsentTypesMapCache() {
+		return _cookiesConsentTypesMapCache;
 	}
 
-	public static Map<String, Integer> getCookiesConsentTypesMapCache() {
-		return cookiesConsentTypesMapCache;
+	private static boolean _isPresent(String cookieName) {
+		return Validator.isNotNull(
+			_cookiesConsentTypesMapCache.get(cookieName));
 	}
+
+	private static final Map<String, Integer> _cookiesConsentTypesMapCache =
+		new HashMap<>();
 
 }


### PR DESCRIPTION
#### Context:
https://liferay.atlassian.net/browse/LPS-176164

#### Implementation details: 
Basically, the ticket describes that after declining all cookies from the cookie banner, the non-necessary cookies should not remain in the browser.
I was analyzing the module responsible for the cookies to provide a solution and these are my findings:
- When adding / updating a cookie, the method [addCookie from CookieManagerImpl class](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java#L133) will be called. In this method, it will check if the cookies preference handling configuration is enabled. If it is, then it [will call the method hasConsentType to check if the consent type value of this cookie is set to true](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java#L151). After that, it will return false, but if there is a cookie already stored it will be remained. 

- Analyzing a little more, I found the [CookiePreAction](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/events/CookiesPreAction.java#L67) class that can be called even if I refresh the page, but there is another problem because the stored cookies do not have their consent types explicitly stored together, so there is no way to "filter" which cookies should remain. The only way to know the consent type of the cookie is when it is being added or updated. (Example: [When the GUEST_LANGUAGE_ID cookie is added](https://github.com/liferay/liferay-portal-ee/blob/master/portal-impl/src/com/liferay/portal/language/LanguageImpl.java#L1715) )

Based on this findings, it was proposed in this [thread](https://liferay.slack.com/archives/GLX0ZN4QH/p1697647943709669) that we could track the unique cookie names and their consent types when the add method is called and then check them afterwards in the CookiesPreAction class. 

#### Commits included: 
- LPS-176164 Create caching utility class to add and search for cookies and their consent types
- LPS-176164 Insert into the caching hashmap when adding the cookie
- LPS-176164 Check if there are cookies with consent type declined so they can be deleted in the pre-action class
- LPS-176164 Add missing copyright
- LPS-176164 SF