### PR TITLE
LPD-38650 2

### DIFF
--- a/modules/test/playwright/tests/cookies-banner-web/cookiesBannerAccessibility.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/cookiesBannerAccessibility.spec.ts
@@ -6,68 +6,31 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {loginTest} from '../../fixtures/loginTest';
-import {systemSettingsPageTest} from '../../fixtures/systemSettingsPageTest';
-import {waitForAlert} from '../../utils/waitForAlert';
+import {cookieBannerPageTest} from './fixtures/cookieBannerPageTest';
 
-export const test = mergeTests(loginTest(), systemSettingsPageTest);
+export const test = mergeTests(loginTest(), cookieBannerPageTest);
+
+test.afterEach(async ({cookieBannerPage}) => {
+	await cookieBannerPage.goToSystemSetting();
+
+	await cookieBannerPage.actionsButton.waitFor({state: 'visible'})
+
+	await cookieBannerPage.resetCookiePreferences();
+});
 
 test('LPD-30822 Cookie Banner Accessibility', async ({
+	cookieBannerPage,
 	page,
-	systemSettingsPage,
 }) => {
 	await test.step('Enable Third Party Cookies', async () => {
-		await systemSettingsPage.goToSystemSetting(
-			'Cookies',
-			'Preference Handling'
-		);
-
-		const enabledButton = page.getByLabel('Enabled');
-
-		await enabledButton.waitFor({state: 'visible'});
-
-		const isChecked = await enabledButton.isChecked();
-
-		if (!isChecked) {
-			await enabledButton.click();
-		}
-
-		await expect(enabledButton).toBeChecked();
-
-		const updateButton = page.getByRole('button', {
-			name: 'Update',
-		});
-
-		const saveButton = page.getByRole('button', {
-			name: 'Save',
-		});
-
-		if (await saveButton.isVisible()) {
-			await saveButton.click();
-		}
-		else if (await updateButton.isVisible()) {
-			await updateButton.click();
-		}
-
-		await waitForAlert(page);
+		await cookieBannerPage.enableThirdPartyCookies();
 	});
 
 	await test.step('Check aria-label, role, and paragraph', async () => {
 		await page.goto('/');
 
-		await page
-			.locator(
-				'#p_p_id_com_liferay_cookies_banner_web_portlet_CookiesBannerPortlet_'
-			)
-			.waitFor({state: 'visible'});
+		await cookieBannerPage.cookieBanner.waitFor({state: 'visible'});
 
-		const cookiesBannerContainer = page.locator(
-			'//div[@role="dialog"][@aria-label="banner cookies"]'
-		);
-
-		await expect(cookiesBannerContainer).toBeVisible();
-
-		const paragraph = cookiesBannerContainer.locator('p.mb-0');
-
-		await expect(paragraph).toBeVisible();
+		await expect(cookieBannerPage.cookieBannerParagraph).toBeVisible();
 	});
 });

--- a/modules/test/playwright/tests/cookies-banner-web/cookiesBannerCadmin.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/cookiesBannerCadmin.spec.ts
@@ -7,66 +7,33 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {isolatedLayoutTest} from '../../fixtures/isolatedLayoutTest';
 import {loginTest} from '../../fixtures/loginTest';
-import {systemSettingsPageTest} from '../../fixtures/systemSettingsPageTest';
-import {waitForAlert} from '../../utils/waitForAlert';
+import {cookieBannerPageTest} from './fixtures/cookieBannerPageTest';
 
 export const test = mergeTests(
 	isolatedLayoutTest(),
 	loginTest(),
-	systemSettingsPageTest
+	cookieBannerPageTest
 );
 
