### PR TITLE
[TS] LPS-200609

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/css/main.scss
@@ -23,6 +23,10 @@ $addedItemHighlightColor: #e6ffed;
 	.padlock {
 		flex: 1;
 	}
+
+	margin: 0 auto;
+	position: absolute !important;
+	right: 0;
 }
 
 .borderless {


### PR DESCRIPTION
### Context:
[LPS-200609 - Edit client credentials modal causes blank space above page and collapses screen](https://liferay.atlassian.net/browse/LPS-200609)

### Steps to reproduce:

1. Go to Control Panel > Security > OAuth 2 Administration
2. Select any "OAuth 2 Administration"
3. Click "Edit" button on "Client ID" or "Client Secret"

Actual result: An unnecessary blank space appears at the top of the screen.
Expected result: Unnecessary blank space is not displayed.

### Implementation details:
It was discovered that the property "position: relative" from modal-dialog class in [clay_admin.scss](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss#L44) was affecting this element. This would make the modal appear above the page. To avoid this, it was necessary to emphasize that this edit modal should have the absolute position on the page.

### Commits included:
- LPS-200609 Set position absolute for oauth2 modal so it does not appear above the page