### PR TITLE
[TS] LPS-201686 

### DIFF
--- a/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/SimpleCaptchaImpl.java
+++ b/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/simplecaptcha/SimpleCaptchaImpl.java
@@ -112,17 +112,12 @@ public class SimpleCaptchaImpl implements Captcha {
 
 		HttpSession httpSession = _getHttpSession(httpServletRequest);
 
-		String key = WebKeys.CAPTCHA_TEXT;
-
-		String portletId = ParamUtil.getString(httpServletRequest, "portletId");
-
-		if (Validator.isNotNull(portletId)) {
-			key = portal.getPortletNamespace(portletId) + key;
-		}
+		String httpSessionKey = _getHttpSessionKey(
+			WebKeys.CAPTCHA_TEXT, httpServletRequest);
 
 		nl.captcha.Captcha simpleCaptcha = getSimpleCaptcha();
 
-		httpSession.setAttribute(key, simpleCaptcha.getAnswer());
+		httpSession.setAttribute(httpSessionKey, simpleCaptcha.getAnswer());
 
 		httpServletResponse.setContentType(ContentTypes.IMAGE_PNG);
 
@@ -435,7 +430,11 @@ public class SimpleCaptchaImpl implements Captcha {
 	private String _getHttpSessionKey(
 		String key, HttpServletRequest httpServletRequest) {
 
-		String portletId = portal.getPortletId(httpServletRequest);
+		String portletId = ParamUtil.getString(httpServletRequest, "portletId");
+
+		if (Validator.isNull(portletId)) {
+			portletId = portal.getPortletId(httpServletRequest);
+		}
 
 		if (Validator.isNotNull(portletId)) {
 			return portal.getPortletNamespace(portletId) + key;


### PR DESCRIPTION
**Steps to reproduce:**
1. Deploy my-test-captcha-1.0.0.jar. This is located in the /build/lib. (the file is attached in [here](https://liferay.atlassian.net/browse/LPS-201686))
2. Add it to a page, as a widget. It's under Sample, or you can search for it.
3. Input an email and the Captcha text.

_Actual Result:_ CAPTCHA Verification will fail.
_Expected Result:_ CAPTCHA Verification is successful

PS: This only happens with a custom captcha portlet, the captcha components from portal (Example: "forgot password" page) are working as expected. 

**Results of investigation:**

After debugging the SimpleCaptchaImpl class, I discovered that the captcha text is being successfully stored in the session attributes when the validateChallenge method is called (CAPTCHA_TEXT).
The problem is that the session key used to fetch the attribute for the captcha answer is made up of the portlet ID, stored as TestCaptcha_TestCaptchaPortlet_INSTANCE_vtmt_CAPTCHA_TEXT.
This attribute is initially set in the serveImage method and the portlet ID is obtained from the http servlet request param util class, which returns null, so is stored only as CAPTCHA_TEXT. 
