### PR TITLE
LPS-206231 [Adding Tests] DXP SP does not correctly handle RelayState provided via IDP Initiated SSO - 2

### DIFF
--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelperImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelperImpl.java
@@ -8,6 +8,7 @@ package com.liferay.saml.opensaml.integration.internal.helper;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.saml.helper.RelayStateHelper;
 
@@ -25,7 +26,13 @@ import org.osgi.service.component.annotations.Component;
 public class RelayStateHelperImpl implements RelayStateHelper {
 
 	public String getRedirectFromRelayStateToken(String relayStateToken) {
-		return _relayStateTokensToRedirects.get(relayStateToken);
+		String redirect = _relayStateTokensToRedirects.get(relayStateToken);
+
+		if (Validator.isNull(redirect)) {
+			return relayStateToken;
+		}
+
+		return redirect;
 	}
 
 	public String getRelayStateTokenFromRedirect(String redirect) {

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelperImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelperImpl.java
@@ -26,13 +26,13 @@ import org.osgi.service.component.annotations.Component;
 public class RelayStateHelperImpl implements RelayStateHelper {
 
 	public String getRedirectFromRelayStateToken(String relayStateToken) {
-		String redirect = _relayStateTokensToRedirects.get(relayStateToken);
+		if (Validator.isNotNull(relayStateToken) &&
+			relayStateToken.startsWith("RDR_")) {
 
-		if (Validator.isNull(redirect)) {
-			return relayStateToken;
+			return _relayStateTokensToRedirects.get(relayStateToken);
 		}
 
-		return redirect;
+		return relayStateToken;
 	}
 
 	public String getRelayStateTokenFromRedirect(String redirect) {
@@ -50,7 +50,7 @@ public class RelayStateHelperImpl implements RelayStateHelper {
 			_relayStateTokensToRedirects.remove(relayStateToken);
 		}
 
-		relayStateToken = PortalUUIDUtil.generate();
+		relayStateToken = "RDR_" + PortalUUIDUtil.generate();
 
 		_redirectsToRelayStateTokens.put(redirect, relayStateToken);
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelperTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelperTest.java
@@ -47,6 +47,8 @@ public class RelayStateHelperTest extends BaseSamlTestCase {
 		String relayState =
 			_relayStateHelperImpl.getRelayStateTokenFromRedirect(RELAY_STATE);
 
+		Assert.assertNotEquals(RELAY_STATE, relayState);
+
 		Assert.assertEquals(
 			RELAY_STATE,
 			_relayStateHelperImpl.getRedirectFromRelayStateToken(relayState));

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelperTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelperTest.java
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.saml.opensaml.integration.internal.helper;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.saml.opensaml.integration.internal.BaseSamlTestCase;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Manuele Castro
+ */
+public class RelayStateHelperTest extends BaseSamlTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		ReflectionTestUtil.invoke(
+			_relayStateHelperImpl, "activate", new Class<?>[0]);
+	}
+
+	@Test
+	public void testGetRedirectFromRelayStateTokenIdpInitiatedSso() {
+		String relayState =
+			_relayStateHelperImpl.getRedirectFromRelayStateToken(RELAY_STATE);
+
+		Assert.assertEquals(RELAY_STATE, relayState);
+	}
+
+	@Test
+	public void testGetRedirectFromRelayStateTokenSpInitiatedSso() {
+		String relayState =
+			_relayStateHelperImpl.getRelayStateTokenFromRedirect(RELAY_STATE);
+
+		Assert.assertEquals(
+			RELAY_STATE,
+			_relayStateHelperImpl.getRedirectFromRelayStateToken(relayState));
+	}
+
+	private final RelayStateHelperImpl _relayStateHelperImpl =
+		new RelayStateHelperImpl();
+
+}

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelperTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/helper/RelayStateHelperTest.java
@@ -36,10 +36,9 @@ public class RelayStateHelperTest extends BaseSamlTestCase {
 
 	@Test
 	public void testGetRedirectFromRelayStateTokenIdpInitiatedSso() {
-		String relayState =
-			_relayStateHelperImpl.getRedirectFromRelayStateToken(RELAY_STATE);
-
-		Assert.assertEquals(RELAY_STATE, relayState);
+		Assert.assertEquals(
+			RELAY_STATE,
+			_relayStateHelperImpl.getRedirectFromRelayStateToken(RELAY_STATE));
 	}
 
 	@Test


### PR DESCRIPTION
@manuelecastro I've just added a bit extra to the tests. I don't see how the runtime code could be improved so hopefully that tests will clear things up.

> Related Issue: [LPD-1257](https://liferay.atlassian.net/browse/LPD-1257)
> 
> Hey @stian-sigvartsen !
> 
> I'm adding the test cases for RelayStateHelper as you asked. Here we can check the case where getRedirectFromRelayStateToken() needs to send back the RelayState as plain text for cases like when the SSO is IdP Initiated so RelayState is already the redirect.
> And also check the case when it is SP Initiated where it gets distinguished by the prefix RDR_ (standing for redirect) and checks if it's still a valid redirect and returns it.
> 
> Thanks!