### PR TITLE
LPD-35832 Allow configuration of ui_locale parameter in lowercase (AD B2C restriction)

### DIFF
--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAuthenticationHandlerImpl.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAuthenticationHandlerImpl.java
@@ -220,7 +220,7 @@ public class OpenIdConnectAuthenticationHandlerImpl
 					"state", new State()
 				).put(
 					"ui_locales",
-					_getLangTags(
+					getLangTags(
 						httpServletRequest,
 						OpenIdConnectRequestParametersUtil.
 							calculateUILocaleMode(
@@ -270,6 +270,39 @@ public class OpenIdConnectAuthenticationHandlerImpl
 				_portal.getCompanyId(httpServletRequest),
 				openIdConnectProviderName, _oAuthClientEntryLocalService),
 			httpServletRequest, httpServletResponse);
+	}
+
+	protected List<LangTag> getLangTags(
+		HttpServletRequest httpServletRequest,
+		OpenIdConnectRequestParametersUtil.UILocaleMode uiLocaleMode) {
+
+		Locale locale = _portal.getLocale(httpServletRequest);
+
+		if ((locale == null) ||
+			uiLocaleMode.equals(
+				OpenIdConnectRequestParametersUtil.UILocaleMode.DISABLED)) {
+
+			return null;
+		}
+
+		try {
+			return Collections.singletonList(
+				LowercaseLangTag.parse(
+					_language.getBCP47LangTag(locale),
+					uiLocaleMode.equals(
+						OpenIdConnectRequestParametersUtil.UILocaleMode.
+							LOWERCASE_BCP47_LANGUAGE_CODE)));
+		}
+		catch (LangTagException langTagException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to create a lang tag with locale " +
+						locale.getLanguage(),
+					langTagException);
+			}
+
+			return null;
+		}
 	}
 
 	protected Map<String, Object> getUserInfoClaims(JWT jwt)
@@ -363,39 +396,6 @@ public class OpenIdConnectAuthenticationHandlerImpl
 					"Unable to process response from ", requestURL, ": ",
 					exception.getMessage()),
 				exception);
-		}
-	}
-
-	private List<LangTag> _getLangTags(
-		HttpServletRequest httpServletRequest,
-		OpenIdConnectRequestParametersUtil.UILocaleMode uiLocaleMode) {
-
-		Locale locale = _portal.getLocale(httpServletRequest);
-
-		if ((locale == null) ||
-			uiLocaleMode.equals(
-				OpenIdConnectRequestParametersUtil.UILocaleMode.DISABLED)) {
-
-			return null;
-		}
-
-		try {
-			return Collections.singletonList(
-				LowercaseLangTag.parse(
-					_language.getBCP47LangTag(locale),
-					uiLocaleMode.equals(
-						OpenIdConnectRequestParametersUtil.UILocaleMode.
-							LOWERCASE_BCP47_LANGUAGE_CODE)));
-		}
-		catch (LangTagException langTagException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					"Unable to create a lang tag with locale " +
-						locale.getLanguage(),
-					langTagException);
-			}
-
-			return null;
 		}
 	}
 

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAuthenticationHandlerImpl.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAuthenticationHandlerImpl.java
@@ -23,6 +23,7 @@ import com.liferay.portal.security.sso.openid.connect.OpenIdConnectAuthenticatio
 import com.liferay.portal.security.sso.openid.connect.OpenIdConnectServiceException;
 import com.liferay.portal.security.sso.openid.connect.constants.OpenIdConnectConstants;
 import com.liferay.portal.security.sso.openid.connect.constants.OpenIdConnectWebKeys;
+import com.liferay.portal.security.sso.openid.connect.internal.model.LowercaseLangTag;
 import com.liferay.portal.security.sso.openid.connect.internal.session.manager.OfflineOpenIdConnectSessionManager;
 import com.liferay.portal.security.sso.openid.connect.internal.util.OpenIdConnectProviderUtil;
 import com.liferay.portal.security.sso.openid.connect.internal.util.OpenIdConnectRequestParametersUtil;
