### PR TITLE
LPD-32196 File Store Migration tool doesn't migrate saml keystore if it's located within Document library

### DIFF
--- a/build-test-gcs-store.xml
+++ b/build-test-gcs-store.xml
@@ -95,6 +95,26 @@
 		</if>
 	</target>
 
+	<target name="assert-document-in-bucket-folder">
+		<local name="bucket.objects" />
+
+		<exec executable="gcloud" outputproperty="bucket.objects">
+			<arg line="storage ls --recursive gs://lfr-qa-poshi-test-${gcs.bucket.id}/${company.id}/${group.id}/${folder.name} --project=liferay-qa-automated-tests" />
+		</exec>
+
+		<echo>${bucket.objects}</echo>
+
+		<if>
+			<contains string="${bucket.objects}" substring="1.0" />
+			<then>
+				<echo>Document is in the bucket.</echo>
+			</then>
+			<else>
+				<fail>Document is not in the bucket.</fail>
+			</else>
+		</if>
+	</target>
+
 	<target name="assert-no-document-in-bucket">
 		<local name="bucket.objects" />
 

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/convert/document/library/DLKeyStoreManagerDLStoreConvertProcess.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/convert/document/library/DLKeyStoreManagerDLStoreConvertProcess.java
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.document.library.internal.convert.document.library;
+
+import com.liferay.document.library.kernel.store.Store;
+import com.liferay.portal.convert.documentlibrary.DLStoreConvertProcess;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.util.MaintenanceUtil;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jorge García Jiménez
+ */
+@Component(service = DLStoreConvertProcess.class)
+public class DLKeyStoreManagerDLStoreConvertProcess
+	implements DLStoreConvertProcess {
+
+	@Override
+	public void copy(Store sourceStore, Store targetStore)
+		throws PortalException {
+
+		_transfer(sourceStore, targetStore, _SAML_KEYSTORE_PATH, false);
+	}
+
+	@Override
+	public void move(Store sourceStore, Store targetStore)
+		throws PortalException {
+
+		_transfer(sourceStore, targetStore, _SAML_KEYSTORE_PATH, true);
+	}
+
+	private void _transfer(
+			Store sourceStore, Store targetStore, String path, boolean delete)
+		throws PortalException {
+
+		MaintenanceUtil.appendStatus("Migrating files from " + path);
+
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
+				if (sourceStore.hasFile(
+						companyId, CompanyConstants.SYSTEM, _SAML_KEYSTORE_PATH,
+						Store.VERSION_DEFAULT)) {
+
+					try {
+						transferFile(
+							sourceStore, targetStore, companyId,
+							CompanyConstants.SYSTEM, _SAML_KEYSTORE_PATH,
+							Store.VERSION_DEFAULT, delete);
+					}
+					catch (Exception exception) {
+						_log.error(
+							"Unable to migrate " + _SAML_KEYSTORE_PATH,
+							exception);
+					}
+				}
+			});
+	}
+
+	private static final String _SAML_KEYSTORE_PATH = "saml/keystore.jks";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DLKeyStoreManagerDLStoreConvertProcess.class);
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+}

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/DLKeyStoreManagerImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/DLKeyStoreManagerImpl.java
@@ -8,7 +8,6 @@ package com.liferay.saml.opensaml.integration.internal.credential;
 import com.liferay.document.library.kernel.exception.NoSuchFileException;
 import com.liferay.document.library.kernel.store.Store;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
@@ -45,7 +44,7 @@ public class DLKeyStoreManagerImpl extends BaseKeyStoreManagerImpl {
 
 		try (InputStream inputStream = _store.getFileAsStream(
 				getCompanyId(), CompanyConstants.SYSTEM, _SAML_KEYSTORE_PATH,
-				StringPool.BLANK)) {
+				Store.VERSION_DEFAULT)) {
 
 			String samlKeyStorePassword = getSamlKeyStorePassword();
 
@@ -119,7 +118,7 @@ public class DLKeyStoreManagerImpl extends BaseKeyStoreManagerImpl {
 		updateConfigurations(properties);
 	}
 
-	private static final String _SAML_KEYSTORE_PATH = "/saml/keystore.jks";
+	private static final String _SAML_KEYSTORE_PATH = "saml/keystore.jks";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DLKeyStoreManagerImpl.class);

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAML.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAML.testcase
@@ -3600,6 +3600,109 @@ definition {
 		}
 	}
 
