### PR TITLE
LPD-33727 Enable ignored tests

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotatedApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotatedApplicationClientTest.java
@@ -27,7 +27,6 @@ import javax.ws.rs.core.Response;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,7 +44,6 @@ public class AnnotatedApplicationClientTest extends BaseClientTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Ignore
 	@Test
 	public void test() throws Exception {
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotatedApplicationPrefixHandlerClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotatedApplicationPrefixHandlerClientTest.java
@@ -22,7 +22,6 @@ import javax.ws.rs.client.WebTarget;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -41,7 +40,6 @@ public class AnnotatedApplicationPrefixHandlerClientTest
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Ignore
 	@Test
 	public void test() throws Exception {
 		WebTarget webTarget = getWebTarget("/annotated");

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotationsAndHttpApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotationsAndHttpApplicationClientTest.java
@@ -23,7 +23,6 @@ import javax.ws.rs.client.WebTarget;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,7 +41,6 @@ public class AnnotationsAndHttpApplicationClientTest
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Ignore
 	@Test
 	public void test() throws Exception {
 		String tokenString = getToken("oauthTestApplication");

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotationsAndHttpPrefixApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotationsAndHttpPrefixApplicationClientTest.java
@@ -26,7 +26,6 @@ import javax.ws.rs.client.WebTarget;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,7 +44,6 @@ public class AnnotationsAndHttpPrefixApplicationClientTest
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Ignore
 	@Test
 	public void test() throws Exception {
 		String tokenString = getToken("oauthTestApplication");

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/HttpMethodApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/HttpMethodApplicationClientTest.java
@@ -28,7 +28,6 @@ import javax.ws.rs.core.Response;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -46,7 +45,6 @@ public class HttpMethodApplicationClientTest extends BaseClientTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Ignore
 	@Test
 	public void test() throws Exception {
 		WebTarget webTarget = getWebTarget("/methods");
@@ -80,7 +78,6 @@ public class HttpMethodApplicationClientTest extends BaseClientTestCase {
 		}
 	}
 
-	@Ignore
 	@Test
 	public void testIgnoredMethods() throws Exception {
 		WebTarget webTarget = getWebTarget("/methods");

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/OAuth2WebServerServletTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/OAuth2WebServerServletTest.java
@@ -35,7 +35,6 @@ import org.apache.cxf.jaxrs.impl.RuntimeDelegateImpl;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -54,7 +53,6 @@ public class OAuth2WebServerServletTest extends BaseClientTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Ignore
 	@Test
 	public void test() throws Exception {
 		String tokenString = getToken("oauthTestApplication");

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SAPClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SAPClientTest.java
@@ -21,7 +21,6 @@ import javax.ws.rs.client.WebTarget;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,7 +38,6 @@ public class SAPClientTest extends BaseClientTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Ignore
 	@Test
 	public void test() throws Exception {
 		WebTarget webTarget = getWebTarget("SAP/AUTHORIZED_OAUTH2_SAP");

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeCheckerGuestAllowedTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeCheckerGuestAllowedTest.java
@@ -30,7 +30,6 @@ import javax.ws.rs.core.Response;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -49,7 +48,6 @@ public class ScopeCheckerGuestAllowedTest extends BaseClientTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Ignore
 	@Test
 	public void test() throws Exception {
 		testApplication("/annotated-guest-allowed/", "everything.read", 200);

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeFinderTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeFinderTest.java
@@ -24,7 +24,6 @@ import javax.ws.rs.client.WebTarget;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,7 +41,6 @@ public class ScopeFinderTest extends BaseClientTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Ignore
 	@Test
 	public void testUnavailableAssignedScopeAliases() {
 		String token = getToken(

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeMapperNarrowDownClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeMapperNarrowDownClientTest.java
@@ -24,7 +24,6 @@ import javax.ws.rs.client.WebTarget;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,7 +41,6 @@ public class ScopeMapperNarrowDownClientTest extends BaseClientTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Ignore
 	@Test
 	public void test() throws Exception {
 		WebTarget webTarget = getWebTarget("/annotated");

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TOCTOUTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TOCTOUTest.java
@@ -33,7 +33,6 @@ import javax.ws.rs.core.Response;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,7 +54,6 @@ public class TOCTOUTest extends BaseClientTestCase {
 	/**
 	 * OAUTH2-101 / OAUTH2-102
 	 */
-	@Ignore
 	@Test
 	public void testPreventTOCTOUWithNewScopes() {
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenExpeditionTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenExpeditionTest.java
@@ -25,7 +25,6 @@ import javax.ws.rs.core.Response;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,7 +42,6 @@ public class TokenExpeditionTest extends BaseClientTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Ignore
 	@Test
 	public void test() throws Exception {
 		WebTarget tokenWebTarget = getTokenWebTarget();

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/RefreshTokenAuthorizationGrantTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/RefreshTokenAuthorizationGrantTest.java
@@ -31,7 +31,6 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -44,7 +43,6 @@ import org.osgi.framework.BundleActivator;
 public class RefreshTokenAuthorizationGrantTest
 	extends BaseAuthorizationGrantTestCase {
 
-	@Ignore
 	@Test
 	public void test() throws Exception {
 		JSONObject jsonObject = getToken(

--- a/modules/apps/portal-security/portal-security-membership-policy-test/src/testIntegration/java/com/liferay/portal/security/membership/policy/organization/test/OrganizationMembershipPolicyMembershipsTest.java
+++ b/modules/apps/portal-security/portal-security-membership-policy-test/src/testIntegration/java/com/liferay/portal/security/membership/policy/organization/test/OrganizationMembershipPolicyMembershipsTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -119,7 +118,6 @@ public class OrganizationMembershipPolicyMembershipsTest
 			Collections.<UserGroupRole>emptyList());
 	}
 
-	@Ignore
 	@Test
 	public void testAssignUserToRequiredOrganizations() throws Exception {
 		long[] userIds = addUsers();

--- a/modules/apps/portal-security/portal-security-membership-policy-test/src/testIntegration/java/com/liferay/portal/security/membership/policy/site/test/SiteMembershipPolicyMembershipsTest.java
+++ b/modules/apps/portal-security/portal-security-membership-policy-test/src/testIntegration/java/com/liferay/portal/security/membership/policy/site/test/SiteMembershipPolicyMembershipsTest.java
@@ -34,7 +34,6 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -208,7 +207,6 @@ public class SiteMembershipPolicyMembershipsTest
 			groups.toString(), userGroupIds.length - 1, groups.size());
 	}
 
-	@Ignore
 	@Test
 	public void testUnassignUserFromRequiredGroups() throws Exception {
 		long[] userIds = addUsers();

--- a/modules/apps/portal-security/portal-security-membership-policy-test/src/testIntegration/java/com/liferay/portal/security/membership/policy/usergroup/test/UserGroupMembershipPolicyMembershipsTest.java
+++ b/modules/apps/portal-security/portal-security-membership-policy-test/src/testIntegration/java/com/liferay/portal/security/membership/policy/usergroup/test/UserGroupMembershipPolicyMembershipsTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -173,7 +172,6 @@ public class UserGroupMembershipPolicyMembershipsTest
 		Assert.assertTrue(isPropagateMembership());
 	}
 
-	@Ignore
 	@Test
 	public void testUnassignUserFromRequiredUserGroups() throws Exception {
 		long[] userIds = addUsers();

--- a/modules/apps/portal-security/portal-security-permission-test/src/testIntegration/java/com/liferay/portal/security/permission/test/ResourcePermissionLocalServiceConcurrentTest.java
+++ b/modules/apps/portal-security/portal-security-permission-test/src/testIntegration/java/com/liferay/portal/security/permission/test/ResourcePermissionLocalServiceConcurrentTest.java
@@ -52,7 +52,6 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -213,7 +212,6 @@ public class ResourcePermissionLocalServiceConcurrentTest {
 			)
 		}
 	)
-	@Ignore
 	@Test
 	public void testAddResourcePermissionConcurrently() throws Exception {
 		SynchronousInvocationHandler.enable();

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/oauth2/OAuth2.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/oauth2/OAuth2.path
@@ -30,7 +30,7 @@
 </tr>
 <tr>
 	<td>ADMIN_CLIENT_CREDENTIALS_USER_SELECTED</td>
-	<td>//td[contains(@class,'lfr-screen-name-column')]/a[contains(.,'${key_clientCredentialsUser}')]</td>
+	<td>//tr[contains(@class,'entry entry-selector')]/td[contains(.,'${key_clientCredentialsUser}')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/oauth2/OAuth2.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/oauth2/OAuth2.testcase
@@ -640,8 +640,7 @@ definition {
 		}
 	}
 
-	@description = "This is a use case for OAUTH2-259 and LPS-156552. Verify that client credential is in the user scope and can be added to an external application. Blocked by LPS-191261."
-	@ignore = "true"
+	@description = "This is a use case for OAUTH2-259 and LPS-156552. Verify that client credential is in the user scope and can be added to an external application."
 	@priority = 5
 	test ClientCredentialsShouldBeConfigurableInUserScope {
 		property custom.properties = "access.control.sanitize.security.exception=false${line.separator}json.service.serialize.throwable=true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAMLUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAMLUpgrade.testcase
@@ -337,8 +337,6 @@ definition {
 	test ViewSAMLConfigurationAfterUpgrade7412 {
 		property data.archive.type = "data-archive-saml";
 		property database.types = "db2,mariadb,mysql,oracle,postgresql";
-		property portal.release = "quarantine";
-		property portal.upstream = "quarantine";
 		property portal.version = "7.4.12";
 
 		task ("View SAML general IdP and connection configuration") {
@@ -421,8 +419,6 @@ definition {
 	test ViewSAMLWithEncryptionConfigurationAfterUpgrade7412 {
 		property data.archive.type = "data-archive-saml-encryption";
 		property database.types = "db2,mariadb,mysql,oracle,postgresql";
-		property portal.release = "quarantine";
-		property portal.upstream = "quarantine";
 		property portal.version = "7.4.12";
 
 		task ("View SAML general IdP and connection with encryption configuration") {


### PR DESCRIPTION
Related issue: [LPD-33727](https://liferay.atlassian.net/browse/LPD-33727)

Some tests that were being ignored due to bug tickets can now be enabled again. These were found on: [LRQA-81639](https://liferay.atlassian.net/browse/LRQA-81639)

I wrote a comment with the results [here](https://github.com/liferay-appsec/liferay-portal/pull/1891#issuecomment-2288736952).