### PR TITLE
LPD-21445 

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/auth/SessionAuthToken.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/SessionAuthToken.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.security.auth;
 
+import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
@@ -82,7 +83,11 @@ public class SessionAuthToken implements AuthToken {
 		long plid = liferayPortletURL.getPlid();
 
 		try {
-			Layout layout = LayoutLocalServiceUtil.getLayout(plid);
+			Layout layout = LayoutLocalServiceUtil.fetchLayout(plid);
+
+			if (layout == null) {
+				throw new NoSuchLayoutException("{plid=" + plid + "}");
+			}
 
 			LayoutTypePortlet layoutTypePortlet =
 				(LayoutTypePortlet)layout.getLayoutType();


### PR DESCRIPTION
[LPD-21445](https://liferay.atlassian.net/browse/LPD-21445)

Reason: the LayoutLocalServiceUtil.getLayout(plid) method triggers siteTemplatePropagation

Please review the change that I've made in the SessionAuthToken.java class from a security point of view.


### Cause
 we should not trigger the site template propagation when editing a web content. 

### Solution
Change getLayout method by fetchLayout and manage if it is null.

The getLayout() method works differently than traditional get methods because Staging team would like to start the propagation on demand(mostly when the page is opened) , and not all at once.

### Tests:
  Manual tests - Following the steps described in the bug.