### PR TITLE
LPS 199721 solving 

### DIFF
--- a/modules/apps/cookies/cookies-test/build.gradle
+++ b/modules/apps/cookies/cookies-test/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
+	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+
 	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testImplementation group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	testImplementation group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"

--- a/modules/apps/cookies/cookies-test/build.gradle
+++ b/modules/apps/cookies/cookies-test/build.gradle
@@ -1,6 +1,4 @@
 dependencies {
-	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
-
 	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testImplementation group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	testImplementation group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.saml.opensaml.integration.internal.servlet.profile;
 
+import com.liferay.portal.kernel.cookies.CookiesManager;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -52,8 +53,10 @@ import net.shibboleth.utilities.java.support.security.IdentifierGenerationStrate
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -94,6 +97,7 @@ import org.opensaml.security.credential.Credential;
 import org.opensaml.xmlsec.signature.Signature;
 
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -109,6 +113,17 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		_cookiesManagerServiceRegistration = _bundleContext.registerService(
+			CookiesManager.class, Mockito.mock(CookiesManager.class), null);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_cookiesManagerServiceRegistration.unregister();
+	}
 
 	@Before
 	@Override
@@ -1266,6 +1281,11 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 			assertion.getSignature(), messageContext,
 			metadataManagerImpl.getSignatureTrustEngine());
 	}
+
+	private static final BundleContext _bundleContext =
+		SystemBundleUtil.getBundleContext();
+	private static ServiceRegistration<CookiesManager>
+		_cookiesManagerServiceRegistration;
 
 	private final RelayStateHelperImpl _relayStateHelperImpl =
 		new RelayStateHelperImpl();

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/XMLSecurityTest.java
@@ -6,6 +6,8 @@
 package com.liferay.saml.opensaml.integration.internal.servlet.profile;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.cookies.CookiesManager;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.saml.constants.SamlWebKeys;
@@ -29,7 +31,9 @@ import java.util.zip.DeflaterOutputStream;
 
 import org.apache.xml.security.algorithms.JCEMapper;
 
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,6 +47,9 @@ import org.opensaml.saml.saml2.core.AuthnRequest;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.security.crypto.SigningUtil;
 
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
@@ -55,6 +62,17 @@ public class XMLSecurityTest extends BaseSamlTestCase {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@BeforeClass
+	public static void setUpClass() {
+		_cookiesManagerServiceRegistration = _bundleContext.registerService(
+			CookiesManager.class, Mockito.mock(CookiesManager.class), null);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_cookiesManagerServiceRegistration.unregister();
+	}
 
 	@Before
 	@Override
@@ -351,6 +369,11 @@ public class XMLSecurityTest extends BaseSamlTestCase {
 
 		return encoder.withoutPadding();
 	}
+
+	private static final BundleContext _bundleContext =
+		SystemBundleUtil.getBundleContext();
+	private static ServiceRegistration<CookiesManager>
+		_cookiesManagerServiceRegistration;
 
 	private final RelayStateHelperImpl _relayStateHelperImpl =
 		new RelayStateHelperImpl();


### PR DESCRIPTION
The error is due to the changes that were made in the [CookieManagerUtil](https://github.com/shuyangzhou/liferay-portal/blob/2a368a71d14218a456848a165ca6afd50d5202ca/portal-kernel/src/com/liferay/portal/kernel/cookies/CookiesManagerUtil.java) class by the ticket [LPS-199721](https://liferay.atlassian.net/browse/LPS-199721).

After the changes, to resolve the exception in the test, the `CookiesManager` service has been registered in the tests. 


Tickets:

- [LPS-200601](https://liferay.atlassian.net/browse/LPS-200601) -> WebSsoProfileIntegrationTest
- [LPS-200599](https://liferay.atlassian.net/browse/LPS-200599) -> CookiesPreActionTest
- [LPS-202837](https://liferay.atlassian.net/browse/LPS-202837) -> CookiesDomainTest
- [LPS-203046](https://liferay.atlassian.net/browse/LPS-203046) -> XMLSecurityTest