### PR TITLE
LPD-5975 Revert "LRQA-81639 Blocked by LPS-160489"

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/DisabledUserClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/DisabledUserClientTest.java
@@ -25,7 +25,6 @@ import javax.ws.rs.core.Response;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,7 +42,6 @@ public class DisabledUserClientTest extends BaseClientTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Ignore
 	@Test
 	public void test() throws Exception {
 		WebTarget webTarget = getWebTarget("/users");


### PR DESCRIPTION
Related Issue: [LPD-5975](https://liferay.atlassian.net/browse/LPD-5975)

Reverting `@Ignore` since `com.liferay.oauth2.provider.client.test.DisabledUserClientTest` is not failing anymore.