### PR TITLE
LPD-16002

### DIFF
--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventServiceImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventServiceImpl.java
@@ -41,7 +41,7 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 
 		PermissionChecker permissionChecker = getPermissionChecker();
 
-		if (!(permissionChecker.isCompanyAdmin() ||
+		if (!(permissionChecker.isCompanyAdmin(companyId) ||
 			  _userLocalService.hasRoleUser(
 				  companyId, RoleConstants.ANALYTICS_ADMINISTRATOR,
 				  permissionChecker.getUserId(), true))) {
@@ -60,7 +60,7 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 
 		PermissionChecker permissionChecker = getPermissionChecker();
 
-		if (!(permissionChecker.isCompanyAdmin() ||
+		if (!(permissionChecker.isCompanyAdmin(companyId) ||
 			  _userLocalService.hasRoleUser(
 				  companyId, RoleConstants.ANALYTICS_ADMINISTRATOR,
 				  permissionChecker.getUserId(), true))) {
@@ -83,7 +83,7 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 
 		PermissionChecker permissionChecker = getPermissionChecker();
 
-		if (!(permissionChecker.isCompanyAdmin() ||
+		if (!(permissionChecker.isCompanyAdmin(companyId) ||
 			  _userLocalService.hasRoleUser(
 				  companyId, RoleConstants.ANALYTICS_ADMINISTRATOR,
 				  permissionChecker.getUserId(), true))) {
@@ -109,7 +109,7 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 
 		PermissionChecker permissionChecker = getPermissionChecker();
 
-		if (!(permissionChecker.isCompanyAdmin() ||
+		if (!(permissionChecker.isCompanyAdmin(companyId) ||
 			  _userLocalService.hasRoleUser(
 				  companyId, RoleConstants.ANALYTICS_ADMINISTRATOR,
 				  permissionChecker.getUserId(), true))) {

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/AuditPortlet.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/AuditPortlet.java
@@ -9,6 +9,9 @@ import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.security.audit.AuditEvent;
+import com.liferay.portal.security.audit.web.internal.AuditEventManagerUtil;
 import com.liferay.portal.security.audit.web.internal.constants.AuditPortletKeys;
 
 import java.io.IOException;
@@ -17,6 +20,7 @@ import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.Portlet;
 import javax.portlet.PortletException;
+import javax.portlet.PortletRequest;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 import javax.portlet.ResourceRequest;
@@ -51,7 +55,7 @@ public class AuditPortlet extends MVCPortlet {
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws IOException, PortletException {
 
-		_checkCompanyAdmin();
+		_checkCompanyAdmin(actionRequest);
 
 		super.processAction(actionRequest, actionResponse);
 	}
@@ -61,7 +65,7 @@ public class AuditPortlet extends MVCPortlet {
 			RenderRequest renderRequest, RenderResponse renderResponse)
 		throws IOException, PortletException {
 
-		_checkCompanyAdmin();
+		_checkCompanyAdmin(renderRequest);
 
 		super.render(renderRequest, renderResponse);
 	}
@@ -71,14 +75,28 @@ public class AuditPortlet extends MVCPortlet {
 			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
 		throws IOException, PortletException {
 
-		_checkCompanyAdmin();
+		_checkCompanyAdmin(resourceRequest);
 
 		super.serveResource(resourceRequest, resourceResponse);
 	}
 
-	private void _checkCompanyAdmin() throws PortletException {
+	private void _checkCompanyAdmin(PortletRequest portletRequest)
+		throws PortletException {
+
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
+
+		long auditEventId = ParamUtil.getLong(portletRequest, "auditEventId");
+
+		if (auditEventId > 0) {
+			AuditEvent auditEvent = AuditEventManagerUtil.fetchAuditEvent(
+				auditEventId);
+
+			if (permissionChecker.getCompanyId() != auditEvent.getCompanyId()) {
+				throw new PortletException(
+					"This event does not belong to this company");
+			}
+		}
 
 		if (!permissionChecker.isCompanyAdmin()) {
 			PrincipalException principalException =


### PR DESCRIPTION
Hi, this solution is doing 2 things: 1) Adding a new check in `AuditPortlet` that prevents users from changing the URL of the page to see an audit event from another company and 2) Also check in the service layer if the companyId passed in the parameters of the remote APIs is of the same company of the user that is requesting them.

The new behavior with those changes is that no user can access other company's audit events through the portlet by manually changing the URL. And for the Audit API endpoints, prevent users getting events from other companies unless they're admins from the default company (Omni Admins). This is due to the logic in `permissionChecker.isCompanyAdmin(long companyId)` as this method always returns true if the user is an Omni Admin. This is acceptable because an Omni Admin user already has access to another company's Audit through the On-Demand Admin functionality for example.

Please let me know if you have any questions, thanks!