### PR TITLE
[prio]LPD-32903 Change upgrade process to prepare for backports

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -425,7 +425,10 @@ public class PortalUpgradeProcessRegistryImpl
 				"User_", "password_", "VARCHAR(255) null"));
 
 		upgradeVersionTreeMap.put(
-			new Version(31, 1, 1), new UpgradePortletPreferencesCompanyId());
+			new Version(31, 1, 1), new DummyUpgradeProcess());
+
+		upgradeVersionTreeMap.put(
+			new Version(31, 1, 2), new UpgradePortletPreferencesCompanyId());
 
 		upgradeVersionTreeMap.put(
 			new Version(31, 2, 0), new UpgradeLayoutExternalReferenceCode());


### PR DESCRIPTION
Related issue: [LPD-32903](https://liferay.atlassian.net/browse/LPD-32903)

This changes are needed so we're able to backport a SEV ticket that contains an upgrade process. [(LPD-1909)](https://liferay.atlassian.net/browse/LPD-1909)

Changes were made based on Alberto Chaparro's guidance on [PTR-5252](https://liferay.atlassian.net/browse/PTR-5252)

cc: @daiazius