### PR TITLE
LPD-20041

### DIFF
--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSessionTerminationSamlPortalFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSessionTerminationSamlPortalFilter.java
@@ -7,7 +7,9 @@ package com.liferay.saml.internal.servlet.filter;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.saml.persistence.model.SamlIdpSpSession;
 import com.liferay.saml.persistence.model.SamlSpSession;
+import com.liferay.saml.persistence.service.SamlIdpSpSessionLocalService;
 import com.liferay.saml.runtime.servlet.profile.SingleLogoutProfile;
 
 import javax.servlet.Filter;
@@ -73,8 +75,14 @@ public class SpSessionTerminationSamlPortalFilter extends BaseSamlPortalFilter {
 			_singleLogoutProfile.terminateSpSession(
 				httpServletRequest, httpServletResponse);
 
-			_singleLogoutProfile.logout(
-				httpServletRequest, httpServletResponse);
+			SamlIdpSpSession samlIdpSpSession =
+				_samlIdpSpSessionLocalService.fetchSamlIdpSpSession(
+					samlSpSession.getSamlSpSessionId());
+
+			if (samlIdpSpSession == null) {
+				_singleLogoutProfile.logout(
+					httpServletRequest, httpServletResponse);
+			}
 		}
 
 		filterChain.doFilter(httpServletRequest, httpServletResponse);
@@ -87,6 +95,9 @@ public class SpSessionTerminationSamlPortalFilter extends BaseSamlPortalFilter {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SpSessionTerminationSamlPortalFilter.class);
+
+	@Reference
+	private SamlIdpSpSessionLocalService _samlIdpSpSessionLocalService;
 
 	private ServletContext _servletContext;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-20041

This is one of those "small change, big impact" kind of fixes, so I apologize in advance.  The root of the problem is we are invalidating the session before running through the LogoutPre/PostAction classes, which means we don't have the user's session, so we don't know who just logged out, or from where.

The fix is fairly straight-forward; we should only invalidate the session if we are on the IdP side, or, if we are on the SP side AND the IdP session has been completely destroyed.  This ensures 1) we don't invalidate early (if the SamlIdpSpSession entry still exists) and 2) we eventually and properly invalidate the session (when we return to the SP side, through the SpSessionTerminationSamlPortalFilter class.  Basically, [this code](https://github.com/liferay-appsec/liferay-portal/compare/master...ChrisKian:LPD-20041?expand=1#diff-84c3978f7c48620abe94027732563a9fadffdcbebb783cbf02cb9e4444ee1a37R83-R84) is only reached when we are revisting the SP, after a complete and successful SLO.

It's a fairly complex issue, so please let me know if you have any questions, or if you want to discuss other solutions I've tried.  Thanks!