### PR TITLE
LPD-36145 Do not add leading period to cookie domains

### DIFF
--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
@@ -337,7 +337,7 @@ public class CookiesManagerImpl implements CookiesManager {
 		}
 
 		if (internetDomainName.isTopPrivateDomain()) {
-			return StringPool.PERIOD + internetDomainName.toString();
+			return internetDomainName.toString();
 		}
 
 		int x = host.indexOf(CharPool.PERIOD);
@@ -349,10 +349,10 @@ public class CookiesManagerImpl implements CookiesManager {
 		int y = host.indexOf(CharPool.PERIOD, x + 1);
 
 		if (y <= 0) {
-			return StringPool.PERIOD + host;
+			return host;
 		}
 
-		return host.substring(x);
+		return host.substring(x + 1);
 	}
 
 	@Override

--- a/modules/apps/cookies/cookies-test/src/test/java/com/liferay/cookies/internal/manager/CookiesDomainTest.java
+++ b/modules/apps/cookies/cookies-test/src/test/java/com/liferay/cookies/internal/manager/CookiesDomainTest.java
@@ -58,25 +58,25 @@ public class CookiesDomainTest {
 	@Test
 	public void testDomain1() throws Exception {
 		Assert.assertEquals(
-			".cdn.liferay.com",
+			"cdn.liferay.com",
 			CookiesManagerUtil.getDomain("www.cdn.liferay.com"));
 		Assert.assertEquals(
-			".cdn.liferay.qld.gov.au",
+			"cdn.liferay.qld.gov.au",
 			CookiesManagerUtil.getDomain("www.cdn.liferay.qld.gov.au"));
 		Assert.assertEquals(
-			".liferay.com", CookiesManagerUtil.getDomain("liferay.com"));
+			"liferay.com", CookiesManagerUtil.getDomain("liferay.com"));
 		Assert.assertEquals(
-			".liferay.com", CookiesManagerUtil.getDomain("www.liferay.com"));
+			"liferay.com", CookiesManagerUtil.getDomain("www.liferay.com"));
 		Assert.assertEquals(
-			".liferay.qld.gov.au",
+			"liferay.qld.gov.au",
 			CookiesManagerUtil.getDomain("liferay.qld.gov.au"));
 		Assert.assertEquals(
-			".liferay.qld.gov.au",
+			"liferay.qld.gov.au",
 			CookiesManagerUtil.getDomain("www.liferay.qld.gov.au"));
 		Assert.assertEquals(
-			".liferay.test", CookiesManagerUtil.getDomain("liferay.test"));
+			"liferay.test", CookiesManagerUtil.getDomain("liferay.test"));
 		Assert.assertEquals(
-			".liferay.test", CookiesManagerUtil.getDomain("www.liferay.test"));
+			"liferay.test", CookiesManagerUtil.getDomain("www.liferay.test"));
 		Assert.assertEquals(
 			"127.0.0.1", CookiesManagerUtil.getDomain("127.0.0.1"));
 		Assert.assertNull(CookiesManagerUtil.getDomain("com"));
@@ -92,7 +92,7 @@ public class CookiesDomainTest {
 		mockHttpServletRequest.setServerName("www.liferay.com");
 
 		Assert.assertEquals(
-			".liferay.com",
+			"liferay.com",
 			CookiesManagerUtil.getDomain(mockHttpServletRequest));
 	}
 
@@ -131,7 +131,7 @@ public class CookiesDomainTest {
 
 		try {
 			Assert.assertEquals(
-				".liferay.com",
+				"liferay.com",
 				CookiesManagerUtil.getDomain(mockHttpServletRequest));
 		}
 		finally {


### PR DESCRIPTION
Related issue: [LPD-36145](https://liferay.atlassian.net/browse/LPD-36145)

When calling [CookiesManagerImpl.getDomain](https://github.com/liferay/liferay-portal/blob/master/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java#L319) the domain is prepended by a period. This was previously the correct convention in order to allow access to subdomains but now is no longer necessary. Now if a domain is specified, then subdomains are always included.

see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#domaindomain-value