### PR TITLE
LPD-28769 Some cookies appear as duplicates when using custom portal context

### DIFF
--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
@@ -155,7 +155,7 @@ public class CookiesManagerImpl implements CookiesManager {
 			}
 		}
 
-		cookie.setPath(_getContextPath(httpServletRequest));
+		cookie.setPath(_getContextPath());
 
 		// LEP-5175
 
@@ -244,7 +244,7 @@ public class CookiesManagerImpl implements CookiesManager {
 			}
 
 			cookie.setMaxAge(0);
-			cookie.setPath(_getContextPath(httpServletRequest));
+			cookie.setPath(_getContextPath());
 			cookie.setValue(StringPool.BLANK);
 
 			httpServletResponse.addCookie(cookie);
@@ -491,14 +491,11 @@ public class CookiesManagerImpl implements CookiesManager {
 		return false;
 	}
 
-	private String _getContextPath(HttpServletRequest httpServletRequest) {
-		if (httpServletRequest != null) {
-			String contextPath = _portal.getPathContext(
-				_portal.getOriginalServletRequest(httpServletRequest));
+	private String _getContextPath() {
+		String contextPath = _portal.getPathContext();
 
-			if (Validator.isNotNull(contextPath)) {
-				return contextPath;
-			}
+		if (Validator.isNotNull(contextPath)) {
+			return contextPath;
 		}
 
 		return StringPool.SLASH;

--- a/modules/apps/cookies/cookies-test/build.gradle
+++ b/modules/apps/cookies/cookies-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testImplementation group: "com.google.guava", name: "guava", version: "32.0.1-jre"
+	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	testImplementation group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	testImplementation group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"

--- a/modules/apps/cookies/cookies-test/src/testIntegration/java/com/liferay/cookies/internal/manager/test/CookiesManagerImplTest.java
+++ b/modules/apps/cookies/cookies-test/src/testIntegration/java/com/liferay/cookies/internal/manager/test/CookiesManagerImplTest.java
@@ -10,15 +10,20 @@ import com.liferay.cookies.configuration.CookiesPreferenceHandlingConfiguration;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.cookies.CookiesManager;
 import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
 import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.util.PortalImpl;
 
 import java.util.List;
 
@@ -119,6 +124,60 @@ public class CookiesManagerImplTest {
 			httpServletRequestWrapper, _mockHttpServletResponse);
 
 		Assert.assertEquals(customContextPath, cookie.getPath());
+	}
+
+	@Test
+	public void testCookiePathIsPortalContextWhenRequestContextIsDifferent()
+		throws Exception {
+
+		String portalContextPath =
+			StringPool.SLASH + RandomTestUtil.randomString();
+
+		try (AutoCloseable autoCloseable =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					_cookiesManager, "_portal",
+					_getPortal(portalContextPath))) {
+
+			Cookie cookie = new Cookie(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+			MockHttpServletRequest customContextMockHttpServletRequest =
+				new MockHttpServletRequest() {
+
+					@Override
+					public String getContextPath() {
+						return StringPool.SLASH + RandomTestUtil.randomString();
+					}
+
+				};
+
+			_cookiesManager.addCookie(
+				CookiesConstants.CONSENT_TYPE_NECESSARY, cookie,
+				customContextMockHttpServletRequest, _mockHttpServletResponse);
+
+			Assert.assertEquals(portalContextPath, cookie.getPath());
+		}
+	}
+
+	@Test
+	public void testCookiePathIsPortalContextWhenRequestIsNull()
+		throws Exception {
+
+		String portalContextPath =
+			StringPool.SLASH + RandomTestUtil.randomString();
+
+		try (AutoCloseable autoCloseable =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					_cookiesManager, "_portal",
+					_getPortal(portalContextPath))) {
+
+			Cookie cookie = new Cookie(
+				CookiesConstants.NAME_COOKIE_SUPPORT, "true");
+
+			_cookiesManager.addCookie(cookie, null, _mockHttpServletResponse);
+
+			Assert.assertEquals(portalContextPath, cookie.getPath());
+		}
 	}
 
 	@Test
@@ -468,6 +527,17 @@ public class CookiesManagerImplTest {
 				consentCookie.getName(), _mockHttpServletRequest));
 	}
 
