### PR TITLE
LPD-17998 ldapadd command fails due deprecated -h switch

### DIFF
--- a/build-test-apacheds.xml
+++ b/build-test-apacheds.xml
@@ -77,7 +77,7 @@
 
 			<exec dir="${liferay.ldap.dependency.dir}" executable="/bin/bash">
 				<arg value="-c" />
-				<arg value="ldapadd -v -h 0.0.0.0:10389 -c -x -D uid=admin,ou=system -w secret -f ${ldifName}.ldif" />
+				<arg value="ldapadd -v -H ldap://0.0.0.0:10389 -c -x -D uid=admin,ou=system -w secret -f ${ldifName}.ldif" />
 			</exec>
 		</sequential>
 	</macrodef>


### PR DESCRIPTION
[LPD-17998](https://liferay.atlassian.net/browse/LPD-17998)
Hi Team,

This is a fix for several LDAP related functional test failures. Please let me know if you have any questions.

Regards,
Istvan

