### PR TITLE
LPS-206231 DXP SP does not correctly handle RelayState provided via IDP Initiated SSO

### DIFF
--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelperImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelperImpl.java
@@ -8,6 +8,7 @@ package com.liferay.saml.opensaml.integration.internal.helper;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.saml.helper.RelayStateHelper;
 
@@ -25,7 +26,13 @@ import org.osgi.service.component.annotations.Component;
 public class RelayStateHelperImpl implements RelayStateHelper {
 
 	public String getRedirectFromRelayStateToken(String relayStateToken) {
-		return _relayStateTokensToRedirects.get(relayStateToken);
+		String redirect = _relayStateTokensToRedirects.get(relayStateToken);
+
+		if (Validator.isNull(redirect)) {
+			return relayStateToken;
+		}
+
+		return redirect;
 	}
 
 	public String getRelayStateTokenFromRedirect(String redirect) {

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelperImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelperImpl.java
@@ -26,13 +26,13 @@ import org.osgi.service.component.annotations.Component;
 public class RelayStateHelperImpl implements RelayStateHelper {
 
 	public String getRedirectFromRelayStateToken(String relayStateToken) {
-		String redirect = _relayStateTokensToRedirects.get(relayStateToken);
+		if (Validator.isNotNull(relayStateToken) &&
+			relayStateToken.startsWith("RDR_")) {
 
-		if (Validator.isNull(redirect)) {
-			return relayStateToken;
+			return _relayStateTokensToRedirects.get(relayStateToken);
 		}
 
-		return redirect;
+		return relayStateToken;
 	}
 
 	public String getRelayStateTokenFromRedirect(String redirect) {
@@ -50,7 +50,7 @@ public class RelayStateHelperImpl implements RelayStateHelper {
 			_relayStateTokensToRedirects.remove(relayStateToken);
 		}
 
-		relayStateToken = PortalUUIDUtil.generate();
+		relayStateToken = "RDR_" + PortalUUIDUtil.generate();
 
 		_redirectsToRelayStateTokens.put(redirect, relayStateToken);
 


### PR DESCRIPTION
Related issue: [LPS-206231](https://liferay.atlassian.net/browse/LPS-206231)

Hi @stian-sigvartsen !

I did what you suggested on the ticket description, but I couldn't think of a way to handle the scenario where  `_relayStateTokensToRedirects` is expired. Can you take a look? 

Thanks :)