@@ -201,21 +202,31 @@ public class OpenIdConnectAuthenticationHandlerImpl
 			_oAuthClientEntryLocalService.getOAuthClientEntry(
 				oAuthClientEntryId);
 
-		Map<String, Object> runtimeRequestParameters =
-			HashMapBuilder.<String, Object>put(
-				"code_challenge",
-				CodeChallenge.compute(CodeChallengeMethod.S256, codeVerifier)
-			).put(
-				"nonce", new Nonce()
-			).put(
-				"redirect_uri", _getLoginRedirectURI(httpServletRequest)
-			).put(
-				"state", new State()
-			).put(
-				"ui_locales", _getLangTags(httpServletRequest)
-			).build();
-
 		try {
+			JSONObject authenticationRequestParametersJSONObject =
+				JSONObjectUtils.parse(
+					oAuthClientEntry.getAuthRequestParametersJSON());
+
+			Map<String, Object> runtimeRequestParameters =
+				HashMapBuilder.<String, Object>put(
+					"code_challenge",
+					CodeChallenge.compute(
+						CodeChallengeMethod.S256, codeVerifier)
+				).put(
+					"nonce", new Nonce()
+				).put(
+					"redirect_uri", _getLoginRedirectURI(httpServletRequest)
+				).put(
+					"state", new State()
+				).put(
+					"ui_locales",
+					_getLangTags(
+						httpServletRequest,
+						OpenIdConnectRequestParametersUtil.
+							calculateUILocaleMode(
+								authenticationRequestParametersJSONObject))
+				).build();
+
 			OIDCProviderMetadata oidcProviderMetadata =
 				_authorizationServerMetadataResolver.
 					resolveOIDCProviderMetadata(
@@ -223,7 +234,7 @@ public class OpenIdConnectAuthenticationHandlerImpl
 
 			URI authenticationRequestURI = _getAuthenticationRequestURI(
 				oidcProviderMetadata.getAuthorizationEndpointURI(),
-				oAuthClientEntry.getAuthRequestParametersJSON(),
+				authenticationRequestParametersJSONObject,
 				oAuthClientEntry.getClientId(), runtimeRequestParameters);
 
 			if (_log.isDebugEnabled()) {
@@ -277,12 +288,9 @@ public class OpenIdConnectAuthenticationHandlerImpl
 
 	private URI _getAuthenticationRequestURI(
 			URI authenticationEndpointURI,
-			String authenticationRequestParametersJSON, String clientId,
-			Map<String, Object> runtimeRequestParameters)
+			JSONObject authenticationRequestParametersJSONObject,
+			String clientId, Map<String, Object> runtimeRequestParameters)
 		throws Exception {
-
-		JSONObject authenticationRequestParametersJSONObject =
-			JSONObjectUtils.parse(authenticationRequestParametersJSON);
 
 		AuthenticationRequest.Builder builder =
 			new AuthenticationRequest.Builder(
@@ -358,16 +366,26 @@ public class OpenIdConnectAuthenticationHandlerImpl
 		}
 	}
 
-	private List<LangTag> _getLangTags(HttpServletRequest httpServletRequest) {
+	private List<LangTag> _getLangTags(
+		HttpServletRequest httpServletRequest,
+		OpenIdConnectRequestParametersUtil.UILocaleMode uiLocaleMode) {
+
 		Locale locale = _portal.getLocale(httpServletRequest);
 
-		if (locale == null) {
+		if ((locale == null) ||
+			uiLocaleMode.equals(
+				OpenIdConnectRequestParametersUtil.UILocaleMode.DISABLED)) {
+
 			return null;
 		}
 
 		try {
 			return Collections.singletonList(
-				LangTag.parse(_language.getBCP47LangTag(locale)));
+				LowercaseLangTag.parse(
+					_language.getBCP47LangTag(locale),
+					uiLocaleMode.equals(
+						OpenIdConnectRequestParametersUtil.UILocaleMode.
+							LOWERCASE_BCP47_LANGUAGE_CODE)));
 		}
 		catch (LangTagException langTagException) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/model/LowercaseLangTag.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/model/LowercaseLangTag.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/model/LowercaseLangTag.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/model/LowercaseLangTag.java
@@ -1,0 +1,149 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.sso.openid.connect.internal.model;
+
+import com.nimbusds.langtag.LangTag;
+import com.nimbusds.langtag.LangTagException;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class LowercaseLangTag extends LangTag {
+
+	public static LowercaseLangTag parse(String s, boolean lowerCase)
+		throws LangTagException {
+
+		if ((s != null) &&
+			!s.trim(
+			).isEmpty()) {
+
+			String[] subtags = s.split("-");
+			int pos = 0;
+			String primaryLang = null;
+			List<String> extLangSubtags = new LinkedList<>();
+
+			if (_isPrimaryLanguage(subtags[0])) {
+				primaryLang = subtags[pos++];
+			}
+
+			while ((pos < subtags.length) &&
+				   _isExtendedLanguageSubtag(subtags[pos])) {
+
+				extLangSubtags.add(subtags[pos++]);
+			}
+
+			LowercaseLangTag langTag = new LowercaseLangTag(
+				primaryLang, lowerCase,
+				(String[])extLangSubtags.toArray(new String[0]));
+
+			if ((pos < subtags.length) && _isScript(subtags[pos])) {
+				langTag.setScript(subtags[pos++]);
+			}
+
+			if ((pos < subtags.length) && _isRegion(subtags[pos])) {
+				langTag.setRegion(subtags[pos++]);
+			}
+
+			LinkedList<String> variantSubtags = new LinkedList<>();
+
+			while ((pos < subtags.length) && _isVariant(subtags[pos])) {
+				variantSubtags.add(subtags[pos++]);
+			}
+
+			if (!variantSubtags.isEmpty()) {
+				langTag.setVariants(
+					(String[])variantSubtags.toArray(new String[0]));
+			}
+
+			LinkedList<String> extSubtags = new LinkedList<>();
+
+			while ((pos < subtags.length) &&
+				   _isExtensionSingleton(subtags[pos])) {
+
+				String singleton = subtags[pos++];
+
+				if (pos == subtags.length) {
+					throw new LangTagException("Invalid extension subtag");
+				}
+
+				extSubtags.add(singleton + "-" + subtags[pos++]);
+			}
+
+			if (!extSubtags.isEmpty()) {
+				langTag.setExtensions(
+					(String[])extSubtags.toArray(new String[0]));
+			}
+
+			if ((pos < subtags.length) && subtags[pos].equals("x")) {
+				++pos;
+
+				if (pos == subtags.length) {
+					throw new LangTagException("Invalid private use subtag");
+				}
+
+				langTag.setPrivateUse("x-" + subtags[pos++]);
+			}
+
+			if (pos < subtags.length) {
+				throw new LangTagException(
+					"Invalid language tag: Unexpected subtag");
+			}
+
+			return langTag;
+		}
+
+		return null;
+	}
+
+	public LowercaseLangTag(
+			String primaryLanguage, boolean lowerCase,
+			String... languageSubtags)
+		throws LangTagException {
+
+		super(primaryLanguage, languageSubtags);
+
+		_lowercase = lowerCase;
+	}
+
+	public String toString() {
+		if (_lowercase) {
+			return super.toString(
+			).toLowerCase();
+		}
+
+		return super.toString();
+	}
+
+	private static boolean _isExtendedLanguageSubtag(String s) {
+		return s.matches("[a-zA-Z]{3}");
+	}
+
+	private static boolean _isExtensionSingleton(String s) {
+		return s.matches("[0-9a-wA-Wy-zY-Z]");
+	}
+
+	private static boolean _isPrimaryLanguage(String s) {
+		return s.matches("[a-zA-Z]{2,3}");
+	}
+
+	private static boolean _isRegion(String s) {
+		return s.matches("[a-zA-Z]{2}|\\d{3}");
+	}
+
+	private static boolean _isScript(String s) {
+		return s.matches("[a-zA-Z]{4}");
+	}
+
+	private static boolean _isVariant(String s) {
+		return s.matches("[a-zA-Z][a-zA-Z0-9]{4,}|[0-9][a-zA-Z0-9]{3,}");
+	}
+
+	private final boolean _lowercase;
+
+}

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectRequestParametersUtil.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectRequestParametersUtil.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.security.sso.openid.connect.internal.util;
 
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringUtil;
 
 import com.nimbusds.oauth2.sdk.ParseException;
 import com.nimbusds.oauth2.sdk.ResponseType;
@@ -22,6 +23,38 @@ import net.minidev.json.JSONObject;
  * @author Arthur Chan
  */
 public class OpenIdConnectRequestParametersUtil {
+
+	public static UILocaleMode calculateUILocaleMode(
+			JSONObject authRequestParametersJSONObject)
+		throws ParseException {
+
+		if (authRequestParametersJSONObject.containsKey(
+				"custom_request_parameters")) {
+
+			JSONObject customRequestParametersJSONObject =
+				JSONObjectUtils.getJSONObject(
+					authRequestParametersJSONObject,
+					"custom_request_parameters");
+
+			if (customRequestParametersJSONObject.containsKey("ui_locale")) {
+				String mode = customRequestParametersJSONObject.getAsString(
+					"ui_locale");
+
+				if (StringUtil.equalsIgnoreCase(
+						mode, "[\"$LOWERCASE_BCP47_LANGUAGE_CODE$\"]")) {
+
+					return UILocaleMode.LOWERCASE_BCP47_LANGUAGE_CODE;
+				}
+				else if (StringUtil.equalsIgnoreCase(
+							mode, "[\"$DISABLED$\"]")) {
+
+					return UILocaleMode.DISABLED;
+				}
+			}
+		}
+
+		return UILocaleMode.DEFAULT;
+	}
 
 	public static void consumeCustomRequestParameters(
 			BiConsumer<String, String[]> biConsumer,
@@ -73,6 +106,12 @@ public class OpenIdConnectRequestParametersUtil {
 
 		return Scope.parse(
 			JSONObjectUtils.getString(requestParametersJSONObject, "scope"));
+	}
+
+	public enum UILocaleMode {
+
+		DEFAULT, DISABLED, LOWERCASE_BCP47_LANGUAGE_CODE
+
 	}
 
 }

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAuthenticationHandlerImplTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/OpenIdConnectAuthenticationHandlerImplTest.java
@@ -6,12 +6,22 @@
 package com.liferay.portal.security.sso.openid.connect.internal;
 
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.security.sso.openid.connect.internal.util.OpenIdConnectRequestParametersUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import com.nimbusds.jwt.JWT;
 import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.langtag.LangTag;
 
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -19,6 +29,8 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
 
 /**
  * @author Tamas Biro
@@ -51,6 +63,72 @@ public class OpenIdConnectAuthenticationHandlerImplTest {
 			).toString());
 
 		Assert.assertNull(claims.get("email"));
+	}
+
+	@Test
+	public void testUILocaleLangTag() {
+		List<LangTag> langTags = _getLangTags(
+			OpenIdConnectRequestParametersUtil.UILocaleMode.DISABLED);
+
+		Assert.assertNull(langTags);
+
+		langTags = _getLangTags(
+			OpenIdConnectRequestParametersUtil.UILocaleMode.
+				LOWERCASE_BCP47_LANGUAGE_CODE);
+
+		Assert.assertEquals(
+			"en-us",
+			langTags.get(
+				0
+			).toString());
+
+		langTags = _getLangTags(
+			OpenIdConnectRequestParametersUtil.UILocaleMode.DEFAULT);
+
+		Assert.assertEquals(
+			"en-US",
+			langTags.get(
+				0
+			).toString());
+	}
+
+	protected Language language = Mockito.mock(Language.class);
+	protected Portal portal = Mockito.mock(Portal.class);
+
+	private List<LangTag> _getLangTags(
+		OpenIdConnectRequestParametersUtil.UILocaleMode uiLocaleMode) {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		Mockito.doReturn(
+			LocaleUtil.US
+		).when(
+			portal
+		).getLocale(
+			Mockito.any(HttpServletRequest.class)
+		);
+
+		Mockito.doReturn(
+			"en-US"
+		).when(
+			language
+		).getBCP47LangTag(
+			Mockito.any(Locale.class)
+		);
+
+		OpenIdConnectAuthenticationHandlerImpl
+			openIdConnectAuthenticationHandlerImpl =
+				new OpenIdConnectAuthenticationHandlerImpl();
+
+		ReflectionTestUtil.setFieldValue(
+			openIdConnectAuthenticationHandlerImpl, "_language", language);
+
+		ReflectionTestUtil.setFieldValue(
+			openIdConnectAuthenticationHandlerImpl, "_portal", portal);
+
+		return openIdConnectAuthenticationHandlerImpl.getLangTags(
+			mockHttpServletRequest, uiLocaleMode);
 	}
 
 	private Map<String, Object> _getUserInfoClaims(String claimSetJSON)


### PR DESCRIPTION
This PR aims to solve the problem of sending ui_locales langTag in lowercase, this is required by azure AD B2C.

We will read from System/Instance Settings Configuration
![imagen](https://github.com/user-attachments/assets/204dd253-92bd-4032-8617-7bad65adf10a)

In OAuthClientAdministration Portlet, the value has to be filled as:
![imagen](https://github.com/user-attachments/assets/a3a17bd2-127f-43ee-85bc-8bc9304fe61e)

Accepted values are:
`$DISABLED$ , $LOWERCASE_BCP47_LANGUAGE_CODE$`

Expected behavior:

DISABLED:

/auth/realms/master/protocol/openid-connect/auth?scope=openid+email+profile&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fc%2Fportal%2Flogin%2Fopenidconnect&state=kbJxEpo-xdcM4w-kTO4dRxExq0nfL6PBFoOhmIzK9kg&code_challenge_method=S256&ui_locale=%24LOWERCASE_BCP47_LANGUAGE_CODE%24&nonce=uC_geb4QLgVZWw4FoB-kSusKtyg0o2J-AAq09T7VJrs&client_id=liferay-limited-session&code_challenge=j5LnomZKcDOhe3CJpb049o1GNhMCXcy5qPx6M4Ttb9M

LOWERCASE_BCP47_LANGUAGE_CODE:

/auth/realms/master/protocol/openid-connect/auth?**ui_locales=en-us**&scope=openid+email+profile&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fc%2Fportal%2Flogin%2Fopenidconnect&state=kbJxEpo-xdcM4w-kTO4dRxExq0nfL6PBFoOhmIzK9kg&code_challenge_method=S256&ui_locale=%24LOWERCASE_BCP47_LANGUAGE_CODE%24&nonce=uC_geb4QLgVZWw4FoB-kSusKtyg0o2J-AAq09T7VJrs&client_id=liferay-limited-session&code_challenge=j5LnomZKcDOhe3CJpb049o1GNhMCXcy5qPx6M4Ttb9M

DEFAULT behavior (according to OIDC standard):

/auth/realms/master/protocol/openid-connect/auth?**ui_locales=en-US**&scope=openid+email+profile&response_type=code&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fc%2Fportal%2Flogin%2Fopenidconnect&state=kbJxEpo-xdcM4w-kTO4dRxExq0nfL6PBFoOhmIzK9kg&code_challenge_method=S256&ui_locale=%24LOWERCASE_BCP47_LANGUAGE_CODE%24&nonce=uC_geb4QLgVZWw4FoB-kSusKtyg0o2J-AAq09T7VJrs&client_id=liferay-limited-session&code_challenge=j5LnomZKcDOhe3CJpb049o1GNhMCXcy5qPx6M4Ttb9M