### PR TITLE
LPS-202716 Wrap all endpoints that does not handle ConflictException

### DIFF
--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserResourceManagerImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserResourceManagerImpl.java
@@ -17,6 +17,39 @@ import org.wso2.charon3.core.protocol.endpoints.UserResourceManager;
 public class UserResourceManagerImpl extends UserResourceManager {
 
 	@Override
+	public SCIMResponse delete(String id, UserManager userManager) {
+		try {
+			return super.delete(id, userManager);
+		}
+		catch (Exception exception) {
+			if (exception instanceof ConflictException) {
+				return AbstractResourceManager.encodeSCIMException(
+					(ConflictException)exception);
+			}
+
+			throw exception;
+		}
+	}
+
+	@Override
+	public SCIMResponse get(
+		String id, UserManager userManager, String attributes,
+		String excludeAttributes) {
+
+		try {
+			return super.get(id, userManager, attributes, excludeAttributes);
+		}
+		catch (Exception exception) {
+			if (exception instanceof ConflictException) {
+				return AbstractResourceManager.encodeSCIMException(
+					(ConflictException)exception);
+			}
+
+			throw exception;
+		}
+	}
+
+	@Override
 	public SCIMResponse updateWithPUT(
 		String existingId, String scimObjectString, UserManager userManager,
 		String attributes, String excludeAttributes) {


### PR DESCRIPTION
We use ConflictException to show that an object was provisioned by another SCIM client, however this exception is only handled in Charon during create. We need to wrap the other endpoints to return the proper response instead of a runtime exception.

[LPS-202716](https://liferay.atlassian.net/browse/LPS-202716)