### PR TITLE
LPD-28319 Invalidate WebDAV session

### DIFF
--- a/modules/apps/portal/portal-servlet-test/src/test/java/com/liferay/portal/servlet/filters/secure/BaseAuthFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/test/java/com/liferay/portal/servlet/filters/secure/BaseAuthFilterTest.java
@@ -419,9 +419,15 @@ public class BaseAuthFilterTest {
 	}
 
 	private User _setUpUser(int status) {
+		String digest = RandomTestUtil.randomString();
+
 		User user = new UserImpl();
 
+		user.setDigest(digest);
+
 		user.setStatus(status);
+
+		_mockHttpSession.setAttribute("DIGEST", digest);
 
 		_mockHttpSession.setAttribute(WebKeys.USER, user);
 
@@ -446,6 +452,12 @@ public class BaseAuthFilterTest {
 			userLocalServiceUtil.getUser(ArgumentMatchers.anyLong())
 		).thenReturn(
 			user
+		);
+
+		Mockito.when(
+			user.isActive()
+		).thenReturn(
+			true
 		);
 
 		return user;

--- a/modules/apps/portal/portal-servlet-test/src/test/java/com/liferay/portal/servlet/filters/secure/BaseAuthFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/test/java/com/liferay/portal/servlet/filters/secure/BaseAuthFilterTest.java
@@ -5,7 +5,6 @@
 
 package com.liferay.portal.servlet.filters.secure;
 
-import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.access.control.AccessControl;
@@ -13,15 +12,8 @@ import com.liferay.portal.kernel.security.access.control.AccessControlUtil;
 import com.liferay.portal.kernel.security.auth.AccessControlContext;
 import com.liferay.portal.kernel.security.auth.http.HttpAuthorizationHeader;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierResult;
-import com.liferay.portal.kernel.service.CompanyLocalService;
-import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
-import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
-import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.util.Digester;
-import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -97,72 +89,6 @@ public class BaseAuthFilterTest {
 	@After
 	public void tearDown() {
 		AccessControlUtil.setAccessControlContext(null);
-	}
-
-	@Test
-	public void testDigestAuthWhenDigestIsNotUpdatedDuringTheSession()
-		throws Exception {
-
-		String digest = RandomTestUtil.randomString();
-
-		_mockHttpSession.setAttribute("DIGEST", digest);
-
-		_mockHttpServletRequest.setSession(_mockHttpSession);
-
-		_setUpCompany();
-
-		_setUpDigester(RandomTestUtil.randomString());
-
-		User user = _setUpUserForDigestRequest();
-
-		Mockito.when(
-			user.getDigest()
-		).thenReturn(
-			digest
-		);
-
-		_authFilter.digestAuth(
-			_mockHttpServletRequest, _mockHttpServletResponse);
-
-		Assert.assertEquals(200, _mockHttpServletResponse.getStatus());
-	}
-
-	@Test
-	public void testDigestAuthWhenDigestIsUpdatedDuringTheSession()
-		throws Exception {
-
-		String digest = RandomTestUtil.randomString();
-
-		_mockHttpSession.setAttribute("DIGEST", digest);
-
-		_mockHttpServletRequest.setSession(_mockHttpSession);
-
-		_setUpCompany();
-
-		String nonce = RandomTestUtil.randomString();
-
-		_setUpDigester(nonce);
-
-		User user = _setUpUserForDigestRequest();
-
-		Mockito.when(
-			user.getDigest()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
-
-		_authFilter.digestAuth(
-			_mockHttpServletRequest, _mockHttpServletResponse);
-
-		String responseHeader = _mockHttpServletResponse.getHeader(
-			HttpHeaders.WWW_AUTHENTICATE);
-
-		Assert.assertNotNull(responseHeader);
-		Assert.assertEquals(
-			"Digest realm=\"PortalRealm\", nonce=\"" + nonce + "\"",
-			responseHeader);
-
-		Assert.assertEquals(401, _mockHttpServletResponse.getStatus());
 	}
 
 	@Test
@@ -366,99 +292,14 @@ public class BaseAuthFilterTest {
 			PropsValues.class, propertyName, value);
 	}
 
-	private void _setUpCompany() throws Exception {
-		CompanyLocalServiceUtil companyLocalServiceUtil =
-			new CompanyLocalServiceUtil();
-
-		companyLocalServiceUtil.setService(_companyLocalService);
-
-		Company company = Mockito.mock(Company.class);
-
-		_mockHttpServletRequest.setAttribute(
-			WebKeys.COMPANY_ID, company.getCompanyId());
-
-		Mockito.when(
-			companyLocalServiceUtil.getCompanyById(ArgumentMatchers.anyLong())
-		).thenReturn(
-			company
-		);
-
-		Mockito.when(
-			_companyLocalService.getCompany(ArgumentMatchers.anyLong())
-		).thenReturn(
-			company
-		);
-
-		Long companyId = RandomTestUtil.randomLong();
-
-		Mockito.when(
-			company.getCompanyId()
-		).thenReturn(
-			companyId
-		);
-
-		Mockito.when(
-			company.getKey()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
-	}
-
-	private void _setUpDigester(String nonce) {
-		DigesterUtil digesterUtil = new DigesterUtil();
-
-		digesterUtil.setDigester(Mockito.mock(Digester.class));
-
-		Mockito.when(
-			digesterUtil.digestHex(
-				Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
-				Mockito.anyString())
-		).thenReturn(
-			nonce
-		);
-	}
-
 	private User _setUpUser(int status) {
-		String digest = RandomTestUtil.randomString();
-
 		User user = new UserImpl();
 
-		user.setDigest(digest);
-
 		user.setStatus(status);
-
-		_mockHttpSession.setAttribute("DIGEST", digest);
 
 		_mockHttpSession.setAttribute(WebKeys.USER, user);
 
 		_mockHttpServletRequest.setSession(_mockHttpSession);
-
-		return user;
-	}
-
-	private User _setUpUserForDigestRequest() throws Exception {
-		UserLocalServiceUtil userLocalServiceUtil = new UserLocalServiceUtil();
-
-		UserLocalService mockUserLocalService = Mockito.mock(
-			UserLocalService.class);
-
-		userLocalServiceUtil.setService(mockUserLocalService);
-
-		User user = Mockito.mock(User.class);
-
-		_mockHttpSession.setAttribute(WebKeys.USER, user);
-
-		Mockito.when(
-			userLocalServiceUtil.getUser(ArgumentMatchers.anyLong())
-		).thenReturn(
-			user
-		);
-
-		Mockito.when(
-			user.isActive()
-		).thenReturn(
-			true
-		);
 
 		return user;
 	}
@@ -503,8 +344,6 @@ public class BaseAuthFilterTest {
 	private static final PortalImpl _testPortalImpl = new TestPortalImpl();
 
 	private TestAuthFilter _authFilter;
-	private final CompanyLocalService _companyLocalService = Mockito.mock(
-		CompanyLocalService.class);
 	private MockFilterChain _mockFilterChain;
 	private MockFilterConfig _mockFilterConfig;
 	private MockHttpServletRequest _mockHttpServletRequest;

--- a/modules/apps/portal/portal-servlet-test/src/test/java/com/liferay/portal/servlet/filters/secure/BaseAuthFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/test/java/com/liferay/portal/servlet/filters/secure/BaseAuthFilterTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.servlet.filters.secure;
 
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.access.control.AccessControl;
@@ -12,8 +13,15 @@ import com.liferay.portal.kernel.security.access.control.AccessControlUtil;
 import com.liferay.portal.kernel.security.auth.AccessControlContext;
 import com.liferay.portal.kernel.security.auth.http.HttpAuthorizationHeader;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierResult;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Digester;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -89,6 +97,72 @@ public class BaseAuthFilterTest {
 	@After
 	public void tearDown() {
 		AccessControlUtil.setAccessControlContext(null);
+	}
+
+	@Test
+	public void testDigestAuthWhenDigestIsNotUpdatedDuringTheSession()
+		throws Exception {
+
+		String digest = RandomTestUtil.randomString();
+
+		_mockHttpSession.setAttribute("DIGEST", digest);
+
+		_mockHttpServletRequest.setSession(_mockHttpSession);
+
+		_setUpCompany();
+
+		_setUpDigester(RandomTestUtil.randomString());
+
+		User user = _setUpUserForDigestRequest();
+
+		Mockito.when(
+			user.getDigest()
+		).thenReturn(
+			digest
+		);
+
+		_authFilter.digestAuth(
+			_mockHttpServletRequest, _mockHttpServletResponse);
+
+		Assert.assertEquals(200, _mockHttpServletResponse.getStatus());
+	}
+
+	@Test
+	public void testDigestAuthWhenDigestIsUpdatedDuringTheSession()
+		throws Exception {
+
+		String digest = RandomTestUtil.randomString();
+
+		_mockHttpSession.setAttribute("DIGEST", digest);
+
+		_mockHttpServletRequest.setSession(_mockHttpSession);
+
+		_setUpCompany();
+
+		String nonce = RandomTestUtil.randomString();
+
+		_setUpDigester(nonce);
+
+		User user = _setUpUserForDigestRequest();
+
+		Mockito.when(
+			user.getDigest()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		_authFilter.digestAuth(
+			_mockHttpServletRequest, _mockHttpServletResponse);
+
+		String responseHeader = _mockHttpServletResponse.getHeader(
+			HttpHeaders.WWW_AUTHENTICATE);
+
+		Assert.assertNotNull(responseHeader);
+		Assert.assertEquals(
+			"Digest realm=\"PortalRealm\", nonce=\"" + nonce + "\"",
+			responseHeader);
+
+		Assert.assertEquals(401, _mockHttpServletResponse.getStatus());
 	}
 
 	@Test
@@ -292,6 +366,58 @@ public class BaseAuthFilterTest {
 			PropsValues.class, propertyName, value);
 	}
 
+	private void _setUpCompany() throws Exception {
+		CompanyLocalServiceUtil companyLocalServiceUtil =
+			new CompanyLocalServiceUtil();
+
+		companyLocalServiceUtil.setService(_companyLocalService);
+
+		Company company = Mockito.mock(Company.class);
+
+		_mockHttpServletRequest.setAttribute(
+			WebKeys.COMPANY_ID, company.getCompanyId());
+
+		Mockito.when(
+			companyLocalServiceUtil.getCompanyById(ArgumentMatchers.anyLong())
+		).thenReturn(
+			company
+		);
+
+		Mockito.when(
+			_companyLocalService.getCompany(ArgumentMatchers.anyLong())
+		).thenReturn(
+			company
+		);
+
+		Long companyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			company.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		Mockito.when(
+			company.getKey()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+	}
+
+	private void _setUpDigester(String nonce) {
+		DigesterUtil digesterUtil = new DigesterUtil();
+
+		digesterUtil.setDigester(Mockito.mock(Digester.class));
+
+		Mockito.when(
+			digesterUtil.digestHex(
+				Mockito.anyString(), Mockito.anyString(), Mockito.anyString(),
+				Mockito.anyString())
+		).thenReturn(
+			nonce
+		);
+	}
+
 	private User _setUpUser(int status) {
 		User user = new UserImpl();
 
@@ -300,6 +426,27 @@ public class BaseAuthFilterTest {
 		_mockHttpSession.setAttribute(WebKeys.USER, user);
 
 		_mockHttpServletRequest.setSession(_mockHttpSession);
+
+		return user;
+	}
+
+	private User _setUpUserForDigestRequest() throws Exception {
+		UserLocalServiceUtil userLocalServiceUtil = new UserLocalServiceUtil();
+
+		UserLocalService mockUserLocalService = Mockito.mock(
+			UserLocalService.class);
+
+		userLocalServiceUtil.setService(mockUserLocalService);
+
+		User user = Mockito.mock(User.class);
+
+		_mockHttpSession.setAttribute(WebKeys.USER, user);
+
+		Mockito.when(
+			userLocalServiceUtil.getUser(ArgumentMatchers.anyLong())
+		).thenReturn(
+			user
+		);
 
 		return user;
 	}
@@ -344,6 +491,8 @@ public class BaseAuthFilterTest {
 	private static final PortalImpl _testPortalImpl = new TestPortalImpl();
 
 	private TestAuthFilter _authFilter;
+	private final CompanyLocalService _companyLocalService = Mockito.mock(
+		CompanyLocalService.class);
 	private MockFilterChain _mockFilterChain;
 	private MockFilterConfig _mockFilterConfig;
 	private MockHttpServletRequest _mockHttpServletRequest;

--- a/modules/apps/portal/portal-servlet-test/src/test/java/com/liferay/portal/servlet/filters/secure/BaseAuthFilterTest.java
+++ b/modules/apps/portal/portal-servlet-test/src/test/java/com/liferay/portal/servlet/filters/secure/BaseAuthFilterTest.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.security.auth.http.HttpAuthorizationHeader;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierResult;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -89,6 +90,23 @@ public class BaseAuthFilterTest {
 	@After
 	public void tearDown() {
 		AccessControlUtil.setAccessControlContext(null);
+	}
+
+	@Test
+	public void testDigestChange() {
+		_mockFilterConfig.addInitParameter("digest_auth", "true");
+
+		User user = _setUpUser(WorkflowConstants.STATUS_APPROVED);
+
+		Assert.assertFalse(
+			_testHttpSessionIsInvalid(
+				HttpAuthorizationHeader.SCHEME_DIGEST, user));
+
+		user.setDigest(RandomTestUtil.randomString());
+
+		Assert.assertTrue(
+			_testHttpSessionIsInvalid(
+				HttpAuthorizationHeader.SCHEME_DIGEST, user));
 	}
 
 	@Test
@@ -293,11 +311,17 @@ public class BaseAuthFilterTest {
 	}
 
 	private User _setUpUser(int status) {
+		String digest = RandomTestUtil.randomString();
+
 		User user = new UserImpl();
+
+		user.setDigest(digest);
 
 		user.setStatus(status);
 
 		_mockHttpSession.setAttribute(WebKeys.USER, user);
+
+		_mockHttpSession.setAttribute("DIGEST", digest);
 
 		_mockHttpServletRequest.setSession(_mockHttpSession);
 

--- a/portal-impl/src/com/liferay/portal/servlet/filters/secure/BaseAuthFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/secure/BaseAuthFilter.java
@@ -230,7 +230,7 @@ public abstract class BaseAuthFilter extends BasePortalFilter {
 
 			user = UserLocalServiceUtil.getUser(user.getUserId());
 
-			if (!digest.equals(user.getDigest())) {
+			if (!StringUtil.equals(digest, user.getDigest())) {
 				return true;
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/servlet/filters/secure/BaseAuthFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/secure/BaseAuthFilter.java
@@ -8,6 +8,7 @@ package com.liferay.portal.servlet.filters.secure;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -165,10 +166,13 @@ public abstract class BaseAuthFilter extends BasePortalFilter {
 			}
 
 			if (userId > 0) {
+				user1 = UserLocalServiceUtil.getUser(userId);
+
 				httpServletRequest = setCredentials(
-					httpServletRequest, httpSession,
-					UserLocalServiceUtil.getUser(userId),
+					httpServletRequest, httpSession, user1,
 					HttpServletRequest.DIGEST_AUTH);
+
+				httpSession.setAttribute("DIGEST", user1.getDigest());
 			}
 			else {
 				HttpAuthManagerUtil.generateChallenge(
@@ -182,7 +186,7 @@ public abstract class BaseAuthFilter extends BasePortalFilter {
 		else {
 			User user2 = UserLocalServiceUtil.getUser(user1.getUserId());
 
-			if (!user2.isActive()) {
+			if (isDigestModified(httpSession) || !user2.isActive()) {
 				httpSession.invalidate();
 
 				HttpAuthManagerUtil.generateChallenge(
@@ -214,6 +218,24 @@ public abstract class BaseAuthFilter extends BasePortalFilter {
 		}
 
 		PermissionThreadLocal.getPermissionChecker(user, true);
+	}
+
+	protected boolean isDigestModified(HttpSession httpSession)
+		throws PortalException {
+
+		User user = (User)httpSession.getAttribute(WebKeys.USER);
+
+		if (user != null) {
+			String digest = (String)httpSession.getAttribute("DIGEST");
+
+			user = UserLocalServiceUtil.getUser(user.getUserId());
+
+			if (!digest.equals(user.getDigest())) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
- LPD-35766 Set user in WebDAVServlet. HttpSession user setting is not duplicated when it is a WebDAV request, partial revert of 033ba596
- LPD-28319 If digest changed, invalidate the session, generate challenge and return HTTP 401
- LPD-28319 Add unit tests
- LPD-28319 comparation using StringUtil
- LPD-28319 Update tests after resolving the WebDAV related merge conflicts
