### PR TITLE
[TS] LPS-200153 

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditUserMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/EditUserMVCActionCommand.java
@@ -503,7 +503,7 @@ public class EditUserMVCActionCommand
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			User.class.getName(), actionRequest);
 
-		User user = _userService.addUser(
+		User user = _userService.addUserWithWorkflow(
 			themeDisplay.getCompanyId(), true, null, null, autoScreenName,
 			screenName, emailAddress, LocaleUtil.fromLanguageId(languageId),
 			firstName, middleName, lastName, prefixListTypeId, suffixListTypeId,


### PR DESCRIPTION
**Context:**
[LPS-200153 - Worfklow assigned to Users asset is not applied
](https://liferay.atlassian.net/browse/LPS-200153)

**Steps to reproduce:**
- Login as admin
- Apply 'Single Approve workflow' to User (Applications tab -> WORKFLOW -> ProcessBuilder -> Configuration tab -> User Asset Type -> Edit -> dropdown = SingleApprover -> Save)
- Create a new user (i.e. 'usernew')(Control Panel tab -> USERS -> Users and Organizations -> Organizations -> Users tab -> Add User)

✅ _Expected behavior:_ A new notification is received by 'test' user related to approve the recently created user 'usernew'.
❌ _Observed behavior:_ User 'usernew' is created and active.

**Implementation details:**

It was discovered that [WorkflowThreadLocal will always set enabled to false before adding the user in addUser from UserServiceImpl class](https://github.com/liferay/liferay-portal/blame/master/portal-impl/src/com/liferay/portal/service/impl/UserServiceImpl.java#L480), so the workflow will never be applied. Looks like this was intentional judging from the commit message 12 years ago:
> [LPS-15131 - using old addUser to signify without workflow; adding new method addUserWithWorkflow to use with workflow.](https://github.com/liferay/liferay-portal-ee/commit/f482cbe52c5c273105fa55234611b3db4c90fb0f)

To avoid this, the method used to add user in Edit User Page has been replaced with [addUserWithWorkflow](https://github.com/liferay-appsec/liferay-portal/pull/1470/commits/e28c4ababc069f97f668e45a9798b1e553150372#diff-e4cda858d7fb8d014352e38c40f7caa5cf553da441392616d1ba2f1c33c18650R506)

**Commits included:**
- LPS-200153 Add user with workflow for edit user action command class