### PR TITLE
pr 1840

### DIFF
--- a/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/basic/auth/header/BasicAuthHeaderAuthVerifier.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/basic/auth/header/BasicAuthHeaderAuthVerifier.java
@@ -28,7 +28,9 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Tomas Polesovsky
  */
-@Component(service = AuthVerifier.class)
+@Component(
+	property = "service.ranking:Integer=100", service = AuthVerifier.class
+)
 public class BasicAuthHeaderAuthVerifier implements AuthVerifier {
 
 	@Override

--- a/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/digest/authentication/DigestAuthenticationAuthVerifier.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/digest/authentication/DigestAuthenticationAuthVerifier.java
@@ -26,7 +26,9 @@ import org.osgi.service.component.annotations.Component;
  * @author Tomas Polesovsky
  * @deprecated As of Cavanaugh (7.4.x), with no direct replacement
  */
-@Component(service = AuthVerifier.class)
+@Component(
+	property = "service.ranking:Integer=90", service = AuthVerifier.class
+)
 @Deprecated
 public class DigestAuthenticationAuthVerifier implements AuthVerifier {
 

--- a/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/portal/session/PortalSessionAuthVerifier.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/portal/session/PortalSessionAuthVerifier.java
@@ -30,7 +30,9 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Tomas Polesovsky
  */
-@Component(service = AuthVerifier.class)
+@Component(
+	property = "service.ranking:Integer=70", service = AuthVerifier.class
+)
 public class PortalSessionAuthVerifier implements AuthVerifier {
 
 	public static final String AUTH_TYPE = HttpServletRequest.FORM_AUTH;

--- a/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/request/parameter/RequestParameterAuthVerifier.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/request/parameter/RequestParameterAuthVerifier.java
@@ -20,7 +20,9 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Tomas Polesovsky
  */
-@Component(service = AuthVerifier.class)
+@Component(
+	property = "service.ranking:Integer=80", service = AuthVerifier.class
+)
 public class RequestParameterAuthVerifier implements AuthVerifier {
 
 	@Override

--- a/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/tunnel/TunnelAuthVerifier.java
+++ b/modules/apps/portal-security/portal-security-auth-verifier/src/main/java/com/liferay/portal/security/auth/verifier/internal/tunnel/TunnelAuthVerifier.java
@@ -32,7 +32,9 @@ import org.osgi.service.component.annotations.Component;
 /**
  * @author Zsolt Berentey
  */
-@Component(service = AuthVerifier.class)
+@Component(
+	property = "service.ranking:Integer=60", service = AuthVerifier.class
+)
 public class TunnelAuthVerifier implements AuthVerifier {
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.security.auth.verifier.AuthVerifier;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierConfiguration;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierResult;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -27,6 +28,7 @@ import com.liferay.portal.spring.context.PortalContextLoaderListener;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -71,6 +73,10 @@ public class AuthVerifierPipeline {
 		_authVerifierConfigurations = new ArrayList<>(
 			authVerifierConfigurations);
 
+		ListUtil.sort(
+			_authVerifierConfigurations,
+			new AuthVerifierConfigurationComparator());
+
 		_contextPath = contextPath;
 
 		_buildURLPatternMapper();
@@ -108,6 +114,10 @@ public class AuthVerifierPipeline {
 		AuthVerifierConfiguration authVerifierConfiguration) {
 
 		_authVerifierConfigurations.add(authVerifierConfiguration);
+
+		ListUtil.sort(
+			_authVerifierConfigurations,
+			new AuthVerifierConfigurationComparator());
 
 		_buildURLPatternMapper();
 	}
@@ -211,6 +221,32 @@ public class AuthVerifierPipeline {
 		_excludeURLPatternMapper;
 	private volatile URLPatternMapper<List<AuthVerifierConfiguration>>
 		_includeURLPatternMapper;
+
+	private static class AuthVerifierConfigurationComparator
+		implements Comparator<AuthVerifierConfiguration> {
+
+		@Override
+		public int compare(
+			AuthVerifierConfiguration authVerifierConfiguration1,
+			AuthVerifierConfiguration authVerifierConfiguration2) {
+
+			AuthVerifier authVerifier1 = AuthVerifierRegistry.getAuthVerifier(
+				authVerifierConfiguration1.getAuthVerifierClassName());
+			AuthVerifier authVerifier2 = AuthVerifierRegistry.getAuthVerifier(
+				authVerifierConfiguration2.getAuthVerifierClassName());
+
+			if ((authVerifier1 == null) || (authVerifier2 == null)) {
+				return -1;
+			}
+
+			return _sortedAuthVerifiers.indexOf(authVerifier1) -
+				_sortedAuthVerifiers.indexOf(authVerifier2);
+		}
+
+		private final List<AuthVerifier> _sortedAuthVerifiers =
+			AuthVerifierRegistry.getAuthVerifiersByPriority();
+
+	}
 
 	private static class AuthVerifierConfigurationConsumer
 		implements Consumer<List<AuthVerifierConfiguration>> {

--- a/portal-impl/src/com/liferay/portal/security/auth/registry/AuthVerifierRegistry.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/registry/AuthVerifierRegistry.java
@@ -5,6 +5,8 @@
 
 package com.liferay.portal.security.auth.registry;
 
+import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerList;
+import com.liferay.osgi.service.tracker.collections.list.ServiceTrackerListFactory;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
@@ -14,6 +16,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.auth.AuthVerifierPipeline;
 
+import java.util.List;
 import java.util.Properties;
 
 import org.osgi.framework.BundleContext;
@@ -29,6 +32,10 @@ public class AuthVerifierRegistry {
 
 	public static AuthVerifier getAuthVerifier(String simpleClassName) {
 		return _serviceTrackerMap.getService(simpleClassName);
+	}
+
+	public static List<AuthVerifier> getAuthVerifiersByPriority() {
+		return _serviceTrackerList.toList();
 	}
 
 	private static AuthVerifierConfiguration _buildAuthVerifierConfiguration(
@@ -65,6 +72,9 @@ public class AuthVerifierRegistry {
 		return authVerifierConfiguration;
 	}
 
+	private static final ServiceTrackerList<AuthVerifier> _serviceTrackerList =
+		ServiceTrackerListFactory.open(
+			SystemBundleUtil.getBundleContext(), AuthVerifier.class);
 	private static final ServiceTrackerMap<String, AuthVerifier>
 		_serviceTrackerMap;
 

--- a/portal-impl/test/unit/com/liferay/portal/security/auth/AuthVerifierPipelineTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/security/auth/AuthVerifierPipelineTest.java
@@ -87,6 +87,32 @@ public class AuthVerifierPipelineTest {
 	}
 
 	@Test
+	public void testVerifyRequestConsidersAuthVerifiersOrder()
+		throws PortalException {
+
+		String contextPath = "";
+		String includeURLs = StringBundler.concat(
+			_BASE_URL, "/regular/*,", _BASE_URL, "/legacy*");
+
+		String legacyRequestURI = contextPath + _BASE_URL + "/legacy/Hello";
+		String regularRequestURI = contextPath + _BASE_URL + "/regular/Hello";
+
+		AuthVerifierResult.State expectedState =
+			AuthVerifierResult.State.UNSUCCESSFUL;
+
+		Mockito.when(
+			AuthVerifierRegistry.getAuthVerifiersByPriority()
+		).thenReturn(
+			ListUtil.fromArray(_authVerifier2, _authVerifier1)
+		);
+
+		_assertAuthVerifierResult(
+			contextPath, includeURLs, legacyRequestURI, expectedState);
+		_assertAuthVerifierResult(
+			contextPath, includeURLs, regularRequestURI, expectedState);
+	}
+
+	@Test
 	public void testVerifyRequestWithContextPath() throws PortalException {
 		String contextPath = "/abc";
 		String includeURLs = StringBundler.concat(

--- a/portal-impl/test/unit/com/liferay/portal/security/auth/AuthVerifierPipelineTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/security/auth/AuthVerifierPipelineTest.java
@@ -9,14 +9,13 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.auth.AccessControlContext;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifier;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierConfiguration;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierResult;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
-import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -25,7 +24,6 @@ import com.liferay.portal.security.auth.registry.AuthVerifierRegistry;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.util.PortalImpl;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Objects;
 import java.util.Properties;
@@ -42,9 +40,6 @@ import org.junit.Test;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.ServiceRegistration;
-
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockServletContext;
 
@@ -60,8 +55,8 @@ public class AuthVerifierPipelineTest {
 
 	@Before
 	public void setUp() throws Exception {
-		_setUpAuthVerifier();
-		_setUpAuthVerifierConfiguration();
+		_setUpAuthVerifiers();
+		_setUpAuthVerifiersConfiguration();
 		_setUpAuthVerifierRegistry();
 		_setUpPortalUtil();
 		_setUpUserLocalServiceUtil();
@@ -158,39 +153,72 @@ public class AuthVerifierPipelineTest {
 		Assert.assertSame(expectedState, authVerifierResult.getState());
 	}
 
-	private void _setUpAuthVerifier() {
+	private AuthVerifier _newAuthVerifier(
+		AuthVerifierResult.State state, int identifier) {
+
 		AuthVerifierResult authVerifierResult = new AuthVerifierResult();
 
 		authVerifierResult.setSettings(new HashMap<>());
-		authVerifierResult.setState(AuthVerifierResult.State.SUCCESS);
+		authVerifierResult.setState(state);
 
-		_authVerifier = (AuthVerifier)ProxyUtil.newProxyInstance(
+		return (AuthVerifier)ProxyUtil.newProxyInstance(
 			AuthVerifier.class.getClassLoader(),
 			new Class<?>[] {AuthVerifier.class},
 			(proxy, method, args) -> {
 				if (Objects.equals(method.getName(), "verify")) {
 					return authVerifierResult;
 				}
+				else if (Objects.equals(method.getName(), "equals")) {
+					return proxy.hashCode() == args[0].hashCode();
+				}
+				else if (Objects.equals(method.getName(), "hashCode")) {
+					return identifier;
+				}
 
 				return null;
 			});
 	}
 
-	private void _setUpAuthVerifierConfiguration() {
-		_authVerifierConfiguration = new AuthVerifierConfiguration();
-
-		Class<? extends AuthVerifier> clazz = _authVerifier.getClass();
-
-		_authVerifierConfiguration.setAuthVerifierClassName(clazz.getName());
-	}
-
 	private void _setUpAuthVerifierRegistry() {
 		Mockito.when(
 			AuthVerifierRegistry.getAuthVerifier(
-				_authVerifierConfiguration.getAuthVerifierClassName())
+				_authVerifierConfiguration1.getAuthVerifierClassName())
 		).thenReturn(
-			_authVerifier
+			_authVerifier1
 		);
+
+		Mockito.when(
+			AuthVerifierRegistry.getAuthVerifier(
+				_authVerifierConfiguration2.getAuthVerifierClassName())
+		).thenReturn(
+			_authVerifier2
+		);
+
+		Mockito.when(
+			AuthVerifierRegistry.getAuthVerifiersByPriority()
+		).thenReturn(
+			ListUtil.fromArray(_authVerifier1, _authVerifier2)
+		);
+	}
+
+	private void _setUpAuthVerifiers() {
+		_authVerifier1 = _newAuthVerifier(AuthVerifierResult.State.SUCCESS, 1);
+		_authVerifier2 = _newAuthVerifier(
+			AuthVerifierResult.State.UNSUCCESSFUL, 2);
+	}
+
+	private void _setUpAuthVerifiersConfiguration() {
+		_authVerifierConfiguration1 = new AuthVerifierConfiguration() {
+			{
+				setAuthVerifierClassName("classname1");
+			}
+		};
+
+		_authVerifierConfiguration2 = new AuthVerifierConfiguration() {
+			{
+				setAuthVerifierClassName("classname2");
+			}
+		};
 	}
 
 	private void _setUpPortalUtil() {
@@ -231,46 +259,36 @@ public class AuthVerifierPipelineTest {
 			String contextPath, String includeURLs, String requestURI)
 		throws PortalException {
 
-		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+		Properties properties = new Properties();
 
-		ServiceRegistration<AuthVerifier> serviceRegistration =
-			bundleContext.registerService(
-				AuthVerifier.class, _authVerifier,
-				MapUtil.singletonDictionary("urls.includes", includeURLs));
+		properties.put("urls.includes", includeURLs);
 
-		try {
-			Properties properties = new Properties();
+		_authVerifierConfiguration1.setProperties(properties);
+		_authVerifierConfiguration2.setProperties(properties);
 
-			properties.put("urls.includes", includeURLs);
+		AuthVerifierPipeline authVerifierPipeline = new AuthVerifierPipeline(
+			ListUtil.fromArray(
+				_authVerifierConfiguration1, _authVerifierConfiguration2),
+			contextPath);
 
-			_authVerifierConfiguration.setProperties(properties);
+		AccessControlContext accessControlContext = new AccessControlContext();
 
-			AuthVerifierPipeline authVerifierPipeline =
-				new AuthVerifierPipeline(
-					Collections.singletonList(_authVerifierConfiguration),
-					contextPath);
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest(new MockServletContext());
 
-			AccessControlContext accessControlContext =
-				new AccessControlContext();
+		mockHttpServletRequest.setRequestURI(requestURI);
 
-			MockHttpServletRequest mockHttpServletRequest =
-				new MockHttpServletRequest(new MockServletContext());
+		accessControlContext.setRequest(mockHttpServletRequest);
 
-			mockHttpServletRequest.setRequestURI(requestURI);
-
-			accessControlContext.setRequest(mockHttpServletRequest);
-
-			return authVerifierPipeline.verifyRequest(accessControlContext);
-		}
-		finally {
-			serviceRegistration.unregister();
-		}
+		return authVerifierPipeline.verifyRequest(accessControlContext);
 	}
 
 	private static final String _BASE_URL = "/TestAuthVerifier";
 
-	private AuthVerifier _authVerifier;
-	private AuthVerifierConfiguration _authVerifierConfiguration;
+	private AuthVerifier _authVerifier1;
+	private AuthVerifier _authVerifier2;
+	private AuthVerifierConfiguration _authVerifierConfiguration1;
+	private AuthVerifierConfiguration _authVerifierConfiguration2;
 	private final MockedStatic<AuthVerifierRegistry>
 		_authVerifierRegistryMockedStatic = Mockito.mockStatic(
 			AuthVerifierRegistry.class);

--- a/portal-impl/test/unit/com/liferay/portal/security/auth/AuthVerifierPipelineTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/security/auth/AuthVerifierPipelineTest.java
@@ -191,14 +191,14 @@ public class AuthVerifierPipelineTest {
 			AuthVerifier.class.getClassLoader(),
 			new Class<?>[] {AuthVerifier.class},
 			(proxy, method, args) -> {
-				if (Objects.equals(method.getName(), "verify")) {
-					return authVerifierResult;
-				}
-				else if (Objects.equals(method.getName(), "equals")) {
+				if (Objects.equals(method.getName(), "equals")) {
 					return proxy.hashCode() == args[0].hashCode();
 				}
 				else if (Objects.equals(method.getName(), "hashCode")) {
 					return identifier;
+				}
+				else if (Objects.equals(method.getName(), "verify")) {
+					return authVerifierResult;
 				}
 
 				return null;


### PR DESCRIPTION
- LPD-30790 Be able to return all registered AuthVerifier ordered by service.ranking.
- LPD-30790 AuthVerifier should be applied taking into account their service.ranking
- LPD-30790 Provide service.ranking so that they can follow the same order as before with auth.verifier.pipeline property. Mainly the important one is BasicAuthHeaderAuthVerifier because:
- LPD-30790 Prepare test to be able to work with several AuthVerifiers to check which one is executed first.
- LPD-30790 Check that order (defined by service.ranking) is taken into account in the pipeline.
- LPD-30790 SF, sort if/else statements
