### PR TITLE
LPD-6875 follow up

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutActionsDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutActionsDisplayContext.java
@@ -13,8 +13,6 @@ import com.liferay.layout.admin.web.internal.security.permission.resource.Layout
 import com.liferay.layout.page.template.constants.LayoutPageTemplateActionKeys;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil;
-import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
-import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -326,11 +324,7 @@ public class LayoutActionsDisplayContext {
 		}
 
 		if (layoutPageTemplateEntry == null) {
-			LayoutUtilityPageEntry layoutUtilityPageEntry =
-				LayoutUtilityPageEntryLocalServiceUtil.
-					fetchLayoutUtilityPageEntryByPlid(layout.getPlid());
-
-			if (layoutUtilityPageEntry != null) {
+			if (layout.isTypeUtility()) {
 				_contentLayout = false;
 			}
 			else {

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -57,8 +57,6 @@ import com.liferay.layout.seo.service.LayoutSEOEntryLocalService;
 import com.liferay.layout.seo.service.LayoutSEOSiteLocalService;
 import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
 import com.liferay.layout.service.LayoutLocalizationLocalService;
-import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
-import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
@@ -2800,18 +2798,7 @@ public class LayoutStagedModelDataHandler
 				}
 			}
 			else {
-				LayoutUtilityPageEntry layoutUtilityPageEntry =
-					_layoutUtilityPageEntryLocalService.
-						fetchLayoutUtilityPageEntryByPlid(layout.getPlid());
-
-				if (layoutUtilityPageEntry == null) {
-					layoutUtilityPageEntry =
-						_layoutUtilityPageEntryLocalService.
-							fetchLayoutUtilityPageEntryByPlid(
-								layout.getClassPK());
-				}
-
-				if (layoutUtilityPageEntry != null) {
+				if (layout.isTypeUtility()) {
 					layoutElement.addAttribute(
 						"layout-content-page-template",
 						Boolean.TRUE.toString());
@@ -3180,10 +3167,6 @@ public class LayoutStagedModelDataHandler
 
 	@Reference
 	private LayoutTemplateLocalService _layoutTemplateLocalService;
-
-	@Reference
-	private LayoutUtilityPageEntryLocalService
-		_layoutUtilityPageEntryLocalService;
 
 	@Reference
 	private PermissionImporter _permissionImporter;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/servlet/taglib/BaseLayoutScreenNavigationEntry.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/servlet/taglib/BaseLayoutScreenNavigationEntry.java
@@ -12,8 +12,6 @@ import com.liferay.frontend.taglib.form.navigator.constants.FormNavigatorConstan
 import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationEntry;
 import com.liferay.frontend.taglib.servlet.taglib.util.JSPRenderer;
 import com.liferay.layout.admin.constants.LayoutScreenNavigationEntryConstants;
-import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
-import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
@@ -53,14 +51,6 @@ public abstract class BaseLayoutScreenNavigationEntry
 
 	@Override
 	public boolean isVisible(User user, Layout layout) {
-		LayoutUtilityPageEntry layoutUtilityPageEntry =
-			layoutUtilityPageEntryLocalService.
-				fetchLayoutUtilityPageEntryByPlid(layout.getPlid());
-
-		if (layoutUtilityPageEntry != null) {
-			return false;
-		}
-
 		List<FormNavigatorCategory> formNavigatorCategories =
 			formNavigatorCategoryProvider.getFormNavigatorCategories(
 				FormNavigatorConstants.FORM_NAVIGATOR_ID_LAYOUT);
@@ -103,9 +93,5 @@ public abstract class BaseLayoutScreenNavigationEntry
 
 	@Reference
 	protected Language language;
-
-	@Reference
-	protected LayoutUtilityPageEntryLocalService
-		layoutUtilityPageEntryLocalService;
 
 }

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/manager/LayoutLockManagerImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/manager/LayoutLockManagerImpl.java
@@ -13,8 +13,6 @@ import com.liferay.layout.model.LockedLayoutType;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
-import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
-import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.DSLFunctionFactoryUtil;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
@@ -487,6 +485,10 @@ public class LayoutLockManagerImpl implements LayoutLockManager {
 			return LockedLayoutType.COLLECTION_PAGE;
 		}
 
+		if (Objects.equals(type, LayoutConstants.TYPE_UTILITY)) {
+			return LockedLayoutType.UTILITY_PAGE;
+		}
+
 		if (!Objects.equals(type, LayoutConstants.TYPE_CONTENT)) {
 			return null;
 		}
@@ -498,14 +500,6 @@ public class LayoutLockManagerImpl implements LayoutLockManager {
 		if (layoutPageTemplateEntry != null) {
 			return _getLayoutPageTemplateEntryTypeLabel(
 				layoutPageTemplateEntry);
-		}
-
-		LayoutUtilityPageEntry layoutUtilityPageEntry =
-			_layoutUtilityPageEntryLocalService.
-				fetchLayoutUtilityPageEntryByPlid(classPK);
-
-		if (layoutUtilityPageEntry != null) {
-			return LockedLayoutType.UTILITY_PAGE;
 		}
 
 		return LockedLayoutType.CONTENT_PAGE;
@@ -526,10 +520,6 @@ public class LayoutLockManagerImpl implements LayoutLockManager {
 	@Reference
 	private LayoutPageTemplateEntryLocalService
 		_layoutPageTemplateEntryLocalService;
-
-	@Reference
-	private LayoutUtilityPageEntryLocalService
-		_layoutUtilityPageEntryLocalService;
 
 	private volatile long _lockExpirationTime;
 

--- a/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/display/context/LayoutsSEODisplayContext.java
+++ b/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/display/context/LayoutsSEODisplayContext.java
@@ -37,8 +37,6 @@ import com.liferay.layout.seo.model.LayoutSEOEntry;
 import com.liferay.layout.seo.model.LayoutSEOSite;
 import com.liferay.layout.seo.service.LayoutSEOEntryLocalServiceUtil;
 import com.liferay.layout.seo.service.LayoutSEOSiteLocalService;
-import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
-import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -101,7 +99,6 @@ public class LayoutsSEODisplayContext {
 		LayoutSEOCanonicalURLProvider layoutSEOCanonicalURLProvider,
 		LayoutSEOLinkManager layoutSEOLinkManager,
 		LayoutSEOSiteLocalService layoutSEOSiteLocalService,
-		LayoutUtilityPageEntryLocalService layoutUtilityPageEntryLocalService,
 		LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse) {
 
@@ -116,8 +113,6 @@ public class LayoutsSEODisplayContext {
 		_layoutSEOCanonicalURLProvider = layoutSEOCanonicalURLProvider;
 		_layoutSEOLinkManager = layoutSEOLinkManager;
 		_layoutSEOSiteLocalService = layoutSEOSiteLocalService;
-		_layoutUtilityPageEntryLocalService =
-			layoutUtilityPageEntryLocalService;
 		_liferayPortletRequest = liferayPortletRequest;
 		_liferayPortletResponse = liferayPortletResponse;
 
@@ -618,25 +613,14 @@ public class LayoutsSEODisplayContext {
 		return false;
 	}
 
-	public boolean isLayoutUtilityPageEntry() throws PortalException {
-		if (_layoutUtilityPageEntry != null) {
-			return _layoutUtilityPageEntry;
-		}
-
+	public boolean isLayoutUtilityPageEntry() {
 		Layout layout = getSelLayout();
 
-		LayoutUtilityPageEntry layoutUtilityPageEntry =
-			_layoutUtilityPageEntryLocalService.
-				fetchLayoutUtilityPageEntryByPlid(layout.getPlid());
-
-		if (layoutUtilityPageEntry != null) {
-			_layoutUtilityPageEntry = true;
-		}
-		else {
-			_layoutUtilityPageEntry = false;
+		if (layout.isTypeUtility()) {
+			return true;
 		}
 
-		return _layoutUtilityPageEntry;
+		return false;
 	}
 
 	public boolean isPrivateLayout() {
@@ -860,9 +844,6 @@ public class LayoutsSEODisplayContext {
 	private final LayoutSEOCanonicalURLProvider _layoutSEOCanonicalURLProvider;
 	private final LayoutSEOLinkManager _layoutSEOLinkManager;
 	private final LayoutSEOSiteLocalService _layoutSEOSiteLocalService;
-	private Boolean _layoutUtilityPageEntry;
-	private final LayoutUtilityPageEntryLocalService
-		_layoutUtilityPageEntryLocalService;
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
 	private Boolean _privateLayout;

--- a/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/frontend/taglib/servlet/taglib/BaseLayoutScreenNavigationEntry.java
+++ b/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/frontend/taglib/servlet/taglib/BaseLayoutScreenNavigationEntry.java
@@ -20,8 +20,6 @@ import com.liferay.layout.seo.kernel.LayoutSEOLinkManager;
 import com.liferay.layout.seo.service.LayoutSEOSiteLocalService;
 import com.liferay.layout.seo.web.internal.constants.LayoutSEOWebKeys;
 import com.liferay.layout.seo.web.internal.display.context.LayoutsSEODisplayContext;
-import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
-import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -83,15 +81,7 @@ public abstract class BaseLayoutScreenNavigationEntry
 			layoutPageTemplateEntryLocalService.
 				fetchLayoutPageTemplateEntryByPlid(layout.getPlid());
 
-		if (layoutPageTemplateEntry != null) {
-			return false;
-		}
-
-		LayoutUtilityPageEntry layoutUtilityPageEntry =
-			layoutUtilityPageEntryLocalService.
-				fetchLayoutUtilityPageEntryByPlid(layout.getPlid());
-
-		if (layoutUtilityPageEntry != null) {
+		if ((layoutPageTemplateEntry != null) || layout.isTypeUtility()) {
 			return false;
 		}
 
@@ -111,7 +101,7 @@ public abstract class BaseLayoutScreenNavigationEntry
 				infoItemServiceRegistry, itemSelector, layoutLocalService,
 				layoutPageTemplateEntryLocalService,
 				layoutSEOCanonicalURLProvider, layoutSEOLinkManager,
-				layoutSEOSiteLocalService, layoutUtilityPageEntryLocalService,
+				layoutSEOSiteLocalService,
 				portal.getLiferayPortletRequest(
 					(PortletRequest)httpServletRequest.getAttribute(
 						JavaConstants.JAVAX_PORTLET_REQUEST)),
@@ -159,10 +149,6 @@ public abstract class BaseLayoutScreenNavigationEntry
 
 	@Reference
 	protected LayoutSEOSiteLocalService layoutSEOSiteLocalService;
-
-	@Reference
-	protected LayoutUtilityPageEntryLocalService
-		layoutUtilityPageEntryLocalService;
 
 	@Reference
 	protected Portal portal;

--- a/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/frontend/taglib/servlet/taglib/LayoutSEOScreenNavigationEntry.java
+++ b/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/frontend/taglib/servlet/taglib/LayoutSEOScreenNavigationEntry.java
@@ -7,7 +7,6 @@ package com.liferay.layout.seo.web.internal.frontend.taglib.servlet.taglib;
 
 import com.liferay.frontend.taglib.servlet.taglib.ScreenNavigationEntry;
 import com.liferay.layout.seo.web.internal.constants.LayoutSEOScreenNavigationEntryConstants;
-import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
 
@@ -30,15 +29,7 @@ public class LayoutSEOScreenNavigationEntry
 
 	@Override
 	public boolean isVisible(User user, Layout layout) {
-		if (layout.isTypeAssetDisplay()) {
-			return true;
-		}
-
-		LayoutUtilityPageEntry layoutUtilityPageEntry =
-			layoutUtilityPageEntryLocalService.
-				fetchLayoutUtilityPageEntryByPlid(layout.getPlid());
-
-		if (layoutUtilityPageEntry != null) {
+		if (layout.isTypeAssetDisplay() || layout.isTypeUtility()) {
 			return true;
 		}
 

--- a/modules/apps/layout/layout-set-prototype-web/src/main/java/com/liferay/layout/set/prototype/web/internal/product/navigation/control/menu/PropagationMessageProductNavigationControlMenuEntry.java
+++ b/modules/apps/layout/layout-set-prototype-web/src/main/java/com/liferay/layout/set/prototype/web/internal/product/navigation/control/menu/PropagationMessageProductNavigationControlMenuEntry.java
@@ -8,8 +8,6 @@ package com.liferay.layout.set.prototype.web.internal.product.navigation.control
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
-import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
-import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -94,16 +92,8 @@ public class PropagationMessageProductNavigationControlMenuEntry
 
 		if ((layoutType == LayoutPageTemplateEntryTypeConstants.BASIC) ||
 			(layoutType ==
-				LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT)) {
-
-			return false;
-		}
-
-		LayoutUtilityPageEntry layoutUtilityPageEntry =
-			_layoutUtilityPageEntryLocalService.
-				fetchLayoutUtilityPageEntryByPlid(layout.getClassPK());
-
-		if ((layoutUtilityPageEntry != null) ||
+				LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT) ||
+			layout.isTypeUtility() ||
 			!LayoutSetPrototypePermissionUtil.contains(
 				themeDisplay.getPermissionChecker(),
 				layoutSetPrototype.getLayoutSetPrototypeId(),
@@ -126,10 +116,6 @@ public class PropagationMessageProductNavigationControlMenuEntry
 
 	@Reference
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
-
-	@Reference
-	private LayoutUtilityPageEntryLocalService
-		_layoutUtilityPageEntryLocalService;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.layout.set.prototype.web)"

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/ContentLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/ContentLayoutTypeController.java
@@ -11,8 +11,6 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.security.permission.resource.LayoutContentModelResourcePermission;
 import com.liferay.layout.type.controller.BaseLayoutTypeControllerImpl;
-import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
-import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalService;
 import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
@@ -283,19 +281,6 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 			return;
 		}
 
-		LayoutUtilityPageEntry layoutUtilityPageEntry =
-			_fetchLayoutUtilityPageEntry(layout);
-
-		if (layoutUtilityPageEntry != null) {
-			httpServletRequest.setAttribute(
-				ContentPageEditorWebKeys.CLASS_NAME,
-				LayoutUtilityPageEntry.class.getName());
-			httpServletRequest.setAttribute(
-				ContentPageEditorWebKeys.CLASS_PK, layout.getPlid());
-
-			return;
-		}
-
 		httpServletRequest.setAttribute(
 			ContentPageEditorWebKeys.CLASS_NAME, Layout.class.getName());
 		httpServletRequest.setAttribute(
@@ -316,23 +301,6 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 		if (layout.isDraftLayout()) {
 			return _layoutPageTemplateEntryLocalService.
 				fetchLayoutPageTemplateEntryByPlid(layout.getClassPK());
-		}
-
-		return null;
-	}
-
-	private LayoutUtilityPageEntry _fetchLayoutUtilityPageEntry(Layout layout) {
-		LayoutUtilityPageEntry layoutUtilityPageEntry =
-			_layoutUtilityPageEntryLocalService.
-				fetchLayoutUtilityPageEntryByPlid(layout.getPlid());
-
-		if (layoutUtilityPageEntry != null) {
-			return layoutUtilityPageEntry;
-		}
-
-		if (layout.isDraftLayout()) {
-			return _layoutUtilityPageEntryLocalService.
-				fetchLayoutUtilityPageEntryByPlid(layout.getClassPK());
 		}
 
 		return null;
@@ -382,9 +350,7 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 			Layout layout, ThemeDisplay themeDisplay)
 		throws Exception {
 
-		if ((_fetchLayoutPageTemplateEntry(layout) != null) ||
-			(_fetchLayoutUtilityPageEntry(layout) != null)) {
-
+		if (_fetchLayoutPageTemplateEntry(layout) != null) {
 			return _hasUpdatePermissions(
 				themeDisplay.getPermissionChecker(), layout);
 		}
@@ -438,10 +404,6 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 
 	@Reference
 	private LayoutPermission _layoutPermission;
-
-	@Reference
-	private LayoutUtilityPageEntryLocalService
-		_layoutUtilityPageEntryLocalService;
 
 	@Reference
 	private LayoutContentModelResourcePermission _modelResourcePermission;

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/resources/META-INF/resources/layout/edit_layout/content.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/resources/META-INF/resources/layout/edit_layout/content.jsp
@@ -13,8 +13,6 @@
 
 <liferay-ui:success key="layoutPublished" message="the-page-was-published-successfully" />
 
-<liferay-ui:success key="layoutUtilityPageEntryAdded" message="the-utility-page-was-created-successfully" />
-
 <%
 String portletResource = ParamUtil.getString(request, "portletResource");
 %>

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
@@ -96,7 +96,7 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 
 		if (plid == 0) {
 			Layout layout = _addLayout(
-				userId, groupId, name, masterLayoutPlid, type, serviceContext);
+				userId, groupId, name, masterLayoutPlid, serviceContext);
 
 			if (layout != null) {
 				plid = layout.getPlid();
@@ -403,7 +403,7 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 
 	private Layout _addLayout(
 			long userId, long groupId, String name, long masterLayoutPlid,
-			String type, ServiceContext serviceContext)
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		Map<Locale, String> titleMap = Collections.singletonMap(
@@ -431,10 +431,9 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 			"layout.instanceable.allowed", Boolean.TRUE);
 
 		Layout layout = _layoutLocalService.addLayout(
-			userId, groupId, !_isPublicLayoutNeeded(type), 0, 0, 0, titleMap,
-			titleMap, null, null, null, LayoutConstants.TYPE_CONTENT,
-			typeSettings, true, true, new HashMap<>(), masterLayoutPlid,
-			serviceContext);
+			userId, groupId, false, 0, 0, 0, titleMap, titleMap, null, null,
+			null, LayoutConstants.TYPE_UTILITY, typeSettings, true, true,
+			new HashMap<>(), masterLayoutPlid, serviceContext);
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
@@ -539,16 +538,6 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 		}
 
 		return name;
-	}
-
-	private boolean _isPublicLayoutNeeded(String type) {
-		if (type.equals("LOGIN") || type.equals("FORGOT_PASSWORD") ||
-			type.equals("CREATE_ACCOUNT")) {
-
-			return true;
-		}
-
-		return false;
 	}
 
 	private void _validateName(

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
@@ -96,7 +96,7 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 
 		if (plid == 0) {
 			Layout layout = _addLayout(
-				userId, groupId, name, masterLayoutPlid, serviceContext);
+				userId, groupId, name, masterLayoutPlid, type, serviceContext);
 
 			if (layout != null) {
 				plid = layout.getPlid();
@@ -403,7 +403,7 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 
 	private Layout _addLayout(
 			long userId, long groupId, String name, long masterLayoutPlid,
-			ServiceContext serviceContext)
+			String type, ServiceContext serviceContext)
 		throws PortalException {
 
 		Map<Locale, String> titleMap = Collections.singletonMap(
@@ -431,9 +431,10 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 			"layout.instanceable.allowed", Boolean.TRUE);
 
 		Layout layout = _layoutLocalService.addLayout(
-			userId, groupId, true, 0, 0, 0, titleMap, titleMap, null, null,
-			null, LayoutConstants.TYPE_CONTENT, typeSettings, true, true,
-			new HashMap<>(), masterLayoutPlid, serviceContext);
+			userId, groupId, !_isPublicLayoutNeeded(type), 0, 0, 0, titleMap,
+			titleMap, null, null, null, LayoutConstants.TYPE_CONTENT,
+			typeSettings, true, true, new HashMap<>(), masterLayoutPlid,
+			serviceContext);
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
@@ -538,6 +539,16 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 		}
 
 		return name;
+	}
+
+	private boolean _isPublicLayoutNeeded(String type) {
+		if (type.equals("LOGIN") || type.equals("FORGOT_PASSWORD") ||
+			type.equals("CREATE_ACCOUNT")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private void _validateName(

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/LoginMVCActionCommand.java
@@ -5,6 +5,8 @@
 
 package com.liferay.login.web.internal.portlet.action;
 
+import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants;
+import com.liferay.layout.utility.page.kernel.provider.util.LayoutUtilityPageEntryLayoutProviderUtil;
 import com.liferay.login.web.constants.LoginPortletKeys;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.CompanyMaxUsersException;
@@ -26,6 +28,7 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.auth.AuthException;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Http;
@@ -252,6 +255,20 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 
 		Layout layout = (Layout)actionRequest.getAttribute(WebKeys.LAYOUT);
 
+		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		Layout loginUtilityPage =
+			LayoutUtilityPageEntryLayoutProviderUtil.
+				getDefaultLayoutUtilityPageEntryLayout(
+					themeDisplay.getScopeGroupId(),
+					LayoutUtilityPageEntryConstants.TYPE_LOGIN);
+
+		if (loginUtilityPage != null) {
+			layout = _layoutLocalService.fetchLayout(
+				loginUtilityPage.getPlid());
+		}
+
 		PortletURL portletURL = PortletURLBuilder.create(
 			PortletURLFactoryUtil.create(
 				actionRequest, liferayPortletRequest.getPortlet(), layout,
@@ -289,6 +306,9 @@ public class LoginMVCActionCommand extends BaseMVCActionCommand {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		LoginMVCActionCommand.class);
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/CreateAccountNavigationPostPageInclude.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/CreateAccountNavigationPostPageInclude.java
@@ -6,31 +6,23 @@
 package com.liferay.login.web.internal.servlet.taglib.include;
 
 import com.liferay.login.web.constants.LoginPortletKeys;
+import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants;
+import com.liferay.layout.utility.page.kernel.provider.LayoutUtilityPageEntryLayoutProvider;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManager;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
-import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
-import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.util.PropsValues;
 import com.liferay.taglib.include.PageInclude;
 import com.liferay.taglib.ui.IconTag;
 
 import java.util.Objects;
 
 import javax.portlet.PortletConfig;
-import javax.portlet.PortletMode;
-import javax.portlet.PortletRequest;
-import javax.portlet.WindowState;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
@@ -92,18 +84,23 @@ public class CreateAccountNavigationPostPageInclude implements PageInclude {
 		iconTag.setMessage("create-account");
 
 		try {
-			String createAccountURL = null;
+			String url = StringPool.BLANK;
 
-			if (_featureFlagManager.isEnabled("LPD-6378")) {
-				createAccountURL = _getCreateAccountURL(
-					httpServletRequest, themeDisplay);
+			Layout layout =
+				_layoutUtilityPageEntryLayoutProvider.
+					getDefaultLayoutUtilityPageEntryLayout(
+						themeDisplay.getScopeGroupId(),
+						LayoutUtilityPageEntryConstants.TYPE_CREATE_ACCOUNT);
+
+			if (layout != null) {
+				url = _portal.getLayoutURL(layout, themeDisplay);
 			}
 			else {
-				createAccountURL = _portal.getCreateAccountURL(
+				url = _portal.getCreateAccountURL(
 					httpServletRequest, themeDisplay);
 			}
 
-			iconTag.setUrl(createAccountURL);
+			iconTag.setUrl(url);
 		}
 		catch (Exception exception) {
 			throw new JspException(exception);
@@ -112,66 +109,12 @@ public class CreateAccountNavigationPostPageInclude implements PageInclude {
 		iconTag.doTag(pageContext);
 	}
 
-	private String _getCreateAccountURL(
-			HttpServletRequest httpServletRequest, ThemeDisplay themeDisplay)
-		throws Exception {
-
-		if (Validator.isNull(PropsValues.COMPANY_SECURITY_STRANGERS_URL)) {
-			long plid = themeDisplay.getPlid();
-
-			Layout layout = themeDisplay.getLayout();
-
-			if (layout.isPrivateLayout()) {
-				plid = _layoutLocalService.getDefaultPlid(
-					layout.getGroupId(), false);
-			}
-
-			PortletConfig portletConfig =
-				(PortletConfig)httpServletRequest.getAttribute(
-					JavaConstants.JAVAX_PORTLET_CONFIG);
-
-			return PortletURLBuilder.create(
-				PortletURLFactoryUtil.create(
-					httpServletRequest, portletConfig.getPortletName(), plid,
-					PortletRequest.RENDER_PHASE)
-			).setMVCRenderCommandName(
-				"/login/create_account"
-			).setParameter(
-				"saveLastPath", false
-			).setPortletMode(
-				PortletMode.VIEW
-			).setWindowState(
-				WindowState.MAXIMIZED
-			).buildString();
-		}
-
-		try {
-			Layout layout = _layoutLocalService.getFriendlyURLLayout(
-				themeDisplay.getScopeGroupId(), false,
-				PropsValues.COMPANY_SECURITY_STRANGERS_URL);
-
-			return _portal.getLayoutURL(layout, themeDisplay);
-		}
-		catch (NoSuchLayoutException noSuchLayoutException) {
-
-			// LPS-52675
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(noSuchLayoutException);
-			}
-		}
-
-		return StringPool.BLANK;
-	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		CreateAccountNavigationPostPageInclude.class);
-
 	@Reference
 	private FeatureFlagManager _featureFlagManager;
 
 	@Reference
-	private LayoutLocalService _layoutLocalService;
+	private LayoutUtilityPageEntryLayoutProvider
+		_layoutUtilityPageEntryLayoutProvider;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/CreateAccountNavigationPostPageInclude.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/CreateAccountNavigationPostPageInclude.java
@@ -5,9 +5,9 @@
 
 package com.liferay.login.web.internal.servlet.taglib.include;
 
-import com.liferay.login.web.constants.LoginPortletKeys;
 import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants;
 import com.liferay.layout.utility.page.kernel.provider.LayoutUtilityPageEntryLayoutProvider;
+import com.liferay.login.web.constants.LoginPortletKeys;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManager;
 import com.liferay.portal.kernel.model.Company;

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/CreateAccountNavigationPostPageInclude.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/CreateAccountNavigationPostPageInclude.java
@@ -9,20 +9,30 @@ import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryCo
 import com.liferay.layout.utility.page.kernel.provider.LayoutUtilityPageEntryLayoutProvider;
 import com.liferay.login.web.constants.LoginPortletKeys;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManager;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.taglib.include.PageInclude;
 import com.liferay.taglib.ui.IconTag;
 
 import java.util.Objects;
 
 import javax.portlet.PortletConfig;
+import javax.portlet.PortletMode;
+import javax.portlet.PortletRequest;
+import javax.portlet.WindowState;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
@@ -86,14 +96,21 @@ public class CreateAccountNavigationPostPageInclude implements PageInclude {
 		try {
 			String url = StringPool.BLANK;
 
-			Layout layout =
-				_layoutUtilityPageEntryLayoutProvider.
-					getDefaultLayoutUtilityPageEntryLayout(
-						themeDisplay.getScopeGroupId(),
-						LayoutUtilityPageEntryConstants.TYPE_CREATE_ACCOUNT);
+			if (_featureFlagManager.isEnabled("LPD-6378")) {
+				Layout layout =
+					_layoutUtilityPageEntryLayoutProvider.
+						getDefaultLayoutUtilityPageEntryLayout(
+							themeDisplay.getScopeGroupId(),
+							LayoutUtilityPageEntryConstants.
+								TYPE_CREATE_ACCOUNT);
 
-			if (layout != null) {
-				url = _portal.getLayoutURL(layout, themeDisplay);
+				if (layout != null) {
+					url = _portal.getLayoutURL(layout, themeDisplay);
+				}
+				else {
+					url = _getCreateAccountURL(
+						httpServletRequest, themeDisplay);
+				}
 			}
 			else {
 				url = _portal.getCreateAccountURL(
@@ -109,8 +126,66 @@ public class CreateAccountNavigationPostPageInclude implements PageInclude {
 		iconTag.doTag(pageContext);
 	}
 
+	private String _getCreateAccountURL(
+			HttpServletRequest httpServletRequest, ThemeDisplay themeDisplay)
+		throws Exception {
+
+		if (Validator.isNull(PropsValues.COMPANY_SECURITY_STRANGERS_URL)) {
+			long plid = themeDisplay.getPlid();
+
+			Layout layout = themeDisplay.getLayout();
+
+			if (layout.isPrivateLayout()) {
+				plid = _layoutLocalService.getDefaultPlid(
+					layout.getGroupId(), false);
+			}
+
+			PortletConfig portletConfig =
+				(PortletConfig)httpServletRequest.getAttribute(
+					JavaConstants.JAVAX_PORTLET_CONFIG);
+
+			return PortletURLBuilder.create(
+				PortletURLFactoryUtil.create(
+					httpServletRequest, portletConfig.getPortletName(), plid,
+					PortletRequest.RENDER_PHASE)
+			).setMVCRenderCommandName(
+				"/login/create_account"
+			).setParameter(
+				"saveLastPath", false
+			).setPortletMode(
+				PortletMode.VIEW
+			).setWindowState(
+				WindowState.MAXIMIZED
+			).buildString();
+		}
+
+		try {
+			Layout layout = _layoutLocalService.getFriendlyURLLayout(
+				themeDisplay.getScopeGroupId(), false,
+				PropsValues.COMPANY_SECURITY_STRANGERS_URL);
+
+			return _portal.getLayoutURL(layout, themeDisplay);
+		}
+		catch (NoSuchLayoutException noSuchLayoutException) {
+
+			// LPS-52675
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchLayoutException);
+			}
+		}
+
+		return StringPool.BLANK;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CreateAccountNavigationPostPageInclude.class);
+
 	@Reference
 	private FeatureFlagManager _featureFlagManager;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 	@Reference
 	private LayoutUtilityPageEntryLayoutProvider

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/ForgetPasswordNavigationPostPageInclude.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/ForgetPasswordNavigationPostPageInclude.java
@@ -79,41 +79,46 @@ public class ForgetPasswordNavigationPostPageInclude implements PageInclude {
 			return;
 		}
 
-		Layout layout =
-			_layoutUtilityPageEntryLayoutProvider.
-				getDefaultLayoutUtilityPageEntryLayout(
-					themeDisplay.getScopeGroupId(),
-					LayoutUtilityPageEntryConstants.
-						TYPE_FORGOT_PASSWORD);
+		try {
+			Layout layout =
+				_layoutUtilityPageEntryLayoutProvider.
+					getDefaultLayoutUtilityPageEntryLayout(
+						themeDisplay.getScopeGroupId(),
+						LayoutUtilityPageEntryConstants.TYPE_FORGOT_PASSWORD);
 
-		String forgetPasswordURL = null;
+			String forgetPasswordURL = null;
 
-		if (layout != null) {
-			forgetPasswordURL = _portal.getLayoutURL(layout, themeDisplay);
+			if (layout != null) {
+				forgetPasswordURL = _portal.getLayoutURL(layout, themeDisplay);
+			}
+			else {
+				RenderURLTag renderURLTag = new RenderURLTag();
+
+				renderURLTag.setPageContext(pageContext);
+
+				renderURLTag.addParam("saveLastPath", Boolean.FALSE.toString());
+				renderURLTag.addParam(
+					"mvcRenderCommandName", "/login/forgot_password");
+				renderURLTag.setVar("forgotPasswordURL");
+				renderURLTag.setWindowState(WindowState.MAXIMIZED.toString());
+
+				renderURLTag.doTag(pageContext);
+
+				forgetPasswordURL = (String)pageContext.getAttribute(
+					"forgotPasswordURL");
+			}
+
+			IconTag iconTag = new IconTag();
+
+			iconTag.setCssClass("text-4");
+			iconTag.setMessage("forgot-password");
+			iconTag.setUrl(forgetPasswordURL);
+
+			iconTag.doTag(pageContext);
 		}
-		else {
-			RenderURLTag renderURLTag = new RenderURLTag();
-
-			renderURLTag.setPageContext(pageContext);
-
-			renderURLTag.addParam("saveLastPath", Boolean.FALSE.toString());
-			renderURLTag.addParam("mvcRenderCommandName", "/login/forgot_password");
-			renderURLTag.setVar("forgotPasswordURL");
-			renderURLTag.setWindowState(WindowState.MAXIMIZED.toString());
-
-			renderURLTag.doTag(pageContext);
-
-			forgetPasswordURL = (String)pageContext.getAttribute(
-				"forgotPasswordURL");
+		catch (Exception exception) {
+			throw new JspException(exception);
 		}
-
-		IconTag iconTag = new IconTag();
-
-		iconTag.setCssClass("text-4");
-		iconTag.setMessage("forgot-password");
-		iconTag.setUrl(forgetPasswordURL);
-
-		iconTag.doTag(pageContext);
 	}
 
 	@Reference

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/ForgetPasswordNavigationPostPageInclude.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/ForgetPasswordNavigationPostPageInclude.java
@@ -5,11 +5,15 @@
 
 package com.liferay.login.web.internal.servlet.taglib.include;
 
+import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants;
+import com.liferay.layout.utility.page.kernel.provider.LayoutUtilityPageEntryLayoutProvider;
 import com.liferay.login.web.constants.LoginPortletKeys;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManager;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.taglib.include.PageInclude;
@@ -75,19 +79,33 @@ public class ForgetPasswordNavigationPostPageInclude implements PageInclude {
 			return;
 		}
 
-		RenderURLTag renderURLTag = new RenderURLTag();
+		Layout layout =
+			_layoutUtilityPageEntryLayoutProvider.
+				getDefaultLayoutUtilityPageEntryLayout(
+					themeDisplay.getScopeGroupId(),
+					LayoutUtilityPageEntryConstants.
+						TYPE_FORGOT_PASSWORD);
 
-		renderURLTag.setPageContext(pageContext);
+		String forgetPasswordURL = null;
 
-		renderURLTag.addParam("saveLastPath", Boolean.FALSE.toString());
-		renderURLTag.addParam("mvcRenderCommandName", "/login/forgot_password");
-		renderURLTag.setVar("forgotPasswordURL");
-		renderURLTag.setWindowState(WindowState.MAXIMIZED.toString());
+		if (layout != null) {
+			forgetPasswordURL = _portal.getLayoutURL(layout, themeDisplay);
+		}
+		else {
+			RenderURLTag renderURLTag = new RenderURLTag();
 
-		renderURLTag.doTag(pageContext);
+			renderURLTag.setPageContext(pageContext);
 
-		String forgetPasswordURL = (String)pageContext.getAttribute(
-			"forgotPasswordURL");
+			renderURLTag.addParam("saveLastPath", Boolean.FALSE.toString());
+			renderURLTag.addParam("mvcRenderCommandName", "/login/forgot_password");
+			renderURLTag.setVar("forgotPasswordURL");
+			renderURLTag.setWindowState(WindowState.MAXIMIZED.toString());
+
+			renderURLTag.doTag(pageContext);
+
+			forgetPasswordURL = (String)pageContext.getAttribute(
+				"forgotPasswordURL");
+		}
 
 		IconTag iconTag = new IconTag();
 
@@ -100,5 +118,12 @@ public class ForgetPasswordNavigationPostPageInclude implements PageInclude {
 
 	@Reference
 	private FeatureFlagManager _featureFlagManager;
+
+	@Reference
+	private LayoutUtilityPageEntryLayoutProvider
+		_layoutUtilityPageEntryLayoutProvider;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/SignInNavigationPrePageInclude.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/SignInNavigationPrePageInclude.java
@@ -93,8 +93,7 @@ public class SignInNavigationPrePageInclude implements PageInclude {
 					_layoutUtilityPageEntryLayoutProvider.
 						getDefaultLayoutUtilityPageEntryLayout(
 							themeDisplay.getScopeGroupId(),
-							LayoutUtilityPageEntryConstants.
-								TYPE_LOGIN);
+							LayoutUtilityPageEntryConstants.TYPE_LOGIN);
 
 				if (layout != null) {
 					signInURL = _portal.getLayoutURL(layout, themeDisplay);

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/SignInNavigationPrePageInclude.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/servlet/taglib/include/SignInNavigationPrePageInclude.java
@@ -5,6 +5,8 @@
 
 package com.liferay.login.web.internal.servlet.taglib.include;
 
+import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants;
+import com.liferay.layout.utility.page.kernel.provider.LayoutUtilityPageEntryLayoutProvider;
 import com.liferay.login.web.constants.LoginPortletKeys;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManager;
 import com.liferay.portal.kernel.model.Layout;
@@ -14,6 +16,7 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -86,7 +89,19 @@ public class SignInNavigationPrePageInclude implements PageInclude {
 
 		try {
 			if (_featureFlagManager.isEnabled("LPD-6378")) {
-				signInURL = _getSignInURL(httpServletRequest, themeDisplay);
+				Layout layout =
+					_layoutUtilityPageEntryLayoutProvider.
+						getDefaultLayoutUtilityPageEntryLayout(
+							themeDisplay.getScopeGroupId(),
+							LayoutUtilityPageEntryConstants.
+								TYPE_LOGIN);
+
+				if (layout != null) {
+					signInURL = _portal.getLayoutURL(layout, themeDisplay);
+				}
+				else {
+					signInURL = _getSignInURL(httpServletRequest, themeDisplay);
+				}
 			}
 			else {
 				signInURL = themeDisplay.getURLSignIn();
@@ -164,5 +179,12 @@ public class SignInNavigationPrePageInclude implements PageInclude {
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private LayoutUtilityPageEntryLayoutProvider
+		_layoutUtilityPageEntryLayoutProvider;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/portal-impl/src/com/liferay/portal/action/LoginAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LoginAction.java
@@ -9,6 +9,7 @@ import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryCo
 import com.liferay.layout.utility.page.kernel.provider.util.LayoutUtilityPageEntryLayoutProviderUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.WindowStateFactory;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
@@ -26,6 +27,8 @@ import com.liferay.portal.struts.Action;
 import com.liferay.portal.struts.model.ActionForward;
 import com.liferay.portal.struts.model.ActionMapping;
 import com.liferay.portal.util.PropsValues;
+
+import java.util.Objects;
 
 import javax.portlet.PortletMode;
 import javax.portlet.PortletRequest;
@@ -115,7 +118,11 @@ public class LoginAction implements Action {
 					themeDisplay.getScopeGroupId(),
 					LayoutUtilityPageEntryConstants.TYPE_LOGIN);
 
-		if (loginUtilityPage != null) {
+		if ((loginUtilityPage != null) &&
+			!Objects.equals(
+				getWindowState(httpServletRequest),
+				LiferayWindowState.EXCLUSIVE)) {
+
 			httpServletResponse.sendRedirect(
 				PortalUtil.getLayoutURL(loginUtilityPage, themeDisplay));
 

--- a/portal-impl/src/com/liferay/portal/action/LoginAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LoginAction.java
@@ -109,6 +109,19 @@ public class LoginAction implements Action {
 			return null;
 		}
 
+		Layout loginUtilityPage =
+			LayoutUtilityPageEntryLayoutProviderUtil.
+				getDefaultLayoutUtilityPageEntryLayout(
+					themeDisplay.getScopeGroupId(),
+					LayoutUtilityPageEntryConstants.TYPE_LOGIN);
+
+		if (loginUtilityPage != null) {
+			httpServletResponse.sendRedirect(
+				PortalUtil.getLayoutURL(loginUtilityPage, themeDisplay));
+
+			return null;
+		}
+
 		String redirect = PortalUtil.getSiteLoginURL(themeDisplay);
 
 		if (Validator.isNull(redirect)) {
@@ -124,6 +137,7 @@ public class LoginAction implements Action {
 
 			long plid = themeDisplay.getPlid();
 
+			
 			if (loginUtilityPage != null) {
 				plid = loginUtilityPage.getPlid();
 			}

--- a/portal-impl/src/com/liferay/portal/action/LoginAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LoginAction.java
@@ -5,7 +5,10 @@
 
 package com.liferay.portal.action;
 
+import com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants;
+import com.liferay.layout.utility.page.kernel.provider.util.LayoutUtilityPageEntryLayoutProviderUtil;
 import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.WindowStateFactory;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
@@ -113,9 +116,21 @@ public class LoginAction implements Action {
 		}
 
 		if (Validator.isNull(redirect)) {
+			Layout loginUtilityPage =
+				LayoutUtilityPageEntryLayoutProviderUtil.
+					getDefaultLayoutUtilityPageEntryLayout(
+						themeDisplay.getScopeGroupId(),
+						LayoutUtilityPageEntryConstants.TYPE_LOGIN);
+
+			long plid = themeDisplay.getPlid();
+
+			if (loginUtilityPage != null) {
+				plid = loginUtilityPage.getPlid();
+			}
+
 			redirect = PortletURLBuilder.create(
 				PortletURLFactoryUtil.create(
-					httpServletRequest, PortletKeys.LOGIN,
+					httpServletRequest, PortletKeys.LOGIN, plid,
 					PortletRequest.RENDER_PHASE)
 			).setMVCRenderCommandName(
 				"/login/login"

--- a/portal-impl/src/com/liferay/portal/action/LoginAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LoginAction.java
@@ -129,22 +129,9 @@ public class LoginAction implements Action {
 		}
 
 		if (Validator.isNull(redirect)) {
-			Layout loginUtilityPage =
-				LayoutUtilityPageEntryLayoutProviderUtil.
-					getDefaultLayoutUtilityPageEntryLayout(
-						themeDisplay.getScopeGroupId(),
-						LayoutUtilityPageEntryConstants.TYPE_LOGIN);
-
-			long plid = themeDisplay.getPlid();
-
-			
-			if (loginUtilityPage != null) {
-				plid = loginUtilityPage.getPlid();
-			}
-
 			redirect = PortletURLBuilder.create(
 				PortletURLFactoryUtil.create(
-					httpServletRequest, PortletKeys.LOGIN, plid,
+					httpServletRequest, PortletKeys.LOGIN,
 					PortletRequest.RENDER_PHASE)
 			).setMVCRenderCommandName(
 				"/login/login"


### PR DESCRIPTION
Hi @stian-sigvartsen ,

I'm sending my changes on top of https://github.com/liferay-appsec/liferay-portal/pull/1696

What I've added:
- Sign in utility pages are considered when rendering ([LPD-6870](https://liferay.atlassian.net/browse/LPD-6870)).
- Navigation footer links are created considering Forgot Password [LPD-6871](https://liferay.atlassian.net/browse/LPD-6871) and Create Account ([LPD-6869](https://liferay.atlassian.net/browse/LPD-6869)) utility pages. cc @alvarosaugarlr 

Notes:
- I'm not sure about 45114fe7e7f5b88c2963229874309ad2c9ff1a70. I don't know for what scenario was it used for.
- I gave a58669964e8fc98f078387801783b1b935972d32 back as I think we agreed that each portlet renders all the views in their own context.

Thanks!