### PR TITLE
LPD-21457

### DIFF
--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/servlet/RESTClientHttpRequest.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/template/servlet/RESTClientHttpRequest.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.servlet.DynamicServletRequest;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.kernel.servlet.PortalSessionThreadLocal;
+import com.liferay.portal.kernel.upload.UploadServletRequest;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -362,6 +363,19 @@ public class RESTClientHttpRequest implements HttpServletRequest {
 				(DynamicServletRequest)servletRequest;
 
 			return dynamicServletRequest.getSession(create);
+		}
+		else if (servletRequest instanceof UploadServletRequest) {
+			UploadServletRequest uploadServletRequest =
+				(UploadServletRequest)servletRequest;
+
+			return uploadServletRequest.getSession(create);
+		}
+
+		HttpServletRequestWrapper protectedServletRequest =
+			(HttpServletRequestWrapper)servletRequest;
+
+		if (protectedServletRequest.getSession(false) != null) {
+			return protectedServletRequest.getSession(false);
 		}
 
 		return _httpServletRequest.getSession(create);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-21457

I've been able to resolve this issue using a similar approach to [LPD-15645](https://liferay.atlassian.net/browse/LPD-15645) in that some requests are wrapped, thus the true session is not exposed.  In my testing of [LPP-53494](https://liferay.atlassian.net/browse/LPP-53494), I've found both the `UploadServletRequest` and a form of a `ProtectedServletRequest` (more specifically, the [DirectRequestDispatcherFactoryUtil.DirectRequestDispatcherServletRequest](https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/servlet/DirectRequestDispatcherFactoryUtil.java#L119)) are used, since the ticket describes two possible ways of reproducing the same issue.

I'm not fully confident in this issue, as you mentioned before we shouldn't unwrap protected sessions.  However, I'm not really sure how else to proceed.  Also, this doesn't cause a regression for [LPD-19377](https://liferay.atlassian.net/browse/LPD-19377), which is important as well.

Please let me know if you'd like to discuss this issue, and if you have any questions, thanks!