### PR TITLE
LPD-33598 urn:ietf:params:scim:schemas:extension:liferay:2.0:User not allowed in SCIM request

### DIFF
--- a/modules/dxp/apps/scim/scim-rest-api/bnd.bnd
+++ b/modules/dxp/apps/scim/scim-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay SCIM REST API
 Bundle-SymbolicName: com.liferay.scim.rest.api
-Bundle-Version: 3.0.6
+Bundle-Version: 3.1.0
 Export-Package:\
 	com.liferay.scim.rest.dto.v1_0,\
 	com.liferay.scim.rest.resource.v1_0,\

--- a/modules/dxp/apps/scim/scim-rest-api/src/main/java/com/liferay/scim/rest/dto/v1_0/User.java
+++ b/modules/dxp/apps/scim/scim-rest-api/src/main/java/com/liferay/scim/rest/dto/v1_0/User.java
@@ -1022,6 +1022,71 @@ public class User implements Serializable {
 	private Supplier<String> _titleSupplier;
 
 	@Schema(
+		description = "The components of the Liferay's User Schema Extension."
+	)
+	@Valid
+	public UserSchemaExtension
+		getUrn_ietf_params_scim_schemas_extension_liferay_2_0_User() {
+
+		if (_urn_ietf_params_scim_schemas_extension_liferay_2_0_UserSupplier !=
+				null) {
+
+			urn_ietf_params_scim_schemas_extension_liferay_2_0_User =
+				_urn_ietf_params_scim_schemas_extension_liferay_2_0_UserSupplier.
+					get();
+
+			_urn_ietf_params_scim_schemas_extension_liferay_2_0_UserSupplier =
+				null;
+		}
+
+		return urn_ietf_params_scim_schemas_extension_liferay_2_0_User;
+	}
+
+	public void setUrn_ietf_params_scim_schemas_extension_liferay_2_0_User(
+		UserSchemaExtension
+			urn_ietf_params_scim_schemas_extension_liferay_2_0_User) {
+
+		this.urn_ietf_params_scim_schemas_extension_liferay_2_0_User =
+			urn_ietf_params_scim_schemas_extension_liferay_2_0_User;
+
+		_urn_ietf_params_scim_schemas_extension_liferay_2_0_UserSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setUrn_ietf_params_scim_schemas_extension_liferay_2_0_User(
+		UnsafeSupplier<UserSchemaExtension, Exception>
+			urn_ietf_params_scim_schemas_extension_liferay_2_0_UserUnsafeSupplier) {
+
+		_urn_ietf_params_scim_schemas_extension_liferay_2_0_UserSupplier =
+			() -> {
+				try {
+					return urn_ietf_params_scim_schemas_extension_liferay_2_0_UserUnsafeSupplier.
+						get();
+				}
+				catch (RuntimeException runtimeException) {
+					throw runtimeException;
+				}
+				catch (Exception exception) {
+					throw new RuntimeException(exception);
+				}
+			};
+	}
+
+	@GraphQLField(
+		description = "The components of the Liferay's User Schema Extension."
+	)
+	@JsonProperty(
+		access = JsonProperty.Access.READ_WRITE,
+		value = "urn:ietf:params:scim:schemas:extension:liferay:2.0:User"
+	)
+	protected UserSchemaExtension
+		urn_ietf_params_scim_schemas_extension_liferay_2_0_User;
+
+	@JsonIgnore
+	private Supplier<UserSchemaExtension>
+		_urn_ietf_params_scim_schemas_extension_liferay_2_0_UserSupplier;
+
+	@Schema(
 		description = "A service provider's unique identifier for the user, typically used by the user to directly authenticate to the service provider."
 	)
 	public String getUserName() {
@@ -1585,6 +1650,23 @@ public class User implements Serializable {
 			sb.append(_escape(title));
 
 			sb.append("\"");
+		}
+
+		UserSchemaExtension
+			urn_ietf_params_scim_schemas_extension_liferay_2_0_User =
+				getUrn_ietf_params_scim_schemas_extension_liferay_2_0_User();
+
+		if (urn_ietf_params_scim_schemas_extension_liferay_2_0_User != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append(
+				"\"urn:ietf:params:scim:schemas:extension:liferay:2.0:User\": ");
+
+			sb.append(
+				String.valueOf(
+					urn_ietf_params_scim_schemas_extension_liferay_2_0_User));
 		}
 
 		String userName = getUserName();

--- a/modules/dxp/apps/scim/scim-rest-api/src/main/java/com/liferay/scim/rest/dto/v1_0/UserSchemaExtension.java
+++ b/modules/dxp/apps/scim/scim-rest-api/src/main/java/com/liferay/scim/rest/dto/v1_0/UserSchemaExtension.java
@@ -1,0 +1,297 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.scim.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Olivér Kecskeméty
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "Liferay's User Schema Extension.",
+	value = "UserSchemaExtension"
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "UserSchemaExtension")
+public class UserSchemaExtension implements Serializable {
+
+	public static UserSchemaExtension toDTO(String json) {
+		return ObjectMapperUtil.readValue(UserSchemaExtension.class, json);
+	}
+
+	public static UserSchemaExtension unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			UserSchemaExtension.class, json);
+	}
+
+	@Schema
+	public Date getBirthday() {
+		if (_birthdaySupplier != null) {
+			birthday = _birthdaySupplier.get();
+
+			_birthdaySupplier = null;
+		}
+
+		return birthday;
+	}
+
+	public void setBirthday(Date birthday) {
+		this.birthday = birthday;
+
+		_birthdaySupplier = null;
+	}
+
+	@JsonIgnore
+	public void setBirthday(
+		UnsafeSupplier<Date, Exception> birthdayUnsafeSupplier) {
+
+		_birthdaySupplier = () -> {
+			try {
+				return birthdayUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Date birthday;
+
+	@JsonIgnore
+	private Supplier<Date> _birthdaySupplier;
+
+	@Schema
+	public Boolean getMale() {
+		if (_maleSupplier != null) {
+			male = _maleSupplier.get();
+
+			_maleSupplier = null;
+		}
+
+		return male;
+	}
+
+	public void setMale(Boolean male) {
+		this.male = male;
+
+		_maleSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setMale(UnsafeSupplier<Boolean, Exception> maleUnsafeSupplier) {
+		_maleSupplier = () -> {
+			try {
+				return maleUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean male;
+
+	@JsonIgnore
+	private Supplier<Boolean> _maleSupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof UserSchemaExtension)) {
+			return false;
+		}
+
+		UserSchemaExtension userSchemaExtension = (UserSchemaExtension)object;
+
+		return Objects.equals(toString(), userSchemaExtension.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		Date birthday = getBirthday();
+
+		if (birthday != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"birthday\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(birthday));
+
+			sb.append("\"");
+		}
+
+		Boolean male = getMale();
+
+		if (male != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"male\": ");
+
+			sb.append(male);
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.scim.rest.dto.v1_0.UserSchemaExtension",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/dxp/apps/scim/scim-rest-api/src/main/resources/com/liferay/scim/rest/dto/v1_0/packageinfo
+++ b/modules/dxp/apps/scim/scim-rest-api/src/main/resources/com/liferay/scim/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0

--- a/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/dto/v1_0/User.java
+++ b/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/dto/v1_0/User.java
@@ -486,6 +486,37 @@ public class User implements Cloneable, Serializable {
 
 	protected String title;
 
+	public UserSchemaExtension
+		getUrn_ietf_params_scim_schemas_extension_liferay_2_0_User() {
+
+		return urn_ietf_params_scim_schemas_extension_liferay_2_0_User;
+	}
+
+	public void setUrn_ietf_params_scim_schemas_extension_liferay_2_0_User(
+		UserSchemaExtension
+			urn_ietf_params_scim_schemas_extension_liferay_2_0_User) {
+
+		this.urn_ietf_params_scim_schemas_extension_liferay_2_0_User =
+			urn_ietf_params_scim_schemas_extension_liferay_2_0_User;
+	}
+
+	public void setUrn_ietf_params_scim_schemas_extension_liferay_2_0_User(
+		UnsafeSupplier<UserSchemaExtension, Exception>
+			urn_ietf_params_scim_schemas_extension_liferay_2_0_UserUnsafeSupplier) {
+
+		try {
+			urn_ietf_params_scim_schemas_extension_liferay_2_0_User =
+				urn_ietf_params_scim_schemas_extension_liferay_2_0_UserUnsafeSupplier.
+					get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected UserSchemaExtension
+		urn_ietf_params_scim_schemas_extension_liferay_2_0_User;
+
 	public String getUserName() {
 		return userName;
 	}

--- a/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/dto/v1_0/UserSchemaExtension.java
+++ b/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/dto/v1_0/UserSchemaExtension.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.scim.rest.client.dto.v1_0;
+
+import com.liferay.scim.rest.client.function.UnsafeSupplier;
+import com.liferay.scim.rest.client.serdes.v1_0.UserSchemaExtensionSerDes;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Olivér Kecskeméty
+ * @generated
+ */
+@Generated("")
+public class UserSchemaExtension implements Cloneable, Serializable {
+
+	public static UserSchemaExtension toDTO(String json) {
+		return UserSchemaExtensionSerDes.toDTO(json);
+	}
+
+	public Date getBirthday() {
+		return birthday;
+	}
+
+	public void setBirthday(Date birthday) {
+		this.birthday = birthday;
+	}
+
+	public void setBirthday(
+		UnsafeSupplier<Date, Exception> birthdayUnsafeSupplier) {
+
+		try {
+			birthday = birthdayUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date birthday;
+
+	public Boolean getMale() {
+		return male;
+	}
+
+	public void setMale(Boolean male) {
+		this.male = male;
+	}
+
+	public void setMale(UnsafeSupplier<Boolean, Exception> maleUnsafeSupplier) {
+		try {
+			male = maleUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean male;
+
+	@Override
+	public UserSchemaExtension clone() throws CloneNotSupportedException {
+		return (UserSchemaExtension)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof UserSchemaExtension)) {
+			return false;
+		}
+
+		UserSchemaExtension userSchemaExtension = (UserSchemaExtension)object;
+
+		return Objects.equals(toString(), userSchemaExtension.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return UserSchemaExtensionSerDes.toJSON(this);
+	}
+
+}

--- a/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/serdes/v1_0/UserSchemaExtensionSerDes.java
+++ b/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/serdes/v1_0/UserSchemaExtensionSerDes.java
@@ -1,0 +1,242 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.scim.rest.client.serdes.v1_0;
+
+import com.liferay.scim.rest.client.dto.v1_0.UserSchemaExtension;
+import com.liferay.scim.rest.client.json.BaseJSONParser;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Olivér Kecskeméty
+ * @generated
+ */
+@Generated("")
+public class UserSchemaExtensionSerDes {
+
+	public static UserSchemaExtension toDTO(String json) {
+		UserSchemaExtensionJSONParser userSchemaExtensionJSONParser =
+			new UserSchemaExtensionJSONParser();
+
+		return userSchemaExtensionJSONParser.parseToDTO(json);
+	}
+
+	public static UserSchemaExtension[] toDTOs(String json) {
+		UserSchemaExtensionJSONParser userSchemaExtensionJSONParser =
+			new UserSchemaExtensionJSONParser();
+
+		return userSchemaExtensionJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(UserSchemaExtension userSchemaExtension) {
+		if (userSchemaExtension == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (userSchemaExtension.getBirthday() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"birthday\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(
+					userSchemaExtension.getBirthday()));
+
+			sb.append("\"");
+		}
+
+		if (userSchemaExtension.getMale() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"male\": ");
+
+			sb.append(userSchemaExtension.getMale());
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		UserSchemaExtensionJSONParser userSchemaExtensionJSONParser =
+			new UserSchemaExtensionJSONParser();
+
+		return userSchemaExtensionJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		UserSchemaExtension userSchemaExtension) {
+
+		if (userSchemaExtension == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (userSchemaExtension.getBirthday() == null) {
+			map.put("birthday", null);
+		}
+		else {
+			map.put(
+				"birthday",
+				liferayToJSONDateFormat.format(
+					userSchemaExtension.getBirthday()));
+		}
+
+		if (userSchemaExtension.getMale() == null) {
+			map.put("male", null);
+		}
+		else {
+			map.put("male", String.valueOf(userSchemaExtension.getMale()));
+		}
+
+		return map;
+	}
+
+	public static class UserSchemaExtensionJSONParser
+		extends BaseJSONParser<UserSchemaExtension> {
+
+		@Override
+		protected UserSchemaExtension createDTO() {
+			return new UserSchemaExtension();
+		}
+
+		@Override
+		protected UserSchemaExtension[] createDTOArray(int size) {
+			return new UserSchemaExtension[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "birthday")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "male")) {
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			UserSchemaExtension userSchemaExtension, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "birthday")) {
+				if (jsonParserFieldValue != null) {
+					userSchemaExtension.setBirthday(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "male")) {
+				if (jsonParserFieldValue != null) {
+					userSchemaExtension.setMale((Boolean)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}

--- a/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/serdes/v1_0/UserSerDes.java
+++ b/modules/dxp/apps/scim/scim-rest-client/src/main/java/com/liferay/scim/rest/client/serdes/v1_0/UserSerDes.java
@@ -395,6 +395,22 @@ public class UserSerDes {
 			sb.append("\"");
 		}
 
+		if (user.getUrn_ietf_params_scim_schemas_extension_liferay_2_0_User() !=
+				null) {
+
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append(
+				"\"urn:ietf:params:scim:schemas:extension:liferay:2.0:User\": ");
+
+			sb.append(
+				String.valueOf(
+					user.
+						getUrn_ietf_params_scim_schemas_extension_liferay_2_0_User()));
+		}
+
 		if (user.getUserName() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -617,6 +633,21 @@ public class UserSerDes {
 			map.put("title", String.valueOf(user.getTitle()));
 		}
 
+		if (user.getUrn_ietf_params_scim_schemas_extension_liferay_2_0_User() ==
+				null) {
+
+			map.put(
+				"urn:ietf:params:scim:schemas:extension:liferay:2.0:User",
+				null);
+		}
+		else {
+			map.put(
+				"urn:ietf:params:scim:schemas:extension:liferay:2.0:User",
+				String.valueOf(
+					user.
+						getUrn_ietf_params_scim_schemas_extension_liferay_2_0_User()));
+		}
+
 		if (user.getUserName() == null) {
 			map.put("userName", null);
 		}
@@ -720,6 +751,12 @@ public class UserSerDes {
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "title")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"urn:ietf:params:scim:schemas:extension:liferay:2.0:User")) {
+
 				return false;
 			}
 			else if (Objects.equals(jsonParserFieldName, "userName")) {
@@ -927,6 +964,17 @@ public class UserSerDes {
 			else if (Objects.equals(jsonParserFieldName, "title")) {
 				if (jsonParserFieldValue != null) {
 					user.setTitle((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName,
+						"urn:ietf:params:scim:schemas:extension:liferay:2.0:User")) {
+
+				if (jsonParserFieldValue != null) {
+					user.
+						setUrn_ietf_params_scim_schemas_extension_liferay_2_0_User(
+							UserSchemaExtensionSerDes.toDTO(
+								(String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "userName")) {

--- a/modules/dxp/apps/scim/scim-rest-impl/rest-openapi.yaml
+++ b/modules/dxp/apps/scim/scim-rest-impl/rest-openapi.yaml
@@ -298,6 +298,11 @@ components:
                           description:
                               The user's title, such as "Vice President".
                           type: string
+                      urn:ietf:params:scim:schemas:extension:liferay:2.0:User:
+                          $ref: "#/components/schemas/UserSchemaExtension"
+                          description:
+                              The components of the Liferay's User Schema Extension.
+                          type: UserSchemaExtension
                       userName:
                           description:
                               A service provider's unique identifier for the user, typically used by the user to
@@ -314,6 +319,16 @@ components:
                               $ref: "#/components/schemas/MultiValuedAttribute"
                           type: array
                   type: object
+        UserSchemaExtension:
+            description:
+                Liferay's User Schema Extension.
+            properties:
+                birthday:
+                    format: date
+                    type: string
+                male:
+                    type: boolean
+            type: object
 info:
     description:
         "Liferay SCIM endpoints. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/BaseUserResourceImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/resource/v1_0/BaseUserResourceImpl.java
@@ -83,7 +83,7 @@ public abstract class BaseUserResourceImpl implements UserResource {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/scim/v1.0/v2/Users' -d $'{"active": ___, "addresses": ___, "displayName": ___, "emails": ___, "entitlements": ___, "externalId": ___, "groups": ___, "ims": ___, "locale": ___, "meta": ___, "name": ___, "nickName": ___, "password": ___, "phoneNumbers": ___, "photos": ___, "preferredLanguage": ___, "profileUrl": ___, "roles": ___, "schemas": ___, "timezone": ___, "title": ___, "userName": ___, "userType": ___, "x509Certificates": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/scim/v1.0/v2/Users' -d $'{"active": ___, "addresses": ___, "displayName": ___, "emails": ___, "entitlements": ___, "externalId": ___, "groups": ___, "ims": ___, "locale": ___, "meta": ___, "name": ___, "nickName": ___, "password": ___, "phoneNumbers": ___, "photos": ___, "preferredLanguage": ___, "profileUrl": ___, "roles": ___, "schemas": ___, "timezone": ___, "title": ___, "urn:ietf:params:scim:schemas:extension:liferay:2.0:User": ___, "userName": ___, "userType": ___, "x509Certificates": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(description = "Creates a user.")
 	@io.swagger.v3.oas.annotations.tags.Tags(
@@ -186,7 +186,7 @@ public abstract class BaseUserResourceImpl implements UserResource {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/scim/v1.0/v2/Users/{id}' -d $'{"active": ___, "addresses": ___, "displayName": ___, "emails": ___, "entitlements": ___, "externalId": ___, "groups": ___, "ims": ___, "locale": ___, "meta": ___, "name": ___, "nickName": ___, "password": ___, "phoneNumbers": ___, "photos": ___, "preferredLanguage": ___, "profileUrl": ___, "roles": ___, "schemas": ___, "timezone": ___, "title": ___, "userName": ___, "userType": ___, "x509Certificates": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'PUT' 'http://localhost:8080/o/scim/v1.0/v2/Users/{id}' -d $'{"active": ___, "addresses": ___, "displayName": ___, "emails": ___, "entitlements": ___, "externalId": ___, "groups": ___, "ims": ___, "locale": ___, "meta": ___, "name": ___, "nickName": ___, "password": ___, "phoneNumbers": ___, "photos": ___, "preferredLanguage": ___, "profileUrl": ___, "roles": ___, "schemas": ___, "timezone": ___, "title": ___, "urn:ietf:params:scim:schemas:extension:liferay:2.0:User": ___, "userName": ___, "userType": ___, "x509Certificates": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(description = "Updates a user.")
 	@io.swagger.v3.oas.annotations.Parameters(

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/util/ScimUtil.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/util/ScimUtil.java
@@ -19,7 +19,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ContactConstants;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
-import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -29,6 +28,9 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.scim.rest.internal.model.ScimUser;
 
 import java.io.File;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 
 import java.util.Calendar;
 import java.util.Collections;
@@ -104,7 +106,7 @@ public class ScimUtil {
 			PrefsPropsUtil.getBoolean(
 				companyId, PropsKeys.USERS_SCREEN_NAME_ALWAYS_AUTOGENERATE));
 		scimUser.setAutoPassword(user.getPassword() == null);
-		scimUser.setBirthday(_getBirthday(locale, user));
+		scimUser.setBirthday(_getBirthday(user));
 		scimUser.setCompanyId(companyId);
 		scimUser.setEmailAddress(_getEmailAddress(user));
 		scimUser.setExternalReferenceCode(user.getExternalId());
@@ -337,9 +339,7 @@ public class ScimUtil {
 				"birthday",
 				_createSimpleAttribute(
 					attributeSchema.getSubAttributeSchema("birthday"),
-					DateUtil.getDate(
-						scimUser.getBirthday(), "yyyy-MM-dd",
-						scimUser.getLocale()))
+					_dateFormat.format(scimUser.getBirthday()))
 			).put(
 				"male",
 				_createSimpleAttribute(
@@ -370,7 +370,7 @@ public class ScimUtil {
 		return birthdayCalendar.getTime();
 	}
 
-	private static Date _getBirthday(Locale locale, User user) {
+	private static Date _getBirthday(User user) {
 		try {
 			ComplexAttribute complexAttribute =
 				(ComplexAttribute)user.getAttribute(
@@ -387,8 +387,7 @@ public class ScimUtil {
 				return _getBirthday();
 			}
 
-			return DateUtil.parseDate(
-				"yyyy-MM-dd", simpleAttribute.getStringValue(), locale);
+			return _dateFormat.parse(simpleAttribute.getStringValue());
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
@@ -487,5 +486,7 @@ public class ScimUtil {
 
 	private static final DCLSingleton<AttributeSchema>
 		_attributeSchemaDCLSingleton = new DCLSingleton<>();
+	private static final DateFormat _dateFormat = new SimpleDateFormat(
+		"yyyy-MM-dd'T'HH:mm:ssXX");
 
 }

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/BaseUserResourceTestCase.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/BaseUserResourceTestCase.java
@@ -484,6 +484,20 @@ public abstract class BaseUserResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals(
+					"urn_ietf_params_scim_schemas_extension_liferay_2_0_User",
+					additionalAssertFieldName)) {
+
+				if (user.
+						getUrn_ietf_params_scim_schemas_extension_liferay_2_0_User() ==
+							null) {
+
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("userName", additionalAssertFieldName)) {
 				if (user.getUserName() == null) {
 					valid = false;
@@ -817,6 +831,22 @@ public abstract class BaseUserResourceTestCase {
 
 			if (Objects.equals("title", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(user1.getTitle(), user2.getTitle())) {
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"urn_ietf_params_scim_schemas_extension_liferay_2_0_User",
+					additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						user1.
+							getUrn_ietf_params_scim_schemas_extension_liferay_2_0_User(),
+						user2.
+							getUrn_ietf_params_scim_schemas_extension_liferay_2_0_User())) {
+
 					return false;
 				}
 
@@ -1479,6 +1509,13 @@ public abstract class BaseUserResourceTestCase {
 			}
 
 			return sb.toString();
+		}
+
+		if (entityFieldName.equals(
+				"urn_ietf_params_scim_schemas_extension_liferay_2_0_User")) {
+
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
 		}
 
 		if (entityFieldName.equals("userName")) {

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/UserResourceTest.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/UserResourceTest.java
@@ -32,10 +32,15 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.scim.rest.client.dto.v1_0.MultiValuedAttribute;
 import com.liferay.scim.rest.client.dto.v1_0.Name;
 import com.liferay.scim.rest.client.dto.v1_0.User;
+import com.liferay.scim.rest.client.dto.v1_0.UserSchemaExtension;
 import com.liferay.scim.rest.client.http.HttpInvoker;
 import com.liferay.scim.rest.resource.v1_0.test.util.ScimTestUtil;
 
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+
+import org.apache.commons.lang.time.DateUtils;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -243,7 +248,8 @@ public class UserResourceTest extends BaseUserResourceTestCase {
 	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {
-			"emails", "externalId", "name", "title", "userName"
+			"emails", "externalId", "name", "title", "userName",
+			"urn_ietf_params_scim_schemas_extension_liferay_2_0_User"
 		};
 	}
 
@@ -272,7 +278,18 @@ public class UserResourceTest extends BaseUserResourceTestCase {
 				}
 			});
 		user.setSchemas(
-			new String[] {"urn:ietf:params:scim:schemas:core:2.0:User"});
+			new String[] {
+				"urn:ietf:params:scim:schemas:core:2.0:User",
+				"urn:ietf:params:scim:schemas:extension:liferay:2.0:User"
+			});
+
+		user.setUrn_ietf_params_scim_schemas_extension_liferay_2_0_User(
+			new UserSchemaExtension() {
+				{
+					birthday = DateUtils.truncate(new Date(), Calendar.DATE);
+					male = true;
+				}
+			});
 
 		return user;
 	}

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/UserResourceTest.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/UserResourceTest.java
@@ -5,6 +5,17 @@
 
 package com.liferay.scim.rest.resource.v1_0.test;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.cfg.MapperConfig;
+import com.fasterxml.jackson.databind.introspect.AnnotatedField;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.expando.kernel.service.ExpandoTableLocalService;
@@ -34,6 +45,7 @@ import com.liferay.scim.rest.client.dto.v1_0.Name;
 import com.liferay.scim.rest.client.dto.v1_0.User;
 import com.liferay.scim.rest.client.dto.v1_0.UserSchemaExtension;
 import com.liferay.scim.rest.client.http.HttpInvoker;
+import com.liferay.scim.rest.client.serdes.v1_0.UserSerDes;
 import com.liferay.scim.rest.resource.v1_0.test.util.ScimTestUtil;
 
 import java.util.Arrays;
@@ -83,6 +95,30 @@ public class UserResourceTest extends BaseUserResourceTestCase {
 	@AfterClass
 	public static void tearDownClass() throws Exception {
 		ConfigurationTestUtil.deleteConfiguration(_pid);
+	}
+
+	@Override
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		User user1 = randomUser();
+
+		String json = _objectMapper.writeValueAsString(user1);
+
+		User user2 = UserSerDes.toDTO(json);
+
+		Assert.assertTrue(equals(user1, user2));
+	}
+
+	@Override
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		User user = randomUser();
+
+		String json1 = _objectMapper.writeValueAsString(user);
+		String json2 = UserSerDes.toJSON(user);
+
+		Assert.assertEquals(
+			_objectMapper.readTree(json1), _objectMapper.readTree(json2));
 	}
 
 	@Override
@@ -377,6 +413,38 @@ public class UserResourceTest extends BaseUserResourceTestCase {
 
 		return User.toDTO(userObject.toString());
 	}
+
+	private static final ObjectMapper _objectMapper = new ObjectMapper() {
+		{
+			configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+			configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+			enable(SerializationFeature.INDENT_OUTPUT);
+			setDateFormat(new ISO8601DateFormat());
+			setPropertyNamingStrategy(
+				new PropertyNamingStrategy() {
+
+					@Override
+					public String nameForField(
+						MapperConfig<?> config, AnnotatedField field,
+						String defaultName) {
+
+						if (StringUtil.startsWith(defaultName, "urn")) {
+							return "urn:ietf:params:scim:schemas:extension:" +
+								"liferay:2.0:User";
+						}
+
+						return super.nameForField(config, field, defaultName);
+					}
+
+				});
+			setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+			setSerializationInclusion(JsonInclude.Include.NON_NULL);
+			setVisibility(
+				PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+			setVisibility(
+				PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+		}
+	};
 
 	private static String _pid;
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/DTOOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/DTOOpenAPIParser.java
@@ -169,7 +169,8 @@ public class DTOOpenAPIParser {
 	private static String _getPropertyName(
 		Schema propertySchema, String propertySchemaName) {
 
-		String name = CamelCaseUtil.toCamelCase(propertySchemaName);
+		String name = StringUtil.removeSubstring(
+			CamelCaseUtil.toCamelCase(propertySchemaName), ":");
 
 		if (StringUtil.equalsIgnoreCase(propertySchema.getType(), "object") &&
 			(propertySchema.getItems() != null)) {

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/DTOOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/DTOOpenAPIParser.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser;
 
+import com.liferay.petra.string.CharPool;
 import com.liferay.portal.kernel.util.CamelCaseUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.tools.rest.builder.internal.freemarker.tool.java.parser.util.OpenAPIParserUtil;
@@ -169,8 +170,10 @@ public class DTOOpenAPIParser {
 	private static String _getPropertyName(
 		Schema propertySchema, String propertySchemaName) {
 
-		String name = StringUtil.removeSubstring(
-			CamelCaseUtil.toCamelCase(propertySchemaName), ":");
+		String name = StringUtil.replace(
+			CamelCaseUtil.toCamelCase(propertySchemaName),
+			new char[] {CharPool.COLON, CharPool.PERIOD},
+			new char[] {CharPool.UNDERLINE, CharPool.UNDERLINE});
 
 		if (StringUtil.equalsIgnoreCase(propertySchema.getType(), "object") &&
 			(propertySchema.getItems() != null)) {


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPD-33598

To fix the issue I had to finish the implementation of the schema extension by adding it in `scim-rest-impl/rest-openapi.yaml`, and to do that we had to make a small change in the REST Builder parser.

@liferay-headless