### PR TITLE
LPD-34178

### DIFF
--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/AssertionConsumerServiceSamlPortalFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/AssertionConsumerServiceSamlPortalFilter.java
@@ -36,11 +36,6 @@ public class AssertionConsumerServiceSamlPortalFilter
 	extends BaseSamlPortalFilter {
 
 	@Override
-	public boolean isFilterEnabled() {
-		return _samlProviderConfigurationHelper.isEnabled();
-	}
-
-	@Override
 	public boolean isFilterEnabled(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {

--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/IdpSsoSamlPortalFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/IdpSsoSamlPortalFilter.java
@@ -39,17 +39,6 @@ import org.osgi.service.component.annotations.Reference;
 public class IdpSsoSamlPortalFilter extends BaseSamlPortalFilter {
 
 	@Override
-	public boolean isFilterEnabled() {
-		if (_samlProviderConfigurationHelper.isEnabled() &&
-			_samlProviderConfigurationHelper.isRoleIdp()) {
-
-			return true;
-		}
-
-		return false;
-	}
-
-	@Override
 	public boolean isFilterEnabled(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {

--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SameSiteLaxCookiesSamlPortalFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SameSiteLaxCookiesSamlPortalFilter.java
@@ -47,15 +47,6 @@ import org.osgi.service.component.annotations.Reference;
 public class SameSiteLaxCookiesSamlPortalFilter extends BaseSamlPortalFilter {
 
 	@Override
-	public boolean isFilterEnabled() {
-		if (_samlProviderConfigurationHelper.isEnabled()) {
-			return _enabled;
-		}
-
-		return false;
-	}
-
-	@Override
 	public boolean isFilterEnabled(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {

--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSessionTerminationSamlPortalFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSessionTerminationSamlPortalFilter.java
@@ -46,11 +46,6 @@ public class SpSessionTerminationSamlPortalFilter extends BaseSamlPortalFilter {
 	}
 
 	@Override
-	public boolean isFilterEnabled() {
-		return _samlProviderConfigurationHelper.isEnabled();
-	}
-
-	@Override
 	public boolean isFilterEnabled(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {

--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSsoSamlPortalFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSsoSamlPortalFilter.java
@@ -61,17 +61,6 @@ public class SpSsoSamlPortalFilter extends BaseSamlPortalFilter {
 	}
 
 	@Override
-	public boolean isFilterEnabled() {
-		if (_samlProviderConfigurationHelper.isEnabled() &&
-			_samlProviderConfigurationHelper.isRoleSp()) {
-
-			return true;
-		}
-
-		return false;
-	}
-
-	@Override
 	public boolean isFilterEnabled(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {


### PR DESCRIPTION
[LPD-34178](https://liferay.atlassian.net/browse/LPD-34178)

Resolves release blocker described in [LPD-34178](https://liferay.atlassian.net/browse/LPD-34178), which was unintentionally caused by the changes in [LPD-33535](https://liferay.atlassian.net/browse/LPD-33535).  After speaking with Shuyang in [this slack thread](https://liferay.slack.com/archives/C01FP01V5L0/p1723845314863859), it was discovered the `isFilterEnabled()` method (notice no arguments) is for statically determining if a given filter should be completely disabled.  This doesn't work for SAML related filters, since they need to dynamically be enabled/disabled.

So, the solution is to remove the `isFilterEnabled()` method from all SAML related filters, so the `BaseFilter` class's `isFilterEnabled()` method will be used instead, and return `true` by default.  This doesn't mean the filters will always be enabled, it just means we aren't outright skipping the filters when we **_dynamically_** determine if the filter is enabled when using the `isFilterEnabled(HttpServletRequest, HttpServletResponse)` method (notice the request and response arguments).

As for including a test, I'm not sure if it is needed, since our SAML tests caught this issue.  I'm also not entirely sure how to implement a test for this situation, so I'm open to suggestions if tests are required.  Thanks!