### PR TITLE
LPS-201090 Remove DictionaryWordTextProducer from the default text producers configuration because it can produce offensive words

### DIFF
--- a/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/configuration/CaptchaConfiguration.java
+++ b/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/configuration/CaptchaConfiguration.java
@@ -118,7 +118,7 @@ public interface CaptchaConfiguration {
 	public String[] simpleCaptchaNoiseProducers();
 
 	@Meta.AD(
-		deflt = "com.liferay.captcha.simplecaptcha.DictionaryWordTextProducer|com.liferay.captcha.simplecaptcha.PinNumberTextProducer|nl.captcha.text.producer.DefaultTextProducer|nl.captcha.text.producer.FiveLetterFirstNameTextProducer",
+		deflt = "com.liferay.captcha.simplecaptcha.PinNumberTextProducer|nl.captcha.text.producer.DefaultTextProducer|nl.captcha.text.producer.FiveLetterFirstNameTextProducer",
 		description = "simple-captcha-text-producers-help",
 		name = "simple-captcha-text-producers", required = false
 	)

--- a/modules/apps/captcha/captcha-api/src/main/resources/com/liferay/captcha/configuration/packageinfo
+++ b/modules/apps/captcha/captcha-api/src/main/resources/com/liferay/captcha/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.2
+version 1.0.3


### PR DESCRIPTION
Ticket: [LPS-201090](https://liferay.atlassian.net/browse/LPS-201090)
Solution discussed on [PTR-4486](https://liferay.atlassian.net/browse/PTR-4486)

Original pr - https://github.com/liferay-appsec/liferay-portal/pull/1502