### PR TITLE
LPD-39115

### DIFF
--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -513,8 +513,10 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			outboundMessageContext.getSubcontext(
 				SAMLBindingContext.class, true);
 
-		samlBindingContext.setRelayState(
-			_relayStateHelper.getRelayStateTokenFromRedirect(relayState));
+		String relayStateToken =
+			_relayStateHelper.getRelayStateTokenFromRedirect(relayState);
+
+		samlBindingContext.setRelayState(relayStateToken);
 
 		SAMLSelfEntityContext samlSelfEntityContext =
 			messageContext.getSubcontext(SAMLSelfEntityContext.class);
@@ -563,7 +565,7 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			authnRequest.setForceAuthn(false);
 		}
 
-		authnRequest.setID(generateIdentifier(20));
+		authnRequest.setID(relayStateToken);
 
 		outboundMessageContext.setMessage(authnRequest);
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -812,11 +812,11 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 				samlBindingContext.getBindingUri()));
 	}
 
-	protected void verifyInResponseTo(Response samlResponse)
+	protected String verifyInResponseTo(Response samlResponse)
 		throws PortalException {
 
 		if (Validator.isNull(samlResponse.getInResponseTo())) {
-			return;
+			return null;
 		}
 
 		Issuer issuer = samlResponse.getIssuer();
@@ -832,13 +832,14 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 		if (samlSpAuthRequest != null) {
 			_samlSpAuthRequestLocalService.deleteSamlSpAuthRequest(
 				samlSpAuthRequest);
+
+			return samlSpAuthRequest.getRelayState();
 		}
-		else {
-			throw new InResponseToException(
-				StringBundler.concat(
-					"Response in response to ", inResponseTo,
-					" does not match any authentication requests"));
-		}
+
+		throw new InResponseToException(
+			StringBundler.concat(
+				"Response in response to ", inResponseTo,
+				" does not match any authentication requests"));
 	}
 
 	protected void verifyIssuer(MessageContext<?> messageContext, Issuer issuer)
@@ -1305,7 +1306,7 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 
 	private String _getAuthRedirectURL(
 			MessageContext<?> messageContext,
-			HttpServletRequest httpServletRequest)
+			HttpServletRequest httpServletRequest, String relayState)
 		throws Exception {
 
 		StringBundler sb = new StringBundler(3);
@@ -1318,12 +1319,14 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 
 		sb.append("/portal/saml/auth_redirect?redirect=");
 
-		SAMLBindingContext samlBindingContext = messageContext.getSubcontext(
-			SAMLBindingContext.class);
+		if (Validator.isNull(relayState)) {
+			SAMLBindingContext samlBindingContext =
+				messageContext.getSubcontext(SAMLBindingContext.class);
 
-		String relayState = portal.escapeRedirect(
-			_relayStateHelper.getRedirectFromRelayStateToken(
-				samlBindingContext.getRelayState()));
+			relayState = portal.escapeRedirect(
+				_relayStateHelper.getRedirectFromRelayStateToken(
+					samlBindingContext.getRelayState()));
+		}
 
 		if (Validator.isNull(relayState)) {
 			relayState = portal.getHomeURL(httpServletRequest);
@@ -1776,7 +1779,8 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			throw new StatusException(statusCodeURI);
 		}
 
-		verifyInResponseTo(samlResponse);
+		String relayState = verifyInResponseTo(samlResponse);
+
 		verifyDestination(messageContext, samlResponse.getDestination());
 
 		Issuer issuer = samlResponse.getIssuer();
@@ -1871,7 +1875,8 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 			samlSpSession.getSamlSpSessionKey());
 
 		httpServletResponse.sendRedirect(
-			_getAuthRedirectURL(messageContext, httpServletRequest));
+			_getAuthRedirectURL(
+				messageContext, httpServletRequest, relayState));
 	}
 
 	private void _redirectToLogin(

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileImpl.java
@@ -594,7 +594,7 @@ public class WebSsoProfileImpl extends BaseProfile implements WebSsoProfile {
 
 		_samlSpAuthRequestLocalService.addSamlSpAuthRequest(
 			samlPeerEntityContext.getEntityId(), authnRequest.getID(),
-			serviceContext);
+			relayState, serviceContext);
 
 		sendSamlMessage(messageContext, httpServletResponse);
 	}

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/BaseSamlTestCase.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/BaseSamlTestCase.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.saml.constants.SamlProviderConfigurationKeys;
 import com.liferay.saml.opensaml.integration.internal.binding.SamlBindingProvider;
 import com.liferay.saml.opensaml.integration.internal.credential.FileSystemKeyStoreManagerImpl;
