### PR TITLE
LRAC-14795 | master

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/handler/OAuth2RESTAuthVerifierErrorResponseHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/handler/OAuth2RESTAuthVerifierErrorResponseHandler.java
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.handler;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Marcos Martins
+ */
+public interface OAuth2RESTAuthVerifierErrorResponseHandler {
+
+	public void handle(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse);
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/security/auth/verifier/OAuth2RESTAuthVerifier.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/security/auth/verifier/OAuth2RESTAuthVerifier.java
@@ -6,6 +6,7 @@
 package com.liferay.oauth2.provider.rest.internal.security.auth.verifier;
 
 import com.liferay.oauth2.provider.constants.OAuth2ProviderConstants;
+import com.liferay.oauth2.provider.handler.OAuth2RESTAuthVerifierErrorResponseHandler;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.rest.spi.bearer.token.provider.BearerTokenProvider;
@@ -19,6 +20,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.security.auth.AccessControlContext;
 import com.liferay.portal.kernel.security.auth.AuthException;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifier;
@@ -97,6 +99,16 @@ public class OAuth2RESTAuthVerifier implements AuthVerifier {
 
 				httpServletResponse.setStatus(
 					HttpServletResponse.SC_UNAUTHORIZED);
+
+				OAuth2RESTAuthVerifierErrorResponseHandler
+					oAuth2RESTAuthVerifierErrorResponseHandler =
+						_oAuth2RESTAuthVerifierErrorResponseHandlerSnapshot.
+							get();
+
+				if (oAuth2RESTAuthVerifierErrorResponseHandler != null) {
+					oAuth2RESTAuthVerifierErrorResponseHandler.handle(
+						accessControlContext.getRequest(), httpServletResponse);
+				}
 
 				authVerifierResult.setState(
 					AuthVerifierResult.State.INVALID_CREDENTIALS);
@@ -213,6 +225,11 @@ public class OAuth2RESTAuthVerifier implements AuthVerifier {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		OAuth2RESTAuthVerifier.class);
+
+	private static final Snapshot<OAuth2RESTAuthVerifierErrorResponseHandler>
+		_oAuth2RESTAuthVerifierErrorResponseHandlerSnapshot = new Snapshot<>(
+			OAuth2RESTAuthVerifier.class,
+			OAuth2RESTAuthVerifierErrorResponseHandler.class, null, true);
 
 	@Reference(
 		policy = ReferencePolicy.DYNAMIC,

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/handler/FaroOAuth2RESTAuthVerifierErrorResponseHandler.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/handler/FaroOAuth2RESTAuthVerifierErrorResponseHandler.java
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.osb.faro.web.internal.handler;
+
+import com.liferay.oauth2.provider.handler.OAuth2RESTAuthVerifierErrorResponseHandler;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.servlet.ServletResponseUtil;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Marcos Martins
+ */
+@Component(service = OAuth2RESTAuthVerifierErrorResponseHandler.class)
+public class FaroOAuth2RESTAuthVerifierErrorResponseHandler
+	implements OAuth2RESTAuthVerifierErrorResponseHandler {
+
+	@Override
+	public void handle(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		try {
+			ServletResponseUtil.write(
+				httpServletResponse,
+				JSONUtil.put(
+					"message",
+					_language.get(
+						httpServletRequest,
+						"your-access-token-has-expired.-please-generate-a-" +
+							"new-one-and-try-again")
+				).put(
+					"status", "ERROR"
+				).toString());
+		}
+		catch (IOException ioException) {
+			_log.error(ioException);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FaroOAuth2RESTAuthVerifierErrorResponseHandler.class.getName());
+
+	@Reference
+	private Language _language;
+
+}

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test.
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation.
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected.
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again.
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize.
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials.
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_ar.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_ar.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_bg.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_bg.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_ca.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_ca.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_cs.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_cs.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_da.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_da.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_de.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_de.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_el.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_el.properties
@@ -1701,6 +1701,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_en.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_en.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test.
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation.
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected.
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again.
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize.
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials.
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_en_AU.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_en_AU.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_en_CA.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_en_CA.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_en_GB.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_en_GB.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_es.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_es.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=Perderá de forma permanente todos los datos de prueba y los resultados recopilados de esta prueba.
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=Perderá de forma permanente los datos de análisis registrados desde hace {0}. Esta operación no se puede deshacer.
 you-will-still-have-access-to-the-data-that-has-already-been-collected=Aún podrá acceder a los datos que ya se han recopilado.
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=El token de autorización de {0} ha caducado. Póngase en contacto con el administrador de OAuth ({1}) para volver a autorizarlo.
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Su token de autorización para {0} ha caducado. {1} sus credenciales de la cuenta.
 your-dxp-instance-is-connected-to-analytics-cloud=Su instancia de DXP está conectada a Analytics Cloud

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_es_AR.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_es_AR.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=Perderá de forma permanente todos los datos de prueba y los resultados recopilados de esta prueba.
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=Perderá de forma permanente los datos de análisis registrados desde hace {0}. Esta operación no se puede deshacer.
 you-will-still-have-access-to-the-data-that-has-already-been-collected=Aún podrá acceder a los datos que ya se han recopilado.
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=El token de autorización de {0} ha caducado. Póngase en contacto con el administrador de OAuth ({1}) para volver a autorizarlo.
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Su token de autorización para {0} ha caducado. {1} sus credenciales de la cuenta.
 your-dxp-instance-is-connected-to-analytics-cloud=Su instancia de DXP está conectada a Analytics Cloud

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_es_CO.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_es_CO.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=Perderá de forma permanente todos los datos de prueba y los resultados recopilados de esta prueba.
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=Perderá de forma permanente los datos de análisis registrados desde hace {0}. Esta operación no se puede deshacer.
 you-will-still-have-access-to-the-data-that-has-already-been-collected=Aún podrá acceder a los datos que ya se han recopilado.
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=El token de autorización de {0} ha caducado. Póngase en contacto con el administrador de OAuth ({1}) para volver a autorizarlo.
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Su token de autorización para {0} ha caducado. {1} sus credenciales de la cuenta.
 your-dxp-instance-is-connected-to-analytics-cloud=Su instancia de DXP está conectada a Analytics Cloud

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_es_MX.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_es_MX.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=Perderá de forma permanente todos los datos de prueba y los resultados recopilados de esta prueba.
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=Perderá de forma permanente los datos de análisis registrados desde hace {0}. Esta operación no se puede deshacer.
 you-will-still-have-access-to-the-data-that-has-already-been-collected=Aún podrá acceder a los datos que ya se han recopilado.
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=El token de autorización de {0} ha caducado. Póngase en contacto con el administrador de OAuth ({1}) para volver a autorizarlo.
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Su token de autorización para {0} ha caducado. {1} sus credenciales de la cuenta.
 your-dxp-instance-is-connected-to-analytics-cloud=Su instancia de DXP está conectada a Analytics Cloud

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_et.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_et.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_eu.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_eu.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_fa.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_fa.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_fi.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_fi.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_fr.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_fr.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_fr_CA.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_gl.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_gl.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_hi_IN.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_hr.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_hr.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_hu.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_hu.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_in.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_in.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_it.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_it.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_iw.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_iw.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_ja.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_ja.properties
@@ -1701,6 +1701,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=このテストから収集したすべてのテストデータと結果が完全に失われます。
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=記録してから{0}を経過した分析データは完全に失われます。この操作を取り消すことはできません。
 you-will-still-have-access-to-the-data-that-has-already-been-collected=収集済みのデータには引き続きアクセスできます。
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize={0}の認証トークンが期限切れになっています。OAuth 管理者である {1} に連絡し、再認証してください。
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials={0}の認証トークンが期限切れになっています。アカウント資格情報を{1}してください。
 your-dxp-instance-is-connected-to-analytics-cloud=DXP インスタンスは Analytics Cloud に接続されています

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_kk.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_kk.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_km.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_km.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_ko.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_ko.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_lo.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_lo.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_lt.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_lt.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_ms.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_ms.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_nb.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_nb.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_nl.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_nl.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_nl_BE.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_pl.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_pl.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_pt_BR.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=Você perderá permanentemente todos os dados e resultados do teste coletados.
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=Você perderá permanentemente os dados analíticos que foram gravados há mais de {0}. Esta operação não poderá ser desfeita.
 you-will-still-have-access-to-the-data-that-has-already-been-collected=Você ainda tem acesso aos dados que já foram coletados.
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Seu token de autorização para {0} expirou. Entre em contato com seu administrador OAuth, {1}, para autorizá-lo novamente.
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Seu token de autorização para {0} expirou. Por favor, {1} suas credenciais de conta.
 your-dxp-instance-is-connected-to-analytics-cloud=Sua instância DXP está conectada ao Analytics Cloud

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_pt_PT.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=Você perderá permanentemente todos os dados e resultados do teste coletados.
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=Você perderá permanentemente os dados analíticos que foram gravados há mais de {0}. Esta operação não poderá ser desfeita.
 you-will-still-have-access-to-the-data-that-has-already-been-collected=Você ainda tem acesso aos dados que já foram coletados.
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Seu token de autorização para {0} expirou. Entre em contato com seu administrador OAuth, {1}, para autorizá-lo novamente.
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Seu token de autorização para {0} expirou. Por favor, {1} suas credenciais de conta.
 your-dxp-instance-is-connected-to-analytics-cloud=Sua instância DXP está conectada ao Analytics Cloud

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_ro.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_ro.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_ru.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_ru.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_sk.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_sk.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_sl.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_sl.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_sr_RS.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_sv.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_sv.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_ta_IN.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_th.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_th.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_tr.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_tr.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_uk.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_uk.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_vi.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_vi.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_zh_CN.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/resources/content/Language_zh_TW.properties
@@ -1702,6 +1702,7 @@ you-will-permanently-lose-all-contacts-and-analytics-data-collected-from-this-da
 you-will-permanently-lose-all-test-data-and-results-collected-from-this-test=You will permanently lose all test data and results collected from this test. (Automatic Copy)
 you-will-permanently-lose-analytics-data-that-has-been-recorded-over-x-ago.-you-will-not-be-able-to-undo-this-operation=You will permanently lose analytics data that has been recorded over {0} ago. You will not be able to undo this operation. (Automatic Copy)
 you-will-still-have-access-to-the-data-that-has-already-been-collected=You will still have access to the data that has already been collected. (Automatic Copy)
+your-access-token-has-expired.-please-generate-a-new-one-and-try-again=Your access token has expired. Please generate a new one and try again. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-contact-your-oauth-administrator,-x,-to-reauthorize=Your authorization token for {0} has expired. Please contact your OAuth Administrator, {1}, to reauthorize. (Automatic Copy)
 your-authorization-token-for-x-has-expired.-please-x-your-account-credentials=Your authorization token for {0} has expired. Please {1} your account credentials. (Automatic Copy)
 your-dxp-instance-is-connected-to-analytics-cloud=Your DXP Instance Is Connected to Analytics Cloud (Automatic Copy)


### PR DESCRIPTION
Jira ticket: https://issues.liferay.com/browse/LRAC-14795

Hi team!
This pull aims find a way to manipulate the response body when we get an 401 error in [OAuth2RESTAuthVerifier](https://github.com/liferay/liferay-portal/blob/master/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/security/auth/verifier/OAuth2RESTAuthVerifier.java).

Basically, I need to set a message in the response body, telling the user the token has expired

I talked to Stian via Slack and he had suggested me to implement `ContainerResponseFilter` to cover this. However, it didn't work because, I believe, when we get 401 error in `OAuth2RESTAuthVerifier`, we also set the state of  `authVerifierResultAuthVerifierResult.State.INVALID_CREDENTIALS` and then ends up to prevent `AuthVerifierFilter` from process the next filter (see [AuthVerifierFilter](https://github.com/liferay/liferay-portal/blob/0848120527e55ff5257496f80e8881ee0ddbaff6/portal-impl/src/com/liferay/portal/servlet/filters/authverifier/AuthVerifierFilter.java#L166))


So I created this interface `OAuth2RESTAuthVerifierErrorResponseHandler` and reference it as optional inside of OAuth2RESTAuthVerifier. This interface is implemented on Faro side, so we can manipulate the response and keep current behavior for the other cases.

Look forward to hear your guys thoughts about this.
Thanks in advance!