### PR TITLE
LPD-36717 Ignore case when comparing email addresses and prevent the overwriting of the new user input by switching it with the current user

### DIFF
--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/field/expression/handler/DefaultUserFieldExpressionHandler.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/field/expression/handler/DefaultUserFieldExpressionHandler.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.ldap.exportimport.LDAPUserImporter;
 import com.liferay.saml.opensaml.integration.field.expression.handler.UserFieldExpressionHandler;
@@ -232,15 +233,15 @@ public class DefaultUserFieldExpressionHandler
 
 		currentUser = _userLocalService.getUserById(currentUser.getUserId());
 
-		if (!Objects.equals(
+		if (!StringUtil.equalsIgnoreCase(
 				currentUser.getEmailAddress(), newUser.getEmailAddress())) {
 
-			newUser = _userLocalService.updateEmailAddress(
-				newUser.getUserId(), StringPool.BLANK,
+			currentUser = _userLocalService.updateEmailAddress(
+				currentUser.getUserId(), StringPool.BLANK,
 				newUser.getEmailAddress(), newUser.getEmailAddress());
 
-			newUser = _userLocalService.updateEmailAddressVerified(
-				newUser.getUserId(), true);
+			_userLocalService.updateEmailAddressVerified(
+				currentUser.getUserId(), true);
 		}
 
 		if (Objects.equals(
@@ -252,7 +253,7 @@ public class DefaultUserFieldExpressionHandler
 				currentUser.getScreenName(), newUser.getScreenName()) &&
 			Objects.equals(currentUser.getUuid(), newUser.getUuid())) {
 
-			return newUser;
+			return currentUser;
 		}
 
 		Contact contact = newUser.getContact();


### PR DESCRIPTION
Hi Team,

I'm sending ONLY the fix for https://liferay.atlassian.net/browse/LPD-36717
Subtask: https://liferay.atlassian.net/browse/LPD-36958

Issue:
We overwrite the newUser's values in [DefaultUserFieldExpressionHandler](https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/field/expression/handler/DefaultUserFieldExpressionHandler.java#L238) with the currentUser's during update, so the firstName and lastName (and all other value) gets lost.

Solution:
Instead of overwriting the newUser when returning the result of _userLocalService.updateEmailAddress(), I update the currentUser instead.
Also added an equalsIgnoreCase to skip the update of the email address if only the case is different (because we won't modify it anyways)

Please don't forget to add a test case to this before sending it forward!

Thank you!

Please review it!
