### PR TITLE
LPD-6085 The target server failed to respond on IsolationAcrossCompaniesTest

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/IsolationAcrossCompaniesTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/IsolationAcrossCompaniesTest.java
@@ -21,7 +21,6 @@ import javax.ws.rs.core.Response;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,7 +60,7 @@ public class IsolationAcrossCompaniesTest extends BaseClientTestCase {
 
 			Response response = builder.get();
 
-			Assert.assertEquals(403, response.getStatus());
+			Assert.assertEquals(401, response.getStatus());
 		}
 	}
 
@@ -87,7 +86,7 @@ public class IsolationAcrossCompaniesTest extends BaseClientTestCase {
 
 			Response response = builder.get();
 
-			Assert.assertEquals(403, response.getStatus());
+			Assert.assertEquals(401, response.getStatus());
 		}
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/IsolationAcrossCompaniesTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/IsolationAcrossCompaniesTest.java
@@ -31,7 +31,6 @@ import org.osgi.framework.BundleActivator;
 /**
  * @author Carlos Sierra Andrés
  */
-@Ignore
 @RunWith(Arquillian.class)
 public class IsolationAcrossCompaniesTest extends BaseClientTestCase {
 


### PR DESCRIPTION
Default behavior was changed in https://github.com/brianchandotcom/liferay-portal/commit/37ba4251cd2cedb8a9e35c799c5fe4ee1034b5c6

Prior to that change, an error returned a forbidden status (403), nowadays we return an unauthorized response status (401).