### PR TITLE
LPD-22074

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/configuration/LDAPServerConfiguration.java
+++ b/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/configuration/LDAPServerConfiguration.java
@@ -161,4 +161,7 @@ public interface LDAPServerConfiguration {
 	)
 	public String[] groupDefaultObjectClasses();
 
+	@Meta.AD(deflt = "", name = "modified-date", required = false)
+	public String modifiedDate();
+
 }

--- a/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/constants/LDAPConstants.java
+++ b/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/constants/LDAPConstants.java
@@ -113,6 +113,8 @@ public class LDAPConstants {
 
 	public static final String LDAP_SERVER_ID = "ldapServerId";
 
+	public static final String MODIFIED_DATE = "modifiedDate";
+
 	public static final String PAGE_SIZE = "pageSize";
 
 	public static final String PASSWORD_ENCRYPTION_ALGORITHM =

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/configuration/LDAPServerConfigurationProviderImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/configuration/LDAPServerConfigurationProviderImpl.java
@@ -424,15 +424,17 @@ public class LDAPServerConfigurationProviderImpl
 		Dictionary<String, Object> properties, Configuration configuration,
 		String property) {
 
-		String[] propertiesCustomMapping = (String[])properties.get(property);
-		String[] configurationCustomMapping =
-			(String[])configuration.getProperties(
-			).get(
-				property
-			);
+		Dictionary<String, Object> oldProperties =
+			configuration.getProperties();
+
+		String[] oldPropertiesCustomMapping = GetterUtil.getStringValues(
+			oldProperties.get(property));
+
+		String[] propertiesCustomMapping = GetterUtil.getStringValues(
+			properties.get(property));
 
 		if (Arrays.equals(
-				propertiesCustomMapping, configurationCustomMapping)) {
+				oldPropertiesCustomMapping, propertiesCustomMapping)) {
 
 			return false;
 		}

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/configuration/LDAPServerConfigurationProviderImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/configuration/LDAPServerConfigurationProviderImpl.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.List;
@@ -380,6 +381,7 @@ public class LDAPServerConfigurationProviderImpl
 
 		properties.put(LDAPConstants.COMPANY_ID, companyId);
 		properties.put(LDAPConstants.LDAP_SERVER_ID, ldapServerId);
+		properties.put(LDAPConstants.MODIFIED_DATE, String.valueOf(new Date()));
 
 		Map<Long, ObjectValuePair<Configuration, LDAPServerConfiguration>>
 			objectValuePairs = _configurations.computeIfAbsent(

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/configuration/LDAPServerConfigurationProviderImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/configuration/LDAPServerConfigurationProviderImpl.java
@@ -23,6 +23,7 @@ import com.liferay.portal.security.ldap.constants.LDAPConstants;
 import java.io.IOException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Date;
@@ -381,7 +382,6 @@ public class LDAPServerConfigurationProviderImpl
 
 		properties.put(LDAPConstants.COMPANY_ID, companyId);
 		properties.put(LDAPConstants.LDAP_SERVER_ID, ldapServerId);
-		properties.put(LDAPConstants.MODIFIED_DATE, String.valueOf(new Date()));
 
 		Map<Long, ObjectValuePair<Configuration, LDAPServerConfiguration>>
 			objectValuePairs = _configurations.computeIfAbsent(
@@ -401,12 +401,43 @@ public class LDAPServerConfigurationProviderImpl
 				configuration = objectValuePair.getKey();
 			}
 
+			if (_isCustomMappingModified(
+					properties, configuration,
+					LDAPConstants.USER_CUSTOM_MAPPINGS) ||
+				_isCustomMappingModified(
+					properties, configuration,
+					LDAPConstants.CONTACT_CUSTOM_MAPPINGS)) {
+
+				properties.put(
+					LDAPConstants.MODIFIED_DATE, String.valueOf(new Date()));
+			}
+
 			configuration.update(properties);
 		}
 		catch (IOException ioException) {
 			throw new SystemException(
 				"Unable to update configuration", ioException);
 		}
