### PR TITLE
LPD-26785 Add Antivirus and SCIM integration tests to security suite

### DIFF
--- a/modules/dxp/apps/scim/test.properties
+++ b/modules/dxp/apps/scim/test.properties
@@ -1,0 +1,27 @@
+##
+## Test Batch
+##
+
+    #
+    # Portal Hotfix Release
+    #
+
+    test.batch.run.property.query[functional-bundle-tomcat-mysql57-jdk8][test-portal-hotfix-release]=\
+        ${test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]}
+
+    #
+    # Relevant
+    #
+
+    test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][relevant]=\
+        (portal.acceptance == true) AND \
+        (\
+            (testray.component.names ~ "SCIM") OR \
+            (testray.main.component.name ~ "SCIM")\
+        )
+
+##
+## Testray
+##
+
+    testray.main.component.name=SCIM

--- a/test.properties
+++ b/test.properties
@@ -9685,6 +9685,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     #
 
     test.batch.class.names.includes[security]=\
+        **/antivirus-async-store-test/**/*Test.java,\
         **/cookies/**/*Test.java,\
         **/multi-factor-authentication/**/*Test.java,\
         **/oauth-client/**/*Test.java,\
@@ -9699,6 +9700,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         **/portal-security-ldap-test/**/*Test.java,\
         **/portal-security-sso/**/*Test.java,\
         **/saml/**/*Test.java,\
+        **/scim/**/*Test.java,\
         **/test/unit/**/security/*Test.java
 
     test.batch.dist.app.servers[security]=tomcat


### PR DESCRIPTION
Related issue: [LPD-26785](https://liferay.atlassian.net/browse/LPD-26785)

The integration tests for the Antivirus and SCIM modules were missing at the security suite.