-test('LPD-25440 Cookie Banner Cadmin', async ({page, systemSettingsPage}) => {
+test.afterEach(async ({cookieBannerPage}) => {
+	await cookieBannerPage.goToSystemSetting();
+
+	await cookieBannerPage.actionsButton.waitFor({state: 'visible'})
+
+	await cookieBannerPage.resetCookiePreferences();
+});
+
+test('LPD-25440 Cookie Banner Cadmin', async ({cookieBannerPage, page}) => {
 	await test.step('Enable Third Party Cookies', async () => {
-		await systemSettingsPage.goToSystemSetting(
-			'Cookies',
-			'Preference Handling'
-		);
-
-		const enabledButton = page.getByLabel('Enabled');
-
-		await enabledButton.waitFor({state: 'visible'});
-
-		const isChecked = await enabledButton.isChecked();
-
-		if (!isChecked) {
-			await enabledButton.click();
-		}
-
-		await expect(enabledButton).toBeChecked();
-
-		const updateButton = page.getByRole('button', {
-			name: 'Update',
-		});
-
-		const saveButton = page.getByRole('button', {
-			name: 'Save',
-		});
-
-		if (await saveButton.isVisible()) {
-			await saveButton.click();
-		}
-		else if (await updateButton.isVisible()) {
-			await updateButton.click();
-		}
-
-		await waitForAlert(page);
+		await cookieBannerPage.enableThirdPartyCookies();
 	});
 
 	await test.step('Open Configuration', async () => {
 		await page.goto('/');
 
-		await page
-			.locator(
-				'#p_p_id_com_liferay_cookies_banner_web_portlet_CookiesBannerPortlet_'
-			)
-			.waitFor({state: 'visible'});
+		await cookieBannerPage.cookieBanner.waitFor({state: 'visible'});
 
-		const configuration = page.getByRole('button', {name: 'Configuration'});
-
-		await configuration.waitFor({state: 'visible'});
-
-		await configuration.click();
+		await cookieBannerPage.cookieBannerConfigurationButton.click();
 	});
 
 	await test.step('Check cadmin is not applied', async () => {

--- a/modules/test/playwright/tests/cookies-banner-web/cookiesBannerCookiePolicy.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/cookiesBannerCookiePolicy.spec.ts
@@ -7,97 +7,53 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {loginTest} from '../../fixtures/loginTest';
-import {systemSettingsPageTest} from '../../fixtures/systemSettingsPageTest';
-import {waitForAlert} from '../../utils/waitForAlert';
+import {cookieBannerPageTest} from './fixtures/cookieBannerPageTest';
 
 export const test = mergeTests(
 	featureFlagsTest({
 		'LPD-10588': true,
 	}),
 	loginTest(),
-	systemSettingsPageTest
+	cookieBannerPageTest
 );
 
+test.afterEach(async ({cookieBannerPage}) => {
+	await cookieBannerPage.goToSystemSetting();
+
+	await cookieBannerPage.actionsButton.waitFor({state: 'visible'})
+
+	await cookieBannerPage.resetCookiePreferences();
+});
+
 test('LPD-30561 Cookie Banner Cookie Policy Page', async ({
+	cookieBannerPage,
 	page,
-	systemSettingsPage,
 }) => {
-	await test.step('Enable Preference Handling Cookies', async () => {
-		await systemSettingsPage.goToSystemSetting(
-			'Cookies',
-			'Preference Handling'
-		);
-
-		const enabledButton = page.getByLabel('Enabled');
-
-		await enabledButton.waitFor({state: 'visible'});
-
-		await page.waitForTimeout(3000);
-
-		const isChecked = await enabledButton.isChecked();
-
-		if (!isChecked) {
-			await enabledButton.click();
-		}
-
-		await expect(enabledButton).toBeChecked();
-	});
-
 	await test.step('Enable Explicit Cookie Consent Mode', async () => {
-		const explicitCookieConsentModeButton = page.getByLabel(
-			'Explicit Cookie Consent Mode'
-		);
+		await cookieBannerPage.goToSystemSetting();
 
-		await explicitCookieConsentModeButton.waitFor({state: 'visible'});
-
-		const isChecked = await explicitCookieConsentModeButton.isChecked();
-
-		if (!isChecked) {
-			await explicitCookieConsentModeButton.click();
+		if (!cookieBannerPage.explicitCookieConsentModeButton.isChecked()) {
+			await cookieBannerPage.explicitCookieConsentModeButton.click();
 		}
 
-		await expect(explicitCookieConsentModeButton).toBeChecked();
+		await expect(
+			cookieBannerPage.explicitCookieConsentModeButton
+		).toBeChecked();
 	});
 
-	await test.step('Update Preference Handling', async () => {
-		const updateButton = page.getByRole('button', {
-			name: 'Update',
-		});
-
-		const saveButton = page.getByRole('button', {
-			name: 'Save',
-		});
-
-		if (await saveButton.isVisible()) {
-			await saveButton.click();
-		}
-		else if (await updateButton.isVisible()) {
-			await updateButton.click();
-		}
-
-		await waitForAlert(page);
+	await test.step('Enable Preference Handling Cookies and save', async () => {
+		await cookieBannerPage.enableThirdPartyCookies();
 	});
 
 	await test.step('Go to Cookie Policy page', async () => {
 		await page.goto('/');
 
-		await page
-			.locator(
-				'#p_p_id_com_liferay_cookies_banner_web_portlet_CookiesBannerPortlet_'
-			)
-			.waitFor({state: 'visible'});
+		await cookieBannerPage.cookieBanner.waitFor({state: 'visible'});
 
-		const cookiesBannerContainer = page.locator(
-			'//div[@role="dialog"][@aria-label="banner cookies"]'
-		);
+		await expect(cookieBannerPage.cookieBannerParagraph).toBeVisible();
 
-		await expect(cookiesBannerContainer).toBeVisible();
-
-		const paragraph = cookiesBannerContainer.locator('p.mb-0');
-
-		await expect(paragraph).toBeVisible();
-
-		const cookiePolicyURL = paragraph.locator('a');
+		const cookiePolicyURL =
+			cookieBannerPage.cookieBannerParagraph.locator('a');
 
 		await cookiePolicyURL.click();
 

--- a/modules/test/playwright/tests/cookies-banner-web/cookiesBannerScript.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/cookiesBannerScript.spec.ts
@@ -7,58 +7,33 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {isolatedLayoutTest} from '../../fixtures/isolatedLayoutTest';
 import {loginTest} from '../../fixtures/loginTest';
-import {systemSettingsPageTest} from '../../fixtures/systemSettingsPageTest';
 import {waitForAlert} from '../../utils/waitForAlert';
+import {cookieBannerPageTest} from './fixtures/cookieBannerPageTest';
 
 export const test = mergeTests(
 	isolatedLayoutTest(),
 	loginTest(),
-	systemSettingsPageTest
+	cookieBannerPageTest
 );
 
+test.afterEach(async ({cookieBannerPage}) => {
+	await cookieBannerPage.goToSystemSetting();
+
+	await cookieBannerPage.actionsButton.waitFor({state: 'visible'})
+
+	await cookieBannerPage.resetCookiePreferences();
+});
+
 test('@LPD-25701 Cookie Banner Script', async ({
+	cookieBannerPage,
 	layout,
 	page,
-	systemSettingsPage,
 }) => {
-	await test.step('Go to page and click edit', async () => {
-		await page.goto(layout.friendlyURL);
-
-		const editButton = page.getByRole('link', {name: 'Edit'});
-
-		await editButton.waitFor({state: 'visible'});
-		await editButton.click();
-	});
-
-	await test.step('Drag and drop html to page', async () => {
-		const searchFragment = page.getByLabel('Search Fragments and Widgets');
-
-		await searchFragment.waitFor({state: 'visible'});
-		await searchFragment.click();
-		await searchFragment.fill('html');
-
-		const htmlItem = page.getByRole('menuitem', {
-			name: 'HTML Add HTML Mark HTML as Favorite',
-		});
-
-		await htmlItem.waitFor({state: 'visible'});
-
-		await htmlItem.dragTo(page.locator('#page-editor div').nth(1));
+	await test.step('Edit page and add html component', async () => {
+		await cookieBannerPage.addHTMLComponent({layout});
 	});
 
 	await test.step('Add script to html and save page', async () => {
-		const htmlExample = page.getByText('HTML Example');
-
-		await htmlExample.waitFor({state: 'visible'});
-		await htmlExample.click();
-		await htmlExample.click();
-		await htmlExample.click();
-
-		const htmlSection = page.locator('.CodeMirror-scroll');
-
-		await htmlSection.waitFor({state: 'visible'});
-		await htmlSection.click();
-
 		const textarea = page.locator('textarea');
 
 		await textarea.press('Control+a');
@@ -86,39 +61,7 @@ test('@LPD-25701 Cookie Banner Script', async ({
 	});
 
 	await test.step('Enable Third Party Cookies', async () => {
-		await systemSettingsPage.goToSystemSetting(
-			'Cookies',
-			'Preference Handling'
-		);
-
-		const enabledButton = page.getByLabel('Enabled');
-
-		await enabledButton.waitFor({state: 'visible'});
-
-		const isChecked = await enabledButton.isChecked();
-
-		if (!isChecked) {
-			await enabledButton.click();
-		}
-
-		await expect(enabledButton).toBeChecked();
-
-		const updateButton = page.getByRole('button', {
-			name: 'Update',
-		});
-
-		const saveButton = page.getByRole('button', {
-			name: 'Save',
-		});
-
-		if (await saveButton.isVisible()) {
-			await saveButton.click();
-		}
-		else if (await updateButton.isVisible()) {
-			await updateButton.click();
-		}
-
-		await waitForAlert(page);
+		await cookieBannerPage.enableThirdPartyCookies();
 	});
 
 	await test.step('Accept Cookies', async () => {
@@ -126,17 +69,7 @@ test('@LPD-25701 Cookie Banner Script', async ({
 
 		await page.getByRole('heading', {name: 'HTML Example'}).waitFor();
 
-		await page
-			.locator(
-				'#p_p_id_com_liferay_cookies_banner_web_portlet_CookiesBannerPortlet_'
-			)
-			.waitFor({state: 'visible'});
-
-		const acceptAll = page.getByRole('button', {name: 'Accept All'});
-
-		await acceptAll.waitFor({state: 'visible'});
-
-		await acceptAll.click();
+		await cookieBannerPage.acceptAllCookies();
 	});
 
 	await test.step('Check if script changed html', async () => {

--- a/modules/test/playwright/tests/cookies-banner-web/fixtures/cookieBannerPageTest.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/fixtures/cookieBannerPageTest.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+// @ts-ignore
+
+import {test} from '@playwright/test';
+
+import {CookieBannerPage} from '../pages/CookieBannerPage';
+
+const cookieBannerPageTest = test.extend<{
+	cookieBannerPage: CookieBannerPage;
+}>({
+	cookieBannerPage: async ({page}, use) => {
+		await use(new CookieBannerPage(page));
+	},
+});
+
+export {cookieBannerPageTest};

--- a/modules/test/playwright/tests/cookies-banner-web/pages/CookieBannerPage.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/pages/CookieBannerPage.ts
@@ -1,0 +1,128 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page, expect} from '@playwright/test';
+
+import {SystemSettingsPage} from '../../../pages/configuration-admin-web/SystemSettingsPage';
+import {waitForAlert} from '../../../utils/waitForAlert';
+
+export class CookieBannerPage {
+	readonly systemSettingsPage: SystemSettingsPage;
+	readonly enabledButton: Locator;
+	readonly explicitCookieConsentModeButton: Locator;
+	readonly actionsButton: Locator;
+	readonly saveButton: Locator;
+	readonly updateButton: Locator;
+	readonly page: Page;
+	readonly cookieBanner: Locator;
+	readonly cookieBannerConfigurationButton: Locator;
+	readonly cookieBannerParagraph: Locator;
+	readonly cookieBannerAcceptAllButton: Locator;
+	readonly cookieBannerDeclineAllButton: Locator;
+	readonly fragmentWidgetSearchInput: Locator;
+
+	constructor(page: Page) {
+		this.systemSettingsPage = new SystemSettingsPage(page);
+		this.enabledButton = page.getByLabel('Enabled');
+		this.explicitCookieConsentModeButton = page.getByLabel(
+			'Explicit Cookie Consent Mode'
+		);
+		this.actionsButton = page.getByRole('button', {name: 'Actions'});
+		this.saveButton = page.getByRole('button', {
+			name: 'Save',
+		});
+		this.updateButton = page.getByRole('button', {
+			name: 'Update',
+		});
+		this.page = page;
+		this.cookieBanner = page.locator(
+			'#p_p_id_com_liferay_cookies_banner_web_portlet_CookiesBannerPortlet_'
+		);
+		this.cookieBannerConfigurationButton = page.getByRole('button', {
+			name: 'Configuration',
+		});
+		this.cookieBannerParagraph = page
+			.locator('//div[@role="dialog"][@aria-label="banner cookies"]')
+			.locator('p.mb-0');
+		this.cookieBannerAcceptAllButton = page.getByRole('button', {
+			name: 'Accept All',
+		});
+		this.cookieBannerDeclineAllButton = page.getByRole('button', {
+			name: 'Decline All',
+		});
+		this.fragmentWidgetSearchInput = page.getByLabel(
+			'Search Fragments and Widgets'
+		);
+	}
+
+	async goToSystemSetting() {
+		await this.systemSettingsPage.goToSystemSetting(
+			'Cookies',
+			'Preference Handling'
+		);
+	}
+
+	async editPage({layout}: {layout: Layout}) {
+		await this.page.goto(`${layout.friendlyURL}?p_l_mode=edit`);
+	}
+
+	async searchFragmentOrWidget(itemName: string) {
+		await this.fragmentWidgetSearchInput.fill(itemName);
+	}
+
+	async addHTMLComponent({layout}: {layout: Layout}) {
+		await this.editPage({layout});
+
+		await this.searchFragmentOrWidget('html');
+
+		const htmlItem = this.page.getByRole('menuitem', {
+			name: 'HTML Add HTML Mark HTML as Favorite',
+		});
+
+		await htmlItem.dragTo(
+			this.page.getByText('Drag and drop fragments or widgets here.')
+		);
+
+		const htmlExample = this.page.getByText('HTML Example');
+
+		await htmlExample.click();
+		await htmlExample.click();
+	}
+
+	async enableThirdPartyCookies() {
+		await this.goToSystemSetting();
+
+		if (!await this.enabledButton.isChecked()) {
+			await this.enabledButton.click();
+		}
+
+		await expect(this.enabledButton).toBeChecked();
+
+		if (await this.saveButton.isVisible()) {
+			await this.saveButton.click();
+		}
+		else if (await this.updateButton.isVisible()) {
+			await this.updateButton.click()
+		}
+
+		await waitForAlert(this.page);
+	}
+
+	async acceptAllCookies() {
+		await this.cookieBanner.waitFor({state: 'visible'});
+
+		await this.cookieBannerAcceptAllButton.click();
+	}
+
+	async resetCookiePreferences() {
+		await this.actionsButton.click();
+
+		await this.page
+			.getByRole('link', {name: 'Reset Default Values'})
+			.click();
+
+		await waitForAlert(this.page);
+	}
+}


### PR DESCRIPTION
- **LPD-36588 Unbind object definitions by updating the object relationship edge property**
- **LPD-36589 Copy resource permissions from old root object definition when unbinding**
- **LPD-36590 Add new object action exception**
- **LPD-36590 buildService**
- **LPD-36590 Add new exception mapper**
- **LPD-36590 The object action cannot be activated if the trigger is onAfterRootUpdate but the object definition is not a root node**
- **LPD-36590 Deactivate existing object actions if the trigger is onAfterRootUpdate but the object definition is not a root node**
- **LPD-36591 After unbinding, all object entries in the subtree will need to have the rootObjectEntryId property updated**
- **LPD-36592 Copy individual resource permissions from the previous root object entry**
- **LPD-36588 Add integration test**
- **LPD-36589 Add integration test**
- **LPD-36590 Add integration test**
- **LPD-36591 Add integration test**
- **LPD-36592 Add integration test**
- **LPD-36591 SF**
- **LPD-36591 Ensure the tree to be built will have items with the same root object definition id**
- **LPD-36591 Simplify**
- **LPD-36591 Apply feature flag**
- **LPD-36591 Rename**
- **LPD-36591 SF**
- **LPD-36591 The tests were moved to ObjectRelationshipLocalServiceTest.java**
- **LPD-36591 SF**
- **LPD-36591 Wordsmith**
- **LPD-36591 SF**
- **LRCI-4706 Simplify**
- **LRCI-4706 Force floating point division**
- **LRCI-4706 prep next**
- **Revert "LPD-37071 Add test to export journal content preferences and see if we are exporting journal article also"**
- **Revert "LPD-37071 Export also the article staged model because if not,it does not make sense to publish web content display without configured article"**
- **LPD-39011 Add expected externalReferenceCode for the creator to fix failing test**
- **LPD-38877 Default value was changed.**
- **LPD-37548 not used**
- **LPD-37548 add dataSourceConnected field**
- **LPD-37548 buildService**
- **LPD-37548 add dropdown item for disconnecting data sources**
- **LPD-37548 create language key**
- **LPD-37548 buildLang**
- **LPD-37548 index dataSourceConnected field**
- **LPD-37548 set dataSourceConnected when connecting and disconnecting all data sources**
- **LPD-37548 disabling deactivating data sources when there is no data source connected**
- **LPD-37548 upgrade step**
- **LPD-37548 Remove other drop down items as they are no longer used**
- **LPD-37548 Fix spaces**
- **LPD-37548 Sort**
- **LPD-37548 Did you really mean to make this a Boolean vs. a boolean?**
- **LPD-37548 Regen**
- **LPD-38991 Don't use the group of the page template, but of the site where it belongs**
- **LPD-38991 Add test**
- **LPD-36494 gradle-plugins-workspace: test Lang idea**
- **LPD-36494 gradle-plugins-workspace: adds helper method for determining if the project is the special Lang project**
- **LPD-36494 gradle-plugins-workspace: adds helper method to add CX ids to the map for validation**
- **LPD-36494 gradle-plugins-workspace: does not add the yaml file as an input to the tasks for the Lang project**
- **LPD-36494 gradle-plugins-workspace: configures the lang project**
- **LPD-36494 gradle-plugins-workspace: adds the Lang project as a CX project**
- **LPD-36494 gradle-plugins-workspace: convert the languages files to a batch file**
- **LPD-36494 add buildLang support**
- **LPD-36494 ignore automatic copies when building the batch file**
- **LPD-36494 we are safe to consider 'en' as 'en_US'**
- **LPD-36494 add sample language cx**
- **LPD-36494 baseline**
- **LPD-36494 SF**
- **LPD-36494 add test**
- **LPD-36494 gradle-plugins-workspace: updates tests to use expected files**
- **LPD-36494 gradle-plugins-workspace: just check to see if the yaml file exists**
- **LPD-36494 gradle-plugins-workspace: updates LanguageBatchUtil and usages**
- **LPD-36494 gradle-plugins-workspace: client-extension.yaml: rely on fromTask for assemble**
- **LPD-36494 gradle-plugins-workspace: uses the standard client-extension.yaml object handling logic**
- **LPD-36494 gradle-plugins-workspace: GenerateLanguageBatchConfigTask: uses lazy configs**
- **LPD-36494 gradle-plugins-workspace: ClientExtensionProjectConfigurator: simplify now that we are relying on the more standard Client Extension path**
- **LPD-36494 gradle-plugins-workspace: renames task to GenerateLanguageBatchEngineDataTask**
- **LPD-36494 gradle-plugins-workspace: do not replace short languageIds**
- **LPD-36494 handle fallback language id. en -> en_US, es -> es_ES etc**
- **LPD-36494 cover fallback languages scenario in test**
- **LPD-36494 no need to prefix those with liferay-**
- **LPD-36494 add feature flag to the workspace**
- **LPD-36494 simplify README file**
- **LPD-36494 Rename**
- **LPD-36494 Task**
- **LPD-36494 Configure**
- **LPD-36494 Move**
- **LPD-36494 Test**
- **LPD-36494 Sort**
- **LPD-36494 remove lang folder**
- **LPD-36494 This is still too wordy. Make it simpler. Get to the essence. See https://www.artyfactory.com/art_appreciation/animals_in_art/pablo_picasso.htm**
- **LPD-36494 See https://www.spanishdict.com/guide/capitalization-in-spanish**
- **LPD-36494 Make it completely unique.**
- **LPD-36494 Add a few more languages**
- **LPD-36494 Prep next**
- **LPD-36494 prep next**
- **LPD-36494 Regen**
- **LPD-38961 Run ant update-portal-osgi-configuration-properties to fix ConfigurationEnvBuilderTest**
- **LPD-17800 LPD-38825 portal-search-web: Apply arguments to range config description**
- **LPD-17800 LPD-38825 portal-language-lang: Update lang keys**
- **LPD-17800 LPD-38825 portal-language-lang: buildLang**
- **LPD-37563 integration test**
- **LPD-37563 Not needed**
- **LPD-37548 Fix compile**
- **LPD-37548 as used**
- **LPD-38908 Fix PortalReadWriteDatabaseConfiguration#LockUnlockDMFileEntryAndMBTread, refresh until Draft tag is removed**
- **LPD-39077 Add missing parameter in expected URL**
- **LPD-38799 Remove ClayTooltipProvider as there is already a gloval provider**
- **Revert "LPD-37767 SF"**
- **Revert "LPD-37767 Fix unit test to provide usage example"**
- **Revert "LPD-37767 Rename"**
- **Revert "LPD-37767 Add integration test"**
- **Revert "LPD-37767 Add unit test"**
- **Revert "LPD-37767 Fix objects date filter issue caused by microseconds in DB"**
- **LPD-38936 Update to new locator due to changes in Web Content UI (see LPD-35921)**
- **LRCI-4281 add logic to set correct jdk based on branch name**
- **LRCI-4743 Add util-taglib to unit-jdk8 test execution**
- **LRSD-6615 Add translations to callback form**
- **LRSD-6615 Add translations to Callback Form SLA Fragment**
- **LRSD-6723 Flaky test indicator should account for environment runs**
- **LRCI-4706 Prevent dividing by zero**
- **LRCI-4706 Ensure that the targetSlave doesn't get lost**
- **LRCI-4731 Add the test task name to JSONObject used for BuildReports**
- **LRCI-4731 Get the test task name from the JSONObject for TestReport objects**
- **LRCI-4731 Add the testTaskName to the TestHistory objects if available**
- **LRCI-4732 Add test task durations to the ci history reports**
- **LRCI-4732 prep next**
- **LPD-38384 bump org.eclipse.equinox.metatype to 1.4.400**
- **LPD-38384 check in files from org.eclipse.equinox.metatype-1.4.400**
- **LPD-38384 remove 01-LPS-96907.patch since we need to re-create the patch to the file due to the upgrade**
- **LPD-38384 create new patch for MetaTypeInformationImpl, MetaTypeProviderImpl, and MetaTypeServiceImpl**
- **LPD-38384 remove 02-LPS-98375.patch since we need to re-create the patch to the file due to the upgrade**
- **LPD-38384 create new patch for Activator, MetaTypeProviderTracker, and MetaTypeServiceImpl**
- **LPD-38384 remove ValueTokenizer from 04-LPS-119196.patch since we need to re-create the patch to the file due to the upgrade**
- **LPD-38384 create new patch for ValueTokenizer**
- **LPD-38384 remove 05-LPS-179629.patch since we need to re-create the patch to the file due to the upgrade**
- **LPD-38384 create new patch for MetaTypeInformationImpl, MetaTypeProviderImpl, and MetaTypeServiceImpl**
- **LPD-38384 apply usage**
- **LPD-38384 prep next**
- **LPD-37131 Preserve the status passed in the JSON response**
- **LPD-37797 create events.ts**
- **LPD-37797 add 'The analysis result should not appear if any of the attribute conditions are not contained within the result' test**
- **LPD-37797 deleting test covered by playwright test**
- **LPD-37841 Add popover when hovering over the Conflict Icon and match scaled size with Timeline Icon**
- **LPD-37841 Update test**
- **LPD-37841 Wordsmith**
- **LPD-37841 Regen**
- **LPD-39101 Use Snapshot for single cardinality service.**
- **LPD-39101 Semantic versioning**
- **LPD-38849 Change StartupHelperUtil log level to INFO to display the 'There are no patches installed' and 'The following patches are installed' missing traces**
- **LPD-34912 Updated Translations**
- **LPD-34912 Updated Provision flow, added In Progress status**
- **LPD-34912 Fixed table index, and added some enhancements**
- **LPD-34912 SF**
- **LPD-34912 Add Go to Cloud link**
- **LRSD-6722 Remove checked icon from level dashboard**
- **LPD-39083 Add 'date_time' to the set of supported fields**
- **LPD-39083 Add integration test**
- **LPD-39083 Rename**
- **LPD-39083 Only 1 test**
- **LPD-38561 - Refactor. Transform method name to cover actions created outside DSM UI**
- **LPD-38501 - Refactor. Ensure that card visualization mode is loaded to match the locator.**
- **LPD-38558 - Feat. Add custom FDSSample fixture and page**
- **LPD-38558 - Add custom views tests to replace Poshi counterpart**
- **LPD-38558 - Remove FrontendDataSetCustomView Poshi stuff**
- **LPD-38558 - Refactor. Replace evaluate by PW getAttribute and clean up awaits**
- **LPD-38558 - Refactor. Use fixture helper to create the FDS Sample site content**
- **LPD-38847 if there is no friendlyURL inserted on the creation of the web content and the title has trailing slashes on it, remove them**
- **LPD-38847 add test to check that the behavior is consistent when adding and updating**
- **LPD-38847 unify names on all the test class**
- **LPD-38847 SF**
- **LPS-77699 Update Translations**
- **LPD-38820 - Removal of Poshi test CPCommerceProducts#ProductPublishing**
- **LPD-32064 - fix Poshi test CanProductMediaAndRelationShowCorrectDateFormat**
- **LPD-39013 - fix failing test OrganizationLocalServiceTest.testOrganizationObjectValidationRule**
- **LPD-37959 Update AlloyUI to v3.1.0-deprecated.124**
- **LPD-37959 Create a test for ensure that accessibility properties are maintained after changing months**
- **LPD-37959 Use the term mini calendar to refer to the alloy's mini calendar component**
- **LPD-38024 Get userId from the same context that it was created instead from TestPropsValues**
- **LPD-39146 Fix Poshi: add connectSite to the Asset Library**
- **LPD-38566 Create the path for new publishing buttons in web content**
- **LPD-38566 Correct data engine poshi tests present in the acceptance routine**
- **LPD-39136 Fix poshi tests**
- **LPD-34912 Minor tweaks**
- **LPD-32043 - added check for success message in productDetailsPage.ts**
- **LPD-24470 Check for all types of null or undefined**
- **LPD-28319 SF**
- **LPD-38995 Fix locators and use openFieldset**
- **LPD-38995 Remove unneeded expect**
- **LPD-39117 Migrates ViewReactFragmentInPage to playwright tests**
- **LPD-39117 Moves react-fragment-example zip files**
- **LPD-39117 Migrates to unit tests**
- **LPD-39117 Use clickAndExpectToBeVisible**
- **LPD-39117 Not needed**
- **LPD-38914 Fix "Missing upgrade process created record" when running external data source controller tests. It's possible that the TestEntityUpgradeStepRegistrator gets tracked earlier than the Spring extender registers the SchemaCreatorImpl for the service module, and when this happens, the upgrade is skipped because the schema version doesn't exist yet.**
- **LPD-38914 Fix upgrade error by partially reverting LPD-19913 (467029e5). When running SQL from an UpgradeProcess, the parent class logic BaseDBProcess#_getConnection tries to get the OSGi bundle using the UpgradeProcess' class. When using an anonymous implementation directly, the class is from the external-data-source-test-service bundle; when using the factory, the class is from the core, resulting in a wrong data source to be used. The decision whether this should be considered as a framework bug or limitation is pending, will re-apply if it's considered as a bug and fixed from the framework side.**
- **LPD-37341 Avoid dynamic Liferay.Language.get**
- **LPD-37341 Remove unused export**
- **LPD-37341 Rename to match with filename and exported module in ../../index.js**
- **LPD-38550 Restore default value when there is no inputValue**
- **LPD-37652 Move site initializer tests back to Solutions until they are assigned to their new teams**
- **LPD-38937 Use ConfigurationTestUtil to reduce flakiness and ensure the configuration has been updated before trying to retrieve it**
- **LPD-38614 Remove the object validation rule to prevent it from impacting other tests during CI execution**
- **LPD-38866 Change createBasicArticleWithFriendlyURL() to fill with fillAndClickOutside**
- **LPD-39057 Add blank if the value is null**
- **LPD-39057 Add unit test**
- **LPD-39057 Simplify and reuse some code**
- **LPD-38983 Adds necessary files for new iframe-web folder in playwright**
- **LPD-38983 Migrates IFrameWithXSS.testcase to playwright**
- **LPD-38983 Removes already covered tests in previous commit**
- **LPD-38983 Clean no needed component names**
- **LPD-38983 Adds missing IFrame Portlet component name to page-management**
- **LPD-38983 Clean Up no needed functional rule since we don't have poshi tests**
- **LPD-38983 Includes iframe-web in page management playwright projects**
- **LPD-37990 Add PropertiesDuplicateKeysCheck**
- **LPD-37990 Improve performance**
- **LPD-37990 Consistency, but I will redo in LPD-38817**
- **LPD-37990 Add allowed duplicate key**
- **LPD-37990 Generated**
- **LPD-37990 Remove duplicate key**
- **LPD-37990 Apply to all branches**
- **LPD-37990 SF**
- **LPD-39098 Must check if the user has permission to View the DDMFormInstance when editing the form**
- **LPD-39098 No need to check permission to View the form when adding a new record.**
- **LPD-39098 Fix existing tests**
- **LPD-39098 Add integration test**
- **LPD-38754 add the specific message on the journal article creation when we add a friendly url ending with a slash**
- **LPD-38754 add integration test to check that if adding a wc with explicit url with trailing slash and exception must be thrown**
- **LPD-38754 add test to check the message when trying to create a WC article with a friendlyURL with trailing slash**
- **LPD-38754 do no nest**
- **LPD-35069 list all available frontend token definitions**
- **LPD-35069 tests**
- **LPD-35069 baseline**
- **LPD-35069 review #1**
- **LPD-35069 review #2**
- **LPD-35069 SF**
- **LPD-35069 review #3**
- **LPD-35069 Rename**
- **LPD-35069 Rename**
- **LPD-35069 Inline**
- **LPD-35069 Rename**
- **LPD-35069 PR review - refactor test**
- **LPD-35069 PR review #2 - refactor test**
- **LPD-35069 PR review #3 - refactor test**
- **LPD-35069 PR review: remove unique usage method**
- **LPD-35069 pr review: rename**
- **LPD-35069 pr review: rename**
- **-LPD-35069 SF**
- **LPD-35069 Prefix so future items would be grouped together**
- **LPD-35069 Can this be random too?**
- **LPS-77699 Update Translations**
- **LPD-38905 Fix Locale#AddFormWithSpanishAsOnlyLocale - Inline macro LexiconEntry#gotoAdd prepping to switch to xpath condition that works with Spanish locale**
- **LPD-38905 Fix Locale#AddFormWithSpanishAsOnlyLocale - Inline Button#Plus path prepping to switch to xpath condition that works with Spanish locale**
- **LPD-38905 Fix Locale#AddFormWithSpanishAsOnlyLocale - Use xpath condition with label "Nuevo" to locate the button instead**
- **LPD-37614 Removing the web content content population and check, as it causes flaky issues and it is not needed for this upgrade test**
- **LRCI-4653 Fix acceptance unit test failures in jenkins-results-parser**
- **LRCI-4653 SF**
- **LRCI-4653 rename variable**
- **LRCI-4653 prep next**
- **LPD-30790 Be able to define which AuthVerifier are forceable, since they need to be executed at first in the pipeline.**
- **LPD-30790 Sort AuthVerifier based on their forceability.**
- **LPD-30790 AuthVerifier should be applied taking into account their defined order (forceable ones first).**
- **LPD-30790 Define classes as forceable so that they can be executed first in the pipeline.     This is important because:**
- **LPD-30790 Prepare test to be able to work with several AuthVerifiers to check which one is executed first.**
- **LPD-30790 Check that order (defined by forceability) is taken into account in the pipeline.**
- **LPD-30790 SF, sort if/else statements**
- **LPD-30790 Rename**
- **LPD-30790 Inline**
- **LPD-30790 Rename**
- **LPD-30790 Merge**
- **LPD-30790 auto SF**
- **LPD-30790 Make initialization lazy.**
- **LPD-30790 Semantic Versioning**
- **Revert "LPD-30790 Semantic Versioning"**
- **Revert "LPD-30790 Make initialization lazy."**
- **Revert "LPD-30790 auto SF"**
- **Revert "LPD-30790 Merge"**
- **Revert "LPD-30790 Rename"**
- **Revert "LPD-30790 Inline"**
- **Revert "LPD-30790 Rename"**
- **Revert "LPD-30790 SF, sort if/else statements"**
- **Revert "LPD-30790 Check that order (defined by forceability) is taken into account in the pipeline."**
- **Revert "LPD-30790 Prepare test to be able to work with several AuthVerifiers to check which one is executed first."**
- **Revert "LPD-30790 Define classes as forceable so that they can be executed first in the pipeline."**
- **Revert "LPD-30790 AuthVerifier should be applied taking into account their defined order (forceable ones first)."**
- **Revert "LPD-30790 Sort AuthVerifier based on their forceability."**
- **Revert "LPD-30790 Be able to define which AuthVerifier are forceable, since they need to be executed at first in the pipeline."**
- **LPD-30790 What need to be ordered is not those AuthVerifiers, but the AuthVerifierResult.State.**
- **LPD-30790 It turns out the ticket description is completely opposite of what they want. It stated the expected behavior as actual behavior, and actual behavior as expected behavior. Fliping the logic to meet this new "fixed" requirement.**
- **LPD-38817 Use double quotes**
- **LPD-38817 Use double quotes**
- **LPD-38817 Auto SF**
- **LPD-38817 SF**
- **LPD-38817 Use double quotes**
- **LPD-38817 Use double quotes**
- **LPD-38817 Use double quotes**
- **LPD-38817 Use double quotes**
- **LPD-38817 Use double quotes**
- **LPD-38817 Fix test cases**
- **LPD-38817 Auto SF**
- **LPD-38817 SF**
- **LPD-38817 Fix test cases**
- **LPD-38817 Use double quotes**
- **LPD-38817 Use double quotes**
- **LPD-38817 Use double quotes**
- **LPD-38817 prep next**
- **LPD-38817 prep next**
- **LPD-39188 Ensure the Liferay FeatureFlags API exists before executing the condition**
- **LPD-35069 rollback random string**
- **LPD-34902 Class naming for extending BaseExternalReferenceCodeUpgradeProcessTestCase and BaseExternalReferenceCodeUpgradeProcess**
- **LPD-37253 Strip -jdk8 from modules.*-jdk8 test batches**
- **LPD-37253 Strip -jdk8 from unit.*-jdk8 test batches**
- **LPD-37253 Add default modules-unit for test.batch.class.names.includes and excludes**
- **LPD-37253 Remove dash since stripped default test batches (unit and modules-unit) do not have dash after**
- **LPD-37253 SF, ordering**
- **LPD-37253 Strip -jdk8 from playwright.*-jdk8 test batches**
- **LPD-37253 Update playwright SF property check**
- **LPD-37253 prep next**
- **LPD-37253 prep next**
- **LPD-39211 Allow Highest Rated Assets as collection provider**
- **LPD-39211 Migrates view in content display to playwright test**
- **LPD-39211 Already covered as playwright test**
- **LPD-39211 Migrates alert message tests to playwright test**
- **LPD-39211 Replace method since it is not working for all checkbox**
- **LPD-39211 AddCollectionDisplayWithMostViewedAssetsToAnotherCollectionDisplayWithManualCollection already covered as playwright test**
- **LPD-39211 ConfigureGridLayoutOfCollectionDisplay already covered as playwright test**
- **LPD-39211 Merge all files in one**
- **LPD-39211 Simplify**
- **LPD-39211 Migrate EditCollectionItems to playwright**
- **LPD-26931 Clarify acroynym**
- **LPD-26931 Regen**
- **LPD-39103 Removes no needed test**
- **LPD-39103 Migrate ViewMappedImageAfterSortDocumentsInDisplayPageTemplate to playwright**
- **LPD-39103 Adds more fields to animal structure and modified web content**
- **LPD-39103 Adds new friendly url constants for animals**
- **LPD-39103 Migrates MapAuthorInfoToEditableField, MapLastEditorInfoToEditableField and MapMultipleCustomDDMFieldsToTextFragment to playwright test**
- **LPD-39103 Migrates MapWebContentImageToBackgoundImageOfBannerCenter to playwright test**
- **LPD-39103 Extract into a new method**
- **LPD-39103 Migrates MapWebContentFieldWithURLToImageFragment, MapWebContentFieldWithURLToLinkFragment and MapWebContentFieldWithURLToTextFragment to playwright test**
- **LPD-39103 Delete display page templates**
- **LPD-39103 Moves tests to proper file**
- **LPD-39103 Move to PageEditorPage**
- **LPD-39103 Order**
- **LPD-39103 It should be uppercase**
- **LPD-35460 Migrate over jsons from minium**
- **LPD-35460 Import layouts and widgets**
- **LPD-35460 Make pages restricted to site members only**
- **LPS-77699 Update Translations**
- **LPD-39215 Refactor, no logic changes**
- **LPD-39215 Extract into a new method**
- **LPD-39215 Migrates PageCustomizations.testcase to playwright test**
- **LPD-39215 Use impersonate to avoid using another user since this is conflicting with other test in the file**
- **LPD-39215 Removed unused and mark variables as private**
- **LPD-39285 Fix poshi tests**
- **LPD-37556 - Replace poshi test with a check in playwright (mostly duplicate test)**
- **LPD-37557 - delete the FrontendDataSetClientExtension.testcase file and tests already covered**
- **LPD-34747 Expose issue through integration test**
- **LPD-34747 Add test for edit mode**
- **LPD-34747 Don't consider an empty value for "mappedField" as a display page mapping**
- **LPD-38938 Replace for assertElementPresentNoWaitForSPAReFresh**
- **LPD-38758 remove poshi test**
- **LPD-38758 translate shows the duplicate fields - playwright test**
- **LPD-38743 Ignore test**
- **LPD-39084 Fix Poshi test**
- **LPD-35912 Fix poshi test**
- **LPD-35911 Fix Poshi tests**
- **LPD-35069 Auto SF**
- **LPD-38911 portal-workflow-metrics-rest-impl: Rely on source filtering only**
- **LPD-38689 Refactor poshi test in playwright**
- **LPD-38689 Remove poshi test**
- **LPD-38828 Merge feature flag LPS-203351 into LPD-11147**
- **LPD-38828 SF**
- **LPD-35776 Avoid blank page when getAllObject Folders returns undefined in View Object Definition**
- **LPD-35776 Validate possible undefined return from getAllObjectFolders request in getUpdatedModelBuilderStructurePayload function**
- **LPD-35776 Validate possible undefined return from getAllObjectFolders request in handleMove function**
- **LPD-35776 Update frontend unit tests**
- **LPD-35776 Move ObjectFolderCardHeader and ObjectFoldersSidebar frontend unit test files to ViewObjectDefinitions folder**
- **LPD-35776 Create unit tests for ObjectFolderCardHeader component**
- **LPD-35776 Create unit tests for ObjectFolderSidebar component**
- **LPD-39243 Check if site exists first**
- **LPD-39243 Fix and use method**
- **LPD-39266 Already covered as part of FragmentEntryStagedModelDataHandlerTest**
- **LPD-39217 Moves test to proper file since LPS-132428 is covering a bug in Kaleo form**
- **LPD-39225 Fix typo, this test shouldn't expect an exception**
- **LPD-39225 Fix portlet alias typo**
- **LPD-39225 Add an integration test to asset can add more than one widget when is an instanciable one**
- **LPD-39271 Fix poshi test**
- **LPD-39099 Unable to send email notification after form submission**
- **LPD-36010 Extract BatchProcessor for reusing**
- **LPD-36010 Batch process user update last log in**
- **LPD-36010 Regenerate**
- **LPD-36010 Get the DataSource before spring shutdown, but only close the DataSource after Hibernate closure, this is to support spring/hibernate shutdown time DB accessing.**
- **LPD-36010 I don't want anyone actually tweaking this but us**
- **LPD-36010 SF**
- **LPD-36010 SF**
- **LPD-36010 SF**
- **LPD-39148 Improvements on forms tests clean up to avoid errors and flakiness**
- **LPD-39147 Redirect to correct site**
- **LPD-38057 Send the type property to the FieldBase since we can have the date or date_time types**
- **LPD-38057 Remove unnecessary condition inside the normalize function since the value is already normalized inside the DatePicker component**
- **LPD-38057 Create unit test to check if the value is being formatted according to their fieldType**
- **LPD-39302 Update locator due to changes in UI for Web Content articles**
- **commerce-notification-service 4.0.63 prep next**
- **commerce-product-definitions-web 7.0.142 prep next**
- **commerce-product-options-web 4.0.78 prep next**
- **dynamic-data-mapping-form-field-type 6.0.181 prep next**
- **dynamic-data-mapping-service 8.0.7 prep next**
- **journal-content-web 6.0.82 prep next**
- **portal-messaging 8.0.34 prep next**
- **portal-instances-service 5.0.39 prep next**
- **portal-language-lang 1.0.235 prep next**
- **portlet-display-template-web 6.0.20 prep next**
- **template-web 1.0.91 prep next**
- **portal-workflow-metrics-rest-impl 3.0.94 prep next**
- **LRSD-6735 remove filters from UserListView**
- **LRSD-6743 client-extension.dev**
- **LRSD-6744 useURIEncode in TestrayTask**
- **LPD-38239 Modify the navigation method to fix a flaky poshi test**
- **LPD-38963 Include alias type information into finder cache key. This issue is exposed by LPD-32543(1884a98a9ea4594860b1b3bd48431ae47109418c) when merging two test methods, reason is two queries are going to generate exactly same key making the second query hit the cache and retrieve a wrong value.**
- **LPD-38520 Use the curWikiPage userName instead of getting it through the userId**
- **LPD-39110 portal-search-web: Fix searchURL attribute for searchbar**
- **LPD-39110 playwright: Add test for search URL**
- **LPD-37525 poshi: Add step to click on 'learn more' link again to reload window**
- **LPD-37525 poshi: Add step to navigate to initial page after workaround LPD-38568**
- **LPD-38755 Add await for .toContainText() method**
- **LPD-38755 Migrate AppendNewFragmentSetToTheBottomOfCustomizedOrder**
- **LPD-38755 Remove unnecessary test**
- **LPD-38755 Migrate test to check that the changes persist in the panel when the page is refreshed**
- **LPD-38755 Remove style test**
- **LPD-38755 Migrate PropogateCustomizedOrderOfWidgetCategoriesToAddPanel**
- **LPD-38755 Migrate ViewVisualFeedbackWhenDragItems**
- **LPD-38755 Migrate PropogateFavoriteWidgetsToAddPanel**
- **LPD-38755 Create method to create a new user with permissions**
- **LPD-38755 Migrate PropogateCustomizedOrderOfWidgetCategoriesAndFavoriteWidgetsToAddPanelByEachUser**
- **LPD-38755 Use createUserWithPermissions in page management tests**
- **LPD-38755 Add await for .click()**
- **LPD-38755 Add forgotten tags**
- **LPD-38755 Fix flaky functions**
- **LPD-38755 Add goto method**
- **LPD-38755 Create a new widget page to check**
- **LPD-25447 Space is needed between attributes**
- **LPD-25447 Add new test for frontend-taglib-clay-sample-web-test**
- **LPD-25447 Sort**
- **LPD-25447 Rename package and SF**
- **LPD-25447 Rename**
- **LPD-32223 LPD-32234 Commerce Data Sets Fragment Renderer Keys**
- **LPD-32224 LPD-32233 Commerce Order and OrderItems FDS Fragment Renderers**
- **LPD-32223 LPD-32234 Correct prefixing for Data Set Fragment Renderers**
- **LPD-32224 LPD-32233 Expose FE utils**
- **LPD-32225 Commerce Order and Order items FDS filters**
- **LPD-32224 LPD-32233 Commerce Order and Order items views and handlers**
- **LPD-32224 LPD-32233 Data sets bulk actions**
- **LPD-32237 Additional header order actions**
- **LPD-33493 Order pages header - Inline editable order field**
- **LPD-33493 Order pages header - Status label**
- **LPD-33493 Step tracker uses util to retrieve order**
- **LPD-33831 Cart event API for components state update in order pages**
- **LPD-32224 LPD-32233 Safety check on accountEntry for Data Sets**
- **LPD-32234 LPD-32223 Adapting existing components to new order pages**
- **LPD-32234 LPD-32223 Data Set JS handlers improved**
- **LPD-33831 Events constants**
- **LPD-33493 Order pages templates in `commerce-site-initializer`**
- **LPD-32234 Correct usage of configurations and redirects**
- **LPD-32223 LPD-32234 Fixed Commerce Shipment Portlet key prefixing**
- **LPD-32223 LPD-32234 Added functional test**
- **LPD-32224 LPD-32233 Updated language keys**
- **LPD-34676 Autogenerated Code (gw buildLang)**
- **LPD-32223 LPD-32234 as used**
- **LPD-32223 LPD-32234 SF**
- **LPD-32223 LPD-32234 SF**
- **LPD-37757 Move content-performance.spec.ts test to the current folder**
- **LPD-39217 Removes no needed properties**
- **LPD-37038 Fix typo**
- **LPD-37589 quarantine remaining functional tests**
- **LPD-37589 excluding tests from all acceptance suites**
- **LPD-38769 Modify null VARCHAR type into empty string**
- **LPD-38769 Use empty string instead null in test assertions**
- **LPD-38769 Update null assert values in testAddObjectAction to empty string**
- **LPD-39213 Take into account the syntax @liferay_portlet.runtime in the pattern**
- **LPD-39213 SF, add an early return in case there isn't any portlet HTML embedded**
- **LPD-39213 Assert the same use cases using the @liferay_portlet.runtime syntax**
- **LPD-39213 SF fix typo**
- **LPD-39213 SF extract and reuse, no logic changes**
- **LPD-39213 Modify tests to assert the behavior with both freemarker syntax**
- **LPD-39213 Add test info annotation**
- **LPD-39213 SF move to fields**
- **LPD-39213 Brand name is FreeMarker, not Freemarker**
- **LPD-39307 Use the right exception**
- **LPD-32234 Moved Util to correct location**
- **LPD-39283 Adds necessary files for layout-locked-layouts-web playwright module**
- **LPD-39283 Execute it as part of page-management playwright**
- **LPD-39283 Migrates NavigateToLockedPagesInList and SearchLockedPagesInLockedPagesAdmin test to playwright**
- **LPD-39283 Migrates ConfigureTimeWithoutAutosaveUnderInstanceSettings test to playwright**
- **LRCI-4730 Add properties for creating dynamic modules junit test groups**
- **LPD-33140 Fix test**
- **LPD-33140 As used**
- **LPD-39249 Upgrade google-cloud-translate to 2.51.0**
- **LPD-39249 Exclude io.opentelemetry.* based on https://repo1.maven.org/maven2/com/google/cloud/google-cloud-translate/2.51.0/google-cloud-translate-2.51.0.pom**
- **LPD-38973 Fix Locale#ViewDefaultEnabledLocales, localization buttons next to each field were removed from journal-web's edit_article.jsp. Update test to use localization button added with translation manager component in 70e4a55b60e4ed4c87389d85d58efc8d45caa467**
- **LPD-38976 Fix VirtualInstances#ViewDeactivatedPortalInstance, Wiki is deprecated in LPD-37306, remove logic related to Wiki**
- **LPD-39336 Fix exception message**
- **LPD-38922 Fix ServiceBuilder#ExternalDataSourceSmoke by correctly copy the directory**
- **LPD-38922 Assert the existence of the copied file**
- **LPD-39182 Migrate ViewWarningMessageWhenPublishingContentPageWithSaveAsDraftOptionDisabled**
- **LPD-39182 Remove test because it is already being tested**
- **LRCI-4733 Add test task history to batch & test history objects**
- **LRCI-4733 Add average test task duration & task name**
- **LRCI-4733 Split the TestClassBalancedListSplitter into 2 separate classes**
- **LRCI-4733 Fix null pointer**
- **LRCI-4733 Fix mistyped return method**
- **LRCI-4733 Fix the balanced list splitter for JUnit test classes**
- **LRCI-4733 Fix estimated durations displayed in the Job Summaries**
- **LRCI-4733 wrong name**
- **LRCI-4683 Grab S3 attachments instead**
- **LRCI-4733 LRCI-4683 prep next**
- **LRCI-4654 Remove uneeded properties**
- **LRCI-4671 Remove redirect of error stream**
- **LRCI-4671 Always log error stream**
- **LRCI-4671 prep next**
- **LPD-38101 Translate aria-label in page_iterator**
- **LPD-38653 Change roles and add aria-selected**
- **LPD-38659 Add aria-labelledby to dropdown**
- **LPD-38101 LPD-38653 LPD-38659 Playwright tests**
- **LPD-37845 Improve filter**
- **LPD-38650 Refactor cookies-banner-web tests to use a CookiesBannerPage to avoid code repetition and improve tests**
