### PR TITLE
LPD-35246 | No content security policy filter needed if company is 0

### DIFF
--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
@@ -145,6 +145,8 @@ function FilterFormComponent({
 		onSave({...responseJSON, displayType, filterType});
 	};
 
+	const selectedField = filter ? {name: filter.fieldName} : undefined;
+
 	return (
 		<>
 			<ClayLayout.SheetHeader className="mb-4">
@@ -168,6 +170,7 @@ function FilterFormComponent({
 				onSave={(formData: any) => saveFDSFilter(formData)}
 				resolvedRESTSchemas={resolvedRESTSchemas}
 				restApplications={restApplications}
+				selectedField={selectedField}
 			/>
 		</>
 	);

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
@@ -311,11 +311,11 @@ function Filters({
 		let availableFieldsListLength = 0;
 
 		if (Liferay.FeatureFlags['LPD-25905']) {
-			const availableFfilterTypeFields = JSON.parse(
+			const availableFilterTypeFields = JSON.parse(
 				JSON.stringify(fields)
 			);
 
-			visit(availableFfilterTypeFields, (field: IFieldTreeItem) => {
+			visit(availableFilterTypeFields, (field: IFieldTreeItem) => {
 				if (
 					!FILTER_TYPES[
 						filterType as EFilterType
@@ -330,7 +330,7 @@ function Filters({
 				}
 			});
 
-			setAvailableFields(availableFfilterTypeFields);
+			setAvailableFields(availableFilterTypeFields);
 		}
 		else {
 			const availableFieldsList = fields.filter((item) =>

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
@@ -85,10 +85,10 @@ type FilterCollection = Array<IFilter>;
 interface IPropsFilterFormComponent {
 	dataSet: IDataSet | FDSViewType;
 	fdsFilterClientExtensions?: IClientExtensionRenderer[];
+	fieldNames?: string[];
 	fields: IField[];
 	filter?: IFilter | ISelectionFilter;
 	filterType?: EFilterType;
-	inUseFieldNames?: string[];
 	namespace: string;
 	onCancel: Function;
 	onSave: (newFilter: IFilter) => void;
@@ -99,10 +99,10 @@ interface IPropsFilterFormComponent {
 function FilterFormComponent({
 	dataSet,
 	fdsFilterClientExtensions = [],
+	fieldNames,
 	fields,
 	filter,
 	filterType,
-	inUseFieldNames,
 	namespace,
 	onCancel,
 	onSave,
@@ -145,8 +145,6 @@ function FilterFormComponent({
 		onSave({...responseJSON, displayType, filterType});
 	};
 
-	const selectedField = filter ? {name: filter.fieldName} : undefined;
-
 	return (
 		<>
 			<ClayLayout.SheetHeader className="mb-4">
@@ -162,15 +160,15 @@ function FilterFormComponent({
 
 			<Component.Body
 				fdsFilterClientExtensions={fdsFilterClientExtensions}
+				fieldNames={fieldNames}
 				fields={fields}
 				filter={filter}
-				inUseFieldNames={inUseFieldNames}
 				namespace={namespace}
 				onCancel={onCancel}
 				onSave={(formData: any) => saveFDSFilter(formData)}
 				resolvedRESTSchemas={resolvedRESTSchemas}
 				restApplications={restApplications}
-				selectedField={selectedField}
+				selectedField={filter ? {name: filter.fieldName} : undefined}
 			/>
 		</>
 	);
@@ -188,9 +186,10 @@ function Filters({
 	const [activeFilterType, setActiveFilterType] =
 		useState<EFilterType | null>(null);
 	const [activeMode, setActiveMode] = useState(FILTER_MODE.LIST);
-	const [filters, setFilters] = useState<IFilter[]>([]);
 	const [availableFields, setAvailableFields] = useState(fields);
-	const [inUseFieldNames, setInUseFieldNames] = useState<string[]>([]);
+	const [fieldNames, setFieldNames] = useState<string[]>([]);
+	const [filters, setFilters] = useState<IFilter[]>([]);
+
 	useEffect(() => {
 		const getFilters = async () => {
 			const response = await fetch(
@@ -239,9 +238,7 @@ function Filters({
 				})
 			);
 
-			setInUseFieldNames(
-				filtersOrdered.map((filter) => filter.fieldName)
-			);
+			setFieldNames(filtersOrdered.map((filter) => filter.fieldName));
 		};
 
 		getFilters();
@@ -429,7 +426,7 @@ function Filters({
 								);
 								setFilters(filterList);
 
-								setInUseFieldNames(
+								setFieldNames(
 									filterList.map((filter) => filter.fieldName)
 								);
 							})
@@ -496,9 +493,9 @@ function Filters({
 							fdsFilterClientExtensions={
 								fdsFilterClientExtensions
 							}
+							fieldNames={fieldNames}
 							fields={availableFields}
 							filterType={activeFilterType}
-							inUseFieldNames={inUseFieldNames}
 							namespace={namespace}
 							onCancel={() => setActiveMode(FILTER_MODE.LIST)}
 							onSave={(newfilter) => {
@@ -506,8 +503,8 @@ function Filters({
 									newfilter.label = '';
 								}
 								setFilters([...filters, newfilter]);
-								setInUseFieldNames([
-									...inUseFieldNames,
+								setFieldNames([
+									...fieldNames,
 									newfilter.fieldName,
 								]);
 								setActiveMode(FILTER_MODE.LIST);
@@ -527,10 +524,10 @@ function Filters({
 							fdsFilterClientExtensions={
 								fdsFilterClientExtensions
 							}
+							fieldNames={fieldNames}
 							fields={fields}
 							filter={activeFilter}
 							filterType={activeFilter.filterType}
-							inUseFieldNames={inUseFieldNames}
 							namespace={namespace}
 							onCancel={() => setActiveMode(FILTER_MODE.LIST)}
 							onSave={(newfilter) => {

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/Filters.tsx
@@ -85,10 +85,10 @@ type FilterCollection = Array<IFilter>;
 interface IPropsFilterFormComponent {
 	dataSet: IDataSet | FDSViewType;
 	fdsFilterClientExtensions?: IClientExtensionRenderer[];
-	fieldNames?: string[];
 	fields: IField[];
 	filter?: IFilter | ISelectionFilter;
 	filterType?: EFilterType;
+	inUseFieldNames?: string[];
 	namespace: string;
 	onCancel: Function;
 	onSave: (newFilter: IFilter) => void;
@@ -99,10 +99,10 @@ interface IPropsFilterFormComponent {
 function FilterFormComponent({
 	dataSet,
 	fdsFilterClientExtensions = [],
-	fieldNames,
 	fields,
 	filter,
 	filterType,
+	inUseFieldNames,
 	namespace,
 	onCancel,
 	onSave,
@@ -160,9 +160,9 @@ function FilterFormComponent({
 
 			<Component.Body
 				fdsFilterClientExtensions={fdsFilterClientExtensions}
-				fieldNames={fieldNames}
 				fields={fields}
 				filter={filter}
+				inUseFieldNames={inUseFieldNames}
 				namespace={namespace}
 				onCancel={onCancel}
 				onSave={(formData: any) => saveFDSFilter(formData)}
@@ -187,6 +187,7 @@ function Filters({
 	const [activeMode, setActiveMode] = useState(FILTER_MODE.LIST);
 	const [filters, setFilters] = useState<IFilter[]>([]);
 	const [availableFields, setAvailableFields] = useState(fields);
+	const [inUseFieldNames, setInUseFieldNames] = useState<string[]>([]);
 	useEffect(() => {
 		const getFilters = async () => {
 			const response = await fetch(
@@ -233,6 +234,10 @@ function Filters({
 						label: filter.label || '',
 					};
 				})
+			);
+
+			setInUseFieldNames(
+				filtersOrdered.map((filter) => filter.fieldName)
 			);
 		};
 
@@ -416,12 +421,13 @@ function Filters({
 						})
 							.then(() => {
 								openDefaultSuccessToast();
+								const filterList = filters.filter(
+									(filter: IFilter) => filter.id !== item.id
+								);
+								setFilters(filterList);
 
-								setFilters(
-									filters.filter(
-										(filter: IFilter) =>
-											filter.id !== item.id
-									)
+								setInUseFieldNames(
+									filterList.map((filter) => filter.fieldName)
 								);
 							})
 							.catch(openDefaultFailureToast);
@@ -487,11 +493,9 @@ function Filters({
 							fdsFilterClientExtensions={
 								fdsFilterClientExtensions
 							}
-							fieldNames={filters.map(
-								(filter) => filter.fieldName
-							)}
 							fields={availableFields}
 							filterType={activeFilterType}
+							inUseFieldNames={inUseFieldNames}
 							namespace={namespace}
 							onCancel={() => setActiveMode(FILTER_MODE.LIST)}
 							onSave={(newfilter) => {
@@ -499,6 +503,10 @@ function Filters({
 									newfilter.label = '';
 								}
 								setFilters([...filters, newfilter]);
+								setInUseFieldNames([
+									...inUseFieldNames,
+									newfilter.fieldName,
+								]);
 								setActiveMode(FILTER_MODE.LIST);
 							}}
 							resolvedRESTSchemas={resolvedRESTSchemas}
@@ -516,12 +524,10 @@ function Filters({
 							fdsFilterClientExtensions={
 								fdsFilterClientExtensions
 							}
-							fieldNames={filters.map(
-								(filter) => filter.fieldName
-							)}
 							fields={fields}
 							filter={activeFilter}
 							filterType={activeFilter.filterType}
+							inUseFieldNames={inUseFieldNames}
 							namespace={namespace}
 							onCancel={() => setActiveMode(FILTER_MODE.LIST)}
 							onSave={(newfilter) => {

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/ClientExtensionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/ClientExtensionFilter.tsx
@@ -23,9 +23,9 @@ function Header() {
 
 interface IBodyProps {
 	fdsFilterClientExtensions: IClientExtensionRenderer[];
+	fieldNames?: string[];
 	fields: IField[];
 	filter?: IFilter;
-	inUseFieldNames?: string[];
 	namespace: string;
 	onCancel: Function;
 	onSave: Function;
@@ -33,9 +33,9 @@ interface IBodyProps {
 
 function Body({
 	fdsFilterClientExtensions,
+	fieldNames: usedFieldNames,
 	fields,
 	filter,
-	inUseFieldNames,
 	namespace,
 	onCancel,
 	onSave,
@@ -106,7 +106,7 @@ function Body({
 		}
 
 		if (selectedField && !filter) {
-			if (inUseFieldNames?.includes(selectedField?.name)) {
+			if (usedFieldNames?.includes(selectedField?.name)) {
 				setFieldInUseValidationError(true);
 
 				isValid = false;
@@ -147,10 +147,10 @@ function Body({
 			<ClayLayout.SheetSection>
 				<Configuration
 					fieldInUseValidationError={fieldInUseValidationError}
+					fieldNames={usedFieldNames}
 					fieldValidationError={fieldValidationError}
 					fields={fields}
 					filter={filter}
-					inUseFieldNames={inUseFieldNames}
 					labelValidationError={labelValidationError}
 					namespace={namespace}
 					onBlur={() => {
@@ -164,7 +164,7 @@ function Body({
 						setFieldValidationError(!newValue);
 						setFieldInUseValidationError(
 							newValue
-								? !!inUseFieldNames?.includes(newValue.name)
+								? !!usedFieldNames?.includes(newValue.name)
 								: false
 						);
 					}}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/ClientExtensionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/ClientExtensionFilter.tsx
@@ -23,9 +23,9 @@ function Header() {
 
 interface IBodyProps {
 	fdsFilterClientExtensions: IClientExtensionRenderer[];
-	fieldNames?: string[];
 	fields: IField[];
 	filter?: IFilter;
+	inUseFieldNames?: string[];
 	namespace: string;
 	onCancel: Function;
 	onSave: Function;
@@ -33,9 +33,9 @@ interface IBodyProps {
 
 function Body({
 	fdsFilterClientExtensions,
-	fieldNames,
 	fields,
 	filter,
+	inUseFieldNames,
 	namespace,
 	onCancel,
 	onSave,
@@ -67,9 +67,7 @@ function Body({
 	const [i18nFilterLabels, setI18nFilterLabels] = useState(
 		fdsFilterLabelTranslations
 	);
-	const inUseFields: (string | undefined)[] = fields.map((item) =>
-		fieldNames?.includes(item.name) ? item.name : undefined
-	);
+
 	const [selectedField, setSelectedField] = useState<IField | undefined>(
 		fields.find((item) => item.name === filter?.fieldName)
 	);
@@ -108,7 +106,7 @@ function Body({
 		}
 
 		if (selectedField && !filter) {
-			if (inUseFields.includes(selectedField?.name)) {
+			if (inUseFieldNames?.includes(selectedField?.name)) {
 				setFieldInUseValidationError(true);
 
 				isValid = false;
@@ -149,10 +147,10 @@ function Body({
 			<ClayLayout.SheetSection>
 				<Configuration
 					fieldInUseValidationError={fieldInUseValidationError}
-					fieldNames={fieldNames}
 					fieldValidationError={fieldValidationError}
 					fields={fields}
 					filter={filter}
+					inUseFieldNames={inUseFieldNames}
 					labelValidationError={labelValidationError}
 					namespace={namespace}
 					onBlur={() => {
@@ -165,7 +163,7 @@ function Body({
 						setFieldValidationError(!newValue);
 						setFieldInUseValidationError(
 							newValue
-								? inUseFields.includes(newValue.name)
+								? !!inUseFieldNames?.includes(newValue.name)
 								: false
 						);
 					}}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/ClientExtensionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/ClientExtensionFilter.tsx
@@ -69,7 +69,7 @@ function Body({
 	);
 
 	const [selectedField, setSelectedField] = useState<IField | undefined>(
-		fields.find((item) => item.name === filter?.fieldName)
+		filter ? {label: filter.fieldName, name: filter.fieldName} : undefined
 	);
 	const fdsFilterClientExtensionFormElementId = `${namespace}fdsFilterClientExtensionERC`;
 
@@ -160,6 +160,7 @@ function Body({
 					}}
 					onChangeField={(newValue) => {
 						setSelectedField(newValue);
+
 						setFieldValidationError(!newValue);
 						setFieldInUseValidationError(
 							newValue
@@ -170,6 +171,7 @@ function Body({
 					onChangeLabel={(newValue) => {
 						setI18nFilterLabels(newValue);
 					}}
+					selectedField={selectedField}
 				/>
 
 				{!fieldInUseValidationError && (

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/Configuration.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/Configuration.tsx
@@ -20,10 +20,10 @@ import {IField, IFilter} from '../../../utils/types';
 
 interface IConfigurationProps {
 	fieldInUseValidationError: boolean;
-	fieldNames?: string[];
 	fieldValidationError: boolean;
 	fields: IField[];
 	filter?: IFilter;
+	inUseFieldNames?: string[];
 	labelValidationError?: boolean;
 	namespace: string;
 	onBlur: (event: React.FocusEvent<HTMLInputElement>) => void;
@@ -35,10 +35,10 @@ interface IConfigurationProps {
 
 function Configuration({
 	fieldInUseValidationError,
-	fieldNames,
 	fieldValidationError,
 	fields,
 	filter,
+	inUseFieldNames,
 	labelValidationError,
 	namespace,
 	onBlur,
@@ -54,9 +54,6 @@ function Configuration({
 		fdsFilterLabelTranslations
 	);
 
-	const inUseFields: (string | undefined)[] = fields.map((item) =>
-		fieldNames?.includes(item.name) ? item.name : undefined
-	);
 	const nameFormElementId = `${namespace}Name`;
 	const selectedFieldFormElementId = `${namespace}SelectedField`;
 
@@ -96,7 +93,7 @@ function Configuration({
 						>
 							{field.label}
 
-							{inUseFields.includes(field.name) && (
+							{inUseFieldNames?.includes(field.name) && (
 								<ClayLabel displayType="info">
 									{Liferay.Language.get('in-use')}
 								</ClayLabel>

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/Configuration.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/Configuration.tsx
@@ -20,10 +20,10 @@ import {IField, IFilter} from '../../../utils/types';
 
 interface IConfigurationProps {
 	fieldInUseValidationError: boolean;
+	fieldNames?: string[];
 	fieldValidationError: boolean;
 	fields: IField[];
 	filter?: IFilter;
-	inUseFieldNames?: string[];
 	labelValidationError?: boolean;
 	namespace: string;
 	onBlur: (event: React.FocusEvent<HTMLInputElement>) => void;
@@ -36,10 +36,10 @@ interface IConfigurationProps {
 
 function Configuration({
 	fieldInUseValidationError,
+	fieldNames: usedFieldNames,
 	fieldValidationError,
 	fields,
 	filter,
-	inUseFieldNames,
 	labelValidationError,
 	namespace,
 	onBlur,
@@ -92,7 +92,7 @@ function Configuration({
 						>
 							{field.label}
 
-							{inUseFieldNames?.includes(field.name) && (
+							{usedFieldNames?.includes(field.name) && (
 								<ClayLabel displayType="info">
 									{Liferay.Language.get('in-use')}
 								</ClayLabel>
@@ -115,9 +115,6 @@ function Configuration({
 					}: {
 						selectedFields: Array<IField>;
 					}) => {
-
-						// setSelectedField(selectedFields[0]);
-
 						onChangeField(selectedFields[0]);
 
 						closeModal();
@@ -214,9 +211,6 @@ function Configuration({
 							});
 
 							if (newVal) {
-
-								// setSelectedField(newVal);
-
 								onChangeField(newVal);
 							}
 						}}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/Configuration.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/Configuration.tsx
@@ -31,6 +31,7 @@ interface IConfigurationProps {
 	onChangeLabel: (
 		i18nFilterLabels: Partial<Liferay.Language.FullyLocalizedValue<string>>
 	) => void;
+	selectedField: IField | undefined;
 }
 
 function Configuration({
@@ -44,10 +45,8 @@ function Configuration({
 	onBlur,
 	onChangeField,
 	onChangeLabel,
+	selectedField,
 }: IConfigurationProps) {
-	const [selectedField, setSelectedField] = useState<IField | undefined>(
-		fields.find((item) => item.name === filter?.fieldName)
-	);
 	const fdsFilterLabelTranslations = filter?.label_i18n ?? {};
 
 	const [i18nFilterLabels, setI18nFilterLabels] = useState(
@@ -116,7 +115,8 @@ function Configuration({
 					}: {
 						selectedFields: Array<IField>;
 					}) => {
-						setSelectedField(selectedFields[0]);
+
+						// setSelectedField(selectedFields[0]);
 
 						onChangeField(selectedFields[0]);
 
@@ -182,6 +182,7 @@ function Configuration({
 					<ClayInput.Group>
 						<ClayInput.GroupItem>
 							<ClayInput
+								id={selectedFieldFormElementId}
 								placeholder={Liferay.Language.get('select')}
 								readOnly
 								type="text"
@@ -213,7 +214,8 @@ function Configuration({
 							});
 
 							if (newVal) {
-								setSelectedField(newVal);
+
+								// setSelectedField(newVal);
 
 								onChangeField(newVal);
 							}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/DateRangeFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/DateRangeFilter.tsx
@@ -21,16 +21,16 @@ function Header() {
 interface IBodyProps {
 	fields: IField[];
 	filter?: IFilter;
-	inUseFieldNames?: string[];
+	fieldNames?: string[];
 	namespace: string;
 	onCancel: Function;
 	onSave: Function;
 }
 
 function Body({
+	fieldNames: usedFieldNames,
 	fields,
 	filter,
-	inUseFieldNames,
 	namespace,
 	onCancel,
 	onSave,
@@ -113,7 +113,7 @@ function Body({
 		}
 
 		if (selectedField && !filter) {
-			if (inUseFieldNames?.includes(selectedField?.name)) {
+			if (usedFieldNames?.includes(selectedField?.name)) {
 				setFieldInUseValidationError(true);
 
 				isValid = false;
@@ -163,10 +163,10 @@ function Body({
 			<ClayLayout.SheetSection>
 				<Configuration
 					fieldInUseValidationError={fieldInUseValidationError}
+					fieldNames={usedFieldNames}
 					fieldValidationError={fieldValidationError}
 					fields={fields}
 					filter={filter}
-					inUseFieldNames={inUseFieldNames}
 					labelValidationError={labelValidationError}
 					namespace={namespace}
 					onBlur={() => {
@@ -179,7 +179,7 @@ function Body({
 						setFieldValidationError(!newValue);
 						setFieldInUseValidationError(
 							newValue
-								? !!inUseFieldNames?.includes(newValue.name)
+								? !!usedFieldNames?.includes(newValue.name)
 								: false
 						);
 					}}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/DateRangeFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/DateRangeFilter.tsx
@@ -49,7 +49,7 @@ function Body({
 	);
 
 	const [selectedField, setSelectedField] = useState<IField | undefined>(
-		fields.find((item) => item.name === filter?.fieldName)
+		filter ? {label: filter.fieldName, name: filter.fieldName} : undefined
 	);
 	const [from, setFrom] = useState<string>(
 		filter && (filter as IDateFilter)?.from
@@ -186,6 +186,7 @@ function Body({
 					onChangeLabel={(newValue) => {
 						setI18nFilterLabels(newValue);
 					}}
+					selectedField={selectedField}
 				/>
 
 				{!fieldInUseValidationError && (

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/DateRangeFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/DateRangeFilter.tsx
@@ -19,9 +19,9 @@ function Header() {
 }
 
 interface IBodyProps {
+	fieldNames?: string[];
 	fields: IField[];
 	filter?: IFilter;
-	fieldNames?: string[];
 	namespace: string;
 	onCancel: Function;
 	onSave: Function;

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/DateRangeFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/DateRangeFilter.tsx
@@ -19,18 +19,18 @@ function Header() {
 }
 
 interface IBodyProps {
-	fieldNames?: string[];
 	fields: IField[];
 	filter?: IFilter;
+	inUseFieldNames?: string[];
 	namespace: string;
 	onCancel: Function;
 	onSave: Function;
 }
 
 function Body({
-	fieldNames,
 	fields,
 	filter,
+	inUseFieldNames,
 	namespace,
 	onCancel,
 	onSave,
@@ -46,10 +46,6 @@ function Body({
 	const fdsFilterLabelTranslations = filter?.label_i18n ?? {};
 	const [i18nFilterLabels, setI18nFilterLabels] = useState(
 		fdsFilterLabelTranslations
-	);
-
-	const inUseFields: (string | undefined)[] = fields.map((item) =>
-		fieldNames?.includes(item.name) ? item.name : undefined
 	);
 
 	const [selectedField, setSelectedField] = useState<IField | undefined>(
@@ -117,7 +113,7 @@ function Body({
 		}
 
 		if (selectedField && !filter) {
-			if (inUseFields.includes(selectedField?.name)) {
+			if (inUseFieldNames?.includes(selectedField?.name)) {
 				setFieldInUseValidationError(true);
 
 				isValid = false;
@@ -167,10 +163,10 @@ function Body({
 			<ClayLayout.SheetSection>
 				<Configuration
 					fieldInUseValidationError={fieldInUseValidationError}
-					fieldNames={fieldNames}
 					fieldValidationError={fieldValidationError}
 					fields={fields}
 					filter={filter}
+					inUseFieldNames={inUseFieldNames}
 					labelValidationError={labelValidationError}
 					namespace={namespace}
 					onBlur={() => {
@@ -183,7 +179,7 @@ function Body({
 						setFieldValidationError(!newValue);
 						setFieldInUseValidationError(
 							newValue
-								? inUseFields.includes(newValue.name)
+								? !!inUseFieldNames?.includes(newValue.name)
 								: false
 						);
 					}}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/selection_filter/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/selection_filter/SelectionFilter.tsx
@@ -33,18 +33,18 @@ function Header() {
 }
 
 function Body({
-	fieldNames,
 	fields,
 	filter,
+	inUseFieldNames,
 	namespace,
 	onCancel,
 	onSave,
 	resolvedRESTSchemas,
 	restApplications,
 }: {
-	fieldNames?: string[];
 	fields: IField[];
 	filter?: IFilter;
+	inUseFieldNames?: string[];
 	namespace: string;
 	onCancel: Function;
 	onSave: Function;
@@ -78,9 +78,7 @@ function Body({
 	const [saveButtonDisabled, setSaveButtonDisabled] =
 		useState<boolean>(false);
 	const [includeMode, setIncludeMode] = useState<string>('include');
-	const inUseFields: (string | undefined)[] = fields.map((item) =>
-		fieldNames?.includes(item.name) ? item.name : undefined
-	);
+
 	const [multiple, setMultiple] = useState(filter?.multiple ?? true);
 	const [picklists, setPicklists] = useState<IPickList[]>();
 	const [preselectedValueInput, setPreselectedValueInput] = useState('');
@@ -155,7 +153,7 @@ function Body({
 		}
 
 		if (selectedField && !filter) {
-			if (inUseFields.includes(selectedField?.name)) {
+			if (inUseFieldNames?.includes(selectedField?.name)) {
 				setFieldInUseValidationError(true);
 
 				isValid = false;
@@ -255,10 +253,10 @@ function Body({
 			<ClayLayout.SheetSection>
 				<Configuration
 					fieldInUseValidationError={fieldInUseValidationError}
-					fieldNames={fieldNames}
 					fieldValidationError={fieldValidationError}
 					fields={fields}
 					filter={filter}
+					inUseFieldNames={inUseFieldNames}
 					labelValidationError={labelValidationError}
 					namespace={namespace}
 					onBlur={() => {
@@ -271,7 +269,7 @@ function Body({
 						setFieldValidationError(!newValue);
 						setFieldInUseValidationError(
 							newValue
-								? inUseFields.includes(newValue.name)
+								? !!inUseFieldNames?.includes(newValue.name)
 								: false
 						);
 					}}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/selection_filter/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/selection_filter/SelectionFilter.tsx
@@ -33,18 +33,18 @@ function Header() {
 }
 
 function Body({
+	fieldNames: usedFieldNames,
 	fields,
 	filter,
-	inUseFieldNames,
 	namespace,
 	onCancel,
 	onSave,
 	resolvedRESTSchemas,
 	restApplications,
 }: {
+	fieldNames?: string[];
 	fields: IField[];
 	filter?: IFilter;
-	inUseFieldNames?: string[];
 	namespace: string;
 	onCancel: Function;
 	onSave: Function;
@@ -153,7 +153,7 @@ function Body({
 		}
 
 		if (selectedField && !filter) {
-			if (inUseFieldNames?.includes(selectedField?.name)) {
+			if (usedFieldNames?.includes(selectedField?.name)) {
 				setFieldInUseValidationError(true);
 
 				isValid = false;
@@ -253,10 +253,10 @@ function Body({
 			<ClayLayout.SheetSection>
 				<Configuration
 					fieldInUseValidationError={fieldInUseValidationError}
+					fieldNames={usedFieldNames}
 					fieldValidationError={fieldValidationError}
 					fields={fields}
 					filter={filter}
-					inUseFieldNames={inUseFieldNames}
 					labelValidationError={labelValidationError}
 					namespace={namespace}
 					onBlur={() => {
@@ -270,7 +270,7 @@ function Body({
 						setFieldValidationError(!newValue);
 						setFieldInUseValidationError(
 							newValue
-								? !!inUseFieldNames?.includes(newValue.name)
+								? !!usedFieldNames?.includes(newValue.name)
 								: false
 						);
 					}}

--- a/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/selection_filter/SelectionFilter.tsx
+++ b/modules/apps/frontend-data-set/frontend-data-set-admin-web/src/main/resources/META-INF/resources/js/data_set/filters/components/selection_filter/SelectionFilter.tsx
@@ -86,7 +86,7 @@ function Body({
 		JSON.parse(filter?.preselectedValues || '[]')
 	);
 	const [selectedField, setSelectedField] = useState<IField | undefined>(
-		fields.find((item) => item.name === filter?.fieldName)
+		filter ? {label: filter.fieldName, name: filter.fieldName} : undefined
 	);
 	const [source, setSource] = useState<string | undefined>(filter?.source);
 	const [sourceType, setSourceType] = useState(filter?.sourceType);
@@ -266,6 +266,7 @@ function Body({
 					}}
 					onChangeField={(newValue) => {
 						setSelectedField(newValue);
+
 						setFieldValidationError(!newValue);
 						setFieldInUseValidationError(
 							newValue
@@ -276,6 +277,7 @@ function Body({
 					onChangeLabel={(newValue) => {
 						setI18nFilterLabels(newValue);
 					}}
+					selectedField={selectedField}
 				/>
 
 				{!fieldInUseValidationError && (

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FormItemManager.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FormItemManager.java
@@ -350,7 +350,8 @@ public class FormItemManager {
 			Collections.emptyList());
 
 		FragmentEntryLink fragmentEntryLink = _addFormButtonFragmentEntryLink(
-			layout, locale, _SUBMIT, segmentsExperienceId, serviceContext);
+			layout, locale, _FORM_BUTTON_SUBMIT, segmentsExperienceId,
+			serviceContext);
 
 		if (fragmentEntryLink == null) {
 			return Collections.emptyList();
@@ -560,7 +561,7 @@ public class FormItemManager {
 		if (stepIndex == 0) {
 			FragmentEntryLink nextFormButtonFragmentEntryLink =
 				_addFormButtonFragmentEntryLink(
-					layout, locale, _NEXT, segmentsExperienceId,
+					layout, locale, _FORM_BUTTON_NEXT, segmentsExperienceId,
 					serviceContext);
 
 			if (nextFormButtonFragmentEntryLink == null) {
@@ -578,7 +579,7 @@ public class FormItemManager {
 
 		FragmentEntryLink previousFormButtonFragmentEntryLink =
 			_addFormButtonFragmentEntryLink(
-				layout, locale, _PREVIOUS, segmentsExperienceId,
+				layout, locale, _FORM_BUTTON_PREVIOUS, segmentsExperienceId,
 				serviceContext);
 
 		if (previousFormButtonFragmentEntryLink != null) {
@@ -589,10 +590,10 @@ public class FormItemManager {
 				containerStyledLayoutStructureItem.getItemId(), -1);
 		}
 
-		String type = _SUBMIT;
+		String type = _FORM_BUTTON_SUBMIT;
 
 		if (stepIndex < numberOfSteps) {
-			type = _NEXT;
+			type = _FORM_BUTTON_NEXT;
 		}
 
 		FragmentEntryLink submitFormButtonFragmentEntryLink =
@@ -848,11 +849,11 @@ public class FormItemManager {
 		return false;
 	}
 
-	private static final String _NEXT = "next";
+	private static final String _FORM_BUTTON_NEXT = "next";
 
-	private static final String _PREVIOUS = "previous";
+	private static final String _FORM_BUTTON_PREVIOUS = "previous";
 
-	private static final String _SUBMIT = "submit";
+	private static final String _FORM_BUTTON_SUBMIT = "submit";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		FormItemManager.class);

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
 	compileInclude group: "javax.annotation", name: "javax.annotation-api", version: "1.3.2"
-	compileInclude group: "org.bitbucket.b_c", name: "jose4j", version: "0.9.3"
+	compileInclude group: "org.bitbucket.b_c", name: "jose4j", version: "0.9.4"
 
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRenderer.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/model/ObjectEntryAssetRenderer.java
@@ -18,17 +18,22 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Locale;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
+import javax.portlet.PortletURL;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -110,6 +115,44 @@ public class ObjectEntryAssetRenderer
 	}
 
 	@Override
+	public PortletURL getURLEdit(HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		Group group = GroupLocalServiceUtil.fetchGroup(
+			_objectEntry.getGroupId());
+
+		if ((group != null) && group.isCompany()) {
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			group = themeDisplay.getScopeGroup();
+		}
+
+		return PortletURLBuilder.create(
+			PortalUtil.getControlPanelPortletURL(
+				httpServletRequest, group, _objectDefinition.getPortletId(), 0,
+				0, PortletRequest.RENDER_PHASE)
+		).setMVCRenderCommandName(
+			"/object_entries/edit_object_entry"
+		).setParameter(
+			"externalReferenceCode", _objectEntry.getExternalReferenceCode()
+		).setParameter(
+			"groupId", _objectEntry.getGroupId()
+		).buildPortletURL();
+	}
+
+	@Override
+	public PortletURL getURLEdit(
+			LiferayPortletRequest liferayPortletRequest,
+			LiferayPortletResponse liferayPortletResponse)
+		throws Exception {
+
+		return getURLEdit(
+			PortalUtil.getHttpServletRequest(liferayPortletRequest));
+	}
+
+	@Override
 	public String getURLViewInContext(
 			LiferayPortletRequest liferayPortletRequest,
 			LiferayPortletResponse liferayPortletResponse,
@@ -160,6 +203,23 @@ public class ObjectEntryAssetRenderer
 	@Override
 	public String getUuid() {
 		return _objectEntry.getUuid();
+	}
+
+	@Override
+	public boolean hasEditPermission(PermissionChecker permissionChecker)
+		throws PortalException {
+
+		try {
+			return _objectEntryService.hasModelResourcePermission(
+				_objectEntry, ActionKeys.UPDATE);
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+
+			return false;
+		}
 	}
 
 	@Override

--- a/modules/apps/portal-security/portal-security-content-security-policy-test/src/testIntegration/java/com/liferay/portal/security/content/security/policy/test/ContentSecurityPolicyFilterTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy-test/src/testIntegration/java/com/liferay/portal/security/content/security/policy/test/ContentSecurityPolicyFilterTest.java
@@ -43,15 +43,39 @@ public class ContentSecurityPolicyFilterTest {
 		new LiferayIntegrationTestRule();
 
 	@Test
+	public void testIsFilterEnabled() throws Exception {
+		try (CompanyConfigurationTemporarySwapper
+				configurationTemporarySwapper =
+					_getCompanyConfigurationTemporarySwapper(false, null, "")) {
+
+			HttpURLConnection httpURLConnection = _openHttpURLConnection(
+				"http://localhost:8080/html/icons/flags.png");
+
+			Map<String, List<String>> headerFields =
+				httpURLConnection.getHeaderFields();
+
+			Assert.assertFalse(
+				headerFields.containsKey("Content-Security-Policy"));
+
+			httpURLConnection.disconnect();
+		}
+	}
+
+	@Test
 	public void testProcessFilter() throws Exception {
 		try (CompanyConfigurationTemporarySwapper
 				configurationTemporarySwapper =
 					_getCompanyConfigurationTemporarySwapper(false, null, "")) {
 
-			HttpURLConnection httpURLConnection = _openHttpURLConnection();
+			HttpURLConnection httpURLConnection = _openHttpURLConnection(
+				"http://localhost:8080/web/guest");
+
+			System.out.println("httpURLConnection: " + httpURLConnection);
 
 			Map<String, List<String>> headerFields =
 				httpURLConnection.getHeaderFields();
+
+			System.out.println("headerFields: " + headerFields);
 
 			Assert.assertFalse(
 				headerFields.containsKey("Content-Security-Policy"));
@@ -63,7 +87,8 @@ public class ContentSecurityPolicyFilterTest {
 				configurationTemporarySwapper =
 					_getCompanyConfigurationTemporarySwapper(true, null, "")) {
 
-			HttpURLConnection httpURLConnection = _openHttpURLConnection();
+			HttpURLConnection httpURLConnection = _openHttpURLConnection(
+				"http://localhost:8080/web/guest");
 
 			Map<String, List<String>> headerFields =
 				httpURLConnection.getHeaderFields();
@@ -85,7 +110,8 @@ public class ContentSecurityPolicyFilterTest {
 					_getCompanyConfigurationTemporarySwapper(
 						true, null, policy)) {
 
-			HttpURLConnection httpURLConnection = _openHttpURLConnection();
+			HttpURLConnection httpURLConnection = _openHttpURLConnection(
+				"http://localhost:8080/web/guest");
 
 			Map<String, List<String>> headerFields =
 				httpURLConnection.getHeaderFields();
@@ -109,7 +135,8 @@ public class ContentSecurityPolicyFilterTest {
 					_getCompanyConfigurationTemporarySwapper(
 						true, null, policy)) {
 
-			HttpURLConnection httpURLConnection = _openHttpURLConnection();
+			HttpURLConnection httpURLConnection = _openHttpURLConnection(
+				"http://localhost:8080/web/guest");
 
 			Map<String, List<String>> headerFields =
 				httpURLConnection.getHeaderFields();
@@ -148,7 +175,8 @@ public class ContentSecurityPolicyFilterTest {
 						true, new String[] {"/c/portal/layout", "/web/guest"},
 						policy)) {
 
-			HttpURLConnection httpURLConnection = _openHttpURLConnection();
+			HttpURLConnection httpURLConnection = _openHttpURLConnection(
+				"http://localhost:8080/web/guest");
 
 			Map<String, List<String>> headerFields =
 				httpURLConnection.getHeaderFields();
@@ -198,8 +226,10 @@ public class ContentSecurityPolicyFilterTest {
 		return sb.toString();
 	}
 
-	private HttpURLConnection _openHttpURLConnection() throws IOException {
-		URL url = new URL("http://localhost:8080/web/guest");
+	private HttpURLConnection _openHttpURLConnection(String spec)
+		throws IOException {
+
+		URL url = new URL(spec);
 
 		HttpURLConnection httpURLConnection =
 			(HttpURLConnection)url.openConnection();

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
@@ -8,6 +8,9 @@ package com.liferay.portal.security.content.security.policy.internal.servlet.fil
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -52,6 +55,17 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 	public boolean isFilterEnabled(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {
+
+		if (_portal.getCompanyId(httpServletRequest) ==
+				CompanyConstants.SYSTEM) {
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					"No content security policy filter needed if company is 0");
+			}
+
+			return false;
+		}
 
 		ContentSecurityPolicyConfiguration contentSecurityPolicyConfiguration =
 			ContentSecurityPolicyConfigurationUtil.
@@ -212,6 +226,9 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 	private static final String[] _INTERNALLY_EXCLUDED_PATHS = {
 		"/group/", "/user/", "/web/"
 	};
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ContentSecurityPolicyFilter.class);
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;

--- a/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTaskDetailsPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTaskDetailsPage.ts
@@ -20,6 +20,7 @@ export class WorkflowTaskDetailsPage {
 	readonly commentsTextbox: Locator;
 	readonly detailsMessage: Locator;
 	readonly doneButton: Locator;
+	readonly editAssetButton: Locator;
 	readonly page: Page;
 	readonly previewMessageBoards: Locator;
 	readonly rejectMenuItem: Locator;
@@ -48,6 +49,7 @@ export class WorkflowTaskDetailsPage {
 			'Ask a user to work on the item.'
 		);
 		this.doneButton = page.getByRole('button', {name: 'Done'});
+		this.editAssetButton = page.locator('[title="Edit"]');
 		this.page = page;
 		this.previewMessageBoards = page.getByRole('button', {
 			name: 'Preview of Message Boards',

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dateRangeFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/dateRangeFilters.spec.ts
@@ -319,9 +319,11 @@ test('No date filters can be created if schema has no date fields', async ({
 });
 
 modalFieldTest(
-	'Can create a date range filter in DSM using the field selection modal',
+	'Can create and edit a date range filter in DSM using the field selection modal',
 	{tag: '@LPD-25905'},
 	async ({filtersPage, page}) => {
+		const filterNewName = 'Date Created';
+
 		await modalFieldTest.step('Create a data range filter', async () => {
 			await filtersPage.createDateRangeFilter({
 				filterBy: 'dateCreated',
@@ -343,6 +345,48 @@ modalFieldTest(
 						name: DATE_FILTER_NAME,
 					})
 				).toBeVisible();
+			}
+		);
+
+		await modalFieldTest.step(
+			'Edit the filter, change its label',
+			async () => {
+				await filtersPage
+					.getRowByText(DATE_FILTER_NAME)
+					.locator('.actions-cell button')
+					.click();
+
+				const editButton = filtersPage.page.getByRole('menuitem', {
+					name: 'Edit',
+				});
+
+				await expect(editButton).toBeInViewport();
+
+				await editButton.click();
+
+				const nameInput = filtersPage.newDateRangeFilterForm.nameInput;
+
+				await expect(nameInput).toBeInViewport();
+
+				await expect(nameInput).toBeEnabled();
+
+				await nameInput.fill(filterNewName);
+
+				await filtersPage.saveAddFilterForm();
+			}
+		);
+
+		await modalFieldTest.step(
+			'Assert filter with new name is saved @LPS-183056',
+			async () => {
+				await expect(
+					filtersPage
+						.getRowByText(filterNewName)
+						.locator('td')
+						.nth(NAME_COLUMN_INDEX)
+				).toHaveText(filterNewName);
+
+				await filtersPage.assertFiltersTableRowCount(1);
 			}
 		);
 	}

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/pages/data_set/tabs/FiltersPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/pages/data_set/tabs/FiltersPage.ts
@@ -64,7 +64,7 @@ export class FiltersPage {
 	readonly newDateRangeFilterForm: NewDateRangeFilterForm;
 	readonly newFilterButton: Locator;
 	private readonly newFilterForm: NewFilterForm;
-	private readonly newSelectionFilterForm: NewSelectionFilterForm;
+	readonly newSelectionFilterForm: NewSelectionFilterForm;
 	readonly page: Page;
 	readonly searchButton: Locator;
 	readonly searchInput: Locator;

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/selectionFilters.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/selectionFilters.spec.ts
@@ -324,7 +324,7 @@ test('Preselected filter values are checked in the multiSelect', async ({
 });
 
 modalFieldTest(
-	'Can create a selection filter with API Headless source using the field selection modal',
+	'Can create and edit a selection filter with API Headless source using the field selection modal',
 	{tag: '@LPD-25905'},
 	async ({filtersPage, page}) => {
 		await modalFieldTest.step(
@@ -344,6 +344,70 @@ modalFieldTest(
 					sourceType: 'API REST Application',
 					useFieldSelectionModal: true,
 				});
+
+				await filtersPage.saveAddFilterForm();
+			}
+		);
+
+		await modalFieldTest.step(
+			'Check that the selection filter is in the list',
+			async () => {
+				await expect(
+					page.getByRole('cell', {
+						exact: true,
+						name: SELECTION_API_HEADLESS_FILTER_NAME,
+					})
+				).toBeVisible();
+			}
+		);
+
+		await modalFieldTest.step('Open the edit filter form', async () => {
+			const filterActionsButton = page
+				.getByRole('cell', {name: 'Actions'})
+				.getByRole('button');
+
+			await expect(filterActionsButton).toBeVisible();
+
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: page.getByRole('menuitem', {name: 'Edit'}),
+				trigger: filterActionsButton,
+			});
+
+			const dialogFilterSourceSubtitle = page.getByRole('heading', {
+				name: 'Filter Source',
+			});
+
+			await expect(dialogFilterSourceSubtitle).toBeVisible();
+
+			const dialogFilterOptionsSubtitle = page.getByRole('heading', {
+				name: 'Filter Options',
+			});
+
+			await expect(dialogFilterOptionsSubtitle).toBeVisible();
+		});
+
+		await modalFieldTest.step('Change the filter name', async () => {
+			await filtersPage.newSelectionFilterForm.nameInput.clear();
+
+			await filtersPage.saveAddFilterForm();
+		});
+
+		await modalFieldTest.step(
+			'Confirm that a "This field is required." message appears in the form',
+			async () => {
+				await filtersPage.page
+					.getByText('This field is required.')
+					.isVisible();
+			}
+		);
+
+		await modalFieldTest.step(
+			'Save filter form without errors',
+			async () => {
+				await filtersPage.newSelectionFilterForm.nameInput.fill(
+					SELECTION_API_HEADLESS_FILTER_NAME
+				);
 
 				await filtersPage.saveAddFilterForm();
 			}

--- a/modules/test/playwright/tests/object-web/objectEntries.spec.ts
+++ b/modules/test/playwright/tests/object-web/objectEntries.spec.ts
@@ -608,7 +608,75 @@ test('can view success message entirely in arabic', async ({
 	await expect(viewObjectEntriesPage.successMessageArabic).toBeVisible();
 });
 
-test.describe('Manage object entries through Workflow Metrics', () => {
+test.describe('Manage object entries through Workflow', () => {
+	test('can edit object entry through workflow task page', async ({
+		apiHelpers,
+		applicationsMenuPage,
+		configurationTabPage,
+		page,
+		viewObjectEntriesPage,
+		workflowTaskDetailsPage,
+		workflowTasksPage,
+	}) => {
+		const {objectDefinitions} = createdEntities;
+
+		const objectDefinition =
+			await apiHelpers.objectAdmin.postRandomObjectDefinition({
+				objectFolderExternalReferenceCode: 'default',
+				status: {code: 0},
+				titleObjectFieldName: 'textField',
+			});
+
+		objectDefinitions.push(objectDefinition);
+
+		await applicationsMenuPage.goToProcessBuilder();
+
+		await configurationTabPage.configurationTabLink.click();
+
+		await configurationTabPage.assignWorkflowToAssetType(
+			'Single Approver',
+			objectDefinition.label['en_US']
+		);
+
+		const applicationName =
+			'c/' + objectDefinition.name.toLowerCase() + 's';
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			{textField: 'entry'},
+			applicationName
+		);
+
+		await workflowTasksPage.goToAssignedToMyRoles();
+
+		await workflowTasksPage.assignToMe('entry');
+
+		await workflowTasksPage.goto();
+
+		await workflowTaskDetailsPage.selectAsset(
+			objectDefinition.label['en_US']
+		);
+
+		await workflowTaskDetailsPage.editAssetButton.click();
+
+		const objectFieldValue = getRandomString();
+
+		await viewObjectEntriesPage.fillObjectEntry({
+			objectFieldBusinessType: 'Text',
+			objectFieldLabel: objectDefinition.titleObjectFieldName,
+			objectFieldValue,
+		});
+
+		await viewObjectEntriesPage.saveObjectEntryButton.click();
+
+		await expect(viewObjectEntriesPage.successMessage).toBeVisible();
+
+		await viewObjectEntriesPage.backButton.click();
+
+		await expect(page.getByLabel('textField', {exact: true})).toHaveValue(
+			objectFieldValue
+		);
+	});
+
 	test('can view Asset Title, Asset Type and Item Subject of an entry on metrics page', async ({
 		apiHelpers,
 		applicationsMenuPage,

--- a/modules/util/source-formatter/src/main/resources/dependencies/imports.txt
+++ b/modules/util/source-formatter/src/main/resources/dependencies/imports.txt
@@ -351,6 +351,7 @@ com.liferay.portal.kernel.mobile.device.rulegroup.RuleGroupProcessorUtil=com.lif
 com.liferay.portal.kernel.mobile.device.rulegroup.action.ActionHandler=com.liferay.mobile.device.rules.action.ActionHandler
 com.liferay.portal.kernel.mobile.device.rulegroup.rule.RuleHandler=com.liferay.mobile.device.rules.rule.RuleHandler
 com.liferay.portal.kernel.mobile.device.rulegroup.rule.UnknownRuleHandlerException=com.liferay.mobile.device.rules.rule.UnknownRuleHandlerException
+com.liferay.portal.kernel.module.configuration.ConfigurationProvider=com.liferay.portal.configuration.module.configuration.ConfigurationProvider
 com.liferay.portal.kernel.nio.charset.CharsetDecoderUtil=com.liferay.petra.nio.CharsetDecoderUtil
 com.liferay.portal.kernel.nio.charset.CharsetEncoderUtil=com.liferay.petra.nio.CharsetEncoderUtil
 com.liferay.portal.kernel.portlet.PortletPreferencesFactoryConstants=com.liferay.portal.kernel.portlet.constants.PortletPreferencesFactoryConstants

--- a/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
+++ b/modules/util/source-formatter/src/main/resources/dependencies/replacements.json
@@ -65,6 +65,15 @@
 		]
 	},
 	{
+		"classNames": [
+			"HttpServletRequest"
+		],
+		"from": "regex:\t*[a-zA-Z0-9_]+\\.setAttribute\\(InfoDisplayWebKeys\\.INFO_ITEM_FIELD_VALUES_PROVIDER,.*?\\);\n",
+		"issueKey": "LPD-8022",
+		"skipParametersValidation": true,
+		"to": ""
+	},
+	{
 		"from": "LayoutFriendlyURLComposite(Layout paramName, String paramName)",
 		"issueKey": "LPD-8025",
 		"skipParametersValidation": true,

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeCatchAllCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/upgrade/UpgradeCatchAllCheck.testjava
@@ -705,6 +705,10 @@ public class UpgradeCatchAllCheck implements ConfigurationBeanDeclaration {
 		_commerceAccountHelper.getCurrentCommerceAccount(null);
 	}
 
+	public void method(HttpServletRequest httpServletRequest, Object value) {
+		httpServletRequest.setAttribute(null, null);
+	}
+
 	public void method(HttpServletRequest httpServletRequest, String name) {
 		CookieKeys.getCookie(httpServletRequest, "test123");
 		CookiesManagerUtil.getCookieValue(name, httpServletRequest);

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeCatchAllCheck.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/upgrade/UpgradeCatchAllCheck.testjava
@@ -691,6 +691,12 @@ public class UpgradeCatchAllCheck implements ConfigurationBeanDeclaration {
 		_commerceAccountHelper.getCurrentCommerceAccount(null);
 	}
 
+	public void method(HttpServletRequest httpServletRequest, Object value) {
+		httpServletRequest.setAttribute(null, null);
+		httpServletRequest.setAttribute(InfoDisplayWebKeys.INFO_ITEM_FIELD_VALUES_PROVIDER, value);
+		httpServletRequest.setAttribute(InfoDisplayWebKeys.INFO_ITEM_FIELD_VALUES_PROVIDER, infoItemServiceTracker.getFirstInfoItemService(InfoItemFieldValuesProvider.class, infoItemClassName));
+	}
+
 	public void method(HttpServletRequest httpServletRequest, String name) {
 		CookieKeys.getCookie(httpServletRequest, "test123");
 		CookieKeys.getCookie(httpServletRequest, name);

--- a/portal-impl/test/unit/com/liferay/portal/configuration/ConfigurationImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/configuration/ConfigurationImplTest.java
@@ -144,6 +144,8 @@ public class ConfigurationImplTest {
 		Assert.assertEquals("valuex", properties.get("key2"));
 	}
 
+	@NewEnv(type = NewEnv.Type.JVM)
+	@NewEnv.Environment(append = false, variables = {})
 	@Test
 	public void testLoadEmptyProperties() throws Exception {
 		TestResourceClassLoader testResourceClassLoader =


### PR DESCRIPTION
Hi Team,
https://liferay.atlassian.net/browse/LPD-35246

Issue:
It was determined that the issue happens because ContentSecurityPolicyFilter runs before AbsoluteRedirectsFilter on any URL starting with /html/ and ending in css, gif, html, ico, jpg, js, or png. Because of this order, the first time ContentSecurityPolicyFilter is called, the companyID is '0' and it logs the error message when it reaches FeatureFlagsBag.

Solution:
With the help of @stian-sigvartsen  and @alvarosaugarlr we came up with the solution that we won't set ContentSecurityPolicFilter if the companyID is 0.

Please review it!

Thanks!

