### PR TITLE
LPD-25363 use virtualHostname instead of host (Failing Test Case with Fix)

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -375,21 +375,19 @@ public class LiferayOAuthDataProvider
 
 	public String getIssuer() {
 		try {
+			Company company = _companyLocalService.fetchCompany(
+				CompanyThreadLocal.getCompanyId());
+
+			if (company != null) {
+				return company.getVirtualHostname();
+			}
+
 			MessageContext messageContext = getMessageContext();
 
 			return _portal.getHost(messageContext.getHttpServletRequest());
 		}
 		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
-
-			Company company = _companyLocalService.fetchCompany(
-				CompanyThreadLocal.getCompanyId());
-
-			if (company != null) {
-				return company.getWebId();
-			}
+			_log.error("Unable to get issuer", exception);
 		}
 
 		return null;

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/JWTClaimsIssuerTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/JWTClaimsIssuerTest.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/JWTClaimsIssuerTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/JWTClaimsIssuerTest.java
@@ -1,0 +1,120 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.token.endpoint.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.internal.test.AuthorizationGrant;
+import com.liferay.oauth2.provider.internal.test.ClientAuthentication;
+import com.liferay.oauth2.provider.internal.test.PasswordAuthorizationGrant;
+import com.liferay.oauth2.provider.internal.test.util.JWTAssertionUtil;
+import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+
+import java.util.function.Function;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+
+import org.apache.cxf.rs.security.jose.jwk.JwkUtils;
+import org.apache.cxf.rs.security.jose.jws.JwsHeaders;
+import org.apache.cxf.rs.security.jose.jws.JwsJwtCompactConsumer;
+import org.apache.cxf.rs.security.jose.jws.JwsSignatureVerifier;
+import org.apache.cxf.rs.security.jose.jws.JwsUtils;
+import org.apache.cxf.rs.security.jose.jwt.JwtClaims;
+import org.apache.cxf.rs.security.jose.jwt.JwtToken;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.BundleActivator;
+
+/**
+ * @author Gregory Amerson
+ */
+@RunWith(Arquillian.class)
+public class JWTClaimsIssuerTest extends BaseTokenEndpointTestCase {
+
+	@Test
+	public void testJWTClaimsIssuer() {
+		JwsJwtCompactConsumer jwsJwtCompactConsumer = new JwsJwtCompactConsumer(
+			getAccessToken(
+				new PasswordAuthorizationGrant("test@liferay.com", "test"),
+				clientAuthentications.get(TEST_CLIENT_ID_1)));
+
+		JwtToken jwtToken = jwsJwtCompactConsumer.getJwtToken();
+
+		JwsHeaders jwsHeaders = jwtToken.getJwsHeaders();
+
+		JwsSignatureVerifier jwsSignatureVerifier =
+			JwsUtils.getSignatureVerifier(
+				JwkUtils.readJwkKey(JWTAssertionUtil.JWK));
+
+		Assert.assertTrue(
+			jwsSignatureVerifier.verify(
+				jwsHeaders, jwsJwtCompactConsumer.getUnsignedEncodedSequence(),
+				jwsJwtCompactConsumer.getDecodedSignature()));
+
+		JwtClaims jwtClaims = jwtToken.getClaims();
+
+		Assert.assertEquals("localhost", jwtClaims.getIssuer());
+	}
+
+	@Override
+	protected BundleActivator getBundleActivator() {
+		return new JWTClaimsIssuerTestPreparatorBundleActivator();
+	}
+
+	protected Response getTokenResponse(
+		AuthorizationGrant authorizationGrant,
+		ClientAuthentication clientAuthentication) {
+
+		MultivaluedMap<String, String> multivaluedMap =
+			new MultivaluedHashMap<>();
+
+		multivaluedMap.putAll(
+			authorizationGrant.getAuthorizationGrantParameters());
+		multivaluedMap.putAll(
+			clientAuthentication.getClientAuthenticationParameters());
+
+		Invocation.Builder invocationBuilder =
+			_getOverrideHostInvocationBuilder();
+
+		return invocationBuilder.post(Entity.form(multivaluedMap));
+	}
+
+	private Invocation.Builder _getOverrideHostInvocationBuilder() {
+		return getInvocationBuilder(
+			"override", getTokenWebTarget(), Function.identity());
+	}
+
+	private static class JWTClaimsIssuerTestPreparatorBundleActivator
+		extends TestPreparatorBundleActivator {
+
+		@Override
+		protected void prepareTest() throws Exception {
+			autoCloseables.add(
+				new ConfigurationTemporarySwapper(
+					"com.liferay.oauth2.provider.rest.internal.configuration." +
+						"OAuth2AuthorizationServerConfiguration",
+					HashMapDictionaryBuilder.<String, Object>put(
+						"oauth2.authorization.server.issue.jwt.access.token",
+						true
+					).put(
+						"oauth2.authorization.server.jwt.access.token." +
+							"signing.json.web.key",
+						JWTAssertionUtil.JWK
+					).build()));
+
+			super.prepareTest();
+		}
+
+	}
+
+}


### PR DESCRIPTION
- **LPD-25363 add failing test case**
- **LPD-25363 use company.getVirtualHostname() for issuer which is more accurate than request host**
