### PR TITLE
LPS-198872 Upgrade Antisamy to 1.7.4 to address CVE-2023-43643

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -3042,7 +3042,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.security.antisamy.jar!antisamy.jar</file-name>
-				<version>1.7.2</version>
+				<version>1.7.4</version>
 				<project-name>OWASP AntiSamy</project-name>
 				<project-url>https://github.com/nahsra/antisamy</project-url>
 				<licenses>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -1022,7 +1022,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.oauth.client.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.oauth.client.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1598,7 +1598,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.security.antisamy.jar!antisamy.jar</td><td nowrap="nowrap">1.7.2</td><td nowrap="nowrap"><a href="https://github.com/nahsra/antisamy">OWASP AntiSamy</a></td><td nowrap><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3</a>
+<td nowrap="nowrap">com.liferay.portal.security.antisamy.jar!antisamy.jar</td><td nowrap="nowrap">1.7.4</td><td nowrap="nowrap"><a href="https://github.com/nahsra/antisamy">OWASP AntiSamy</a></td><td nowrap><a href="https://opensource.org/licenses/BSD-3-Clause">BSD 3</a>
 <br>
 </td><td></td>
 </tr>
@@ -1724,7 +1724,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.impl.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.impl.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>
@@ -1754,7 +1754,7 @@
 </tr>
 			
 <tr>
-<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html&lrm;">Apache License, version 2.0</a>
+<td nowrap="nowrap">com.liferay.portal.security.sso.openid.connect.persistence.service.jar!oauth2-oidc-sdk.jar</td><td nowrap="nowrap">8.11</td><td nowrap="nowrap"><a href="https://connect2id.com">OAuth 2.0 SDK with OpenID Connect extensions</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.html?">Apache License, version 2.0</a>
 <br>
 </td><td></td>
 </tr>

--- a/modules/apps/portal-security/portal-security-antisamy/build.gradle
+++ b/modules/apps/portal-security/portal-security-antisamy/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 	compileInclude group: "org.apache.xmlgraphics", name: "batik-i18n", version: "1.16"
 	compileInclude group: "org.apache.xmlgraphics", name: "batik-util", version: "1.16"
 	compileInclude group: "org.apache.xmlgraphics", name: "xmlgraphics-commons", version: "2.6"
-	compileInclude group: "org.owasp.antisamy", name: "antisamy", version: "1.7.2"
+	compileInclude group: "org.owasp.antisamy", name: "antisamy", version: "1.7.4"
 	compileInclude group: "xml-apis", name: "xml-apis-ext", version: "1.3.04"
 
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"


### PR DESCRIPTION
Antisamy 1.7.2 contains a known vulnerability [CVE-2023-43643](https://nvd.nist.gov/vuln/detail/CVE-2023-43643). This ticket upgrades it to 1.7.4 to address this vulnerability.

Ticket: [LPS-198872](https://liferay.atlassian.net/browse/LPS-198872)