### PR TITLE
LPD-35768 Add playwright tests to security related suites

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -4929,6 +4929,9 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     # Cookies
     #
 
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][cookies]=\
+        cookies-banner-web
+
     test.batch.class.names.includes[cookies]=\
         **/cookies/**/*Test.java
 
@@ -6818,6 +6821,9 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     #
     # OpenID Connect
     #
+
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][oidc]=\
+        openid-link
 
     test.batch.class.names.includes[oidc]=\
         **/portal-security-sso/**/*Test.java
@@ -8881,6 +8887,9 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     # SAML
     #
 
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][saml]=\
+        saml-web
+
     test.batch.class.names.includes[saml]=\
         **/saml/**/*Test.java
 
@@ -8898,6 +8907,9 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     #
     # SCIM
     #
+
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][scim]=\
+        scim-configuration-web
 
     test.batch.class.names.includes[scim]=\
         **/scim/**/*Test.java

--- a/test.properties
+++ b/test.properties
@@ -9653,6 +9653,14 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     # Security
     #
 
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][security]=\
+        cookies-banner-web,\
+        login-web,\
+        openid-link,\
+        portal-security-service-access-policy-service,\
+        saml-web,\
+        scim-configuration-web
+
     test.batch.class.names.includes[security]=\
         **/antivirus-async-store-test/**/*Test.java,\
         **/cookies/**/*Test.java,\
@@ -9681,6 +9689,8 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         modules-integration-mysql57-jdk8,\
         modules-semantic-versioning-jdk8,\
         modules-unit-jdk8,\
+        playwright-compile-jdk8,\
+        playwright-js-tomcat90-mysql57-jdk8,\
         semantic-versioning-jdk8,\
         unit-jdk8
 


### PR DESCRIPTION
Related issue: [LPD-35769](https://liferay.atlassian.net/browse/LPD-35769)

Playwright tests are not included on security related suites and this impacts our daily analysis, since we're not tracking those tests.