+	}
+
+	private boolean _isCustomMappingModified(
+		Dictionary<String, Object> properties, Configuration configuration,
+		String property) {
+
+		String[] propertiesCustomMapping = (String[])properties.get(property);
+		String[] configurationCustomMapping =
+			(String[])configuration.getProperties(
+			).get(
+				property
+			);
+
+		if (Arrays.equals(
+				propertiesCustomMapping, configurationCustomMapping)) {
+
+			return false;
+		}
+
+		return true;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -1747,18 +1747,13 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 
 		ServiceContext serviceContext = ldapUser.getServiceContext();
 
-		Date serverConfigurationModifiedDate;
+		Date serverConfigurationModifiedDate = _lastImportDate;
 
-		if (!ldapServerConfiguration.modifiedDate(
-			).isEmpty()) {
-
+		if (Validator.isNotNull(ldapServerConfiguration.modifiedDate())) {
 			serverConfigurationModifiedDate = DateUtil.parseDate(
 				"EEE MMM d HH:mm:ss zzz yyyy",
 				ldapServerConfiguration.modifiedDate(),
 				serviceContext.getLocale());
-		}
-		else {
-			serverConfigurationModifiedDate = _lastImportDate;
 		}
 
 		if ((modifiedDate != null) &&

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -541,10 +541,6 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			return;
 		}
 
-		_lastImportDate = new Date(_lastImportTime);
-
-		_lastImportTime = System.currentTimeMillis();
-
 		LDAPImportConfiguration ldapImportConfiguration =
 			_ldapImportConfigurationProvider.getConfiguration(companyId);
 
@@ -560,6 +556,8 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 						" is no longer valid, company ", companyId,
 						" now uses ", ldapServerConfiguration.ldapServerId()));
 			}
+
+			_lastImportTime = System.currentTimeMillis();
 
 			return;
 		}
@@ -601,6 +599,8 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			_log.error("Unable to import LDAP users and groups", exception);
 		}
 		finally {
+			_lastImportTime = System.currentTimeMillis();
+
 			safeLdapContext.close();
 		}
 	}
@@ -1747,18 +1747,21 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 
 		ServiceContext serviceContext = ldapUser.getServiceContext();
 
