### PR TITLE
LPD-39324 Investigate flaky OIDC tests failing at prepare-selenium-keycloak-server

### DIFF
--- a/build-test-keycloak.xml
+++ b/build-test-keycloak.xml
@@ -34,6 +34,21 @@
 			<waitfor maxwait="120" maxwaitunit="second">
 				<http url="http://127.0.0.1:18080/" />
 			</waitfor>
+			<exec executable="curl" outputproperty="curl.output">
+				<arg line="-s -o /dev/null -w '%{http_code}' http://127.0.0.1:18080" />
+			</exec>
+
+			<echo>${curl.output}</echo>
+
+			<if>
+				<contains string="${curl.output}" substring="200" />
+				<then>
+					<echo>Keycloak started succesfully</echo>
+				</then>
+				<else>
+					<fail>Keycloak startup failed.</fail>
+				</else>
+			</if>
 		</sequential>
 	</macrodef>
 


### PR DESCRIPTION
[LPD-39324](https://liferay.atlassian.net/browse/LPD-39324)

Add a curl request to assert that keycloak server is up and running