### PR TITLE
LPS-198530

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -774,8 +774,7 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 
 		User user = _userService.getUserById(userAccountId);
 
-		if ((user.getStatus() == WorkflowConstants.STATUS_PENDING)) {
-
+		if (user.getStatus() == WorkflowConstants.STATUS_PENDING) {
 			throw new UserActiveException(
 				"User " + user.getUuid() +
 					" cannot be changed under verification");

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/UserAccountResourceImpl.java
@@ -38,6 +38,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.captcha.CaptchaSettings;
 import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
 import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
+import com.liferay.portal.kernel.exception.UserActiveException;
 import com.liferay.portal.kernel.exception.UserLockoutException;
 import com.liferay.portal.kernel.exception.UserPasswordException;
 import com.liferay.portal.kernel.model.Address;
@@ -771,6 +772,15 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 			Long userAccountId, UserAccount userAccount)
 		throws Exception {
 
+		User user = _userService.getUserById(userAccountId);
+
+		if ((user.getStatus() == WorkflowConstants.STATUS_PENDING)) {
+
+			throw new UserActiveException(
+				"User " + user.getUuid() +
+					" cannot be changed under verification");
+		}
+
 		String status = userAccount.getStatusAsString();
 
 		Integer workflowStatus = null;
@@ -800,8 +810,6 @@ public class UserAccountResourceImpl extends BaseUserAccountResourceImpl {
 					accountBrief.getId(), userAccountId);
 			}
 		}
-
-		User user = _userService.getUserById(userAccountId);
 
 		String sms = null;
 		String facebook = null;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-198530

- LPS-198530 Get user old status and avoid updating it if the workflow status is pending
- LPS-198530 SF

**Reproduction:**
1. Login with admin user
2. Apply Single Approve workflow to User (CP/Applications/Workflow/ProcessBuilder/Configuration/User/Edit/dropdown=SingleApprover/Save)
3. Create a new user 
4. Via Headless API check the users status is ‘Inactive’ 
Use Headless API getUserAccount method (v1.0/user-accounts/${userID})
(curl -X 'GET' 'http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/34029' -H 'accept: application/json' -u 'test@liferay.com:test')
5. Via Headless API try to set status to ‘Active'
Use Headless API patchUserAccount method (v1.0/user-accounts/${userID})
(curl -X 'PATCH' 'http://localhost:8080/o/headless-admin-user/v1.0/user-accounts/33949' -H 'accept: application/json' -H 'Content-Type: application/json' -u 'test@liferay.com:test' -d '${responseFromGet}') -> change 'status' to 'Avaliable'

_Actual behavior:_
Status is set to ‘Active’

_Expected behavior:_
Status cannot be changed while user creation under verification