-		Date serverConfigurationModifiedDate = _lastImportDate;
+		boolean updatedCustomMappings = false;
 
 		if (Validator.isNotNull(ldapServerConfiguration.modifiedDate())) {
-			serverConfigurationModifiedDate = DateUtil.parseDate(
+			Date serverConfigurationModifiedDate = DateUtil.parseDate(
 				"EEE MMM d HH:mm:ss zzz yyyy",
 				ldapServerConfiguration.modifiedDate(),
 				serviceContext.getLocale());
+
+			updatedCustomMappings = serverConfigurationModifiedDate.after(
+				new Date(_lastImportTime));
 		}
 
 		if ((modifiedDate != null) &&
 			modifiedDate.equals(user.getModifiedDate()) &&
-			(serverConfigurationModifiedDate.compareTo(_lastImportDate) <= 0)) {
+			!updatedCustomMappings) {
 
 			if ((ldapUser.isUpdatePassword() ||
 				 !ldapImportConfiguration.importUserPasswordEnabled()) &&
@@ -2017,7 +2020,6 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 	@Reference
 	private GroupLocalService _groupLocalService;
 
-	private Date _lastImportDate;
 	private long _lastImportTime;
 
 	@Reference

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -1738,8 +1738,22 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			passwordReset = user.isPasswordReset();
 		}
 
+		ExpandoBridge userExpandoBridge = user.getExpandoBridge();
+
+		long userExpandoValuesCount =
+			_expandoValueLocalService.getRowValuesCount(
+				userExpandoBridge.getCompanyId(),
+				userExpandoBridge.getClassName(),
+				ExpandoTableConstants.DEFAULT_TABLE_NAME,
+				userExpandoBridge.getClassPK());
+
+		int ldapUserExpandoMappingsCount =
+			ldapImportContext.getUserExpandoMappings(
+			).size();
+
 		if ((modifiedDate != null) &&
-			modifiedDate.equals(user.getModifiedDate())) {
+			modifiedDate.equals(user.getModifiedDate()) &&
+			(ldapUserExpandoMappingsCount == userExpandoValuesCount)) {
 
 			if ((ldapUser.isUpdatePassword() ||
 				 !ldapImportConfiguration.importUserPasswordEnabled()) &&
@@ -1809,8 +1823,6 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 		}
 
 		Contact ldapContact = ldapUser.getContact();
-
-		ExpandoBridge userExpandoBridge = user.getExpandoBridge();
 
 		_populateExpandoAttributes(
 			userExpandoBridge, ldapUser.getUserExpandoAttributes(),

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -44,6 +44,7 @@ import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
@@ -539,6 +540,8 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 		if (safeLdapContext == null) {
 			return;
 		}
+
+		_lastImportDate = new Date(_lastImportTime);
 
 		_lastImportTime = System.currentTimeMillis();
 
@@ -1738,22 +1741,19 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			passwordReset = user.isPasswordReset();
 		}
 
-		ExpandoBridge userExpandoBridge = user.getExpandoBridge();
+		LDAPServerConfiguration ldapServerConfiguration =
+			_ldapServerConfigurationProvider.getConfiguration(
+				companyId, ldapServerId);
 
-		long userExpandoValuesCount =
-			_expandoValueLocalService.getRowValuesCount(
-				userExpandoBridge.getCompanyId(),
-				userExpandoBridge.getClassName(),
-				ExpandoTableConstants.DEFAULT_TABLE_NAME,
-				userExpandoBridge.getClassPK());
+		ServiceContext serviceContext = ldapUser.getServiceContext();
 
-		int ldapUserExpandoMappingsCount =
-			ldapImportContext.getUserExpandoMappings(
-			).size();
+		Date serverConfigurationModifiedDate = DateUtil.parseDate(
+			"EEE MMM d HH:mm:ss zzz yyyy",
+			ldapServerConfiguration.modifiedDate(), serviceContext.getLocale());
 
 		if ((modifiedDate != null) &&
 			modifiedDate.equals(user.getModifiedDate()) &&
-			(ldapUserExpandoMappingsCount == userExpandoValuesCount)) {
+			(serverConfigurationModifiedDate.compareTo(_lastImportDate) <= 0)) {
 
 			if ((ldapUser.isUpdatePassword() ||
 				 !ldapImportConfiguration.importUserPasswordEnabled()) &&
@@ -1784,10 +1784,6 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 
 			return user;
 		}
-
-		LDAPServerConfiguration ldapServerConfiguration =
-			_ldapServerConfigurationProvider.getConfiguration(
-				companyId, ldapServerId);
 
 		if (ldapServerConfiguration.ldapServerId() != ldapServerId) {
 			if (_log.isDebugEnabled()) {
@@ -1824,6 +1820,8 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 
 		Contact ldapContact = ldapUser.getContact();
 
+		ExpandoBridge userExpandoBridge = user.getExpandoBridge();
+
 		_populateExpandoAttributes(
 			userExpandoBridge, ldapUser.getUserExpandoAttributes(),
 			ldapImportContext.getUserExpandoMappings(),
@@ -1850,8 +1848,6 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 		int birthdayMonth = birthdayCal.get(Calendar.MONTH);
 		int birthdayDay = birthdayCal.get(Calendar.DAY_OF_MONTH);
 		int birthdayYear = birthdayCal.get(Calendar.YEAR);
-
-		ServiceContext serviceContext = ldapUser.getServiceContext();
 
 		if (modifiedDate != null) {
 			serviceContext.setModifiedDate(modifiedDate);
@@ -2016,6 +2012,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 	@Reference
 	private GroupLocalService _groupLocalService;
 
+	private Date _lastImportDate;
 	private long _lastImportTime;
 
 	@Reference

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -1747,9 +1747,19 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 
 		ServiceContext serviceContext = ldapUser.getServiceContext();
 
-		Date serverConfigurationModifiedDate = DateUtil.parseDate(
-			"EEE MMM d HH:mm:ss zzz yyyy",
-			ldapServerConfiguration.modifiedDate(), serviceContext.getLocale());
+		Date serverConfigurationModifiedDate;
+
+		if (!ldapServerConfiguration.modifiedDate(
+			).isEmpty()) {
+
+			serverConfigurationModifiedDate = DateUtil.parseDate(
+				"EEE MMM d HH:mm:ss zzz yyyy",
+				ldapServerConfiguration.modifiedDate(),
+				serviceContext.getLocale());
+		}
+		else {
+			serverConfigurationModifiedDate = _lastImportDate;
+		}
 
 		if ((modifiedDate != null) &&
 			modifiedDate.equals(user.getModifiedDate()) &&


### PR DESCRIPTION
Resent from https://github.com/liferay-appsec/liferay-portal/pull/1725 with SF commits added.

Original message:

> Issue: https://liferay.atlassian.net/browse/LPD-22074
> Hi, after some time debugging I noticed that the problem with updating the custom fields in LdapUserImporterImpl is that when a new custom field is added to the portal the users don't get their modifiedDate changed. So, if a user has been imported before and therefore their modifyTimestamp in the LDAP server is the same as their modifiedDate in Liferay, that user won't be updated. So the only way the custom fields can be updated is if something changes one of these dates, via Liferay or LDAP. My solution is to check the user's currently populated custom fields, and if there are fewer fields than the ones mapped in the LDAP server configuration, proceed with the update.
> 
> Please let me know if you have any questions, thanks!