+	private Portal _getPortal(String contextPath) {
+		return new PortalImpl() {
+
+			@Override
+			public String getPathContext() {
+				return contextPath;
+			}
+
+		};
+	}
+
 	private void _testCookiesConsentType(int consentType) {
 		_addConsentCookie(false, consentType);
 
@@ -533,6 +603,9 @@ public class CookiesManagerImplTest {
 
 	private static final String _CLASS_NAME =
 		"com.liferay.cookies.internal.manager.CookiesManagerImpl";
+
+	@Inject
+	private CookiesManager _cookiesManager;
 
 	private final MockHttpServletRequest _mockHttpServletRequest =
 		new MockHttpServletRequest();

--- a/modules/apps/cookies/cookies-test/src/testIntegration/java/com/liferay/cookies/internal/manager/test/CookiesManagerImplTest.java
+++ b/modules/apps/cookies/cookies-test/src/testIntegration/java/com/liferay/cookies/internal/manager/test/CookiesManagerImplTest.java
@@ -65,65 +65,78 @@ public class CookiesManagerImplTest {
 	public void testCookiePathIsCustomContextWhenUsingCustomContext()
 		throws Exception {
 
-		Cookie cookie = new Cookie(
-			RandomTestUtil.randomString(), RandomTestUtil.randomString());
-
 		String customContextPath =
 			StringPool.SLASH + RandomTestUtil.randomString();
 
-		MockHttpServletRequest customContextMockHttpServletRequest =
-			new MockHttpServletRequest() {
+		try (AutoCloseable autoCloseable =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					_cookiesManager, "_portal",
+					_getPortal(customContextPath))) {
 
-				@Override
-				public String getContextPath() {
-					return customContextPath;
-				}
+			Cookie cookie = new Cookie(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
-			};
+			MockHttpServletRequest customContextMockHttpServletRequest =
+				new MockHttpServletRequest() {
 
-		CookiesManagerUtil.addCookie(
-			CookiesConstants.CONSENT_TYPE_NECESSARY, cookie,
-			customContextMockHttpServletRequest, _mockHttpServletResponse);
+					@Override
+					public String getContextPath() {
+						return customContextPath;
+					}
 
-		Assert.assertEquals(customContextPath, cookie.getPath());
+				};
+
+			_cookiesManager.addCookie(
+				CookiesConstants.CONSENT_TYPE_NECESSARY, cookie,
+				customContextMockHttpServletRequest, _mockHttpServletResponse);
+
+			Assert.assertEquals(customContextPath, cookie.getPath());
+		}
 	}
 
 	@Test
 	public void testCookiePathIsCustomContextWhenUsingCustomContextWithCustomModuleWebContextPath()
 		throws Exception {
 
-		Cookie cookie = new Cookie(
-			RandomTestUtil.randomString(), RandomTestUtil.randomString());
-
 		String customContextPath =
 			StringPool.SLASH + RandomTestUtil.randomString();
 
-		MockHttpServletRequest customContextMockHttpServletRequest =
-			new MockHttpServletRequest() {
+		try (AutoCloseable autoCloseable =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					_cookiesManager, "_portal",
+					_getPortal(customContextPath))) {
 
-				@Override
-				public String getContextPath() {
-					return customContextPath;
-				}
+			Cookie cookie = new Cookie(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
-			};
+			MockHttpServletRequest customContextMockHttpServletRequest =
+				new MockHttpServletRequest() {
 
-		HttpServletRequestWrapper httpServletRequestWrapper =
-			new HttpServletRequestWrapper(customContextMockHttpServletRequest) {
+					@Override
+					public String getContextPath() {
+						return customContextPath;
+					}
 
-				@Override
-				public String getContextPath() {
-					return PortalUtil.getPathModule() + StringPool.SLASH +
-						RandomTestUtil.randomString();
-				}
+				};
 
-			};
+			HttpServletRequestWrapper httpServletRequestWrapper =
+				new HttpServletRequestWrapper(
+					customContextMockHttpServletRequest) {
 
-		CookiesManagerUtil.addCookie(
-			CookiesConstants.CONSENT_TYPE_NECESSARY, cookie,
-			httpServletRequestWrapper, _mockHttpServletResponse);
+					@Override
+					public String getContextPath() {
+						return PortalUtil.getPathModule() + StringPool.SLASH +
+							RandomTestUtil.randomString();
+					}
 
-		Assert.assertEquals(customContextPath, cookie.getPath());
+				};
+
+			_cookiesManager.addCookie(
+				CookiesConstants.CONSENT_TYPE_NECESSARY, cookie,
+				httpServletRequestWrapper, _mockHttpServletResponse);
+
+			Assert.assertEquals(customContextPath, cookie.getPath());
+		}
 	}
 
 	@Test

--- a/modules/apps/cookies/cookies-test/src/testIntegration/java/com/liferay/cookies/internal/manager/test/CookiesManagerImplTest.java
+++ b/modules/apps/cookies/cookies-test/src/testIntegration/java/com/liferay/cookies/internal/manager/test/CookiesManagerImplTest.java
@@ -11,7 +11,6 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.cookies.CookiesManager;
-import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
 import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -198,7 +197,7 @@ public class CookiesManagerImplTest {
 		Cookie cookie = new Cookie(
 			RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
-		CookiesManagerUtil.addCookie(
+		_cookiesManager.addCookie(
 			CookiesConstants.CONSENT_TYPE_NECESSARY, cookie,
 			_mockHttpServletRequest, _mockHttpServletResponse);
 
@@ -223,7 +222,7 @@ public class CookiesManagerImplTest {
 
 			};
 
-		CookiesManagerUtil.addCookie(
+		_cookiesManager.addCookie(
 			CookiesConstants.CONSENT_TYPE_NECESSARY, cookie,
 			httpServletRequestWrapper, _mockHttpServletResponse);
 
@@ -248,11 +247,11 @@ public class CookiesManagerImplTest {
 			Cookie cookie = new Cookie(
 				RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
-			CookiesManagerUtil.addCookie(
+			_cookiesManager.addCookie(
 				cookie, _mockHttpServletRequest, _mockHttpServletResponse);
 
 			Assert.assertNull(
-				CookiesManagerUtil.getCookieValue(
+				_cookiesManager.getCookieValue(
 					cookie.getName(), _mockHttpServletRequest));
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
@@ -291,20 +290,20 @@ public class CookiesManagerImplTest {
 		Cookie cookie = new Cookie(
 			RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
-		CookiesManagerUtil.addCookie(
+		_cookiesManager.addCookie(
 			CookiesConstants.CONSENT_TYPE_PERFORMANCE, cookie,
 			_mockHttpServletRequest, _mockHttpServletResponse);
 
 		Assert.assertNotNull(
-			CookiesManagerUtil.getCookieValue(
+			_cookiesManager.getCookieValue(
 				cookie.getName(), _mockHttpServletRequest));
 
 		Assert.assertNull(
-			CookiesManagerUtil.getCookieValue(
+			_cookiesManager.getCookieValue(
 				CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL,
 				_mockHttpServletRequest));
 		Assert.assertNull(
-			CookiesManagerUtil.getCookieValue(
+			_cookiesManager.getCookieValue(
 				CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
 				_mockHttpServletRequest));
 	}
@@ -322,16 +321,16 @@ public class CookiesManagerImplTest {
 		Cookie cookie = new Cookie(
 			RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
-		CookiesManagerUtil.addCookie(
+		_cookiesManager.addCookie(
 			CookiesConstants.CONSENT_TYPE_PERFORMANCE, cookie,
 			_mockHttpServletRequest, _mockHttpServletResponse);
 
 		Assert.assertNull(
-			CookiesManagerUtil.getCookieValue(
+			_cookiesManager.getCookieValue(
 				CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE,
 				_mockHttpServletRequest));
 		Assert.assertNull(
-			CookiesManagerUtil.getCookieValue(
+			_cookiesManager.getCookieValue(
 				cookie.getName(), _mockHttpServletRequest));
 	}
 
@@ -348,16 +347,16 @@ public class CookiesManagerImplTest {
 		Cookie cookie = new Cookie(
 			RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
-		CookiesManagerUtil.addCookie(
+		_cookiesManager.addCookie(
 			CookiesConstants.CONSENT_TYPE_PERFORMANCE, cookie,
 			_mockHttpServletRequest, _mockHttpServletResponse);
 
 		Assert.assertNull(
-			CookiesManagerUtil.getCookieValue(
+			_cookiesManager.getCookieValue(
 				CookiesConstants.NAME_CONSENT_TYPE_PERFORMANCE,
 				_mockHttpServletRequest));
 		Assert.assertNotNull(
-			CookiesManagerUtil.getCookieValue(
+			_cookiesManager.getCookieValue(
 				cookie.getName(), _mockHttpServletRequest));
 	}
 
@@ -398,23 +397,23 @@ public class CookiesManagerImplTest {
 			Cookie cookie = new Cookie(
 				RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
-			CookiesManagerUtil.addCookie(
+			_cookiesManager.addCookie(
 				CookiesConstants.CONSENT_TYPE_PERFORMANCE, cookie,
 				_mockHttpServletRequest, _mockHttpServletResponse);
 
 			Assert.assertEquals(
 				cookie.getValue(),
-				CookiesManagerUtil.getCookieValue(
+				_cookiesManager.getCookieValue(
 					cookie.getName(), _mockHttpServletRequest));
 
 			cookie.setValue(RandomTestUtil.randomString());
 
-			CookiesManagerUtil.addCookie(
+			_cookiesManager.addCookie(
 				cookie, _mockHttpServletRequest, _mockHttpServletResponse);
 
 			Assert.assertEquals(
 				cookie.getValue(),
-				CookiesManagerUtil.getCookieValue(
+				_cookiesManager.getCookieValue(
 					cookie.getName(), _mockHttpServletRequest));
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
@@ -450,20 +449,20 @@ public class CookiesManagerImplTest {
 			Cookie cookie = new Cookie(
 				RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
-			CookiesManagerUtil.addCookie(
+			_cookiesManager.addCookie(
 				CookiesConstants.CONSENT_TYPE_NECESSARY, cookie,
 				_mockHttpServletRequest, _mockHttpServletResponse);
 
 			Assert.assertNotNull(
-				CookiesManagerUtil.getCookieValue(
+				_cookiesManager.getCookieValue(
 					cookie.getName(), _mockHttpServletRequest));
 
-			CookiesManagerUtil.addCookie(
+			_cookiesManager.addCookie(
 				CookiesConstants.CONSENT_TYPE_FUNCTIONAL, cookie,
 				_mockHttpServletRequest, _mockHttpServletResponse);
 
 			Assert.assertNotNull(
-				CookiesManagerUtil.getCookieValue(
+				_cookiesManager.getCookieValue(
 					cookie.getName(), _mockHttpServletRequest));
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
@@ -498,16 +497,16 @@ public class CookiesManagerImplTest {
 		Cookie cookie = new Cookie(
 			RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
-		CookiesManagerUtil.addCookie(
+		_cookiesManager.addCookie(
 			CookiesConstants.CONSENT_TYPE_PERSONALIZATION, cookie,
 			_mockHttpServletRequest, _mockHttpServletResponse);
 
 		Assert.assertNull(
-			CookiesManagerUtil.getCookieValue(
+			_cookiesManager.getCookieValue(
 				CookiesConstants.NAME_CONSENT_TYPE_PERSONALIZATION,
 				_mockHttpServletRequest));
 		Assert.assertNotNull(
-			CookiesManagerUtil.getCookieValue(
+			_cookiesManager.getCookieValue(
 				cookie.getName(), _mockHttpServletRequest));
 	}
 
@@ -530,13 +529,13 @@ public class CookiesManagerImplTest {
 
 		Cookie consentCookie = new Cookie(cookieName, String.valueOf(accepted));
 
-		CookiesManagerUtil.addCookie(
+		_cookiesManager.addCookie(
 			CookiesConstants.CONSENT_TYPE_NECESSARY, consentCookie,
 			_mockHttpServletRequest, _mockHttpServletResponse);
 
 		Assert.assertEquals(
 			String.valueOf(accepted),
-			CookiesManagerUtil.getCookieValue(
+			_cookiesManager.getCookieValue(
 				consentCookie.getName(), _mockHttpServletRequest));
 	}
 
@@ -557,29 +556,29 @@ public class CookiesManagerImplTest {
 		Cookie cookie = new Cookie(
 			RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
-		CookiesManagerUtil.addCookie(
+		_cookiesManager.addCookie(
 			consentType, cookie, _mockHttpServletRequest,
 			_mockHttpServletResponse);
 
 		if (consentType == CookiesConstants.CONSENT_TYPE_NECESSARY) {
 			Assert.assertNotNull(
-				CookiesManagerUtil.getCookieValue(
+				_cookiesManager.getCookieValue(
 					cookie.getName(), _mockHttpServletRequest));
 		}
 		else {
 			Assert.assertNull(
-				CookiesManagerUtil.getCookieValue(
+				_cookiesManager.getCookieValue(
 					cookie.getName(), _mockHttpServletRequest));
 		}
 
 		_addConsentCookie(true, consentType);
 
-		CookiesManagerUtil.addCookie(
+		_cookiesManager.addCookie(
 			consentType, cookie, _mockHttpServletRequest,
 			_mockHttpServletResponse);
 
 		Assert.assertNotNull(
-			CookiesManagerUtil.getCookieValue(
+			_cookiesManager.getCookieValue(
 				cookie.getName(), _mockHttpServletRequest));
 	}
 
@@ -590,27 +589,27 @@ public class CookiesManagerImplTest {
 
 		Cookie cookie = new Cookie(name, RandomTestUtil.randomString());
 
-		CookiesManagerUtil.addCookie(
+		_cookiesManager.addCookie(
 			cookie, _mockHttpServletRequest, _mockHttpServletResponse);
 
 		if (consentType == CookiesConstants.CONSENT_TYPE_NECESSARY) {
 			Assert.assertNotNull(
-				CookiesManagerUtil.getCookieValue(
+				_cookiesManager.getCookieValue(
 					cookie.getName(), _mockHttpServletRequest));
 		}
 		else {
 			Assert.assertNull(
-				CookiesManagerUtil.getCookieValue(
+				_cookiesManager.getCookieValue(
 					cookie.getName(), _mockHttpServletRequest));
 		}
 
 		_addConsentCookie(true, consentType);
 
-		CookiesManagerUtil.addCookie(
+		_cookiesManager.addCookie(
 			cookie, _mockHttpServletRequest, _mockHttpServletResponse);
 
 		Assert.assertNotNull(
-			CookiesManagerUtil.getCookieValue(
+			_cookiesManager.getCookieValue(
 				cookie.getName(), _mockHttpServletRequest));
 	}
 


### PR DESCRIPTION
[LPD-28769](https://liferay.atlassian.net/browse/LPD-28769)

Hi,

Before you start reviewing, please note that I was unable to reproduce the issue by just following the reproduction steps. The mentioned duplicates are probably just leftover cookies created before applying [LPD-25476](https://liferay.atlassian.net/browse/LPD-25476). Despite that, the possibility for cookie duplication is there, because currently we are relying on the request when determining the context path, which can be problem in the following cases:

1. when the request is null, we set cookie path to '/' independently of the actual context path
2. when multiple context path is configured to a single Liferay deployment (not sure we support it, I couldn't configure it myself to work), then request on different context path would cause duplicates.

For case 1, I see [Header](https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/servlet/Header.java) and [TransferHeadersHelperUtil](https://github.com/liferay/liferay-portal/blob/master/portal-kernel/src/com/liferay/portal/kernel/servlet/TransferHeadersHelperUtil.java) as risks because they call CookiesManagerUtil.addCookie with null request. As I see, TransferHeadersHelperUtil is for transferring headers from portlet response to the servlet response. If required, I can write a simple MVCPortlet that sets a cookie on the portlet request for demonstration purposes, just let me know.

FYI, I covered both cases with integration test.

Thank you,
István

cc @stian-sigvartsen @alvarosaugarlr @zsigmondrab 