### PR TITLE
LPD-34901 Cache metadata

### DIFF
--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/AuthorizationServerMetadataResolver.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/AuthorizationServerMetadataResolver.java
@@ -7,6 +7,9 @@ package com.liferay.portal.security.sso.openid.connect.internal;
 
 import com.liferay.oauth.client.persistence.model.OAuthClientASLocalMetadata;
 import com.liferay.oauth.client.persistence.service.OAuthClientASLocalMetadataLocalService;
+import com.liferay.portal.kernel.cache.PortalCache;
+import com.liferay.portal.kernel.cache.PortalCacheHelperUtil;
+import com.liferay.portal.kernel.cache.PortalCacheManagerNames;
 import com.liferay.portal.security.sso.openid.connect.OpenIdConnectServiceException;
 
 import com.nimbusds.oauth2.sdk.http.HTTPRequest;
@@ -25,7 +28,7 @@ import org.osgi.service.component.annotations.Reference;
 public class AuthorizationServerMetadataResolver {
 
 	public OIDCProviderMetadata resolveOIDCProviderMetadata(
-			String authServerWellKnownURI)
+			String authServerWellKnownURI, int discoveryEndPointCacheInSecs)
 		throws Exception {
 
 		if (authServerWellKnownURI.endsWith("local")) {
@@ -35,6 +38,13 @@ public class AuthorizationServerMetadataResolver {
 
 			return OIDCProviderMetadata.parse(
 				oAuthClientASLocalMetadata.getMetadataJSON());
+		}
+
+		OIDCProviderMetadata oidcProviderMetadata =
+			_oidcProviderMetadataPortalCache.get(authServerWellKnownURI);
+
+		if (oidcProviderMetadata != null) {
+			return oidcProviderMetadata;
 		}
 
 		HTTPRequest httpRequest = new HTTPRequest(
@@ -47,11 +57,23 @@ public class AuthorizationServerMetadataResolver {
 				httpResponse.getStatusMessage());
 		}
 
-		return OIDCProviderMetadata.parse(httpResponse.getContent());
+		oidcProviderMetadata = OIDCProviderMetadata.parse(
+			httpResponse.getContent());
+
+		_oidcProviderMetadataPortalCache.put(
+			authServerWellKnownURI, oidcProviderMetadata,
+			discoveryEndPointCacheInSecs);
+
+		return oidcProviderMetadata;
 	}
 
 	@Reference
 	private OAuthClientASLocalMetadataLocalService
 		_oAuthClientASLocalMetadataLocalService;
+
+	private final PortalCache<String, OIDCProviderMetadata>
+		_oidcProviderMetadataPortalCache = PortalCacheHelperUtil.getPortalCache(
+			PortalCacheManagerNames.SINGLE_VM,
+			AuthorizationServerMetadataResolver.class.getName());
 
 }

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAuthenticationHandlerImpl.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAuthenticationHandlerImpl.java
@@ -23,6 +23,7 @@ import com.liferay.portal.security.sso.openid.connect.OpenIdConnectAuthenticatio
 import com.liferay.portal.security.sso.openid.connect.OpenIdConnectServiceException;
 import com.liferay.portal.security.sso.openid.connect.constants.OpenIdConnectConstants;
 import com.liferay.portal.security.sso.openid.connect.constants.OpenIdConnectWebKeys;
+import com.liferay.portal.security.sso.openid.connect.internal.configuration.OpenIdConnectProviderConfiguration;
 import com.liferay.portal.security.sso.openid.connect.internal.session.manager.OfflineOpenIdConnectSessionManager;
 import com.liferay.portal.security.sso.openid.connect.internal.util.OpenIdConnectProviderUtil;
 import com.liferay.portal.security.sso.openid.connect.internal.util.OpenIdConnectRequestParametersUtil;
@@ -127,9 +128,20 @@ public class OpenIdConnectAuthenticationHandlerImpl
 			OIDCClientInformation.parse(
 				JSONObjectUtils.parse(oAuthClientEntry.getInfoJSON()));
 
