### PR TITLE
LPD-26979 Scan is initiated with null parameter instead of the expected root directory path

### DIFF
--- a/modules/dxp/apps/antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/internal/scheduler/AntivirusAsyncFileStoreSchedulerJobConfiguration.java
+++ b/modules/dxp/apps/antivirus/antivirus-async-store/src/main/java/com/liferay/antivirus/async/store/internal/scheduler/AntivirusAsyncFileStoreSchedulerJobConfiguration.java
@@ -10,7 +10,7 @@ import com.liferay.antivirus.async.store.constants.AntivirusAsyncConstants;
 import com.liferay.antivirus.async.store.constants.AntivirusAsyncDestinationNames;
 import com.liferay.antivirus.async.store.internal.event.AntivirusAsyncEventListenerManager;
 import com.liferay.antivirus.async.store.util.AntivirusAsyncUtil;
-import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.document.library.kernel.store.Store;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.CharPool;
@@ -39,6 +39,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Date;
 import java.util.Map;
 
+import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.ConfigurationPolicy;
@@ -62,13 +63,11 @@ public class AntivirusAsyncFileStoreSchedulerJobConfiguration
 	}
 
 	@Override
-	public UnsafeConsumer<Message, Exception> getJobExecutorUnsafeConsumer() {
-		return message -> scan((String)message.getPayload());
-	}
-
-	@Override
 	public UnsafeRunnable<Exception> getJobExecutorUnsafeRunnable() {
-		throw new UnsupportedOperationException();
+		java.io.File file = (java.io.File)_storeServiceReference.getProperty(
+			"rootDir");
+
+		return () -> scan((String)file.getAbsolutePath());
 	}
 
 	@Override
@@ -264,6 +263,9 @@ public class AntivirusAsyncFileStoreSchedulerJobConfiguration
 
 	@Reference
 	private MessageBus _messageBus;
+
+	@Reference(target = "(rootDir=*)")
+	private ServiceReference<Store> _storeServiceReference;
 
 	private TriggerConfiguration _triggerConfiguration;
 


### PR DESCRIPTION
Hi Team,

LPS-183809 refactored AntivirusAsyncFileStoreMessageListener to AntivirusAsyncFileStoreSchedulerJobConfiguration (see https://github.com/liferay/liferay-portal/commit/be240f78f32f215b7fe759edb567146224081ce2) and as a side effect caused a NullPointerException. The problem comes from the removal of the following statement which set the message payload (root directory path) as the last parameter.

```
    _schedulerEngineHelper.schedule(
			trigger, StorageType.MEMORY_CLUSTERED, null,
			AntivirusAsyncDestinationNames.ANTIVIRUS_BATCH,
			rootDir.getAbsolutePath());
```

The message payload was used when initiating the scan with the root directory path.

```
@Override
public UnsafeConsumer<Message, Exception> getJobExecutorUnsafeConsumer() {
  return message -> scan((String)message.getPayload());
}
```

Thanks for reviewing!

István