### PR TITLE
LPD-38938 Fix SAML tests that use WaitForSPAReFresh

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/SAML.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SAML.macro
@@ -621,7 +621,7 @@ definition {
 		if (${autoLogin} == "true") {
 			Open.openNoError(value1 = ${idpInitiatedSsourl});
 
-			AssertElementPresent(locator1 = "UserBar#USER_AVATAR_IMAGE");
+			AssertElementPresent.assertElementPresentNoWaitForSPAReFresh(locator1 = "UserBar#USER_AVATAR_IMAGE");
 		}
 		else {
 			User.firstLoginUI(
@@ -641,7 +641,7 @@ definition {
 		if (${autoLogin} == "true") {
 			Navigator.openSpecificURL(url = ${spURL});
 
-			AssertElementPresent(locator1 = "UserBar#USER_AVATAR_IMAGE");
+			AssertElementPresent.assertElementPresentNoWaitForSPAReFresh(locator1 = "UserBar#USER_AVATAR_IMAGE");
 		}
 		else if (isSet(userEmailAddress)) {
 			User.firstLoginUI(
@@ -927,7 +927,7 @@ definition {
 
 	@summary = "Default summary"
 	macro viewEmailInputPresent() {
-		AssertElementPresent(locator1 = "TextInput#EMAIL_ADDRESS");
+		AssertElementPresent.assertElementPresentNoWaitForSPAReFresh(locator1 = "TextInput#EMAIL_ADDRESS");
 	}
 
 	@summary = "Default summary"
@@ -943,7 +943,7 @@ definition {
 	macro viewNoAttributeMappingSelectedForUserMatching() {
 		AssertConsoleTextPresent(value1 = "No attribute mapping selected for user matching");
 
-		AssertElementPresent(locator1 = "CPSAMLAdminIdentityProviderConnection#IDENTITY_PROVIDER_CONNECTION_ERROR_NO_MAPPING_SELECTED");
+		AssertElementPresent.assertElementPresentNoWaitForSPAReFresh(locator1 = "CPSAMLAdminIdentityProviderConnection#IDENTITY_PROVIDER_CONNECTION_ERROR_NO_MAPPING_SELECTED");
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/macros/SAMLRole.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SAMLRole.macro
@@ -45,11 +45,11 @@ definition {
 
 		WaitForElementNotPresent(locator1 = "IFrame#MODAL_BODY");
 
-		AssertElementPresent(
+		AssertElementPresent.assertElementPresentNoWaitForSPAReFresh(
 			key_certificateUsage = ${certificateUsage},
 			locator1 = "CPSAMLAdmin#DOWNLOAD_CERTIFICATE");
 
-		AssertElementPresent(
+		AssertElementPresent.assertElementPresentNoWaitForSPAReFresh(
 			key_certificateUsage = ${certificateUsage},
 			locator1 = "CPSAMLAdmin#REPLACE_CERTIFICATE");
 	}
@@ -188,12 +188,12 @@ definition {
 		Button.clickImport();
 
 		if (${certificateUsage} == "SIGNING") {
-			AssertElementPresent(
+			AssertElementPresent.assertElementPresentNoWaitForSPAReFresh(
 				key_certificateUsage = "SIGNING",
 				locator1 = "CPSAMLAdmin#REPLACE_CERTIFICATE");
 		}
 		else {
-			AssertElementPresent(
+			AssertElementPresent.assertElementPresentNoWaitForSPAReFresh(
 				key_certificateUsage = "ENCRYPTION",
 				locator1 = "CPSAMLAdmin#REPLACE_CERTIFICATE");
 		}
@@ -203,11 +203,11 @@ definition {
 	macro viewGeneralConfigurations(samlRoleType = null, samlEntityId = null) {
 		AssertChecked(locator1 = "CPSAMLAdmin#SAML_ENABLED_CHECKBOX");
 
-		AssertElementPresent(
+		AssertElementPresent.assertElementPresentNoWaitForSPAReFresh(
 			locator1 = "CPSAMLAdmin#SAML_ROLE_SELECT",
 			value1 = ${samlRoleType});
 
-		AssertElementPresent(
+		AssertElementPresent.assertElementPresentNoWaitForSPAReFresh(
 			locator1 = "CPSAMLAdmin#SAML_ENTITY_ID_FIELD",
 			value1 = ${samlEntityId});
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAML.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAML.testcase
@@ -459,7 +459,7 @@ definition {
 
 			SAML.goToSAMLAdmin(baseURL = "http://www.able.com:8080");
 
-			AssertElementPresent(locator1 = "CPSAMLAdmin#SAML_ROLE_SELECT_DISABLED");
+			AssertElementPresent.assertElementPresentNoWaitForSPAReFresh(locator1 = "CPSAMLAdmin#SAML_ROLE_SELECT_DISABLED");
 		}
 	}
 
@@ -2842,7 +2842,7 @@ definition {
 		task ("Assert certificate is migrated.") {
 			SAML.goToSAMLAdmin();
 
-			AssertElementPresent(
+			AssertElementPresent.assertElementPresentNoWaitForSPAReFresh(
 				key_certificateUsage = "SIGNING",
 				locator1 = "CPSAMLAdmin#DOWNLOAD_CERTIFICATE");
 		}


### PR DESCRIPTION
Related issue: [LPD-38938](https://liferay.atlassian.net/browse/LPD-38938)

Test is flaky because sometimes it fails asserting `//div[contains(@class,'lfr-notification-wrapper') and contains(@style,'height: 82px;')]}]` which happens at `waitForSPARefresh()`. So I changed the AssertElementPresent for  `AssertElementPresent.assertElementPresentNoWaitForSPAReFresh()` to prevent the errors.