### PR TITLE
LPD-34782 Fix com.liferay.portal.security.auth.test.AuthenticatedSessionManagerUtilTest

### DIFF
--- a/modules/apps/portal-security/portal-security-auth-test/src/testIntegration/java/com/liferay/portal/security/auth/test/AuthenticatedSessionManagerUtilTest.java
+++ b/modules/apps/portal-security/portal-security-auth-test/src/testIntegration/java/com/liferay/portal/security/auth/test/AuthenticatedSessionManagerUtilTest.java
@@ -131,11 +131,16 @@ public class AuthenticatedSessionManagerUtilTest {
 			CookiesConstants.CONSENT_TYPE_FUNCTIONAL, cookie,
 			mockHttpServletRequest, mockHttpServletResponse);
 
+		mockHttpServletRequest.setCookies(mockHttpServletResponse.getCookies());
+
+		mockHttpServletRequest.setPathInfo(StringPool.SLASH);
+
 		ThemeDisplay themeDisplay = ThemeDisplayFactory.create();
 
 		themeDisplay.setCompany(
 			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
 		themeDisplay.setSiteGroupId(TestPropsValues.getGroupId());
+		themeDisplay.setUser(_user);
 
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);

--- a/modules/apps/portal-security/portal-security-auth-test/src/testIntegration/java/com/liferay/portal/security/auth/test/AuthenticatedSessionManagerUtilTest.java
+++ b/modules/apps/portal-security/portal-security-auth-test/src/testIntegration/java/com/liferay/portal/security/auth/test/AuthenticatedSessionManagerUtilTest.java
@@ -13,7 +13,6 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.RememberMeToken;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.RememberMeTokenLocalService;
-import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -179,8 +178,5 @@ public class AuthenticatedSessionManagerUtilTest {
 
 	@DeleteAfterTestRun
 	private User _user;
-
-	@Inject
-	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/portal-security/portal-security-auth-test/src/testIntegration/java/com/liferay/portal/security/auth/test/AuthenticatedSessionManagerUtilTest.java
+++ b/modules/apps/portal-security/portal-security-auth-test/src/testIntegration/java/com/liferay/portal/security/auth/test/AuthenticatedSessionManagerUtilTest.java
@@ -9,16 +9,14 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cookies.CookiesManager;
 import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.RememberMeToken;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.RememberMeTokenLocalService;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
-import com.liferay.portal.kernel.test.util.CompanyTestUtil;
-import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -133,12 +131,11 @@ public class AuthenticatedSessionManagerUtilTest {
 			CookiesConstants.CONSENT_TYPE_FUNCTIONAL, cookie,
 			mockHttpServletRequest, mockHttpServletResponse);
 
-		Group group = GroupTestUtil.addGroup();
-
 		ThemeDisplay themeDisplay = ThemeDisplayFactory.create();
 
-		themeDisplay.setCompany(CompanyTestUtil.addCompany());
-		themeDisplay.setSiteGroupId(group.getGroupId());
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+		themeDisplay.setSiteGroupId(TestPropsValues.getGroupId());
 
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
@@ -169,6 +166,9 @@ public class AuthenticatedSessionManagerUtilTest {
 	}
 
 	private static final String _PASSWORD = RandomTestUtil.randomString();
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
 
 	@Inject
 	private CookiesManager _cookiesManager;

--- a/modules/apps/portal-security/portal-security-auth-test/src/testIntegration/java/com/liferay/portal/security/auth/test/AuthenticatedSessionManagerUtilTest.java
+++ b/modules/apps/portal-security/portal-security-auth-test/src/testIntegration/java/com/liferay/portal/security/auth/test/AuthenticatedSessionManagerUtilTest.java
@@ -133,9 +133,9 @@ public class AuthenticatedSessionManagerUtilTest {
 			CookiesConstants.CONSENT_TYPE_FUNCTIONAL, cookie,
 			mockHttpServletRequest, mockHttpServletResponse);
 
-		ThemeDisplay themeDisplay = ThemeDisplayFactory.create();
-
 		Group group = GroupTestUtil.addGroup();
+
+		ThemeDisplay themeDisplay = ThemeDisplayFactory.create();
 
 		themeDisplay.setCompany(CompanyTestUtil.addCompany());
 		themeDisplay.setSiteGroupId(group.getGroupId());

--- a/modules/apps/portal-security/portal-security-auth-test/src/testIntegration/java/com/liferay/portal/security/auth/test/AuthenticatedSessionManagerUtilTest.java
+++ b/modules/apps/portal-security/portal-security-auth-test/src/testIntegration/java/com/liferay/portal/security/auth/test/AuthenticatedSessionManagerUtilTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cookies.CookiesManager;
 import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.RememberMeToken;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.RememberMeTokenLocalService;
@@ -17,15 +18,19 @@ import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerB
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.security.auth.session.AuthenticatedSessionManagerUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.theme.ThemeDisplayFactory;
 
 import java.util.Date;
 
@@ -128,6 +133,16 @@ public class AuthenticatedSessionManagerUtilTest {
 		_cookiesManager.addCookie(
 			CookiesConstants.CONSENT_TYPE_FUNCTIONAL, cookie,
 			mockHttpServletRequest, mockHttpServletResponse);
+
+		ThemeDisplay themeDisplay = ThemeDisplayFactory.create();
+
+		Group group = GroupTestUtil.addGroup();
+
+		themeDisplay.setCompany(CompanyTestUtil.addCompany());
+		themeDisplay.setSiteGroupId(group.getGroupId());
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
 
 		AuthenticatedSessionManagerUtil.logout(
 			mockHttpServletRequest, mockHttpServletResponse);


### PR DESCRIPTION
Forwarded from https://github.com/liferay-appsec/liferay-portal/pull/1915 with minor SF change, see 8317e4ec89a9be746fd76f9617e13ff9ab08f300.

Original message:

> Related issue: [LPD-34873](https://liferay.atlassian.net/browse/LPD-34873)
> 
> After a new impl of [LogoutPreAction#Run](https://github.com/liferay-appsec/liferay-portal/blob/8aecdeea188c7659808f4893f1adab1ebbbe48d9/modules/apps/click-to-chat/click-to-chat-web/src/main/java/com/liferay/click/to/chat/web/internal/events/LogoutPreAction.java#L30), the test started failing because of NPE. I added a ThemeDisplay for the test to properly work.