### PR TITLE
LPD-1240 SAML IDP is unable to initiate SLO with reverse proxy server

### DIFF
--- a/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/utilities/cookies.js
+++ b/modules/apps/commerce/commerce-frontend-js/src/main/resources/META-INF/resources/utilities/cookies.js
@@ -19,7 +19,7 @@ class CommerceCookie {
 		return getCookie(this.scope + key, this.cookieType);
 	}
 
-	setValue(key, value, expires, path = '/') {
+	setValue(key, value, expires, path = themeDisplay.getPathContext() || '/') {
 		const options = {path};
 
 		if (expires) {

--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/js/CookiesUtil.js
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/js/CookiesUtil.js
@@ -43,7 +43,9 @@ export function getCookie(name) {
 }
 
 export function setCookie(name, value) {
-	setCookieUtil(name, value, COOKIE_TYPES.NECESSARY);
+	setCookieUtil(name, value, COOKIE_TYPES.NECESSARY, {
+		path: themeDisplay.getPathContext() || '/',
+	});
 }
 
 export function setUserConfigCookie() {

--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
@@ -177,13 +177,15 @@ public class CookiesManagerImpl implements CookiesManager {
 		cookie.setValue(encodedCookieValue);
 		cookie.setVersion(0);
 
-		httpServletResponse.addCookie(cookie);
-
 		if (httpServletRequest != null) {
 			Map<String, Cookie> cookiesMap = _getCookiesMap(httpServletRequest);
 
 			cookiesMap.put(StringUtil.toUpperCase(cookie.getName()), cookie);
 		}
+
+		cookie.setPath(_getContextPath());
+
+		httpServletResponse.addCookie(cookie);
 
 		if (_log.isWarnEnabled() &&
 			(_knownCookies.get(cookie.getName()) != null) &&
@@ -211,7 +213,7 @@ public class CookiesManagerImpl implements CookiesManager {
 			CookiesConstants.NAME_COOKIE_SUPPORT, "true");
 
 		cookieSupportCookie.setMaxAge(CookiesConstants.MAX_AGE);
-		cookieSupportCookie.setPath(StringPool.SLASH);
+		cookieSupportCookie.setPath(_getContextPath());
 
 		return addCookie(
 			CookiesConstants.CONSENT_TYPE_NECESSARY, cookieSupportCookie, null,
@@ -242,7 +244,7 @@ public class CookiesManagerImpl implements CookiesManager {
 			}
 
 			cookie.setMaxAge(0);
-			cookie.setPath(StringPool.SLASH);
+			cookie.setPath(_getContextPath());
 			cookie.setValue(StringPool.BLANK);
 
 			httpServletResponse.addCookie(cookie);
@@ -487,6 +489,16 @@ public class CookiesManagerImpl implements CookiesManager {
 		}
 
 		return false;
+	}
+
+	private String _getContextPath() {
+		String contextPath = _portal.getPathContext();
+
+		if (Validator.isNotNull(contextPath)) {
+			return contextPath;
+		}
+
+		return StringPool.SLASH;
 	}
 
 	private Map<String, Cookie> _getCookiesMap(

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/session.js
@@ -325,7 +325,7 @@ AUI.add(
 						'LFR_SESSION_STATE_' + themeDisplay.getRealUserId();
 
 					instance._cookieOptions = {
-						path: '/',
+						path: themeDisplay.getPathContext() || '/',
 						secure: A.UA.secure,
 					};
 


### PR DESCRIPTION
- LPD-1240 set cookie path based on portal.getPathContext, this should add correct path for proxy path or modified path at application server level
- LPD-1240 send contextPath based on themeDisplay.getPathContext and fallback to slash if none is configured
