### PR TITLE
LPD-24972 - changing the xpath

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/CookiesConsentPanel.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/CookiesConsentPanel.testcase
@@ -152,7 +152,7 @@ definition {
 		task ("Then: the configuration value changes cannot be saved because Title must have a value.") {
 			AssertElementPresent(
 				key_alertMessage = "This field is required.",
-				locator1 = "Message#ERROR_ENTER_A_VALID_VALUE");
+				locator1 = "Message#ERROR_FORM_FIELD_REQUIRED");
 		}
 	}
 


### PR DESCRIPTION
[LPD-24972](https://liferay.atlassian.net/browse/LPD-24972)

Changes due to the ticket- [LPD-25187](https://liferay.atlassian.net/browse/LPD-25187)

### Changes
Manual tests have shown that the portal works correctly and the error message was displayed. 
The change has been made in the test to check another xpath (locator1 field).

### Test
In this [comment](https://liferay.atlassian.net/browse/LPD-24972?focusedCommentId=2648043) there is a video where you can see the result executed in local