@@ -71,6 +72,7 @@ import org.apache.http.client.HttpClient;
 import org.junit.After;
 import org.junit.Before;
 
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
@@ -605,6 +607,19 @@ public abstract class BaseSamlTestCase {
 				return identifier;
 			}
 		);
+
+		_portalUUIDUtilMockedStatic.when(
+			PortalUUIDUtil::generate
+		).thenAnswer(
+			(Answer<String>)invocationOnMock -> {
+				String identifier =
+					samlIdentifierGenerator.generateIdentifier();
+
+				identifiers.add(identifier);
+
+				return identifier;
+			}
+		);
 	}
 
 	private void _setupMetadata() throws Exception {
@@ -764,6 +779,9 @@ public abstract class BaseSamlTestCase {
 			answer -> _samlPeerBindings.get((long)answer.getArguments()[0])
 		);
 	}
+
+	private static final MockedStatic<PortalUUIDUtil>
+		_portalUUIDUtilMockedStatic = Mockito.mockStatic(PortalUUIDUtil.class);
 
 	private final Map<Long, SamlPeerBinding> _samlPeerBindings =
 		new HashMap<>();

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/WebSsoProfileIntegrationTest.java
@@ -622,7 +622,7 @@ public class WebSsoProfileIntegrationTest extends BaseSamlTestCase {
 		AuthnRequest authnRequest =
 			(AuthnRequest)inboundMessageContext.getMessage();
 
-		Assert.assertEquals(identifiers.get(0), authnRequest.getID());
+		Assert.assertEquals("RDR_" + identifiers.get(0), authnRequest.getID());
 
 		Assert.assertEquals(2, identifiers.size());
 		Assert.assertFalse(authnRequest.isForceAuthn());

--- a/modules/dxp/apps/saml/saml-persistence-api/bnd.bnd
+++ b/modules/dxp/apps/saml/saml-persistence-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay SAML Persistence API
 Bundle-SymbolicName: com.liferay.saml.persistence.api
-Bundle-Version: 12.0.1
+Bundle-Version: 13.0.0
 Export-Package:\
 	com.liferay.saml.persistence.exception,\
 	com.liferay.saml.persistence.model,\

--- a/modules/dxp/apps/saml/saml-persistence-api/src/main/java/com/liferay/saml/persistence/model/SamlSpAuthRequestModel.java
+++ b/modules/dxp/apps/saml/saml-persistence-api/src/main/java/com/liferay/saml/persistence/model/SamlSpAuthRequestModel.java
@@ -122,6 +122,21 @@ public interface SamlSpAuthRequestModel
 	 */
 	public void setSamlSpAuthRequestKey(String samlSpAuthRequestKey);
 
+	/**
+	 * Returns the relay state of this saml sp auth request.
+	 *
+	 * @return the relay state of this saml sp auth request
+	 */
+	@AutoEscape
+	public String getRelayState();
+
+	/**
+	 * Sets the relay state of this saml sp auth request.
+	 *
+	 * @param relayState the relay state of this saml sp auth request
+	 */
+	public void setRelayState(String relayState);
+
 	@Override
 	public SamlSpAuthRequest cloneWithOriginalValues();
 

--- a/modules/dxp/apps/saml/saml-persistence-api/src/main/java/com/liferay/saml/persistence/model/SamlSpAuthRequestTable.java
+++ b/modules/dxp/apps/saml/saml-persistence-api/src/main/java/com/liferay/saml/persistence/model/SamlSpAuthRequestTable.java
@@ -8,6 +8,7 @@ package com.liferay.saml.persistence.model;
 import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.base.BaseTable;
 
+import java.sql.Clob;
 import java.sql.Types;
 
 import java.util.Date;
@@ -40,6 +41,8 @@ public class SamlSpAuthRequestTable extends BaseTable<SamlSpAuthRequestTable> {
 		createColumn(
 			"samlSpAuthRequestKey", String.class, Types.VARCHAR,
 			Column.FLAG_DEFAULT);
+	public final Column<SamlSpAuthRequestTable, Clob> relayState = createColumn(
+		"relayState", Clob.class, Types.CLOB, Column.FLAG_DEFAULT);
 
 	private SamlSpAuthRequestTable() {
 		super("SamlSpAuthRequest", SamlSpAuthRequestTable::new);

--- a/modules/dxp/apps/saml/saml-persistence-api/src/main/java/com/liferay/saml/persistence/model/SamlSpAuthRequestWrapper.java
+++ b/modules/dxp/apps/saml/saml-persistence-api/src/main/java/com/liferay/saml/persistence/model/SamlSpAuthRequestWrapper.java
@@ -38,6 +38,7 @@ public class SamlSpAuthRequestWrapper
 		attributes.put("createDate", getCreateDate());
 		attributes.put("samlIdpEntityId", getSamlIdpEntityId());
 		attributes.put("samlSpAuthRequestKey", getSamlSpAuthRequestKey());
+		attributes.put("relayState", getRelayState());
 
 		return attributes;
 	}
@@ -75,6 +76,12 @@ public class SamlSpAuthRequestWrapper
 		if (samlSpAuthRequestKey != null) {
 			setSamlSpAuthRequestKey(samlSpAuthRequestKey);
 		}
+
+		String relayState = (String)attributes.get("relayState");
+
+		if (relayState != null) {
+			setRelayState(relayState);
+		}
 	}
 
 	@Override
@@ -110,6 +117,16 @@ public class SamlSpAuthRequestWrapper
 	@Override
 	public long getPrimaryKey() {
 		return model.getPrimaryKey();
+	}
+
+	/**
+	 * Returns the relay state of this saml sp auth request.
+	 *
+	 * @return the relay state of this saml sp auth request
+	 */
+	@Override
+	public String getRelayState() {
+		return model.getRelayState();
 	}
 
 	/**
@@ -175,6 +192,16 @@ public class SamlSpAuthRequestWrapper
 	@Override
 	public void setPrimaryKey(long primaryKey) {
 		model.setPrimaryKey(primaryKey);
+	}
+
+	/**
+	 * Sets the relay state of this saml sp auth request.
+	 *
+	 * @param relayState the relay state of this saml sp auth request
+	 */
+	@Override
+	public void setRelayState(String relayState) {
+		model.setRelayState(relayState);
 	}
 
 	/**

--- a/modules/dxp/apps/saml/saml-persistence-api/src/main/java/com/liferay/saml/persistence/service/SamlSpAuthRequestLocalService.java
+++ b/modules/dxp/apps/saml/saml-persistence-api/src/main/java/com/liferay/saml/persistence/service/SamlSpAuthRequestLocalService.java
@@ -69,7 +69,7 @@ public interface SamlSpAuthRequestLocalService
 		SamlSpAuthRequest samlSpAuthRequest);
 
 	public SamlSpAuthRequest addSamlSpAuthRequest(
-		String samlIdpEntityId, String samlSpAuthRequestKey,
+		String samlIdpEntityId, String samlSpAuthRequestKey, String relayState,
 		ServiceContext serviceContext);
 
 	/**

--- a/modules/dxp/apps/saml/saml-persistence-api/src/main/java/com/liferay/saml/persistence/service/SamlSpAuthRequestLocalServiceUtil.java
+++ b/modules/dxp/apps/saml/saml-persistence-api/src/main/java/com/liferay/saml/persistence/service/SamlSpAuthRequestLocalServiceUtil.java
@@ -54,11 +54,11 @@ public class SamlSpAuthRequestLocalServiceUtil {
 	}
 
 	public static SamlSpAuthRequest addSamlSpAuthRequest(
-		String samlIdpEntityId, String samlSpAuthRequestKey,
+		String samlIdpEntityId, String samlSpAuthRequestKey, String relayState,
 		com.liferay.portal.kernel.service.ServiceContext serviceContext) {
 
 		return getService().addSamlSpAuthRequest(
-			samlIdpEntityId, samlSpAuthRequestKey, serviceContext);
+			samlIdpEntityId, samlSpAuthRequestKey, relayState, serviceContext);
 	}
 
 	/**

--- a/modules/dxp/apps/saml/saml-persistence-api/src/main/java/com/liferay/saml/persistence/service/SamlSpAuthRequestLocalServiceWrapper.java
+++ b/modules/dxp/apps/saml/saml-persistence-api/src/main/java/com/liferay/saml/persistence/service/SamlSpAuthRequestLocalServiceWrapper.java
@@ -53,10 +53,11 @@ public class SamlSpAuthRequestLocalServiceWrapper
 	public com.liferay.saml.persistence.model.SamlSpAuthRequest
 		addSamlSpAuthRequest(
 			String samlIdpEntityId, String samlSpAuthRequestKey,
+			String relayState,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext) {
 
 		return _samlSpAuthRequestLocalService.addSamlSpAuthRequest(
-			samlIdpEntityId, samlSpAuthRequestKey, serviceContext);
+			samlIdpEntityId, samlSpAuthRequestKey, relayState, serviceContext);
 	}
 
 	/**

--- a/modules/dxp/apps/saml/saml-persistence-api/src/main/resources/com/liferay/saml/persistence/model/packageinfo
+++ b/modules/dxp/apps/saml/saml-persistence-api/src/main/resources/com/liferay/saml/persistence/model/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 4.2.0

--- a/modules/dxp/apps/saml/saml-persistence-api/src/main/resources/com/liferay/saml/persistence/service/packageinfo
+++ b/modules/dxp/apps/saml/saml-persistence-api/src/main/resources/com/liferay/saml/persistence/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 7.0.0

--- a/modules/dxp/apps/saml/saml-persistence-service/bnd.bnd
+++ b/modules/dxp/apps/saml/saml-persistence-service/bnd.bnd
@@ -28,6 +28,6 @@ Import-Package:\
 	\
 	*
 Liferay-Releng-Module-Group-Title: SAML
-Liferay-Require-SchemaVersion: 3.0.4
+Liferay-Require-SchemaVersion: 3.1.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/dxp/apps/saml/saml-persistence-service/service.xml
+++ b/modules/dxp/apps/saml/saml-persistence-service/service.xml
@@ -151,6 +151,7 @@
 
 		<column name="samlIdpEntityId" type="String" />
 		<column name="samlSpAuthRequestKey" type="String" />
+		<column name="relayState" type="String" />
 
 		<!-- Finder methods -->
 

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/registry/SamlServiceUpgradeStepRegistrator.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/registry/SamlServiceUpgradeStepRegistrator.java
@@ -152,6 +152,11 @@ public class SamlServiceUpgradeStepRegistrator
 			UpgradeProcessFactory.alterColumnType(
 				"SamlPeerBinding", "samlNameIdNameQualifier",
 				"VARCHAR(1024) null"));
+
+		registry.register(
+			"3.0.4", "3.1.0",
+			UpgradeProcessFactory.addColumns(
+				"SamlSpAuthRequest", "relayState TEXT null"));
 	}
 
 	@Reference

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/model/impl/SamlSpAuthRequestCacheModel.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/model/impl/SamlSpAuthRequestCacheModel.java
@@ -55,7 +55,7 @@ public class SamlSpAuthRequestCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(11);
+		StringBundler sb = new StringBundler(13);
 
 		sb.append("{samlSpAuthnRequestId=");
 		sb.append(samlSpAuthnRequestId);
@@ -67,6 +67,8 @@ public class SamlSpAuthRequestCacheModel
 		sb.append(samlIdpEntityId);
 		sb.append(", samlSpAuthRequestKey=");
 		sb.append(samlSpAuthRequestKey);
+		sb.append(", relayState=");
+		sb.append(relayState);
 		sb.append("}");
 
 		return sb.toString();
@@ -101,19 +103,29 @@ public class SamlSpAuthRequestCacheModel
 			samlSpAuthRequestImpl.setSamlSpAuthRequestKey(samlSpAuthRequestKey);
 		}
 
+		if (relayState == null) {
+			samlSpAuthRequestImpl.setRelayState("");
+		}
+		else {
+			samlSpAuthRequestImpl.setRelayState(relayState);
+		}
+
 		samlSpAuthRequestImpl.resetOriginalValues();
 
 		return samlSpAuthRequestImpl;
 	}
 
 	@Override
-	public void readExternal(ObjectInput objectInput) throws IOException {
+	public void readExternal(ObjectInput objectInput)
+		throws ClassNotFoundException, IOException {
+
 		samlSpAuthnRequestId = objectInput.readLong();
 
 		companyId = objectInput.readLong();
 		createDate = objectInput.readLong();
 		samlIdpEntityId = objectInput.readUTF();
 		samlSpAuthRequestKey = objectInput.readUTF();
+		relayState = (String)objectInput.readObject();
 	}
 
 	@Override
@@ -136,6 +148,13 @@ public class SamlSpAuthRequestCacheModel
 		else {
 			objectOutput.writeUTF(samlSpAuthRequestKey);
 		}
+
+		if (relayState == null) {
+			objectOutput.writeObject("");
+		}
+		else {
+			objectOutput.writeObject(relayState);
+		}
 	}
 
 	public long samlSpAuthnRequestId;
@@ -143,5 +162,6 @@ public class SamlSpAuthRequestCacheModel
 	public long createDate;
 	public String samlIdpEntityId;
 	public String samlSpAuthRequestKey;
+	public String relayState;
 
 }

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/model/impl/SamlSpAuthRequestModelImpl.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/model/impl/SamlSpAuthRequestModelImpl.java
@@ -58,7 +58,7 @@ public class SamlSpAuthRequestModelImpl
 	public static final Object[][] TABLE_COLUMNS = {
 		{"samlSpAuthnRequestId", Types.BIGINT}, {"companyId", Types.BIGINT},
 		{"createDate", Types.TIMESTAMP}, {"samlIdpEntityId", Types.VARCHAR},
-		{"samlSpAuthRequestKey", Types.VARCHAR}
+		{"samlSpAuthRequestKey", Types.VARCHAR}, {"relayState", Types.CLOB}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -70,10 +70,11 @@ public class SamlSpAuthRequestModelImpl
 		TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
 		TABLE_COLUMNS_MAP.put("samlIdpEntityId", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("samlSpAuthRequestKey", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("relayState", Types.CLOB);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table SamlSpAuthRequest (samlSpAuthnRequestId LONG not null primary key,companyId LONG,createDate DATE null,samlIdpEntityId VARCHAR(1024) null,samlSpAuthRequestKey VARCHAR(75) null)";
+		"create table SamlSpAuthRequest (samlSpAuthnRequestId LONG not null primary key,companyId LONG,createDate DATE null,samlIdpEntityId VARCHAR(1024) null,samlSpAuthRequestKey VARCHAR(75) null,relayState TEXT null)";
 
 	public static final String TABLE_SQL_DROP = "drop table SamlSpAuthRequest";
 
@@ -236,6 +237,8 @@ public class SamlSpAuthRequestModelImpl
 			attributeGetterFunctions.put(
 				"samlSpAuthRequestKey",
 				SamlSpAuthRequest::getSamlSpAuthRequestKey);
+			attributeGetterFunctions.put(
+				"relayState", SamlSpAuthRequest::getRelayState);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -274,6 +277,10 @@ public class SamlSpAuthRequestModelImpl
 				"samlSpAuthRequestKey",
 				(BiConsumer<SamlSpAuthRequest, String>)
 					SamlSpAuthRequest::setSamlSpAuthRequestKey);
+			attributeSetterBiConsumers.put(
+				"relayState",
+				(BiConsumer<SamlSpAuthRequest, String>)
+					SamlSpAuthRequest::setRelayState);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -388,6 +395,25 @@ public class SamlSpAuthRequestModelImpl
 		return getColumnOriginalValue("samlSpAuthRequestKey");
 	}
 
+	@Override
+	public String getRelayState() {
+		if (_relayState == null) {
+			return "";
+		}
+		else {
+			return _relayState;
+		}
+	}
+
+	@Override
+	public void setRelayState(String relayState) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_relayState = relayState;
+	}
+
 	public long getColumnBitmask() {
 		if (_columnBitmask > 0) {
 			return _columnBitmask;
@@ -452,6 +478,7 @@ public class SamlSpAuthRequestModelImpl
 		samlSpAuthRequestImpl.setSamlIdpEntityId(getSamlIdpEntityId());
 		samlSpAuthRequestImpl.setSamlSpAuthRequestKey(
 			getSamlSpAuthRequestKey());
+		samlSpAuthRequestImpl.setRelayState(getRelayState());
 
 		samlSpAuthRequestImpl.resetOriginalValues();
 
@@ -473,6 +500,8 @@ public class SamlSpAuthRequestModelImpl
 			this.<String>getColumnOriginalValue("samlIdpEntityId"));
 		samlSpAuthRequestImpl.setSamlSpAuthRequestKey(
 			this.<String>getColumnOriginalValue("samlSpAuthRequestKey"));
+		samlSpAuthRequestImpl.setRelayState(
+			this.<String>getColumnOriginalValue("relayState"));
 
 		return samlSpAuthRequestImpl;
 	}
@@ -583,6 +612,14 @@ public class SamlSpAuthRequestModelImpl
 			samlSpAuthRequestCacheModel.samlSpAuthRequestKey = null;
 		}
 
+		samlSpAuthRequestCacheModel.relayState = getRelayState();
+
+		String relayState = samlSpAuthRequestCacheModel.relayState;
+
+		if ((relayState != null) && (relayState.length() == 0)) {
+			samlSpAuthRequestCacheModel.relayState = null;
+		}
+
 		return samlSpAuthRequestCacheModel;
 	}
 
@@ -650,6 +687,7 @@ public class SamlSpAuthRequestModelImpl
 	private Date _createDate;
 	private String _samlIdpEntityId;
 	private String _samlSpAuthRequestKey;
+	private String _relayState;
 
 	public <T> T getColumnValue(String columnName) {
 		Function<SamlSpAuthRequest, Object> function =
@@ -686,6 +724,7 @@ public class SamlSpAuthRequestModelImpl
 		_columnOriginalValues.put("samlIdpEntityId", _samlIdpEntityId);
 		_columnOriginalValues.put(
 			"samlSpAuthRequestKey", _samlSpAuthRequestKey);
+		_columnOriginalValues.put("relayState", _relayState);
 	}
 
 	private transient Map<String, Object> _columnOriginalValues;
@@ -708,6 +747,8 @@ public class SamlSpAuthRequestModelImpl
 		columnBitmasks.put("samlIdpEntityId", 8L);
 
 		columnBitmasks.put("samlSpAuthRequestKey", 16L);
+
+		columnBitmasks.put("relayState", 32L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/service/impl/SamlSpAuthRequestLocalServiceImpl.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/service/impl/SamlSpAuthRequestLocalServiceImpl.java
@@ -32,7 +32,7 @@ public class SamlSpAuthRequestLocalServiceImpl
 
 	@Override
 	public SamlSpAuthRequest addSamlSpAuthRequest(
-		String samlIdpEntityId, String samlSpAuthRequestKey,
+		String samlIdpEntityId, String samlSpAuthRequestKey, String relayState,
 		ServiceContext serviceContext) {
 
 		long samlSpAuthRequestId = counterLocalService.increment(
@@ -45,6 +45,7 @@ public class SamlSpAuthRequestLocalServiceImpl
 		samlSpAuthRequest.setCreateDate(new Date());
 		samlSpAuthRequest.setSamlIdpEntityId(samlIdpEntityId);
 		samlSpAuthRequest.setSamlSpAuthRequestKey(samlSpAuthRequestKey);
+		samlSpAuthRequest.setRelayState(relayState);
 
 		return samlSpAuthRequestPersistence.update(samlSpAuthRequest);
 	}

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/module-hbm.xml
@@ -80,6 +80,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="createDate" type="org.hibernate.type.TimestampType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="samlIdpEntityId" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="samlSpAuthRequestKey" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="relayState" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />
 	</class>
 	<class name="com.liferay.saml.persistence.model.impl.SamlSpIdpConnectionImpl" table="SamlSpIdpConnection">
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="samlSpIdpConnectionId" type="long">

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -86,6 +86,9 @@
 			<hint-collection name="ENTITY-ID" />
 		</field>
 		<field name="samlSpAuthRequestKey" type="String" />
+		<field name="relayState" type="String">
+			<hint-collection name="CLOB" />
+		</field>
 	</model>
 	<model name="com.liferay.saml.persistence.model.SamlSpIdpConnection">
 		<field name="samlSpIdpConnectionId" type="long" />

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/tables.sql
@@ -61,7 +61,8 @@ create table SamlSpAuthRequest (
 	companyId LONG,
 	createDate DATE null,
 	samlIdpEntityId VARCHAR(1024) null,
-	samlSpAuthRequestKey VARCHAR(75) null
+	samlSpAuthRequestKey VARCHAR(75) null,
+	relayState TEXT null
 );
 
 create table SamlSpIdpConnection (

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpAuthRequestPersistenceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/persistence/test/SamlSpAuthRequestPersistenceTest.java
@@ -125,6 +125,8 @@ public class SamlSpAuthRequestPersistenceTest {
 		newSamlSpAuthRequest.setSamlSpAuthRequestKey(
 			RandomTestUtil.randomString());
 
+		newSamlSpAuthRequest.setRelayState(RandomTestUtil.randomString());
+
 		_samlSpAuthRequests.add(_persistence.update(newSamlSpAuthRequest));
 
 		SamlSpAuthRequest existingSamlSpAuthRequest =
@@ -145,6 +147,9 @@ public class SamlSpAuthRequestPersistenceTest {
 		Assert.assertEquals(
 			existingSamlSpAuthRequest.getSamlSpAuthRequestKey(),
 			newSamlSpAuthRequest.getSamlSpAuthRequestKey());
+		Assert.assertEquals(
+			existingSamlSpAuthRequest.getRelayState(),
+			newSamlSpAuthRequest.getRelayState());
 	}
 
 	@Test
@@ -492,6 +497,8 @@ public class SamlSpAuthRequestPersistenceTest {
 
 		samlSpAuthRequest.setSamlSpAuthRequestKey(
 			RandomTestUtil.randomString());
+
+		samlSpAuthRequest.setRelayState(RandomTestUtil.randomString());
 
 		_samlSpAuthRequests.add(_persistence.update(samlSpAuthRequest));
 

--- a/modules/test/playwright/helpers/ServerAdministrationHelper.ts
+++ b/modules/test/playwright/helpers/ServerAdministrationHelper.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export enum EActions {
+	CLEAN_UP_ORPHANED_PAGE_REVISION_PORTLET_PREFERENCES = 'Clean up orphaned page revision portlet preferences. Execute',
+	CLEAN_UP_ORPHANED_THEME_PORTLET_PREFERENCES = 'Clean up orphaned theme portlet preferences. Execute',
+	CLEAN_UP_PERMISSIONS = 'Clean up permissions. Execute',
+	CLEAR_CLUSTER_CACHE = 'Clear content cached across the cluster. Execute',
+	CLEAR_DATABASE_CACHE = 'Clear the database cache. Execute',
+	CLEAR_DIRECT_SERVLET_CACHE = 'Clear the direct servlet cache. Execute',
+	CLEAR_VM_CACHE = 'Clear content cached by this VM. Execute',
+	GARBAGE_COLLECTION = 'Run the garbage collector to free up memory. Execute',
+	GENERATE_THREAD_DUMP = 'Generate thread dump. Execute',
+	REGENERATE_PREVIEW_AND_THUMBNAIL_OF_PDF_FILES = 'Regenerate preview and thumbnail of PDF files in documents and media. Execute',
+	RESET_PREVIEW_AND_THUMBNAIL_FILES = 'Reset preview and thumbnail files for documents and media. Execute',
+	VERIFY_MEMBERSHIP_POLICIES = 'Verify membership policies. Execute',
+}

--- a/modules/test/playwright/pages/server-admin-web/ServerAdministrationPage.ts
+++ b/modules/test/playwright/pages/server-admin-web/ServerAdministrationPage.ts
@@ -5,6 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
+import {EActions} from '../../helpers/ServerAdministrationHelper';
 import {UIElementsPage} from '../uielements/UIElementsPage';
 
 export class ServerAdministrationPage {
@@ -22,6 +23,15 @@ export class ServerAdministrationPage {
 		this.executeButton = page.getByRole('button', {name: 'Execute'});
 		this.scriptBox = page.getByLabel('Script', {exact: true});
 		this.scriptLink = page.getByRole('link', {name: 'Script'});
+	}
+
+	async executeAction(action: EActions) {
+		await this.page
+			.getByText(action)
+			.getByRole('button', {name: 'Execute'})
+			.click();
+		await this.uiElementsPage.anySuccessAlert.waitFor({state: 'visible'});
+		await this.uiElementsPage.anySuccessAlert.waitFor({state: 'hidden'});
 	}
 
 	async executeScript(script: string) {

--- a/modules/test/playwright/tests/saml-web/env/osgi/configs/com.liferay.captcha.configuration.CaptchaConfiguration.config
+++ b/modules/test/playwright/tests/saml-web/env/osgi/configs/com.liferay.captcha.configuration.CaptchaConfiguration.config
@@ -1,0 +1,1 @@
+maxChallenges="-1"

--- a/modules/test/playwright/tests/saml-web/env/portal-ext.properties
+++ b/modules/test/playwright/tests/saml-web/env/portal-ext.properties
@@ -1,0 +1,1 @@
+captcha.enforce.disabled=true

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -1292,13 +1292,13 @@ test('Verify SSO login and logout mechanism works the same when having multiple 
 
 	liferayConfig.environment.baseUrl = defaultBaseUrl;
 
-	await apiHelpers.headlessSite.createSite({
+	const site1 = await apiHelpers.headlessSite.createSite({
 		name: site1Name,
 		templateKey: 'com.liferay.site.initializer.welcome',
 		templateType: 'site-initializer',
 	});
 
-	await apiHelpers.headlessSite.createSite({
+	const site2 = await apiHelpers.headlessSite.createSite({
 		name: site2Name,
 		templateKey: 'com.liferay.site.initializer.welcome',
 		templateType: 'site-initializer',
@@ -1310,7 +1310,11 @@ test('Verify SSO login and logout mechanism works the same when having multiple 
 
 	let siteSettingsPage = new SiteSettingsPage(secondarySpAdminPage);
 
-	await siteSettingsPage.goToSiteSetting('Site Configuration', 'Site URL');
+	await siteSettingsPage.goToSiteSetting(
+		'Site Configuration',
+		'Site URL',
+		site1.friendlyUrlPath
+	);
 
 	const site1VirtualHostName = 'www.easy.com';
 
@@ -1328,7 +1332,11 @@ test('Verify SSO login and logout mechanism works the same when having multiple 
 
 	siteSettingsPage = new SiteSettingsPage(secondarySpAdminPage);
 
-	await siteSettingsPage.goToSiteSetting('Site Configuration', 'Site URL');
+	await siteSettingsPage.goToSiteSetting(
+		'Site Configuration',
+		'Site URL',
+		site2.friendlyUrlPath
+	);
 
 	const site2VirtualHostName = 'www.fox.com';
 
@@ -1596,7 +1604,11 @@ test('Verify the SAML configuration is not applied to the sites when ACS is disa
 
 	const siteSettingsPage = new SiteSettingsPage(spAdminPage);
 
-	await siteSettingsPage.goToSiteSetting('Site Configuration', 'Site URL');
+	await siteSettingsPage.goToSiteSetting(
+		'Site Configuration',
+		'Site URL',
+		site.friendlyUrlPath
+	);
 
 	const siteVirtualHostName = 'www.easy.com';
 

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -5,8 +5,10 @@
 
 import {expect, mergeTests} from '@playwright/test';
 
+import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {searchAdminPageTest} from '../../fixtures/searchAdminPageTest';
+import {serverAdministrationPageTest} from '../../fixtures/serverAdministrationPageTest';
 import {usersAndOrganizationsPagesTest} from '../../fixtures/usersAndOrganizationsPagesTest';
 import {virtualInstancesPagesTest} from '../../fixtures/virtualInstancesPagesTest';
 import {ApiHelpers} from '../../helpers/ApiHelpers';
@@ -17,7 +19,9 @@ import {
 	TIdpConnection,
 	TSpConnection,
 } from '../../helpers/SamlProviderConnectionHelper';
+import {EActions} from '../../helpers/ServerAdministrationHelper';
 import {liferayConfig} from '../../liferay.config';
+import {PagesAdminPage} from '../../pages/layout-admin-web/PagesAdminPage';
 import {
 	AttributeMapping,
 	IdentityProviderConnectionsPage,
@@ -74,9 +78,11 @@ import {
 } from './utils/samlVirtualInstanceUtil';
 
 export const test = mergeTests(
+	applicationsMenuPageTest,
 	loginTest(),
 	searchAdminPageTest,
 	usersAndOrganizationsPagesTest,
+	serverAdministrationPageTest,
 	virtualInstancesPagesTest
 );
 
@@ -1038,6 +1044,94 @@ test('Verify Custom Fields can be used for user matching in SAML, see LPS-128600
 	await expect(await editUserPage.customField(customFieldName)).toHaveValue(
 		'newValue'
 	);
+});
+
+test('Verify during SP initiated SSO, RelayState is correct and present regardless of VM cache', async ({
+	applicationsMenuPage,
+	browser,
+	serverAdministrationPage,
+}) => {
+	const idpAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_IDP_NAME,
+		'Identity Provider'
+	);
+
+	const spAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_SP_NAME,
+		'Service Provider'
+	);
+
+	await connectSpAndIdp(
+		idpAdminPage,
+		DEFAULT_IDP_NAME,
+		spAdminPage,
+		DEFAULT_SP_NAME
+	);
+
+	// Create a user on the IdP instance
+
+	const userAccount = await createUser(idpAdminPage, DEFAULT_IDP_NAME);
+
+	// Create a new page on the SP Instance
+
+	const pagesAdminPage = new PagesAdminPage(spAdminPage);
+
+	await pagesAdminPage.goto();
+
+	const pageTitle = getRandomString();
+
+	await pagesAdminPage.createNewPage({
+		name: pageTitle,
+	});
+
+	const spNewPageUrl = DEFAULT_SP_URL + '/web/guest/' + pageTitle;
+
+	// Perform Sp initiated SSO with the new user from the new page
+
+	const spInstancePage = await performSpInitiatedSSO(
+		browser,
+		userAccount.emailAddress,
+		spNewPageUrl
+	);
+
+	// Assert user is redirected back to new page after SSO
+
+	expect(await spInstancePage.url()).toEqual(spNewPageUrl);
+
+	await performLogout(spInstancePage);
+
+	await spInstancePage.waitForTimeout(8000);
+
+	// Perform Sp to IdP SSO redirection only, no authentication yet
+
+	await spInstancePage.goto(spNewPageUrl);
+
+	await clickSignInButton(spInstancePage);
+
+	// Reset VM cache to clear relayState cache
+
+	await applicationsMenuPage.goToServerAdministration();
+
+	await serverAdministrationPage.executeAction(EActions.CLEAR_VM_CACHE);
+
+	// Authenticate on IdP to finish SSO
+
+	await spInstancePage
+		.getByLabel('Email Address')
+		.fill(userAccount.emailAddress);
+	await spInstancePage.getByLabel('Password').fill('test');
+	await spInstancePage.getByLabel('Remember Me').check();
+	await spInstancePage.getByRole('button', {name: 'Sign In'}).click();
+
+	await spInstancePage
+		.getByTitle('User Profile Menu')
+		.waitFor({timeout: 30 * 1000});
+
+	// Assert we are redirected to correct URL, even without relayState cache
+
+	expect(await spInstancePage.url()).toEqual(spNewPageUrl);
 });
 
 test('Verify IdP initiated SLO also logs out of authenticated SP when Require Authn Request Signature and Sign Metadata are enabled.  See LPS-128578.', async ({


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-39115
https://liferay.atlassian.net/browse/LPD-39986

This PR also contains the test fix for LPD-39986, since the SAML test suite will partially fail without it.

The solution I came up with for the relayState token caching problem was to add a new "relayState" column onto the SamlSpAuthRequest table.  Since this problem only occurs with SP initiated SSO, this approach made the most sense to me.

Please let me know if you have any questions, thanks!