### PR TITLE
LPD-38925 Fix CSP integration test

### DIFF
--- a/modules/apps/portal-security/portal-security-content-security-policy-test/src/testIntegration/java/com/liferay/portal/security/content/security/policy/test/ContentSecurityPolicyFilterTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy-test/src/testIntegration/java/com/liferay/portal/security/content/security/policy/test/ContentSecurityPolicyFilterTest.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -157,11 +158,17 @@ public class ContentSecurityPolicyFilterTest {
 			String content = _getContent(httpURLConnection);
 
 			Assert.assertTrue(
-				content.matches(".*<link [^>]*nonce=\"" + nonce + "\".*"));
+				content.matches(
+					".*<link [^>]*nonce=\"" + HtmlUtil.escapeJS(nonce) +
+						"\".*"));
 			Assert.assertTrue(
-				content.matches(".*<script [^>]*nonce=\"" + nonce + "\".*"));
+				content.matches(
+					".*<script [^>]*nonce=\"" + HtmlUtil.escapeJS(nonce) +
+						"\".*"));
 			Assert.assertTrue(
-				content.matches(".*<style [^>]*nonce=\"" + nonce + "\".*"));
+				content.matches(
+					".*<style [^>]*nonce=\"" + HtmlUtil.escapeJS(nonce) +
+						"\".*"));
 
 			httpURLConnection.disconnect();
 		}


### PR DESCRIPTION
Related issue: [LPD-38925](https://liferay.atlassian.net/browse/LPD-38925)

Since the nonce value might sometimes carry especial characters like `+`, it would be interpreted as a regexp quantifier, instead of as a regular character. We need to escape the nonce value on assertions since it's being used on regex param.