### PR TITLE
LPD-15645 Unwrap HttpServletRequest in instances of DynamicServletReq…

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/servlet/RESTClientHttpRequest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/servlet/RESTClientHttpRequest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.vulcan.internal.template.servlet;
 
+import com.liferay.portal.kernel.servlet.DynamicServletRequest;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.kernel.servlet.PortalSessionThreadLocal;
@@ -36,6 +37,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import javax.servlet.http.HttpUpgradeHandler;
@@ -345,11 +347,23 @@ public class RESTClientHttpRequest implements HttpServletRequest {
 
 	@Override
 	public HttpSession getSession() {
-		return _httpServletRequest.getSession();
+		return getSession(false);
 	}
 
 	@Override
 	public HttpSession getSession(boolean create) {
+		HttpServletRequestWrapper httpServletRequestWrapper =
+			(HttpServletRequestWrapper)_httpServletRequest;
+
+		ServletRequest servletRequest = httpServletRequestWrapper.getRequest();
+
+		if (servletRequest instanceof DynamicServletRequest) {
+			DynamicServletRequest dynamicServletRequest =
+				(DynamicServletRequest)servletRequest;
+
+			return dynamicServletRequest.getSession(create);
+		}
+
 		return _httpServletRequest.getSession(create);
 	}
 


### PR DESCRIPTION
…uest so we can return the StandardSession object

https://liferay.atlassian.net/browse/LPD-15645

I'm not sure if unwrapping the request to get the StandardSession is somehow insecure or incorrect, but I haven't seen the solution break anything yet.

Otherwise, I could just attempt to retrieve the `X-CSRF-Token` header in [SessionAuthToken](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/security/auth/SessionAuthToken.java), where [we fail this check](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/security/auth/SessionAuthToken.java#L142) without my fix.  That just seems a bit redundant, since we would just be checking that value against itself a few lines later.

My last potential solution would be to unwrap the _httpServletRequest before storing it in the [RESTClientTemplateContextContributor#RestClient class](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/RESTClientTemplateContextContributor.java#L56).  This isn't too different from my fix now, just something to consider.

Please let me know if you have any questions, or suggestions for a different solution if needed, thanks!