### PR TITLE
LPD-1245

### DIFF
--- a/build-test.xml
+++ b/build-test.xml
@@ -11907,7 +11907,18 @@ mail.session.jndi.name=
 memory.scheduler.org.quartz.threadPool.threadCount=1
 persisted.scheduler.org.quartz.threadPool.threadCount=1
 virtual.hosts.default.site.name=
-virtual.hosts.valid.hosts=*
+virtual.hosts.valid.hosts=\
+	localhost,\
+	127.0.0.1,\
+	[::1],\
+	[0:0:0:0:0:0:0:1],\
+	${env.HOSTNAME},\
+	www.able.com,\
+	www.baker.com,\
+	www.charlie.com,\
+	www.dog.com,\
+	www.easy.com,\
+	www.fox.com
 com.liferay.portal.servlet.filters.strip.StripFilter=true
 web.server.http.port=8080
 admin.email.from.address=test@liferay.com

--- a/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/configuration/RedirectURLConfiguration.java
+++ b/modules/apps/redirect/redirect-service/src/main/java/com/liferay/redirect/internal/configuration/RedirectURLConfiguration.java
@@ -23,7 +23,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 public interface RedirectURLConfiguration {
 
 	@Meta.AD(
-		deflt = "", description = "allowed-domains-help",
+		deflt = "localhost", description = "allowed-domains-help",
 		name = "allowed-domains", required = false
 	)
 	public String[] allowedDomains();
@@ -35,7 +35,7 @@ public interface RedirectURLConfiguration {
 	public String[] allowedIPs();
 
 	@Meta.AD(
-		deflt = "ip", description = "security-mode-help",
+		deflt = "domain", description = "security-mode-help",
 		name = "security-mode", optionLabels = {"Domain", "IP"},
 		optionValues = {"domain", "ip"}, required = false
 	)


### PR DESCRIPTION
Related Issue: [LPD-1245](https://liferay.atlassian.net/browse/LPD-1245)

Summary: DXP is vulnerable to DNS rebinding attacks

to resolve this, we need to change the Redirect URL default from IP to Domain based. When changing to Domain it turned out to break several Poshi tests so we made a change on the tests properties to accept all the current used domains on tests.

Previous PR: https://github.com/liferay-appsec/liferay-portal/pull/1605