+		OpenIdConnectProviderConfiguration openIdConnectProviderConfiguration =
+			OpenIdConnectProviderUtil.getOpenIdConnectProviderConfiguration(
+				oAuthClientEntry.getClientId());
+
+		long discoveryEndPointCacheInMillis =
+			openIdConnectProviderConfiguration.discoveryEndPointCacheInMillis();
+
+		int discoveryEndPointCacheInSecs =
+			(int)(discoveryEndPointCacheInMillis / 1000);
+
 		OIDCProviderMetadata oidcProviderMetadata =
 			_authorizationServerMetadataResolver.resolveOIDCProviderMetadata(
-				oAuthClientEntry.getAuthServerWellKnownURI());
+				oAuthClientEntry.getAuthServerWellKnownURI(),
+				discoveryEndPointCacheInSecs);
 
 		OIDCTokens oidcTokens = OpenIdConnectTokenRequestUtil.request(
 			authenticationSuccessResponse,
@@ -216,10 +228,24 @@ public class OpenIdConnectAuthenticationHandlerImpl
 			).build();
 
 		try {
+			OpenIdConnectProviderConfiguration
+				openIdConnectProviderConfiguration =
+					OpenIdConnectProviderUtil.
+						getOpenIdConnectProviderConfiguration(
+							oAuthClientEntry.getClientId());
+
+			long discoveryEndPointCacheInMillis =
+				openIdConnectProviderConfiguration.
+					discoveryEndPointCacheInMillis();
+
+			int discoveryEndPointCacheInSecs =
+				(int)(discoveryEndPointCacheInMillis / 1000);
+
 			OIDCProviderMetadata oidcProviderMetadata =
 				_authorizationServerMetadataResolver.
 					resolveOIDCProviderMetadata(
-						oAuthClientEntry.getAuthServerWellKnownURI());
+						oAuthClientEntry.getAuthServerWellKnownURI(),
+						discoveryEndPointCacheInSecs);
 
 			URI authenticationRequestURI = _getAuthenticationRequestURI(
 				oidcProviderMetadata.getAuthorizationEndpointURI(),

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/session/manager/OfflineOpenIdConnectSessionManager.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/session/manager/OfflineOpenIdConnectSessionManager.java
@@ -32,7 +32,9 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.sso.openid.connect.configuration.OpenIdConnectConfiguration;
 import com.liferay.portal.security.sso.openid.connect.constants.OpenIdConnectWebKeys;
 import com.liferay.portal.security.sso.openid.connect.internal.AuthorizationServerMetadataResolver;
+import com.liferay.portal.security.sso.openid.connect.internal.configuration.OpenIdConnectProviderConfiguration;
 import com.liferay.portal.security.sso.openid.connect.internal.constants.OpenIdConnectDestinationNames;
+import com.liferay.portal.security.sso.openid.connect.internal.util.OpenIdConnectProviderUtil;
 import com.liferay.portal.security.sso.openid.connect.internal.util.OpenIdConnectTokenRequestUtil;
 import com.liferay.portal.security.sso.openid.connect.persistence.model.OpenIdConnectSession;
 import com.liferay.portal.security.sso.openid.connect.persistence.service.OpenIdConnectSessionLocalService;
@@ -232,12 +234,26 @@ public class OfflineOpenIdConnectSessionManager {
 		}
 
 		try {
+			OpenIdConnectProviderConfiguration
+				openIdConnectProviderConfiguration =
+					OpenIdConnectProviderUtil.
+						getOpenIdConnectProviderConfiguration(
+							oAuthClientEntry.getClientId());
+
+			long discoveryEndPointCacheInMillis =
+				openIdConnectProviderConfiguration.
+					discoveryEndPointCacheInMillis();
+
+			int discoveryEndPointCacheInSecs =
+				(int)(discoveryEndPointCacheInMillis / 1000);
+
 			OIDCTokens oidcTokens = OpenIdConnectTokenRequestUtil.request(
 				OIDCClientInformation.parse(
 					JSONObjectUtils.parse(oAuthClientEntry.getInfoJSON())),
 				_authorizationServerMetadataResolver.
 					resolveOIDCProviderMetadata(
-						openIdConnectSession.getAuthServerWellKnownURI()),
+						openIdConnectSession.getAuthServerWellKnownURI(),
+						discoveryEndPointCacheInSecs),
 				refreshToken, oAuthClientEntry.getTokenRequestParametersJSON());
 
 			_updateOpenIdConnectSession(

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtil.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtil.java
@@ -7,14 +7,24 @@ package com.liferay.portal.security.sso.openid.connect.internal.util;
 
 import com.liferay.oauth.client.persistence.model.OAuthClientEntry;
 import com.liferay.oauth.client.persistence.service.OAuthClientEntryLocalService;
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.security.sso.openid.connect.internal.configuration.OpenIdConnectProviderConfiguration;
 
+import java.util.Dictionary;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * @author Renan Vasconcelos
@@ -44,6 +54,36 @@ public class OpenIdConnectProviderUtil {
 		}
 
 		return oAuthClientEntryId;
+	}
+
+	public static OpenIdConnectProviderConfiguration
+			getOpenIdConnectProviderConfiguration(String clientId)
+		throws Exception {
+
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			"(service.factoryPid=com.liferay.portal.security.sso.openid." +
+				"connect.internal.configuration." +
+					"OpenIdConnectProviderConfiguration)");
+
+		if (configurations != null) {
+			for (Configuration configuration : configurations) {
+				Dictionary<String, Object> properties =
+					configuration.getProperties();
+
+				if (properties != null) {
+					String openIdConnectClientId = GetterUtil.getString(
+						properties.get("openIdConnectClientId"));
+
+					if (clientId.equals(openIdConnectClientId)) {
+						return ConfigurableUtil.createConfigurable(
+							OpenIdConnectProviderConfiguration.class,
+							properties);
+					}
+				}
+			}
+		}
+
+		return null;
 	}
 
 	public static Map<String, Long> removeOAuthClientEntryIdsByCompanyId(
@@ -93,7 +133,24 @@ public class OpenIdConnectProviderUtil {
 
 	private static final String _CLIENT_TO = "Client to ";
 
+	private static final Bundle _bundle = FrameworkUtil.getBundle(
+		OpenIdConnectProviderUtil.class);
+	private static final ConfigurationAdmin _configurationAdmin;
 	private static final Map<Long, Map<String, Long>> _oAuthClientEntryIds =
 		new ConcurrentHashMap<>();
+
+	private static final ServiceTracker<ConfigurationAdmin, ConfigurationAdmin>
+		_serviceTracker =
+			new ServiceTracker<ConfigurationAdmin, ConfigurationAdmin>(
+				_bundle.getBundleContext(), ConfigurationAdmin.class, null) {
+
+				{
+					open();
+				}
+			};
+
+	static {
+		_configurationAdmin = _serviceTracker.getService();
+	}
 
 }


### PR DESCRIPTION
Hi,

I'm sending this for an initial review to see if the solution is good enough. I will send another pull request as soon as I implemented the automated tests as well.

The story in short is that with [LPS-150092](https://liferay.atlassian.net/browse/LPS-150092) we removed OpenIdConnectMetadataFactoryImpl that was responsible for metadata caching. Now I'm giving back metadata caching.

Thank you for checking!
István

cc @stian-sigvartsen @alvarosaugarlr 