### PR TITLE
LPD-36964 Update test path

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -9496,7 +9496,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         **/multi-factor-authentication/**/*Test.java,\
         **/oauth-client/**/*Test.java,\
         **/oauth2-provider/**/*Test.java,\
-        **/password-policies-admin/**/*test.js,\
+        **/password-policies-admin/**/*Test.java,\
         **/portal-crypto-hash/**/*Test.java,\
         **/portal-remote-cors-test/**/*Test.java,\
         **/portal-security/**/*Test.java,\


### PR DESCRIPTION
Related issue: [LPD-36964](https://liferay.atlassian.net/browse/LPD-36964)

Password Policies integration tests are not on security suite because they have changed files (from test.js to Test.java), so we need to update that.