### PR TITLE
LPD-38918 Move Cors tests to App Sec team

### DIFF
--- a/modules/apps/portal-remote/portal-remote-cors-test/test.properties
+++ b/modules/apps/portal-remote/portal-remote-cors-test/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Security


### PR DESCRIPTION
**Ticket:** https://liferay.atlassian.net/browse/LPD-38918

Hi Team,

This PR is to transfer the `portal-remote-cors-test` test module to be under App Sec's component for CI testing. Currently, it is being shown under core-infra. 

From my understanding, these tests are related to App Sec. And, the ticket is currently reporting a test failure for `AnnotationCORSClientTest`.

**Note:** I have left my findings in a comment on the ticket, in case it's helpful
https://liferay.atlassian.net/browse/LPD-38918?focusedCommentId=2768247

Please let me know if you have an questions.
Thanks!

/cc @julschong