### PR TITLE
LPD-31188 ClassCastException after non-graceful shutdown using SimpleSAML

### DIFF
--- a/modules/dxp/apps/saml/saml-opensaml-integration/build.gradle
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/build.gradle
@@ -10,7 +10,6 @@ dependencies {
 	compileInclude group: "org.bouncycastle", name: "bcutil-jdk18on", version: "1.76"
 	compileInclude group: "org.codehaus.woodstox", name: "stax2-api", version: "3.1.4"
 	compileInclude group: "org.cryptacular", name: "cryptacular", version: "1.2.4"
-	compileInclude group: "xerces", name: "xercesImpl", version: "2.12.2"
 	compileInclude group: "xml-resolver", name: "xml-resolver", version: "1.2"
 
 	compileOnly group: "com.fasterxml.woodstox", name: "woodstox-core", version: "6.4.0"
@@ -47,6 +46,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly group: "xerces", name: "xercesImpl", version: "2.12.2"
 	compileOnly group: "xml-apis", name: "xml-apis", version: "1.4.01"
 	compileOnly project(":apps:portal-security:portal-security-export-import-api")
 	compileOnly project(":apps:portal-security:portal-security-ldap-api")

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/util/ConfigurationServiceBootstrapUtil.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/util/ConfigurationServiceBootstrapUtil.java
@@ -8,7 +8,9 @@ package com.liferay.saml.opensaml.integration.internal.util;
 import com.liferay.petra.concurrent.DefaultNoticeableFuture;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.lang.ThreadContextClassLoaderUtil;
+import com.liferay.portal.kernel.util.AggregateClassLoader;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 
 import java.lang.reflect.Method;
 
@@ -90,8 +92,10 @@ public class ConfigurationServiceBootstrapUtil {
 			() -> {
 				try (SafeCloseable safeCloseable =
 						ThreadContextClassLoaderUtil.swap(
-							ConfigurationServiceBootstrapUtil.class.
-								getClassLoader())) {
+							AggregateClassLoader.getAggregateClassLoader(
+								ConfigurationServiceBootstrapUtil.class.
+									getClassLoader(),
+								PortalClassLoaderUtil.getClassLoader()))) {
 
 					InitializationService.initialize();
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAML.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAML.testcase
@@ -1356,6 +1356,103 @@ definition {
 		}
 	}
 
+	@description = "This is a use case for LPD-31188: ClassCastException after non-graceful shutdown."
+	@priority = 4
+	test AssertUserLoggedInAfterNonGracefulShutdown {
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Edit user screen name") {
+			MyAccount.openMyAccountAdmin();
+
+			User.editUserInformation(userScreenNameEdit = "tester");
+		}
+
+		task ("Add virtual instance able.com") {
+			HeadlessPortalInstanceAPI.addPortalInstance(
+				domain = "www.able.com",
+				portalInstanceId = "www.able.com",
+				virtualHost = "www.able.com");
+
+			User.logoutPG();
+
+			User.viewLoggedOutPG();
+		}
+
+		task ("Setup IdP") {
+			SAML.setupIDP(
+				idpURL = "http://localhost:8080",
+				samlEntityId = "samlidp",
+				userEmailAddress = "test@liferay.com");
+		}
+
+		task ("Setup SP") {
+			SAML.setupSP(
+				encryptionCertificate = "true",
+				samlEntityId = "samlsp",
+				spURL = "http://www.able.com:8080",
+				userEmailAddress = "test@www.able.com");
+		}
+
+		task ("Add IdP configurations to service provider") {
+			SAML.addIDPConfigurationsToServiceProvider(
+				idpAttributeMapping = "UUID,emailAddress,firstName,lastName,screenName",
+				idpEntityId = "samlidp",
+				idpKeepAliveURL = "http://localhost:8080/c/portal/saml/keep_alive",
+				idpURL = "http://localhost:8080",
+				nameIdentifierFormat = "Email Address",
+				spURL = "http://www.able.com:8080",
+				userEmailAddress = "test@www.able.com",
+				userResolution = "dynamic");
+		}
+
+		task ("Enable SP roles and SP configurations to IdP") {
+			SAML.enableSPRoles(
+				samlEntityId = "samlsp",
+				spURL = "http://www.able.com:8080",
+				userEmailAddress = "test@www.able.com");
+
+			SAML.addSPConfigurationsToIdentityProvider(
+				idpURL = "http://localhost:8080",
+				nameIdentifierAttributeName = "emailAddress",
+				nameIdentifierFormat = "Email Address",
+				spAttributes = '''emailAddress
+				firstName
+				lastName
+				screenName
+				uuid''',
+				spEntityId = "samlsp",
+				spKeepAliveURL = "http://www.able.com:8080/c/portal/saml/keep_alive",
+				spURL = "http://www.able.com:8080",
+				userEmailAddress = "test@liferay.com");
+		}
+
+		task ("Login at able.com:8080 and assert Logged in") {
+			User.firstLoginUI(
+				password = PropsUtil.get("default.admin.password"),
+				specificURL = "http://www.able.com:8080",
+				userEmailAddress = "test@liferay.com");
+
+			User.viewLoggedInPG();
+		}
+
+		task ("Kill server and start it") {
+			AntCommands.runCommand("build-test.xml", "terminate-one-java-process -Dprocess.name=Bootstrap");
+
+			Portlet.startServer(deleteLiferayHome = "false");
+		}
+
+		task ("Refresh and assert logged in") {
+			Navigator.openSpecificURL(url = "http://www.able.com:8080");
+
+			Refresh();
+
+			User.viewLoggedInPG();
+
+			Portlet.shutdownServer();
+		}
+	}
+
 	@description = "This is a use case for LPS-105170 TC-5: Verification for portal User Attributes when they are duplicated in the mapping  when saving the SAML configuration - Using virtual instances."
 	@priority = 4
 	test AssertVerificationForDuplicatedUserAttributeMappingSAML {


### PR DESCRIPTION
Rebased from #1835 

[LPD-31188](https://liferay.atlassian.net/browse/LPD-31188)

There's a ClassCastException due to org.apache.xerces.xni.parser.XMLParserConfiguration is in different ClassLoaders along the portal:

context "ShieldedContainerClassLoader" and classloader "com.liferay.shielded.container.internal.ShieldedContainerClassLoader@457c9034"

context "com.liferay.saml.opensaml.integration_6.2.17" and classloader "org.eclipse.osgi.internal.loader.EquinoxClassLoader@158d9ed3[com.liferay.saml.opensaml.integration:6.2.17(id=1112)]"

If we use CompileOnly, the ClassCastExceptions disappears.

This change (compileOnly to compileInclude) was made as a workaround to solve: https://liferay.atlassian.net/browse/LPS-142409.
I've tested this change in a local websphere and it works as expected.