### PR TITLE
LPD-38816 | Show the warning messages about the invalid ticket even when the user is logged in

### DIFF
--- a/modules/apps/portal-security/portal-security-auto-login-test/src/testIntegration/java/com/liferay/portal/security/auto/login/test/UpdatePasswordActionTest.java
+++ b/modules/apps/portal-security/portal-security-auto-login-test/src/testIntegration/java/com/liferay/portal/security/auto/login/test/UpdatePasswordActionTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.security.auto.login.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.action.UpdatePasswordAction;
 import com.liferay.portal.kernel.model.Company;
@@ -26,13 +27,21 @@ import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.kernel.servlet.ServletContextPool;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.struts.Action;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
 
 import java.util.Date;
 
@@ -81,6 +90,34 @@ public class UpdatePasswordActionTest {
 			company.getCompanyId(), user.getEmailAddress());
 
 		Assert.assertNotNull(user.getLastLoginDate());
+
+		// Update password link returns alert message when the ticket is
+		// no longer valid and user is logged out
+
+		_testAlertMessage(user);
+
+		// Update password link returns alert message when the ticket is
+		// no longer valid and user is logged out
+
+		_loginUser(user);
+
+		_testAlertMessage(user);
+	}
+
+	private void _loginUser(User user) throws Exception {
+		UserTestUtil.setUser(user);
+
+		URL url = new URL(
+			"http://localhost:8080/c/portal/login?p_l_id=" +
+				TestPropsValues.getPlid(user.getGroupId()) +
+					"&windowState=exclusive");
+
+		HttpURLConnection httpURLConnection =
+			(HttpURLConnection)url.openConnection();
+
+		httpURLConnection.setRequestMethod("GET");
+
+		Assert.assertEquals(200, httpURLConnection.getResponseCode());
 	}
 
 	private MockHttpServletRequest _mockHttpServletRequest(
@@ -128,6 +165,9 @@ public class UpdatePasswordActionTest {
 			TicketConstants.TYPE_PASSWORD, null, expirationDate,
 			new ServiceContext());
 
+		_ticketId = String.valueOf(ticket.getTicketId());
+		_ticketKey = ticket.getKey();
+
 		mockHttpServletRequest.setParameter(
 			"ticketId", String.valueOf(ticket.getTicketId()));
 		mockHttpServletRequest.setParameter("ticketKey", ticket.getKey());
@@ -148,6 +188,46 @@ public class UpdatePasswordActionTest {
 
 		return mockHttpServletRequest;
 	}
+
+	private void _testAlertMessage(User user) throws Exception {
+		URL url = new URL(
+			StringBundler.concat(
+				"http://localhost:8080/c/portal/update_password?languageId=",
+				user.getLanguageId(), "&ticketId=", _ticketId, "&ticketKey=",
+				_ticketKey));
+
+		HttpURLConnection connection = (HttpURLConnection)url.openConnection();
+
+		connection.setRequestMethod("GET");
+
+		BufferedReader reader = new BufferedReader(
+			new InputStreamReader(connection.getInputStream()));
+
+		boolean findText = false;
+		String searchText = "Your password reset link is no longer valid";
+
+		StringBuilder response = new StringBuilder();
+		String line;
+
+		while (((line = reader.readLine()) != null) && !findText) {
+			findText = line.contains(searchText);
+
+			if (findText) {
+				response.append(StringUtil.trim(line));
+			}
+		}
+
+		reader.close();
+
+		Assert.assertTrue(
+			response.toString(
+			).contains(
+				searchText
+			));
+	}
+
+	private String _ticketId;
+	private String _ticketKey;
 
 	@Inject
 	private TicketLocalService _ticketLocalService;

--- a/portal-impl/src/com/liferay/portal/struts/PortalRequestProcessor.java
+++ b/portal-impl/src/com/liferay/portal/struts/PortalRequestProcessor.java
@@ -635,7 +635,7 @@ public class PortalRequestProcessor {
 					return _PATH_PORTAL_UPDATE_PASSWORD;
 				}
 				else if (path.equals(_PATH_PORTAL_UPDATE_PASSWORD)) {
-					return _PATH_PORTAL_LAYOUT;
+					return _PATH_PORTAL_UPDATE_PASSWORD;
 				}
 
 				// Authenticated users must have an email address

--- a/portal-web/docroot/html/portal/update_password.jsp
+++ b/portal-web/docroot/html/portal/update_password.jsp
@@ -48,7 +48,7 @@ if (Validator.isNull(titlePage)) {
 
 	<div class="sheet-text">
 		<c:choose>
-			<c:when test="<%= !themeDisplay.isSignedIn() && (ticket == null) %>">
+			<c:when test="<%= ticket == null %>">
 				<div class="alert alert-warning">
 					<c:choose>
 						<c:when test="<%= (ticket == null) && (ticketKey != null) && Validator.isNull(ticketId) %>">


### PR DESCRIPTION
Hi Team,
LPD: https://liferay.atlassian.net/browse/LPD-38816

Issue:
While logged in, you're redirected to the company default home URL when you go to the password reset URL (which is in the email to newly created users)

Solution:
The product team’s decision is to display the same alert message that is shown while logged out.

Please review it, thank you!