### PR TITLE
LPD-20500

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
@@ -181,7 +181,7 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 	};
 
 	window.<portlet:namespace />getSelectedClientProfile = function () {
-		return A.one('#<portlet:namespace />clientProfile option:selected');
+		return A.one('#<portlet:namespace />clientProfile').get('selectedOptions');
 	};
 
 	window.<portlet:namespace />isClientCredentialsSectionRequired = function () {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-20500

This stems from what I believe to be a race condition of some sort.  TBH, I'm not sure about the underlaying problem (if any), but I know my solution works fine.  Here's what I've found:

1. Sometimes, the original logic works correctly, other times it returns `null`.
2. In both situations, the `clientProfile` `aui:select` tag is populated, and the correct option has it's `selected` attribute set to `true`.  I say "correct" option because changing the option works too, it's not just the default value of `Web Application`.
3. With my fix, the correct option is always returned, even when `null` would be returned using the original code.

Please let me know if you have any questions, thanks!