### PR TITLE
LPD-30141 Technical Task | Move SCIM integration tests to the Security team

### DIFF
--- a/modules/dxp/apps/scim/test.properties
+++ b/modules/dxp/apps/scim/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=SCIM

--- a/modules/test/playwright/pages/wiki-web/WikiPage.ts
+++ b/modules/test/playwright/pages/wiki-web/WikiPage.ts
@@ -9,9 +9,12 @@ import {PORTLET_URLS} from '../../utils/portletUrls';
 
 export class WikiPage {
 	readonly page: Page;
+	readonly publishButton: Locator;
 
 	constructor(page: Page) {
 		this.page = page;
+
+		this.publishButton = page.getByRole('button', {name: 'Publish'});
 	}
 
 	async goto(siteUrl?: Site['friendlyUrlPath']) {
@@ -68,5 +71,9 @@ export class WikiPage {
 
 	async goToWikiNode(title: string) {
 		await this.page.getByRole('link', {exact: true, name: title}).click();
+	}
+
+	async publishPage() {
+		await this.publishButton.click();
 	}
 }

--- a/modules/test/playwright/tests/wiki-web/wiki.spec.ts
+++ b/modules/test/playwright/tests/wiki-web/wiki.spec.ts
@@ -19,6 +19,8 @@ test('LPD-26435 Icon menu should close when another icon menu is open', async ({
 
 	await wikiPage.createNewWikiNode('Wiki Node Title');
 
+	await page.getByLabel('Order').waitFor();
+
 	const wikiNodeMenu = await page.locator(
 		'[id="_com_liferay_wiki_web_portlet_WikiAdminPortlet_wikiNodes_1_menu"]'
 	);

--- a/modules/test/playwright/tests/wiki-web/wiki.spec.ts
+++ b/modules/test/playwright/tests/wiki-web/wiki.spec.ts
@@ -77,6 +77,8 @@ test('LPD-28898 Image added via rich text editor on Wiki tool losing reference',
 		image
 	);
 
+	await wikiPage.publishPage();
+
 	await wikiPage.goto();
 
 	await wikiPage.goToWikiNode('Main');

--- a/modules/test/playwright/tests/wiki-web/wiki.spec.ts
+++ b/modules/test/playwright/tests/wiki-web/wiki.spec.ts
@@ -5,10 +5,11 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {wikiPagesTest} from '../../fixtures/wikiPagesTest';
 
-export const test = mergeTests(loginTest(), wikiPagesTest);
+export const test = mergeTests(isolatedSiteTest, loginTest(), wikiPagesTest);
 
 test('LPD-26435 Icon menu should close when another icon menu is open', async ({
 	page,


### PR DESCRIPTION
Add properties file in order to testray identifies SCIM tests as belonging to appsec team