### PR TITLE
LPD-34165 Fix Login#TokenBasedSSOSmoke

### DIFF
--- a/build-test-token-based-sso.xml
+++ b/build-test-token-based-sso.xml
@@ -5,7 +5,7 @@
 
 	<target name="verify-token-based-login">
 		<exec executable="curl" outputproperty="curl.output">
-			<arg line="-H SM_USER:${user.token} ${portal.url}" />
+			<arg line="-H 'SM_USER:${user.token}' ${portal.url}" />
 		</exec>
 
 		<echo>${curl.output}</echo>


### PR DESCRIPTION
[LPD-34165](https://liferay.atlassian.net/browse/LPD-34165)

Saving the configuration after the reset step seems to have fixed this test's flakyness. 