### PR TITLE
LPD-18593 Fix Funtional Test: LocalFile.Audit#VerifyAuditMessageAfterModifyImpersonatedUserDisplaySettings with CLDR locale provider

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/administration/auditing/Audit.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/administration/auditing/Audit.testcase
@@ -945,12 +945,7 @@ definition {
 
 			UserNavigator.gotoDisplaySettings();
 
-			Select(
-				key_fieldLabel = "Time Zone",
-				locator1 = "Select#GENERIC_SELECT_FIELD",
-				value1 = "(UTC +01:00) Central European Time");
-
-			Click(locator1 = "Select#TIME_ZONE");
+			Click.clickNoMouseOver(locator1 = "//option[@value='Europe/Paris']");
 
 			PortletEntry.save();
 		}


### PR DESCRIPTION
Related issue: [LPD-18593](https://liferay.atlassian.net/browse/LPD-18593)

JDK internal may provide different display name based on the different locale providers used. JDK8 uses JRE/COMPAT by default. JDK21 uses CLDR as default. This made many locale related things change a little bit but enough to make many functional tests fail. Core Infra team decision is to move to use CLDR locale provider. So we need to update our functional tests or our production code accordingly.