### PR TITLE
LPD-32888 When CAPTCHA validation fails, text is not cleared from Text Validation field

### DIFF
--- a/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
+++ b/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
@@ -36,7 +36,7 @@ String url = (String)request.getAttribute("liferay-captcha:captcha:url");
 			url="javascript:void(0);"
 		/>
 
-			<aui:input aria-labelledby="<portlet:namespace />captchaLabel <portlet:namespace />captchaError" class="form-control" label="text-verification" name="captchaText" required="<%= true %>" size="10" type="text" value="" />
+			<aui:input aria-labelledby="<portlet:namespace />captchaLabel <portlet:namespace />captchaError" class="form-control" ignoreRequestValue="<%= true %>" label="text-verification" name="captchaText" required="<%= true %>" size="10" type="text" value="" />
 
 			<c:if test="<%= Validator.isNotNull(errorMessage) %>">
 				<p class="font-weight-semi-bold mt-1 text-danger" id="<portlet:namespace />captchaError">

--- a/modules/test/playwright/tests/login-web/forgotPasswordCaptcha.spec.ts
+++ b/modules/test/playwright/tests/login-web/forgotPasswordCaptcha.spec.ts
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, test} from '@playwright/test';
+
+import {liferayConfig} from '../../liferay.config';
+
+test('LPD-32888 Check captcha verification text is cleared after a wrong captcha', async ({
+	page,
+}) => {
+	await page.goto(liferayConfig.environment.baseUrl);
+	await page.getByRole('button', {name: 'Sign In'}).click();
+	await page.getByText('Forgot Password').click();
+	await page.waitForTimeout(1000);
+	await page.getByLabel('Email Address').fill('test@liferay.com');
+	await page
+		.locator(
+			'[id="_com_liferay_login_web_portlet_LoginPortlet_captchaText"]'
+		)
+		.fill('abcd');
+	await page.getByRole('button', {name: 'Send new password'}).click();
+	await expect(
+		page.locator(
+			'[id="_com_liferay_login_web_portlet_LoginPortlet_captchaText"]'
+		)
+	).toBeEmpty();
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-32888 

Re-add ignoreRequestValue param as it was removed in a prior commit by mistake.

Created playwright test to address this behavior