+	@description = "This is a use case for LPD-32196. Certificate file should be migrated when fileStore change to GCS and Keystore Manager Target is Document Library Keystore Manager"
+	@priority = 5
+	test KeystoreManagerTargetShouldWorkAfterChangeFromDefaultAndMigratedToGCSStore {
+		property app.server.bundles.size = "0";
+		property gcs.store.enabled = "true";
+		property store.migration.test = "true";
+		property test.liferay.virtual.instance = "false";
+		property test.run.type = "single";
+
+		task ("Given: Deploy the OSGI configuration file") {
+			SAML.deployConfigFile(osgiConfigFileName = "com.liferay.saml.runtime.configuration.SamlKeyStoreManagerConfiguration.config");
+
+			OSGiConfig.waitForOSGiConfig();
+		}
+
+		task ("When: Generate a certificate") {
+			SAML.goToSAMLAdmin();
+
+			SAMLRole.configure(
+				samlEntityId = "samlidp",
+				samlRoleType = "Identity Provider");
+
+			SAMLRole.configureCertificateAndPrivateKey(
+				certificateUsage = "SIGNING",
+				samlKeyPassword = "samlidp");
+		}
+
+		task ("Then: Verify that the certificate file should be saved to DL root folder") {
+			SAML.validateFolderExist();
+		}
+
+		task ("And the user cannot migrate data to GCS store without setting up a connection configuration") {
+			ServerAdministration.openServerAdmin();
+
+			Navigator.gotoNavItem(navItem = "Data Migration");
+
+			AssertElementNotPresent(
+				key_fieldLabel = "dl.store.impl",
+				key_value = "com.liferay.portal.store.gcs.GCSStore",
+				locator1 = "Select#GENERIC_SELECT_VALUE");
+		}
+
+		task ("When the user adds the configuration") {
+			var bucketId = PropsUtil.get("gcs.bucket.id");
+
+			AntCommands.runCommand("build-test.xml", "prepare-gcs-store-configuration -Dgcs.bucket.id=${bucketId}");
+
+			while ((IsElementNotPresent(locator1 = "Select#SELECT_VALUE_ID", option = "com.liferay.portal.store.gcs.GCSStore", selectFieldId = "dl-store-impl")) && (maxIterations = "2")) {
+				OSGiConfig.waitForOSGiConfig();
+
+				Refresh();
+			}
+		}
+
+		task ("Then the user can now migrate data over to the GCS bucket") {
+			SelectField.select(
+				selectFieldLabel = "dl.store.impl",
+				selectFieldValue = "com.liferay.portal.store.gcs.GCSStore");
+		}
+
+		task ("When the user executes the data migration") {
+			Button.click(button = "Execute");
+
+			AssertTextPresent(
+				locator1 = "//body",
+				value1 = "Executing com.liferay.document.library.internal.convert.document.library.DocumentLibraryConvertProcess");
+
+			WaitForElementNotPresent(
+				locator1 = "//body",
+				value1 = "Migrating files from saml/keystore.jks");
+
+			WaitForConsoleTextPresent(value1 = "Please set dl.store.impl in your portal-ext.properties to use com.liferay.portal.store.gcs.GCSStore");
+
+			WaitForConsoleTextPresent(value1 = "Finished conversion for com.liferay.document.library.internal.convert.document.library.DocumentLibraryConvertProcess");
+		}
+
+		task ("Then the document is migrated over from the default store to the GCS bucket") {
+			var companyId = JSONCompany.getCompanyId();
+			var folderName = "saml";
+			var groupId = 0;
+
+			AntCommands.runCommand("build-test-gcs-store.xml", "assert-document-in-bucket -Dcompany.id=${companyId} -Dfolder.name=${folderName} -Dgcs.bucket.id=${bucketId} -Dgroup.id=${groupId}");
+		}
+
+		task ("And the user can configure the portal to use GCS store without issue") {
+			Portlet.shutdownServer();
+
+			var newProperty = "dl.store.impl=com.liferay.portal.store.gcs.GCSStore";
+
+			AntCommands.runCommand("build-test.xml", "portal-ext-properties-update -Dadd.new.properties=true -Dupdate.properties=${newProperty}");
+
+			Portlet.startServer(deleteLiferayHome = "false");
+
+			User.firstLoginPG();
+		}
+
+		task ("Assert certificate is migrated.") {
+			SAML.goToSAMLAdmin();
+
+			AssertElementPresent(locator1 = "CPSAMLAdmin#DOWNLOAD_CERTIFICATE");
+		}
+	}
+
 	@description = "This is a use case for LPS-147809. TC2: Metadata source is changed after changed from XML File To URL."
 	@priority = 4
 	test MetadataSourceIsChangedAfterChangedFromXMLFileToURL {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAML.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAML.testcase
@@ -3667,10 +3667,6 @@ definition {
 				locator1 = "//body",
 				value1 = "Executing com.liferay.document.library.internal.convert.document.library.DocumentLibraryConvertProcess");
 
-			WaitForElementNotPresent(
-				locator1 = "//body",
-				value1 = "Migrating files from saml/keystore.jks");
-
 			WaitForConsoleTextPresent(value1 = "Please set dl.store.impl in your portal-ext.properties to use com.liferay.portal.store.gcs.GCSStore");
 
 			WaitForConsoleTextPresent(value1 = "Finished conversion for com.liferay.document.library.internal.convert.document.library.DocumentLibraryConvertProcess");
@@ -3678,10 +3674,10 @@ definition {
 
 		task ("Then the document is migrated over from the default store to the GCS bucket") {
 			var companyId = JSONCompany.getCompanyId();
-			var folderName = "saml";
+			var folderName = "saml/keystore.jks";
 			var groupId = 0;
 
-			AntCommands.runCommand("build-test-gcs-store.xml", "assert-document-in-bucket -Dcompany.id=${companyId} -Dfolder.name=${folderName} -Dgcs.bucket.id=${bucketId} -Dgroup.id=${groupId}");
+			AntCommands.runCommand("build-test-gcs-store.xml", "assert-document-in-bucket-folder -Dcompany.id=${companyId} -Dfolder.name=${folderName} -Dgcs.bucket.id=${bucketId} -Dgroup.id=${groupId}");
 		}
 
 		task ("And the user can configure the portal to use GCS store without issue") {
@@ -3699,7 +3695,9 @@ definition {
 		task ("Assert certificate is migrated.") {
 			SAML.goToSAMLAdmin();
 
-			AssertElementPresent(locator1 = "CPSAMLAdmin#DOWNLOAD_CERTIFICATE");
+			AssertElementPresent(
+				key_certificateUsage = "SIGNING",
+				locator1 = "CPSAMLAdmin#DOWNLOAD_CERTIFICATE");
 		}
 	}
 


### PR DESCRIPTION
[LPD-32196](https://liferay.atlassian.net/browse/LPD-32196)
[LPD-32190](https://liferay.atlassian.net/browse/LPD-32190)

This PR aims to solve migration from SAML keystore between different FileStores when DLKeyStoreManager's value is Document Library.

It also solves the problem retrieving the keystore from GCSStore. This is achieved by removing the double slash in the calculated path when trying to retrieve the file. This is caused by having an slash as first character of SAML_Keystore_Path constant.
 
We already added default store version to match save method logic. This avoids delegating the calculation to Store's logic, as we are saving this file with Store.VERSION_DEFAULT.