### PR TITLE
LPD-36309

### DIFF
--- a/modules/apps/login/login-web-test/src/testIntegration/java/com/liferay/login/web/internal/portlet/action/test/ForgotPasswordMVCActionCommandTest.java
+++ b/modules/apps/login/login-web-test/src/testIntegration/java/com/liferay/login/web/internal/portlet/action/test/ForgotPasswordMVCActionCommandTest.java
@@ -61,69 +61,50 @@ public class ForgotPasswordMVCActionCommandTest {
 		new LiferayIntegrationTestRule();
 
 	@Test
-	public void testLDAPPasswordPolicyPreventsPasswordReset() throws Exception {
-		_user = UserTestUtil.addUser();
+	public void testLDAPPasswordPolicyPreventsLdapUserPasswordReset()
+		throws Exception {
 
-		Dictionary<String, Object> configurations =
-			_ldapAuthConfigurationProvider.getConfigurationProperties(
-				_user.getCompanyId());
+		_createUser(true, false);
 
-		Object existingValue = configurations.put(
-			"passwordPolicyEnabled", true);
+		List<Ticket> tickets = _performForgotPasswordAction(true);
 
-		_ldapAuthConfigurationProvider.updateProperties(
-			_user.getCompanyId(), configurations);
+		Assert.assertTrue(
+			"New ticket created for LDAP user during password reset while " +
+				"LDAP password policy is enabled",
+			tickets.isEmpty());
+	}
 
-		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
-				new ConfigurationTemporarySwapper(
-					"com.liferay.captcha.configuration.CaptchaConfiguration",
-					HashMapDictionaryBuilder.<String, Object>put(
-						"sendPasswordCaptchaEnabled", false
-					).build());
-			SafeCloseable safeCloseable =
-				PrefsPropsTestUtil.swapWithSafeCloseable(
-					_user.getCompanyId(),
-					PropsKeys.USERS_REMINDER_QUERIES_ENABLED,
-					Boolean.FALSE.toString())) {
+	@Test
+	public void testLDAPUserWithoutLDAPPasswordPolicyCanResetPassword()
+		throws Exception {
 
-			List<Ticket> tickets = _ticketLocalService.getTickets(
-				_user.getCompanyId(), User.class.getName(), _user.getUserId());
+		_createUser(true, false);
 
-			MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
-				_getMockLiferayPortletActionRequest();
+		List<Ticket> tickets = _performForgotPasswordAction(false);
 
-			_mvcActionCommand.processAction(
-				mockLiferayPortletActionRequest,
-				new MockLiferayPortletActionResponse());
+		Assert.assertTrue(
+			"No ticket created for LDAP user during password reset while " +
+				"LDAP password policy is not enabled",
+			tickets.size() == 1);
+	}
 
-			Object message = SessionMessages.get(
-				_portal.getHttpServletRequest(mockLiferayPortletActionRequest),
-				"forgotPasswordSent");
+	@Test
+	public void testPortalUserWithLDAPPasswordPolicyCanResetPassword()
+		throws Exception {
 
-			Assert.assertNotNull(message);
+		_createUser(false, false);
 
-			Assert.assertEquals(
-				tickets,
-				_ticketLocalService.getTickets(
-					_user.getCompanyId(), User.class.getName(),
-					_user.getUserId()));
-		}
-		finally {
-			if (existingValue != null) {
-				configurations.put("passwordPolicyEnabled", existingValue);
-			}
-			else {
-				configurations.remove("passwordPolicyEnabled");
-			}
+		List<Ticket> tickets = _performForgotPasswordAction(true);
 
-			_ldapAuthConfigurationProvider.updateProperties(
-				_user.getCompanyId(), configurations);
-		}
+		Assert.assertTrue(
+			"No ticket created for portal user during password reset while " +
+				"LDAP password policy is enabled",
+			tickets.size() == 1);
 	}
 
 	@Test
 	public void testSendPasswordReminderToLockedOutUser() throws Exception {
-		_createUser();
+		_createUser(false, true);
 
 		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
 				new ConfigurationTemporarySwapper(
@@ -151,10 +132,16 @@ public class ForgotPasswordMVCActionCommandTest {
 		}
 	}
 
-	private void _createUser() throws Exception {
+	private void _createUser(boolean ldapUser, boolean lockout)
+		throws Exception {
+
 		_user = UserTestUtil.addUser();
 
-		_user.setLockout(true);
+		if (ldapUser) {
+			_user.setLdapServerId(1);
+		}
+
+		_user.setLockout(lockout);
 		_user.setLockoutDate(new Date());
 
 		_user = _userLocalService.updateUser(_user);
@@ -170,7 +157,7 @@ public class ForgotPasswordMVCActionCommandTest {
 			serviceContext);
 
 		_testPasswordPolicy.setChangeable(true);
-		_testPasswordPolicy.setLockout(true);
+		_testPasswordPolicy.setLockout(lockout);
 		_testPasswordPolicy.setLockoutDuration(0);
 		_testPasswordPolicy.setResetTicketMaxAge(10);
 
@@ -205,6 +192,61 @@ public class ForgotPasswordMVCActionCommandTest {
 			WebKeys.THEME_DISPLAY, themeDisplay);
 
 		return mockLiferayPortletActionRequest;
+	}
+
+	private List<Ticket> _performForgotPasswordAction(
+			boolean passwordPolicyEnabled)
+		throws Exception {
+
+		Dictionary<String, Object> configurations =
+			_ldapAuthConfigurationProvider.getConfigurationProperties(
+				_user.getCompanyId());
+
+		Object existingValue = configurations.put(
+			"passwordPolicyEnabled", passwordPolicyEnabled);
+
+		_ldapAuthConfigurationProvider.updateProperties(
+			_user.getCompanyId(), configurations);
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					"com.liferay.captcha.configuration.CaptchaConfiguration",
+					HashMapDictionaryBuilder.<String, Object>put(
+						"sendPasswordCaptchaEnabled", false
+					).build());
+			SafeCloseable safeCloseable =
+				PrefsPropsTestUtil.swapWithSafeCloseable(
+					_user.getCompanyId(),
+					PropsKeys.USERS_REMINDER_QUERIES_ENABLED,
+					Boolean.FALSE.toString())) {
+
+			MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+				_getMockLiferayPortletActionRequest();
+
+			_mvcActionCommand.processAction(
+				mockLiferayPortletActionRequest,
+				new MockLiferayPortletActionResponse());
+
+			Object message = SessionMessages.get(
+				_portal.getHttpServletRequest(mockLiferayPortletActionRequest),
+				"forgotPasswordSent");
+
+			Assert.assertNotNull(message);
+
+			return _ticketLocalService.getTickets(
+				_user.getCompanyId(), User.class.getName(), _user.getUserId());
+		}
+		finally {
+			if (existingValue != null) {
+				configurations.put("passwordPolicyEnabled", existingValue);
+			}
+			else {
+				configurations.remove("passwordPolicyEnabled");
+			}
+
+			_ldapAuthConfigurationProvider.updateProperties(
+				_user.getCompanyId(), configurations);
+		}
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/password-policies-admin/password-policies-admin-test/build.gradle
+++ b/modules/apps/password-policies-admin/password-policies-admin-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationImplementation project(":apps:export-import:export-import-test-util")
 	testIntegrationImplementation project(":apps:password-policies-admin:password-policies-admin-api")
+	testIntegrationImplementation project(":apps:portal-security:portal-security-ldap-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/password-policies-admin/password-policies-admin-test/src/testIntegration/java/com/liferay/password/policies/admin/internal/exportimport/data/handler/test/PasswordPolicyLocalServiceTest.java
+++ b/modules/apps/password-policies-admin/password-policies-admin-test/src/testIntegration/java/com/liferay/password/policies/admin/internal/exportimport/data/handler/test/PasswordPolicyLocalServiceTest.java
@@ -1,0 +1,171 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.password.policies.admin.internal.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.PasswordPolicyLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.security.ldap.authenticator.configuration.LDAPAuthConfiguration;
+import com.liferay.portal.security.ldap.configuration.ConfigurationProvider;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.Dictionary;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Christopher Kian
+ */
+@DataGuard(scope = DataGuard.Scope.METHOD)
+@RunWith(Arquillian.class)
+public class PasswordPolicyLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testPasswordPolicyGettersWithLDAPUser() throws Exception {
+		boolean ldapPasswordPolicyEnabled = _updateLDAPPasswordPolicyEnabled(
+			false);
+
+		User user = UserTestUtil.addUser();
+
+		user.setLdapServerId(1);
+
+		user = _userLocalService.updateUser(user);
+
+		try {
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.getDefaultPasswordPolicy(
+					TestPropsValues.getCompanyId()));
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.getPasswordPolicy(
+					TestPropsValues.getCompanyId(), true));
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.getPasswordPolicy(
+					TestPropsValues.getCompanyId(), new long[0]));
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.getPasswordPolicyByUser(user));
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.getPasswordPolicyByUserId(
+					user.getUserId()));
+		}
+		finally {
+			_updateLDAPPasswordPolicyEnabled(ldapPasswordPolicyEnabled);
+		}
+	}
+
+	@Test
+	public void testPasswordPolicyGettersWithLDAPUserAndLDAPPasswordPolicy()
+		throws Exception {
+
+		boolean ldapPasswordPolicyEnabled = _updateLDAPPasswordPolicyEnabled(
+			true);
+
+		User user = UserTestUtil.addUser();
+
+		user.setLdapServerId(1);
+
+		user = _userLocalService.updateUser(user);
+
+		try {
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.getDefaultPasswordPolicy(
+					TestPropsValues.getCompanyId()));
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.getPasswordPolicy(
+					TestPropsValues.getCompanyId(), true));
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.getPasswordPolicy(
+					TestPropsValues.getCompanyId(), new long[0]));
+			Assert.assertNull(
+				_passwordPolicyLocalService.getPasswordPolicyByUser(user));
+			Assert.assertNull(
+				_passwordPolicyLocalService.getPasswordPolicyByUserId(
+					user.getUserId()));
+		}
+		finally {
+			_updateLDAPPasswordPolicyEnabled(ldapPasswordPolicyEnabled);
+		}
+	}
+
+	@Test
+	public void testPasswordPolicyGettersWithPortalUserAndLDAPPasswordPolicy()
+		throws Exception {
+
+		boolean ldapPasswordPolicyEnabled = _updateLDAPPasswordPolicyEnabled(
+			true);
+
+		User user = UserTestUtil.addUser();
+
+		try {
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.getDefaultPasswordPolicy(
+					TestPropsValues.getCompanyId()));
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.getPasswordPolicy(
+					TestPropsValues.getCompanyId(), true));
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.getPasswordPolicy(
+					TestPropsValues.getCompanyId(), new long[0]));
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.getPasswordPolicyByUser(user));
+			Assert.assertNotNull(
+				_passwordPolicyLocalService.getPasswordPolicyByUserId(
+					user.getUserId()));
+		}
+		finally {
+			_updateLDAPPasswordPolicyEnabled(ldapPasswordPolicyEnabled);
+		}
+	}
+
+	private boolean _updateLDAPPasswordPolicyEnabled(
+			boolean passwordPolicyEnabled)
+		throws PortalException {
+
+		Dictionary<String, Object> configurations =
+			_ldapAuthConfigurationProvider.getConfigurationProperties(
+				TestPropsValues.getCompanyId());
+
+		boolean existingValue = GetterUtil.getBoolean(
+			configurations.put("passwordPolicyEnabled", passwordPolicyEnabled));
+
+		_ldapAuthConfigurationProvider.updateProperties(
+			TestPropsValues.getCompanyId(), configurations);
+
+		return existingValue;
+	}
+
+	@Inject(
+		filter = "factoryPid=com.liferay.portal.security.ldap.authenticator.configuration.LDAPAuthConfiguration"
+	)
+	private ConfigurationProvider<LDAPAuthConfiguration>
+		_ldapAuthConfigurationProvider;
+
+	@Inject
+	private PasswordPolicyLocalService _passwordPolicyLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/java/com/liferay/password/policies/admin/web/internal/display/context/EditPasswordPolicyAssignmentsManagementToolbarDisplayContext.java
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/java/com/liferay/password/policies/admin/web/internal/display/context/EditPasswordPolicyAssignmentsManagementToolbarDisplayContext.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.model.PasswordPolicy;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.security.ldap.LDAPSettingsUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.kernel.service.PasswordPolicyLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
@@ -307,14 +308,18 @@ public class EditPasswordPolicyAssignmentsManagementToolbarDisplayContext {
 		UserSearchTerms searchTerms =
 			(UserSearchTerms)userSearch.getSearchTerms();
 
-		userSearch.setResultsAndTotal(
-			() -> UserLocalServiceUtil.search(
-				themeDisplay.getCompanyId(), searchTerms.getKeywords(),
-				searchTerms.getStatus(), userParams, userSearch.getStart(),
-				userSearch.getEnd(), userSearch.getOrderByComparator()),
-			UserLocalServiceUtil.searchCount(
-				themeDisplay.getCompanyId(), searchTerms.getKeywords(),
-				searchTerms.getStatus(), userParams));
+		List<User> users = UserLocalServiceUtil.search(
+			themeDisplay.getCompanyId(), searchTerms.getKeywords(),
+			searchTerms.getStatus(), userParams, userSearch.getStart(),
+			userSearch.getEnd(), userSearch.getOrderByComparator());
+
+		if (LDAPSettingsUtil.isPasswordPolicyEnabled(
+				themeDisplay.getCompanyId())) {
+
+			users.removeIf(user -> user.getLdapServerId() > 0);
+		}
+
+		userSearch.setResultsAndTotal(users);
 
 		userSearch.setRowChecker(rowChecker);
 

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -41,7 +41,6 @@ page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
 page import="com.liferay.portal.kernel.portlet.PortalPreferences" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder" %><%@
-page import="com.liferay.portal.kernel.security.ldap.LDAPSettingsUtil" %><%@
 page import="com.liferay.portal.kernel.security.permission.ActionKeys" %><%@
 page import="com.liferay.portal.kernel.service.PasswordPolicyLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.PasswordPolicyRelLocalServiceUtil" %><%@

--- a/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -19,8 +19,6 @@ else {
 	request.setAttribute(WebKeys.SINGLE_PAGE_APPLICATION_CLEAR_CACHE, Boolean.TRUE);
 }
 
-boolean passwordPolicyEnabled = LDAPSettingsUtil.isPasswordPolicyEnabled(company.getCompanyId());
-
 String description = LanguageUtil.get(request, "javax.portlet.description.com_liferay_password_policies_admin_web_portlet_PasswordPoliciesAdminPortlet") + " " + LanguageUtil.get(request, "when-no-password-policy-is-assigned-to-a-user,-either-explicitly-or-through-an-organization,-the-default-password-policy-is-used");
 
 portletDisplay.setDescription(description);
@@ -64,13 +62,7 @@ PortletURL portletURL = viewPasswordPoliciesManagementToolbarDisplayContext.getP
 		/>
 	</div>
 
-	<c:if test="<%= passwordPolicyEnabled %>">
-		<div class="alert alert-info">
-			<liferay-ui:message key="you-are-using-ldaps-password-policy" />
-		</div>
-	</c:if>
-
-	<c:if test="<%= !passwordPolicyEnabled && windowState.equals(WindowState.MAXIMIZED) %>">
+	<c:if test="<%= windowState.equals(WindowState.MAXIMIZED) %>">
 		<liferay-ui:search-container
 			id="passwordPolicies"
 			searchContainer="<%= searchContainer %>"

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -22218,7 +22218,6 @@ you-are-now-following-this-user=You are now following this user.
 you-are-signed-in-as-x=You are signed in as {0}.
 you-are-subscribed-to-this-page=You are subscribed to this page.
 you-are-subscribed-to-this-wiki=You are subscribed to this wiki.
-you-are-using-ldaps-password-policy=You are using LDAP's password policy. Please change your LDAP password policy settings if you wish to use a local password policy.
 you-are-viewing-an-archived-version-of-this-page=You are viewing an archived version of this page.
 you-are-x=You are {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=You authenticated with this identity provider too long ago. To continue you must reauthenticate.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=أنت الآن تتابع هذا المستخد
 you-are-signed-in-as-x=لقد تم دخولك بإسم {0}.
 you-are-subscribed-to-this-page=أنت مشترك بهذه الصفحة.
 you-are-subscribed-to-this-wiki=أنت مشترك بهذه الويكي.
-you-are-using-ldaps-password-policy=أنت تستخدم نهج كلمة مرور LDAP. يرجى تغيير إعدادات سايسة كلمة مرور LDAP إذا كنت تريد استخدام سياسة كلمة مرور محلية.
 you-are-viewing-an-archived-version-of-this-page=أنت تعرض نسخة أرشيف من هذه الصفحة.
 you-are-x=أنت {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=تمت المصادقة عليك مع موفر الهوية هذا منذ فترة طويلة للغاية. للاستمرار يجب عليك إعادة المصادقة.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Сега следвате този потреб�
 you-are-signed-in-as-x=Влезли сте като {0}.
 you-are-subscribed-to-this-page=Абонирани сте за тази страница.
 you-are-subscribed-to-this-wiki=Абонирани сте за това wiki.
-you-are-using-ldaps-password-policy=Използвате политика за пароли на LDAP. Моля, променете настройките на вашата политика за пароли на LDAP ако искате да използвате локална политика за пароли.
 you-are-viewing-an-archived-version-of-this-page=Преглеждате активирана версия на тази страница.
 you-are-x=Вие сте {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Вие сте се удостоверили с този доставчик на самоличност твърде отдавна. За да продължите, трябва да се преотстъпите. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -22214,7 +22214,6 @@ you-are-now-following-this-user=Ara estàs seguint a aquest usuari.
 you-are-signed-in-as-x=Us heu validat com a {0}.
 you-are-subscribed-to-this-page=Esteu subscrits a aquesta pàgina.
 you-are-subscribed-to-this-wiki=Esteu subscrit a aquest wiki.
-you-are-using-ldaps-password-policy=Esteu utilitzant la política de contrasenyes del LDAP. Canvieu-ne la configuració si voleu utilitzar una política de contrasenyes local.
 you-are-viewing-an-archived-version-of-this-page=Esteu veient una versió arxivada d'aquesta pàgina.
 you-are-x=Sou {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Fa massa temps que us heu autenticat amb aquest proveïdor d'identitat. Per continuar, us heu de tornar a autenticar.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Od teď sledujete tohoto uživatele.
 you-are-signed-in-as-x=Nyní jste přihlášen(a) jako {0}.
 you-are-subscribed-to-this-page=Tuto stránku sledujete.
 you-are-subscribed-to-this-wiki=Tuto wiki sledujete.
-you-are-using-ldaps-password-policy=Používáte politiku hesel LDAP. Prosím, změňte Vaše nastavení politiky LDAP hesel pokud chcete používat místní politiku hesel.
 you-are-viewing-an-archived-version-of-this-page=Zobrazuje se verze stránky z archívu.
 you-are-x=Jste {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Ověřil jste si to u tohoto zprostředkovatele identity příliš dávno. Chcete-li pokračovat, je nutné znovu ověřit. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Du følger nu denne bruger. (Automatic Translati
 you-are-signed-in-as-x=Du er logget ind som {0}.
 you-are-subscribed-to-this-page=Du abonnerer på denne side.
 you-are-subscribed-to-this-wiki=Du abonnerer på denne wiki.
-you-are-using-ldaps-password-policy=Du bruger LDAP's adgangskodepolitik. Rediger indstillingerne for LDAP-adgangskodepolitikken, hvis du vil bruge en lokal adgangskodepolitik. (Automatic Translation)
 you-are-viewing-an-archived-version-of-this-page=You are viewing an archived version of this page. (Automatic Copy)
 you-are-x=Du er {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Du har godkendt denne identitetsudbyder for længe siden. For at fortsætte skal du godkende igen. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -22214,7 +22214,6 @@ you-are-now-following-this-user=Sie folgen nun diesem Benutzer.
 you-are-signed-in-as-x=Sie sind angemeldet als {0}.
 you-are-subscribed-to-this-page=Sie haben diese Seite abonniert.
 you-are-subscribed-to-this-wiki=Sie haben dieses Wiki abonniert.
-you-are-using-ldaps-password-policy=Sie verwenden die LDAP-Kennwortrichtlinie. Ändern Sie bitte Ihre LDAP-Kennworteinstellungen, wenn Sie eine lokale Kennwortrichtlinie verwenden möchten.
 you-are-viewing-an-archived-version-of-this-page=Sie sehen eine archivierte Version dieser Seite an.
 you-are-x=Sie sind {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Sie haben sich vor zu langer Zeit bei diesem Identitätsanbieter authentisiert. Um fortzufahren, müssen Sie sich erneut authentisieren.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Τώρα ακολουθείτε αυτόν το 
 you-are-signed-in-as-x=Έχετε εισέλθει στο σύστημα ως {0}.
 you-are-subscribed-to-this-page=Έχετε εγγραφεί σε αυτήν την σελίδα.
 you-are-subscribed-to-this-wiki=Έχετε εγγραφεί σε αυτό το wiki.
-you-are-using-ldaps-password-policy=Χρησιμοποιείτε την πολιτική κωδικών πρόσβασης του LDAP. Παρακαλώ αλλάξτε τις ρυθμίσεις της πολιτικής κωδικών πρόσβασης σας στις ρυθμίσεις του LDAP εάν επιθυμείτε να χρησιμοποιήσετε μια τοπική πολιτική κωδικών πρόσβασης.
 you-are-viewing-an-archived-version-of-this-page=Βλέπετε μια αρχειοθετημένη έκδοση αυτής της σελίδας.
 you-are-x=Είστε ο/η {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Έγινε έλεγχος ταυτότητας με αυτήν την υπηρεσία παροχής ταυτότητας εδώ και πολύ καιρό. Για να συνεχίσετε, πρέπει να κάνετε εκ νέου έλεγχο ταυτότητας. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -22218,7 +22218,6 @@ you-are-now-following-this-user=You are now following this user.
 you-are-signed-in-as-x=You are signed in as {0}.
 you-are-subscribed-to-this-page=You are subscribed to this page.
 you-are-subscribed-to-this-wiki=You are subscribed to this wiki.
-you-are-using-ldaps-password-policy=You are using LDAP's password policy. Please change your LDAP password policy settings if you wish to use a local password policy.
 you-are-viewing-an-archived-version-of-this-page=You are viewing an archived version of this page.
 you-are-x=You are {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=You authenticated with this identity provider too long ago. To continue you must reauthenticate.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=You are now following this user. (Automatic Copy
 you-are-signed-in-as-x=You are signed in as {0}. (Automatic Copy)
 you-are-subscribed-to-this-page=You are subscribed to this page. (Automatic Copy)
 you-are-subscribed-to-this-wiki=You are subscribed to this wiki. (Automatic Copy)
-you-are-using-ldaps-password-policy=You are using LDAP's password policy. Please change your LDAP password policy settings if you wish to use a local password policy. (Automatic Copy)
 you-are-viewing-an-archived-version-of-this-page=You are viewing an archived version of this page. (Automatic Copy)
 you-are-x=You are {0}. (Automatic Copy)
 you-authenticated-with-this-identity-provide-too-long-ago=You authenticated with this identity provider too long ago. To continue you must reauthenticate. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=You are now following this user. (Automatic Copy
 you-are-signed-in-as-x=You are signed in as {0}. (Automatic Copy)
 you-are-subscribed-to-this-page=You are subscribed to this page. (Automatic Copy)
 you-are-subscribed-to-this-wiki=You are subscribed to this wiki. (Automatic Copy)
-you-are-using-ldaps-password-policy=You are using LDAP's password policy. Please change your LDAP password policy settings if you wish to use a local password policy. (Automatic Copy)
 you-are-viewing-an-archived-version-of-this-page=You are viewing an archived version of this page. (Automatic Copy)
 you-are-x=You are {0}. (Automatic Copy)
 you-authenticated-with-this-identity-provide-too-long-ago=You authenticated with this identity provider too long ago. To continue you must reauthenticate. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=You are now following this user. (Automatic Copy
 you-are-signed-in-as-x=You are signed in as {0}. (Automatic Copy)
 you-are-subscribed-to-this-page=You are subscribed to this page. (Automatic Copy)
 you-are-subscribed-to-this-wiki=You are subscribed to this wiki. (Automatic Copy)
-you-are-using-ldaps-password-policy=You are using LDAP's password policy. Please change your LDAP password policy settings if you wish to use a local password policy. (Automatic Copy)
 you-are-viewing-an-archived-version-of-this-page=You are viewing an archived version of this page. (Automatic Copy)
 you-are-x=You are {0}. (Automatic Copy)
 you-authenticated-with-this-identity-provide-too-long-ago=You authenticated with this identity provider too long ago. To continue you must reauthenticate. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -22214,7 +22214,6 @@ you-are-now-following-this-user=Ahora estás siguiendo a este usuario.
 you-are-signed-in-as-x=Está conectado como {0}.
 you-are-subscribed-to-this-page=Ya está suscrito a esta página.
 you-are-subscribed-to-this-wiki=Ya está suscrito a esta wiki.
-you-are-using-ldaps-password-policy=Actualmente se está utilizando la política de contraseñas de LDAP. Cambie la configuracion de la política de contraseñas si desea utilizar una política local de contraseñas.
 you-are-viewing-an-archived-version-of-this-page=Esta es una una versión archivada de esta página.
 you-are-x=Usted es {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=La autenticación con este proveedor de identidades ha expirado. Para continuar, deberá volver a autenticarse.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -22214,7 +22214,6 @@ you-are-now-following-this-user=Ahora estás siguiendo a este usuario.
 you-are-signed-in-as-x=Está conectado como {0}.
 you-are-subscribed-to-this-page=Ya está suscrito a esta página.
 you-are-subscribed-to-this-wiki=Ya está suscrito a esta wiki.
-you-are-using-ldaps-password-policy=Actualmente se está utilizando la política de contraseñas de LDAP. Cambie la configuracion de la política de contraseñas si desea utilizar una política local de contraseñas.
 you-are-viewing-an-archived-version-of-this-page=Esta es una una versión archivada de esta página.
 you-are-x=Usted es {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=La autenticación con este proveedor de identidades ha expirado. Para continuar, deberá volver a autenticarse.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -22214,7 +22214,6 @@ you-are-now-following-this-user=Ahora estás siguiendo a este usuario.
 you-are-signed-in-as-x=Está conectado como {0}.
 you-are-subscribed-to-this-page=Ya está suscrito a esta página.
 you-are-subscribed-to-this-wiki=Ya está suscrito a esta wiki.
-you-are-using-ldaps-password-policy=Actualmente se está utilizando la política de contraseñas de LDAP. Cambie la configuracion de la política de contraseñas si desea utilizar una política local de contraseñas.
 you-are-viewing-an-archived-version-of-this-page=Esta es una una versión archivada de esta página.
 you-are-x=Usted es {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=La autenticación con este proveedor de identidades ha expirado. Para continuar, deberá volver a autenticarse.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -22214,7 +22214,6 @@ you-are-now-following-this-user=Ahora estás siguiendo a este usuario.
 you-are-signed-in-as-x=Está conectado como {0}.
 you-are-subscribed-to-this-page=Ya está suscrito a esta página.
 you-are-subscribed-to-this-wiki=Ya está suscrito a esta wiki.
-you-are-using-ldaps-password-policy=Actualmente se está utilizando la política de contraseñas de LDAP. Cambie la configuracion de la política de contraseñas si desea utilizar una política local de contraseñas.
 you-are-viewing-an-archived-version-of-this-page=Esta es una una versión archivada de esta página.
 you-are-x=Usted es {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=La autenticación con este proveedor de identidades ha expirado. Para continuar, deberá volver a autenticarse.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Te jälgite nüüd seda kasutajat. (Automatic Tr
 you-are-signed-in-as-x=Oled sisse logitud kui {0}.
 you-are-subscribed-to-this-page=Sa oled selle lehega liitunud.
 you-are-subscribed-to-this-wiki=Sa oled selle wikiga liitunud.
-you-are-using-ldaps-password-policy=Sa kasutad LDAP'i salasõna reeglit. Kui soovid kasutada kohalikku salasõna reeglit, muuda oma LDAP salasõna reeglite seadeid.
 you-are-viewing-an-archived-version-of-this-page=Sa vaatad selle lehe arhiveeritud versiooni.
 you-are-x=Sa oled {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Autenditud selle identiteedi pakkuja liiga kaua aega tagasi. Jätkamiseks peate autentima. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Erabiltzaile hau jarraitzen duzu orain.
 you-are-signed-in-as-x={0} gisa baimenduta zaude.
 you-are-subscribed-to-this-page=Orrialde honetan harpidetuta zaude dagoeneko.
 you-are-subscribed-to-this-wiki=Wiki honetan harpidetuta zaude dagoeneko.
-you-are-using-ldaps-password-policy=Gaur egun LDAP pasahitza politika erabiltzen ari da. Aldatu pasahitzen konfigurazio politika, bertako pasahitzen politika erabili nahi baduzu.
 you-are-viewing-an-archived-version-of-this-page=Orrialde honen bertsio artxibatu bat ikusten ari zara.
 you-are-x=Zu zara {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=You authenticated with this identity provider too long ago. To continue you must reauthenticate. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=شما در حال دنبال کردن این ک
 you-are-signed-in-as-x=شما با نام {0} به سایت وارد شدهاید.
 you-are-subscribed-to-this-page=شما مشترک این صفحه هستید.
 you-are-subscribed-to-this-wiki=شما در این ویکی مشترک هستید.
-you-are-using-ldaps-password-policy=شما از قوانین رمز عبور LDAP استفاده می‌کنید. اگر مایلید که از قوانین رمز عبور محلی استفاده نمایید، لطفا تنظیمات مربوط به قوانین رمز عبور LDAP را تغییر دهید.
 you-are-viewing-an-archived-version-of-this-page=شما نسخه‌ی آرشیو شده‌ی این صفحه را ملاحظه می‌فرمایید.
 you-are-x=شما {0} هستید.
 you-authenticated-with-this-identity-provide-too-long-ago=شما خیلی وقت پیش با این ارائه دهنده هویت تصدیق شده بودید. برای ادامه شما باید دوباره معتبر. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -22210,7 +22210,6 @@ you-are-now-following-this-user=Seuraat tätä käyttäjää.
 you-are-signed-in-as-x=Olet kirjautunut sisään nimellä {0}.
 you-are-subscribed-to-this-page=Olet tilannut tämän sivun.
 you-are-subscribed-to-this-wiki=Olet tilannut tämän wikin.
-you-are-using-ldaps-password-policy=Käytät LDAP-palvelimen salasanakäytäntöjä. Muuta asetus LDAP-asetuksista mikäli haluat käyttää paikallista käytäntöjä.
 you-are-viewing-an-archived-version-of-this-page=Sinulle näytetään arkistoitua versiota tästä sivusta.
 you-are-x=Olet {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Todensit tämän identiteetin tarjoajan kautta liian kauan sitten. Jatkaaksesi sinun on todennettava uudelleen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -22214,7 +22214,6 @@ you-are-now-following-this-user=Vous suivez désormais cet utilisateur.
 you-are-signed-in-as-x=Vous êtes connecté en tant que {0}.
 you-are-subscribed-to-this-page=Vous avez souscrit à cette page.
 you-are-subscribed-to-this-wiki=Vous avez souscrit à ce wiki.
-you-are-using-ldaps-password-policy=Vous employez la politique du mot de passe de LDAP. Veuillez changer votre politique de mot de passe de LDAP si vous souhaitez employer une politique locale de mot de passe.
 you-are-viewing-an-archived-version-of-this-page=Vous regardez une version archivée de cette page.
 you-are-x=Vous êtes {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Votre authentification auprès de ce fournisseur d'identité remonte à trop de temps. Pour continuer, vous devez vous authentifier à nouveau.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Vous suivez désormais cet utilisateur.
 you-are-signed-in-as-x=Vous êtes connecté en tant que {0}.
 you-are-subscribed-to-this-page=Vous avez souscrit à cette page.
 you-are-subscribed-to-this-wiki=Vous avez souscrit à ce wiki.
-you-are-using-ldaps-password-policy=Vous employez la politique du mot de passe de LDAP. Veuillez changer votre politique de mot de passe de LDAP si vous souhaitez employer une politique locale de mot de passe.
 you-are-viewing-an-archived-version-of-this-page=Vous regardez une version archivée de cette page.
 you-are-x=Vous êtes {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Votre authentification auprès de ce fournisseur d'identité remonte à trop de temps. Pour continuer, vous devez vous authentifier à nouveau.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Agora sigues a este usuario.
 you-are-signed-in-as-x=Estás identificado como {0}.
 you-are-subscribed-to-this-page=Xa estás subscrito a esta páxina.
 you-are-subscribed-to-this-wiki=Xa estás subscrito a este Wiki.
-you-are-using-ldaps-password-policy=Actualmente estase utilizando a política de contrasinais de LDAP. Cambie a configuración da política de contrasinais se desexa utilizar unha política local de contrasinais.
 you-are-viewing-an-archived-version-of-this-page=Esta é unha versión arquivada desta páxina.
 you-are-x=Ti eres {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Vostede autenticado con este provedor de identidade hai moito tempo. Para continuar debes reutentalo.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=अब आप इस उपयोगकर्त
 you-are-signed-in-as-x=आपने {0} के रूप में साइन इन किया हैं|
 you-are-subscribed-to-this-page=आपने इस पेज को subscribe किया है|
 you-are-subscribed-to-this-wiki=आपने इस विकी को subscribe किया है|
-you-are-using-ldaps-password-policy=आप LDAP पासवर्ड policy का प्रयोग कर रहे हैं| कृपया अपने LDAP पासवर्ड policy सेटिंग्स को बदलदे यदि आप एक local पासवर्ड policy का उपयोग करना चाहते हैं|
 you-are-viewing-an-archived-version-of-this-page=आप इस पेज का एक archived version देख रहे हैं|
 you-are-x=आप {0} हैं|
 you-authenticated-with-this-identity-provide-too-long-ago=आप इस पहचान प्रदाता के साथ बहुत पहले प्रमाणित । जारी रखने के लिए आपको फिर से अप्रामाणित करना होगा। (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=You are now following this user. (Automatic Copy
 you-are-signed-in-as-x=Upisali ste se kao {0}.
 you-are-subscribed-to-this-page=Pretplaćeni ste na ovu stranicu.
 you-are-subscribed-to-this-wiki=Pretplaćeni ste na ovaj wiki.
-you-are-using-ldaps-password-policy=Koristite LDAP's pravila lozinke. Molimo, promijenite svoje postavke za LDAP pravila lozinke ako želite upotrijebiti lokalna pravila lozinke.
 you-are-viewing-an-archived-version-of-this-page=Pregledavate arhiviranu verziju ove stranice.
 you-are-x=Vi ste {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=You authenticated with this identity provider too long ago. To continue you must reauthenticate. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -22215,7 +22215,6 @@ you-are-now-following-this-user=Követed ezt a felhasználót.
 you-are-signed-in-as-x=Ön {0} néven jelentkezett be.
 you-are-subscribed-to-this-page=Fel vagy iratkozva erre az oldalra.
 you-are-subscribed-to-this-wiki=Fel vagy iratkozva erre a wikire.
-you-are-using-ldaps-password-policy=Az LDAP jelszószabályait használod. Változtasd meg az LDAP jelszóbeállításait, ha helyi jelszószabályokat kívánsz használni.
 you-are-viewing-an-archived-version-of-this-page=Az oldal archivált verzióját látod.
 you-are-x={0} vagy.
 you-authenticated-with-this-identity-provide-too-long-ago=Már túl régen hitelesített ezzel az identitásszolgáltatóval. A folytatáshoz újra kell magát hitelesítenie.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Anda sekarang mengikuti pengguna ini.
 you-are-signed-in-as-x=Anda masuk sebagai {0}.
 you-are-subscribed-to-this-page=Anda berlangganan ke halaman ini.
 you-are-subscribed-to-this-wiki=Anda berlangganan ke wiki ini.
-you-are-using-ldaps-password-policy=Anda menggunakan Password kebijakan LDAP. Silahkan ubah pengaturan Password kebijakan LDAP Anda jika Anda ingin menggunakan Password kebijakan lokal.
 you-are-viewing-an-archived-version-of-this-page=Anda sedang melihat versi halaman arsip ini.
 you-are-x=Anda {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Anda diautentikasi dengan penyedia identitas ini terlalu lama. Untuk melanjutkan, Anda harus mengotorisasi ulang. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -22213,7 +22213,6 @@ you-are-now-following-this-user=Ora stai seguendo questo utente.
 you-are-signed-in-as-x=Sei autenticato come {0}.
 you-are-subscribed-to-this-page=Sei iscritto a questa pagina.
 you-are-subscribed-to-this-wiki=Sei iscritto a questa wiki.
-you-are-using-ldaps-password-policy=Stai usando i criteri password di LDAP. Cambia le impostazioni per le password di LDAP se vuoi usare criteri password locali.
 you-are-viewing-an-archived-version-of-this-page=Stai visualizzando una versione archiviata di questa pagina.
 you-are-x=Sei {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=L'autenticazione con questo provider di identità è stata autenticata troppo tempo fa. Per continuare è necessario eseguire nuovamente l'autenticazione. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=כעת אתה עוקב אחר משתמש זה.
 you-are-signed-in-as-x=אתה מחובר בתור {0}.
 you-are-subscribed-to-this-page=הינך מנוי לדף זה
 you-are-subscribed-to-this-wiki=הינך מנוי של ויקי זה.
-you-are-using-ldaps-password-policy=אתה משתמש במדיניות הסיסמאות של LDAP. אנא שנה את הגדרות מדיניות סיסמאות ה-LDAP שלך, אם ברצונך להשתמש במדיניות הסיסמאות המקומית.
 you-are-viewing-an-archived-version-of-this-page=הינך צופה בגרסאת ארכיון לדף זה
 you-are-x=אתה {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=אתה מאומת עם ספק זהות זה לפני זמן רב מדי. כדי להמשיך עליך לאותת מחדש. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -22214,7 +22214,6 @@ you-are-now-following-this-user=このユーザーをフォローしました。
 you-are-signed-in-as-x={0}さんでログインしています。
 you-are-subscribed-to-this-page=このページはメール通知設定されています。
 you-are-subscribed-to-this-wiki=このWikiはメール通知設定されています。
-you-are-using-ldaps-password-policy=LDAPのパスワードポリシーを利用しています。ローカルのパスワードポリシーを利用したい場合、LDAPパスワードポリシーの設定を変更してください。
 you-are-viewing-an-archived-version-of-this-page=古いページを参照しています。
 you-are-x=あなたは、{0}です。
 you-authenticated-with-this-identity-provide-too-long-ago=このアイデンティティプロバイダーで認証したのはかなり前です。続行するには再認証が必要です。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=You are now following this user. (Automatic Copy
 you-are-signed-in-as-x=You are signed in as {0}. (Automatic Copy)
 you-are-subscribed-to-this-page=You are subscribed to this page. (Automatic Copy)
 you-are-subscribed-to-this-wiki=You are subscribed to this wiki. (Automatic Copy)
-you-are-using-ldaps-password-policy=You are using LDAP's password policy. Please change your LDAP password policy settings if you wish to use a local password policy. (Automatic Copy)
 you-are-viewing-an-archived-version-of-this-page=You are viewing an archived version of this page. (Automatic Copy)
 you-are-x=You are {0}. (Automatic Copy)
 you-authenticated-with-this-identity-provide-too-long-ago=You authenticated with this identity provider too long ago. To continue you must reauthenticate. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -22218,7 +22218,6 @@ you-are-now-following-this-user=You are now following this user.
 you-are-signed-in-as-x=You are signed in as {0}.
 you-are-subscribed-to-this-page=You are subscribed to this page.
 you-are-subscribed-to-this-wiki=You are subscribed to this wiki.
-you-are-using-ldaps-password-policy=You are using LDAP's password policy. Please change your LDAP password policy settings if you wish to use a local password policy.
 you-are-viewing-an-archived-version-of-this-page=You are viewing an archived version of this page.
 you-are-x=You are {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=You authenticated with this identity provider too long ago. To continue you must reauthenticate.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -22211,7 +22211,6 @@ you-are-now-following-this-user=이제 이 사용자를 팔로우하고 있습�
 you-are-signed-in-as-x={0}(으)로 로그인했습니다.
 you-are-subscribed-to-this-page=너는 이 페이지에 구독된다.
 you-are-subscribed-to-this-wiki=너는 이wiki에 구독된다.
-you-are-using-ldaps-password-policy=너는LDAP's암호 방침을 사용하고 있다. 너가 현지 암호 방침을 사용하기 위하여 바라면 너의LDAP암호 방침 조정을 변화하십시요.
 you-are-viewing-an-archived-version-of-this-page=너는 이 페이지의 보관한 버전을 전망하고 있다.
 you-are-x=당신은 {0}입니다.
 you-authenticated-with-this-identity-provide-too-long-ago=너무 오래 전에 이 ID 공급자로 인증했습니다. 계속하려면 재인증해야 합니다.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=You are now following this user. (Automatic Copy
 you-are-signed-in-as-x=ທ່ານເຂົ້າໃນນາມຂອງ{0}.
 you-are-subscribed-to-this-page=ທ່ານໄດ້ຊັບສກິບໄປຍັງໜ້ານີ້
 you-are-subscribed-to-this-wiki=ທ່ານໄດ້ຊັບສກິບໄປຍັງວີກີນີ້
-you-are-using-ldaps-password-policy=ທ່ານກຳລັງນຳໃຊ້ນະໂຍບາຍລະຫັດຜ່ານຂອງ LDAP. ກະລຸນາປ່ຽນແປງການກຳນົດນະໂຍບາຍລະຫັດຜ່ານຂອງ LDAP ຖ້າທ່ານຄິດວ່າທ່ານນຳໃຊ້ນະໂຍບາຍລະຫັດຜ່ານຂອງການໃຊ້ພາຍໃນ
 you-are-viewing-an-archived-version-of-this-page=ທ່ານກຳລັງສະແດງການຮັບເອົາເວີເຊີ້ນຂອງໜ້ານີ້
 you-are-x=ທ່ານແມ່ນ {0}
 you-authenticated-with-this-identity-provide-too-long-ago=You authenticated with this identity provider too long ago. To continue you must reauthenticate. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Dabar sekate šį vartotoją. (Automatic Transla
 you-are-signed-in-as-x=You are signed in as {0}. (Automatic Copy)
 you-are-subscribed-to-this-page=Jūs esate užsiprenumeravę šį puslapį. (Automatic Translation)
 you-are-subscribed-to-this-wiki=Jūs esate užsiprenumeravę šį wiki. (Automatic Translation)
-you-are-using-ldaps-password-policy=Naudojate LDAP slaptažodžio strategiją. Jei norite naudoti vietinio slaptažodžio strategiją, pakeiskite LDAP slaptažodžio strategijos parametrus. (Automatic Translation)
 you-are-viewing-an-archived-version-of-this-page=Peržiūrite archyvuotą šio puslapio versiją. (Automatic Translation)
 you-are-x=You are {0}. (Automatic Copy)
 you-authenticated-with-this-identity-provide-too-long-ago=Jūs autentiškumo su šiuo tapatybės teikėjas per seniai. Norėdami tęsti, turite iš naujo aauthenticate. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Awda sedang mengikuti pengguna ini sekarang. (Au
 you-are-signed-in-as-x=You are signed in as {0}. (Automatic Copy)
 you-are-subscribed-to-this-page=Anda melanggan halaman ini. (Automatic Translation)
 you-are-subscribed-to-this-wiki=Anda melanggan wiki ini. (Automatic Translation)
-you-are-using-ldaps-password-policy=Anda menggunakan dasar kata laluan LDAP. Sila tukar seting dasar kata laluan LDAP anda jika anda ingin menggunakan dasar kata laluan tempatan. (Automatic Translation)
 you-are-viewing-an-archived-version-of-this-page=Anda sedang melihat versi arkib halaman ini. (Automatic Translation)
 you-are-x=You are {0}. (Automatic Copy)
 you-authenticated-with-this-identity-provide-too-long-ago=Anda telah mengesahkan dengan pembekal identiti ini terlalu lama dahulu. Untuk meneruskan anda mestilah mengesahkan semula. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Du følger denne brukeren.
 you-are-signed-in-as-x=Du er innlogget som {0}.
 you-are-subscribed-to-this-page=Du abonnerer på denne siden.
 you-are-subscribed-to-this-wiki=Du abonnerer på denne wikien.
-you-are-using-ldaps-password-policy=Du bruker passordsregler fra LDAP. Endre dine LDAP-innstillinger om du ønsker å bruke lokale passordsregler.
 you-are-viewing-an-archived-version-of-this-page=Du ser på en arkivert versjon av denne siden.
 you-are-x=Du er {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Du autentiserte med denne identitetsleverandøren for lenge siden. For å fortsette må du godkjenne på nytt. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -22215,7 +22215,6 @@ you-are-now-following-this-user=U volgt nu deze gebruiker.
 you-are-signed-in-as-x=U bent ingelogd als {0}.
 you-are-subscribed-to-this-page=U volgt deze pagina.
 you-are-subscribed-to-this-wiki=U volgt deze wiki.
-you-are-using-ldaps-password-policy=U gebruikt het LDAP-wachtwoordbeleid. Wijzig de LDAP-wachtwoordsinstellingen als u het lokale wachtwoordbeleid wilt gebruiken.
 you-are-viewing-an-archived-version-of-this-page=U bekijkt een gearchiveerde versie van deze pagina.
 you-are-x=U bent {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Het is te lang geleden dat u deze identiteitsprovider hebt geauthenticeerd. U moet hem opnieuw authenticeren om door te gaan.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -22215,7 +22215,6 @@ you-are-now-following-this-user=You are now following this user. (Automatic Copy
 you-are-signed-in-as-x=Aangemeld als {0}.
 you-are-subscribed-to-this-page=Je bent op deze pagina ingeschreven.
 you-are-subscribed-to-this-wiki=Je bent op deze Wiki ingeschreven.
-you-are-using-ldaps-password-policy=Je gebruikt het LDAP-wachtwoordbeleid. Verander de LDAP-wachtwoordsinstellingen als je van het lokale beleid gebruik wil maken.
 you-are-viewing-an-archived-version-of-this-page=Je bekijkt een gearchiveerde versie van deze pagina.
 you-are-x=Je bent {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=You authenticated with this identity provider too long ago. To continue you must reauthenticate. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Obserwujesz już tego użytkownika.
 you-are-signed-in-as-x=Jesteś zalogowany jako {0}.
 you-are-subscribed-to-this-page=Subskrybujesz tą stronę.
 you-are-subscribed-to-this-wiki=Subskrybujesz to wiki.
-you-are-using-ldaps-password-policy=Stosujesz politykę tworzenia haseł LDAP. Zmień ustawienia polityki tworzenia haseł LDAP, jeżeli chcesz wykorzystać lokalną politykę tworzenia haseł.
 you-are-viewing-an-archived-version-of-this-page=Oglądasz archiwalną wersję tej strony.
 you-are-x=Jesteś {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Uwierzytelniony z tego dostawcy tożsamości zbyt dawno temu. Aby kontynuować, należy ponownie uwierzytelnić. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Você está seguindo este usuário agora.
 you-are-signed-in-as-x=Você entrou como {0}.
 you-are-subscribed-to-this-page=Você está subscrito a esta página.
 you-are-subscribed-to-this-wiki=Você está subscrito a este wiki.
-you-are-using-ldaps-password-policy=Você está usando a política da senha de LDAP. Mude por favor suas configurações da política da senha de LDAP se você desejar usar uma política local da senha.
 you-are-viewing-an-archived-version-of-this-page=Você está vendo uma versão arquivada desta página.
 you-are-x=Você está {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Você autenticou com este provedor de identidade há muito tempo. Para continuar, você deve autenticar novamente.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -22214,7 +22214,6 @@ you-are-now-following-this-user=Passou a seguir este utilizador.
 you-are-signed-in-as-x=Está logado como {0}.
 you-are-subscribed-to-this-page=Você está subscrito a esta página.
 you-are-subscribed-to-this-wiki=Está subscrito nesta wiki.
-you-are-using-ldaps-password-policy=Está a ser utilizada a política da senha de LDAP. Por favor, altere as suas configurações da política da senha de LDAP se deseja utilizar uma política de senhas local.
 you-are-viewing-an-archived-version-of-this-page=Você está a ver uma versão arquivada desta página.
 you-are-x=Você está {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Você se autuou com este provedor de identidade há muito tempo. Para continuar, você deve reautenticizar. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Acum urmăriți acest utilizator. (Automatic Tra
 you-are-signed-in-as-x=Esti autentificat ca {0}.
 you-are-subscribed-to-this-page=Esti abonat la acesta pagina.
 you-are-subscribed-to-this-wiki=Esti abonat la acest wiki.
-you-are-using-ldaps-password-policy=Folosesti politica de parolare LDAP. Te rog schimba setarile politicii de parolare LDAP daca doresti sa folosesti o politica de parolare locala.
 you-are-viewing-an-archived-version-of-this-page=Vizualizezi o versiune arhivata a acestei pagini.
 you-are-x=Esti {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Te-ai autentificat cu acest furnizor de identitate cu prea mult timp în urmă. Pentru a continua trebuie să reautenticate. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Теперь вы следите за этим �
 you-are-signed-in-as-x=Вы зашли как {0}.
 you-are-subscribed-to-this-page=Вы подписаны на эту страницу.
 you-are-subscribed-to-this-wiki=Вы не подписаны на эту wiki.
-you-are-using-ldaps-password-policy=Вы используете политику паролей LDAP. Пожалуйста, смените настройки вашей политики паролей LDAP, если вы хотите использовать локальную политику.
 you-are-viewing-an-archived-version-of-this-page=Вы просматриваете архивную версию этой страницы.
 you-are-x=Вы {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Вы подлинность с этим поставщиком идентификационных данных слишком давно. Чтобы продолжить вы должны reauthenticate. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Sledujete tohto používateľa.
 you-are-signed-in-as-x=Ste prihlásený ako {0}.
 you-are-subscribed-to-this-page=Ste odberateľom tejto stránky.
 you-are-subscribed-to-this-wiki=Ste odberateľom tejto wiki.
-you-are-using-ldaps-password-policy=Používate LDAP pravidlá pre heslá. Zmeňte si prosím Vaše LDAP nastavenie pravidiel ak si želáte použivať lokálne pravidlá pre heslá.
 you-are-viewing-an-archived-version-of-this-page=Prezeráte si archivovanú verziu tejto stránky.
 you-are-x=Ste {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Overil si to u tohto poskytovateľa identity príliš dávno. Ak chcete pokračovať, musíte znovu použiť. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Zdaj sledite temu uporabniku. (Automatic Transla
 you-are-signed-in-as-x=Vpisani ste kot {0}.
 you-are-subscribed-to-this-page=Prijavljeni ste na to stran.
 you-are-subscribed-to-this-wiki=Pripravljeni ste na ta wiki.
-you-are-using-ldaps-password-policy=Uporabljate LDAP pravila za gesla. Spremenite nastavitve LDAP pravil za gesla če želite uporabljati lokalna pravila za gesla.
 you-are-viewing-an-archived-version-of-this-page=Gledate arhivirano različico te strani.
 you-are-x=Vi ste {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Predolgo ste preverili pristnost pri tem ponudniku identitete. Če želite nadaljevati, morate ponovno podati. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=You are now following this user. (Automatic Copy
 you-are-signed-in-as-x=Пријављени сте као {0}.
 you-are-subscribed-to-this-page=Пријавили сте се на овој страници.
 you-are-subscribed-to-this-wiki=Пријавили сте се на овом викију.
-you-are-using-ldaps-password-policy=Ви користите ЛДАП политике лозинке. Молимо вас да промените ЛДАП поставке политике лозинке ако желите да користите локалне политике лозинке.
 you-are-viewing-an-archived-version-of-this-page=Ви сте прегледате архивиране верзије ове странице.
 you-are-x=Ви {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=You authenticated with this identity provider too long ago. To continue you must reauthenticate. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=You are now following this user. (Automatic Copy
 you-are-signed-in-as-x=Prijavljeni ste kao {0}.
 you-are-subscribed-to-this-page=Prijavili ste se na ovoj stranici.
 you-are-subscribed-to-this-wiki=Prijavili ste se na ovom vikiju.
-you-are-using-ldaps-password-policy=Vi koristite LDAP politike lozinke. Molimo vas da promenite LDAP postavke politike lozinke ako želite da koristite lokalne politike lozinke.
 you-are-viewing-an-archived-version-of-this-page=Vi ste pregledate arhivirane verzije ove stranice.
 you-are-x=Vi {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=You authenticated with this identity provider too long ago. To continue you must reauthenticate. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Du följer nu den här användaren.
 you-are-signed-in-as-x=Du är inloggad som {0}.
 you-are-subscribed-to-this-page=Du prenumererar på den här sidan.
 you-are-subscribed-to-this-wiki=Du prenumererar på den här wikin.
-you-are-using-ldaps-password-policy=Du använder lösenordspolicy från LDAP. Ändra dina inställningar om du vill använda en lokal lösenordspolicy.
 you-are-viewing-an-archived-version-of-this-page=Det du ser är en arkiverad version av sidan
 you-are-x=Du är {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Du har autentiserat med den här identitetsleverantören för länge sedan. Du måste återautentisera för att fortsätta.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=இப்போது நீங்கள் இ�
 you-are-signed-in-as-x=நீங்கள் {0}-ஆக லாகின் செய்துள்ளீர்கள்.
 you-are-subscribed-to-this-page=இந்த பக்கத்திற்கு நீங்கள் சேர்ந்துள்ளீர்கள்.
 you-are-subscribed-to-this-wiki=இந்த wiki பக்கத்திற்கு நீங்கள் சேர்ந்துள்ளீர்கள்.
-you-are-using-ldaps-password-policy=நீங்கள் LDAP இன் பாஸ்வேர்டு பாலிசியை பயன்படுத்துகிறீர்கள். ஒரு லோக்கல் பாஸ்வேர்டு பாலிசியை நீங்கள் பயன்படுத்த விரும்பினால், உங்கள் LDAP பாஸ்வேர்டு பாலிசி அமைப்புகளை மாற்றவும்.
 you-are-viewing-an-archived-version-of-this-page=இந்த பக்கத்தின் காப்பகப்படுத்தப்பட்ட பதிப்பை நீங்கள் பார்க்கிறீர்கள்.
 you-are-x=நீங்கள் {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=You authenticated with this identity provider too long ago. To continue you must reauthenticate. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=คุณกำลังติดตามผู
 you-are-signed-in-as-x=คุณลงชื่อเข้าใช้เป็น {0}
 you-are-subscribed-to-this-page=คุณสมัครรับข้อมูลจากหน้านี้
 you-are-subscribed-to-this-wiki=คุณสมัครรับข้อมูลจากวิกินี้
-you-are-using-ldaps-password-policy=คุณกำลังใช้นโยบายรหัสผ่านของ LDAP โปรดเปลี่ยนการตั้งค่านโยบายรหัสผ่าน LDAP ของคุณ หากคุณต้องการใช้นโยบายรหัสผ่านในเครื่อง
 you-are-viewing-an-archived-version-of-this-page=คุณกำลังดูเวอร์ชันที่เก็บถาวรของหน้านี้
 you-are-x=คุณคือ {0}
 you-authenticated-with-this-identity-provide-too-long-ago=คุณรับรองความถูกต้องกับผู้ให้บริการข้อมูลประจำตัวนี้นานเกินไป คุณต้องตรวจสอบสิทธิ์อีกครั้งเพื่อดำเนินการต่อ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Şimdi bu kullanıcıyı takip ediyorsunuz. (Aut
 you-are-signed-in-as-x={0} olarak giriş yaptınız.
 you-are-subscribed-to-this-page=Bu sayfaya abonesiniz.
 you-are-subscribed-to-this-wiki=Bu vikiye abone oldunuz.
-you-are-using-ldaps-password-policy=LDAP parola politikası kullanıyorsunuz. Yerel parola politikası kullanmak istiyorsanız lütfen LDAP parola politikası ayarlarınızı değiştiriniz.
 you-are-viewing-an-archived-version-of-this-page=Bu sayfanın arşivlenmiş bir sürümünü görüyorsunuz.
 you-are-x=Siz {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Bu kimlik sağlayıcısıyla çok uzun zaman önce kimlik doğrulaması yaptığınız. Devam etmek için yeniden kimlik doğrulamanız gerekir. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Зараз ви слідкоїте за цим �
 you-are-signed-in-as-x=Ви зайшли як {0}.
 you-are-subscribed-to-this-page=Ви не підписані на цю сторінку.
 you-are-subscribed-to-this-wiki=Ви не підписані на цю Вікі.
-you-are-using-ldaps-password-policy=Ви використовуєте паролів LDAP. Будь ласка, зніміть налаштування вашої політики паролів LDAP, якщо ви бажаєте використовувати локальну політику.
 you-are-viewing-an-archived-version-of-this-page=Ви переглядаєте архівну версію цієї сторінки.
 you-are-x=Ви {0}.
 you-authenticated-with-this-identity-provide-too-long-ago=Ви занадто давно автентифіковані з цим постачальником посвідчень. Щоб продовжити, необхідно повторно ввести. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -22212,7 +22212,6 @@ you-are-now-following-this-user=Bạn hiện đang theo dõi người dùng này
 you-are-signed-in-as-x=Bạn đang truy cập với tài khoản {0}.
 you-are-subscribed-to-this-page=Bạn đã đăng ký vào trang này.
 you-are-subscribed-to-this-wiki=Bạn đã đăng ký vào Wiki trực tuyến này.
-you-are-using-ldaps-password-policy=Bạn đang áp dụng chính sách thiết lập mật khẩu theo LDAP. Bạn hãy thay đổi chính sách trên LDAP nếu bạn muốn sử dụng chính sách thiết lập mật khẩu tại địa phương.
 you-are-viewing-an-archived-version-of-this-page=Bạng đang xem một phiên bản lưu trữ của trang này.
 you-are-x=Bạn là {0}
 you-authenticated-with-this-identity-provide-too-long-ago=Bạn đã xác thực với nhà cung cấp danh tính này quá lâu trước đây. Để tiếp tục, bạn phải xác thực lại. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -22214,7 +22214,6 @@ you-are-now-following-this-user=您已关注此用户。
 you-are-signed-in-as-x=您已经以{0}身份登录。
 you-are-subscribed-to-this-page=您订阅了此页面。
 you-are-subscribed-to-this-wiki=您订阅了此Wiki。
-you-are-using-ldaps-password-policy=您在使用LDAP密码政策。如果您想使用本地密码政策，请更改您的LDAP密码政策设置。
 you-are-viewing-an-archived-version-of-this-page=您正在查看此页面的已归档版本。
 you-are-x=您是{0}。
 you-authenticated-with-this-identity-provide-too-long-ago=您使用此身份提供程序验证身份已过去太长时间。要继续，您必须重新验证。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -22213,7 +22213,6 @@ you-are-now-following-this-user=您正跟隨這使用者。
 you-are-signed-in-as-x=您以 {0} 登入。
 you-are-subscribed-to-this-page=您被訂閱到這頁面。
 you-are-subscribed-to-this-wiki=您被訂閱到這Wiki。
-you-are-using-ldaps-password-policy=您正在使用LDAP的密碼政策。請改變您的LDAP密碼政策設置如果您希望使用一個本地密碼政策。
 you-are-viewing-an-archived-version-of-this-page=您正在檢視這頁面的歷史版本。
 you-are-x=您正在 {0}。
 you-authenticated-with-this-identity-provide-too-long-ago=You authenticated with this identity provider too long ago. To continue you must reauthenticate.

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/model/listener/BaseLDAPExportModelListener.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/model/listener/BaseLDAPExportModelListener.java
@@ -79,7 +79,8 @@ public abstract class BaseLDAPExportModelListener<T extends BaseModel<T>>
 		};
 
 		if (ldapSettings.isPasswordPolicyEnabled(user.getCompanyId()) &&
-			PasswordModificationThreadLocal.isPasswordModified()) {
+			PasswordModificationThreadLocal.isPasswordModified() &&
+			(user.getLdapServerId() > 0)) {
 
 			callable.call();
 		}

--- a/modules/apps/user/user-test/build.gradle
+++ b/modules/apps/user/user-test/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
 	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-api")
 	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-event-generators-api")
+	testIntegrationImplementation project(":apps:portal-security:portal-security-ldap-api")
 	testIntegrationImplementation project(":apps:ratings:ratings-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
@@ -44,12 +44,14 @@ import com.liferay.portal.kernel.service.PasswordPolicyLocalService;
 import com.liferay.portal.kernel.service.PortalPreferencesLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
 import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
@@ -68,14 +70,18 @@ import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
+import com.liferay.portal.security.ldap.authenticator.configuration.LDAPAuthConfiguration;
+import com.liferay.portal.security.ldap.configuration.ConfigurationProvider;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -83,6 +89,7 @@ import com.liferay.portal.util.DigesterImpl;
 
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Dictionary;
 import java.util.List;
 import java.util.Map;
 
@@ -144,6 +151,125 @@ public class UserLocalServiceTest {
 	@After
 	public void tearDown() throws Exception {
 		_bundleActivator.stop(_bundleContext);
+	}
+
+	@Test
+	public void testAddUserWithWorkflowForLDAPUserWithLDAPPasswordPolicy()
+		throws Exception {
+
+		PasswordPolicy passwordPolicy =
+			_passwordPolicyLocalService.getDefaultPasswordPolicy(
+				TestPropsValues.getCompanyId());
+
+		passwordPolicy.setChangeRequired(true);
+		passwordPolicy.setCheckSyntax(true);
+
+		passwordPolicy = _passwordPolicyLocalService.updatePasswordPolicy(
+			passwordPolicy);
+
+		boolean ldapPasswordPolicyEnabled = _updateLDAPPasswordPolicyEnabled(
+			true);
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setAttribute("ldapServerId", 1);
+
+		try {
+			User user = _attemptUserCreation(_INVALID_PASSWORD, true);
+
+			Assert.assertEquals(
+				"User was created with incorrect LDAP Server Id", 1,
+				user.getLdapServerId());
+			Assert.assertFalse(
+				"During creation, LDAP user had portal password policy applied",
+				user.isPasswordReset());
+			Assert.assertNull(
+				"LDAP user is not bypassing portal password policy",
+				user.getPasswordPolicy());
+		}
+		catch (Throwable throwable) {
+			if (throwable instanceof UserPasswordException) {
+				throw new Exception(
+					"Exception relate to password policy was thrown",
+					throwable);
+			}
+
+			throw new Exception(
+				"Exception unrelated to password policy was thrown", throwable);
+		}
+		finally {
+			passwordPolicy.setChangeRequired(false);
+			passwordPolicy.setCheckSyntax(false);
+
+			_passwordPolicyLocalService.updatePasswordPolicy(passwordPolicy);
+
+			_updateLDAPPasswordPolicyEnabled(ldapPasswordPolicyEnabled);
+		}
+	}
+
+	@Test
+	public void testAddUserWithWorkflowForLDAPUserWithoutLDAPPasswordPolicy()
+		throws Exception {
+
+		PasswordPolicy passwordPolicy =
+			_passwordPolicyLocalService.getDefaultPasswordPolicy(
+				TestPropsValues.getCompanyId());
+
+		passwordPolicy.setChangeRequired(true);
+		passwordPolicy.setCheckSyntax(true);
+
+		passwordPolicy = _passwordPolicyLocalService.updatePasswordPolicy(
+			passwordPolicy);
+
+		boolean ldapPasswordPolicyEnabled = _updateLDAPPasswordPolicyEnabled(
+			false);
+
+		try {
+			_assertUserPasswordException(_INVALID_PASSWORD, true);
+
+			_assertUserCreatedWithPasswordPolicy(_VALID_PASSWORD, true);
+		}
+		finally {
+			passwordPolicy.setChangeRequired(false);
+			passwordPolicy.setCheckSyntax(false);
+
+			_passwordPolicyLocalService.updatePasswordPolicy(passwordPolicy);
+
+			_updateLDAPPasswordPolicyEnabled(ldapPasswordPolicyEnabled);
+		}
+	}
+
+	@Test
+	public void testAddUserWithWorkflowForPortalUserWithLDAPPasswordPolicy()
+		throws Exception {
+
+		PasswordPolicy passwordPolicy =
+			_passwordPolicyLocalService.getDefaultPasswordPolicy(
+				TestPropsValues.getCompanyId());
+
+		passwordPolicy.setChangeRequired(true);
+		passwordPolicy.setCheckSyntax(true);
+
+		passwordPolicy = _passwordPolicyLocalService.updatePasswordPolicy(
+			passwordPolicy);
+
+		boolean ldapPasswordPolicyEnabled = _updateLDAPPasswordPolicyEnabled(
+			true);
+
+		try {
+			_assertUserPasswordException(_INVALID_PASSWORD, false);
+
+			_assertUserCreatedWithPasswordPolicy(_VALID_PASSWORD, false);
+		}
+		finally {
+			passwordPolicy.setChangeRequired(false);
+			passwordPolicy.setCheckSyntax(false);
+
+			_passwordPolicyLocalService.updatePasswordPolicy(passwordPolicy);
+
+			_updateLDAPPasswordPolicyEnabled(ldapPasswordPolicyEnabled);
+		}
 	}
 
 	@Test
@@ -1122,6 +1248,93 @@ public class UserLocalServiceTest {
 		return user;
 	}
 
+	private void _assertUserCreatedWithPasswordPolicy(
+			String password, boolean ldapUser)
+		throws Exception {
+
+		try {
+			User user = _attemptUserCreation(password, ldapUser);
+
+			Assert.assertEquals(
+				"User was created with incorrect LDAP Server Id",
+				ldapUser ? 1 : -1, user.getLdapServerId());
+			Assert.assertTrue(
+				"During creation, user did not have password policy applied",
+				user.isPasswordReset());
+			Assert.assertNotNull(
+				"User is bypassing portal password policy",
+				user.getPasswordPolicy());
+		}
+		catch (Throwable throwable) {
+			throw new Exception("Unable to create user", throwable);
+		}
+	}
+
+	private void _assertUserPasswordException(String password, boolean ldapUser)
+		throws Exception {
+
+		try {
+			_attemptUserCreation(password, ldapUser);
+
+			Assert.fail("Password policy is not being applied to user");
+		}
+		catch (Throwable throwable) {
+			if (!(throwable instanceof UserPasswordException)) {
+				throw new Exception(
+					"Exception unrelated to password policy was thrown",
+					throwable);
+			}
+		}
+	}
+
+	private User _attemptUserCreation(String password, boolean ldapUser)
+		throws Exception {
+
+		long ldapServerId = -1;
+
+		if (ldapUser) {
+			ldapServerId = 1;
+		}
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setAttribute("ldapServerId", ldapServerId);
+
+		return UserTestUtil.addUser(
+			TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+			password,
+			RandomTestUtil.randomString() + RandomTestUtil.nextLong() +
+				"@liferay.com",
+			RandomTestUtil.randomString(
+				NumericStringRandomizerBumper.INSTANCE,
+				UniqueStringRandomizerBumper.INSTANCE),
+			LocaleUtil.getDefault(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(),
+			new long[] {TestPropsValues.getGroupId()}, serviceContext);
+	}
+
+	private boolean _updateLDAPPasswordPolicyEnabled(
+			boolean passwordPolicyEnabled)
+		throws PortalException {
+
+		Dictionary<String, Object> configurations =
+			_ldapAuthConfigurationProvider.getConfigurationProperties(
+				TestPropsValues.getCompanyId());
+
+		boolean existingValue = GetterUtil.getBoolean(
+			configurations.put("passwordPolicyEnabled", passwordPolicyEnabled));
+
+		_ldapAuthConfigurationProvider.updateProperties(
+			TestPropsValues.getCompanyId(), configurations);
+
+		return existingValue;
+	}
+
+	private static final String _INVALID_PASSWORD = "abc";
+
+	private static final String _VALID_PASSWORD = "Liferay123";
+
 	private static Company _company;
 
 	@Inject
@@ -1139,6 +1352,12 @@ public class UserLocalServiceTest {
 
 	@Inject
 	private GroupLocalService _groupLocalService;
+
+	@Inject(
+		filter = "factoryPid=com.liferay.portal.security.ldap.authenticator.configuration.LDAPAuthConfiguration"
+	)
+	private ConfigurationProvider<LDAPAuthConfiguration>
+		_ldapAuthConfigurationProvider;
 
 	@Inject
 	private PasswordPolicyLocalService _passwordPolicyLocalService;

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
@@ -333,6 +333,257 @@ public class UserLocalServiceTest {
 	}
 
 	@Test
+	public void testCheckLockoutLDAPUserWithLDAPPasswordPolicy()
+		throws Exception {
+
+		PasswordPolicy passwordPolicy =
+			_passwordPolicyLocalService.getDefaultPasswordPolicy(
+				TestPropsValues.getCompanyId());
+
+		passwordPolicy.setLockout(true);
+
+		passwordPolicy = _passwordPolicyLocalService.updatePasswordPolicy(
+			passwordPolicy);
+
+		boolean ldapPasswordPolicyEnabled = _updateLDAPPasswordPolicyEnabled(
+			true);
+
+		try {
+			User user = UserTestUtil.addUser();
+
+			user.setLdapServerId(1);
+			user.setLockout(true);
+			user.setLockoutDate(user.getModifiedDate());
+
+			user = _userLocalService.updateUser(user);
+
+			try {
+				_userLocalService.checkLockout(user);
+			}
+			catch (UserLockoutException userLockoutException) {
+				throw new Exception("Password policy is being enforced");
+			}
+			catch (Throwable throwable) {
+				throw new Exception(
+					"Exception unrelated to lockout was thrown", throwable);
+			}
+		}
+		finally {
+			passwordPolicy.setLockout(false);
+
+			_passwordPolicyLocalService.updatePasswordPolicy(passwordPolicy);
+
+			_updateLDAPPasswordPolicyEnabled(ldapPasswordPolicyEnabled);
+		}
+	}
+
+	@Test
+	public void testCheckLockoutLDAPUserWithoutLDAPPasswordPolicy()
+		throws Exception {
+
+		PasswordPolicy passwordPolicy =
+			_passwordPolicyLocalService.getDefaultPasswordPolicy(
+				TestPropsValues.getCompanyId());
+
+		passwordPolicy.setLockout(true);
+
+		passwordPolicy = _passwordPolicyLocalService.updatePasswordPolicy(
+			passwordPolicy);
+
+		boolean ldapPasswordPolicyEnabled = _updateLDAPPasswordPolicyEnabled(
+			false);
+
+		try {
+			User user = UserTestUtil.addUser();
+
+			user.setLdapServerId(1);
+			user.setLockout(true);
+			user.setLockoutDate(user.getModifiedDate());
+
+			user = _userLocalService.updateUser(user);
+
+			try {
+				_userLocalService.checkLockout(user);
+
+				Assert.fail("Password policy is not being enforced");
+			}
+			catch (UserLockoutException userLockoutException) {
+			}
+			catch (Throwable throwable) {
+				throw new Exception(
+					"Exception unrelated to lockout was thrown", throwable);
+			}
+		}
+		finally {
+			passwordPolicy.setLockout(false);
+
+			_passwordPolicyLocalService.updatePasswordPolicy(passwordPolicy);
+
+			_updateLDAPPasswordPolicyEnabled(ldapPasswordPolicyEnabled);
+		}
+	}
+
+	@Test
+	public void testCheckLockoutPortalUserWithLDAPPasswordPolicy()
+		throws Exception {
+
+		PasswordPolicy passwordPolicy =
+			_passwordPolicyLocalService.getDefaultPasswordPolicy(
+				TestPropsValues.getCompanyId());
+
+		passwordPolicy.setLockout(true);
+
+		passwordPolicy = _passwordPolicyLocalService.updatePasswordPolicy(
+			passwordPolicy);
+
+		boolean ldapPasswordPolicyEnabled = _updateLDAPPasswordPolicyEnabled(
+			true);
+
+		try {
+			User user = UserTestUtil.addUser();
+
+			user.setLockout(true);
+			user.setLockoutDate(user.getModifiedDate());
+
+			user = _userLocalService.updateUser(user);
+
+			try {
+				_userLocalService.checkLockout(user);
+
+				Assert.fail("Password policy is not being enforced");
+			}
+			catch (UserLockoutException userLockoutException) {
+			}
+			catch (Throwable throwable) {
+				throw new Exception(
+					"Exception unrelated to lockout was thrown", throwable);
+			}
+		}
+		finally {
+			passwordPolicy.setLockout(false);
+
+			_passwordPolicyLocalService.updatePasswordPolicy(passwordPolicy);
+
+			_updateLDAPPasswordPolicyEnabled(ldapPasswordPolicyEnabled);
+		}
+	}
+
+	@Test
+	public void testCheckPasswordExpiredLDAPUserWithLDAPPasswordPolicy()
+		throws Exception {
+
+		PasswordPolicy passwordPolicy =
+			_passwordPolicyLocalService.getDefaultPasswordPolicy(
+				TestPropsValues.getCompanyId());
+
+		passwordPolicy.setChangeRequired(true);
+
+		passwordPolicy = _passwordPolicyLocalService.updatePasswordPolicy(
+			passwordPolicy);
+
+		boolean ldapPasswordPolicyEnabled = _updateLDAPPasswordPolicyEnabled(
+			true);
+
+		try {
+			User user = _attemptUserCreation(_VALID_PASSWORD, true);
+
+			_userLocalService.checkPasswordExpired(user);
+
+			user = _userLocalService.fetchUser(user.getUserId());
+
+			Assert.assertFalse(
+				"LDAP user is not bypassing password policy check",
+				user.isPasswordReset());
+		}
+		finally {
+			passwordPolicy.setChangeRequired(false);
+
+			_passwordPolicyLocalService.updatePasswordPolicy(passwordPolicy);
+
+			_updateLDAPPasswordPolicyEnabled(ldapPasswordPolicyEnabled);
+		}
+	}
+
+	@Test
+	public void testCheckPasswordExpiredLDAPUserWithoutLDAPPasswordPolicy()
+		throws Exception {
+
+		PasswordPolicy passwordPolicy =
+			_passwordPolicyLocalService.getDefaultPasswordPolicy(
+				TestPropsValues.getCompanyId());
+
+		passwordPolicy.setChangeRequired(true);
+
+		passwordPolicy = _passwordPolicyLocalService.updatePasswordPolicy(
+			passwordPolicy);
+
+		boolean ldapPasswordPolicyEnabled = _updateLDAPPasswordPolicyEnabled(
+			false);
+
+		try {
+			User user = _attemptUserCreation(_VALID_PASSWORD, true);
+
+			_userLocalService.checkPasswordExpired(user);
+
+			user = _userLocalService.fetchUser(user.getUserId());
+
+			Assert.assertTrue(
+				"LDAP user is not adhering to password policy check",
+				user.isPasswordReset());
+		}
+		finally {
+			passwordPolicy.setChangeRequired(false);
+
+			_passwordPolicyLocalService.updatePasswordPolicy(passwordPolicy);
+
+			_updateLDAPPasswordPolicyEnabled(ldapPasswordPolicyEnabled);
+		}
+	}
+
+	@Test
+	public void testCheckPasswordExpiredPortalUser() throws Exception {
+		PasswordPolicy passwordPolicy =
+			_passwordPolicyLocalService.getDefaultPasswordPolicy(
+				TestPropsValues.getCompanyId());
+
+		passwordPolicy.setChangeable(false);
+
+		passwordPolicy = _passwordPolicyLocalService.updatePasswordPolicy(
+			passwordPolicy);
+
+		boolean ldapPasswordPolicyEnabled = _updateLDAPPasswordPolicyEnabled(
+			true);
+
+		try {
+			User user = UserTestUtil.addUser();
+
+			Assert.assertFalse(user.isPasswordReset());
+
+			passwordPolicy.setChangeable(true);
+			passwordPolicy.setChangeRequired(true);
+
+			passwordPolicy = _passwordPolicyLocalService.updatePasswordPolicy(
+				passwordPolicy);
+
+			_userLocalService.checkPasswordExpired(user);
+
+			user = _userLocalService.fetchUser(user.getUserId());
+
+			Assert.assertTrue(
+				"User should have to reset their password on first login",
+				user.isPasswordReset());
+		}
+		finally {
+			passwordPolicy.setChangeable(true);
+			passwordPolicy.setChangeRequired(false);
+
+			_passwordPolicyLocalService.updatePasswordPolicy(passwordPolicy);
+
+			_updateLDAPPasswordPolicyEnabled(ldapPasswordPolicyEnabled);
+		}
+	}
+
+	@Test
 	public void testDeleteUserDeletesNotificationEvents() throws Exception {
 		User user = UserTestUtil.addUser();
 

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/frontend/taglib/servlet/taglib/UserPasswordScreenNavigationEntry.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/frontend/taglib/servlet/taglib/UserPasswordScreenNavigationEntry.java
@@ -55,7 +55,7 @@ public class UserPasswordScreenNavigationEntry
 			PasswordPolicy passwordPolicy = selUser.getPasswordPolicy();
 
 			if (passwordPolicy == null) {
-				return true;
+				return false;
 			}
 
 			return passwordPolicy.isChangeable();
@@ -63,7 +63,7 @@ public class UserPasswordScreenNavigationEntry
 		catch (PortalException portalException) {
 			_log.error(portalException);
 
-			return true;
+			return false;
 		}
 	}
 

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -103,7 +103,6 @@ page import="com.liferay.portal.kernel.portlet.PortletProviderUtil" %><%@
 page import="com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder" %><%@
 page import="com.liferay.portal.kernel.security.auth.AuthTokenUtil" %><%@
 page import="com.liferay.portal.kernel.security.auth.ScreenNameValidator" %><%@
-page import="com.liferay.portal.kernel.security.ldap.LDAPSettingsUtil" %><%@
 page import="com.liferay.portal.kernel.security.membershippolicy.OrganizationMembershipPolicyUtil" %><%@
 page import="com.liferay.portal.kernel.security.permission.ActionKeys" %><%@
 page import="com.liferay.portal.kernel.service.AddressServiceUtil" %><%@

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/password.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/password.jsp
@@ -14,14 +14,14 @@ User selUser = userDisplayContext.getSelectedUser();
 boolean passwordReset = false;
 boolean passwordResetDisabled = false;
 
-if (((selUser == null) || (selUser.getLastLoginDate() == null)) && (passwordPolicy != null) && passwordPolicy.isChangeable() && passwordPolicy.isChangeRequired()) {
+if (((selUser == null) || (selUser.getLastLoginDate() == null)) && passwordPolicy.isChangeable() && passwordPolicy.isChangeRequired()) {
 	passwordReset = true;
 	passwordResetDisabled = true;
 }
 else {
 	passwordReset = BeanParamUtil.getBoolean(selUser, request, "passwordReset");
 
-	if ((passwordPolicy == null) || !passwordPolicy.isChangeable()) {
+	if (!passwordPolicy.isChangeable()) {
 		passwordResetDisabled = true;
 	}
 }

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/password.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/password.jsp
@@ -11,18 +11,17 @@
 PasswordPolicy passwordPolicy = userDisplayContext.getPasswordPolicy();
 User selUser = userDisplayContext.getSelectedUser();
 
-boolean ldapPasswordPolicyEnabled = LDAPSettingsUtil.isPasswordPolicyEnabled(company.getCompanyId());
 boolean passwordReset = false;
 boolean passwordResetDisabled = false;
 
-if (((selUser == null) || (selUser.getLastLoginDate() == null)) && (((passwordPolicy == null) && !ldapPasswordPolicyEnabled) || ((passwordPolicy != null) && passwordPolicy.isChangeable() && passwordPolicy.isChangeRequired()))) {
+if (((selUser == null) || (selUser.getLastLoginDate() == null)) && (passwordPolicy != null) && passwordPolicy.isChangeable() && passwordPolicy.isChangeRequired()) {
 	passwordReset = true;
 	passwordResetDisabled = true;
 }
 else {
 	passwordReset = BeanParamUtil.getBoolean(selUser, request, "passwordReset");
 
-	if ((passwordPolicy != null) && !passwordPolicy.isChangeable()) {
+	if ((passwordPolicy == null) || !passwordPolicy.isChangeable()) {
 		passwordResetDisabled = true;
 	}
 }

--- a/portal-impl/src/com/liferay/portal/security/pwd/PwdToolkitUtil.java
+++ b/portal-impl/src/com/liferay/portal/security/pwd/PwdToolkitUtil.java
@@ -9,7 +9,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.UserPasswordException;
 import com.liferay.portal.kernel.model.PasswordPolicy;
 import com.liferay.portal.kernel.module.service.Snapshot;
-import com.liferay.portal.kernel.security.ldap.LDAPSettingsUtil;
 import com.liferay.portal.kernel.security.pwd.Toolkit;
 
 /**
@@ -23,8 +22,21 @@ public class PwdToolkitUtil {
 		return toolkit.generate(passwordPolicy);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #validate(long, String, String, PasswordPolicy)}
+	 */
+	@Deprecated
 	public static void validate(
 			long companyId, long userId, String password1, String password2,
+			PasswordPolicy passwordPolicy)
+		throws PortalException {
+
+		validate(userId, password1, password2, passwordPolicy);
+	}
+
+	public static void validate(
+			long userId, String password1, String password2,
 			PasswordPolicy passwordPolicy)
 		throws PortalException {
 
@@ -32,7 +44,7 @@ public class PwdToolkitUtil {
 			throw new UserPasswordException.MustMatch(userId);
 		}
 
-		if (!LDAPSettingsUtil.isPasswordPolicyEnabled(companyId) &&
+		if ((passwordPolicy != null) &&
 			PwdToolkitUtilThreadLocal.isValidate()) {
 
 			Toolkit toolkit = _toolkitSnapshot.get();

--- a/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
@@ -224,10 +224,6 @@ public class PasswordPolicyLocalServiceImpl
 	public PasswordPolicy getDefaultPasswordPolicy(long companyId)
 		throws PortalException {
 
-		if (LDAPSettingsUtil.isPasswordPolicyEnabled(companyId)) {
-			return null;
-		}
-
 		return passwordPolicyPersistence.findByC_DP(companyId, true);
 	}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
@@ -266,7 +266,9 @@ public class PasswordPolicyLocalServiceImpl
 	public PasswordPolicy getPasswordPolicyByUser(User user)
 		throws PortalException {
 
-		if (LDAPSettingsUtil.isPasswordPolicyEnabled(user.getCompanyId())) {
+		if ((user.getLdapServerId() > 0) &&
+			LDAPSettingsUtil.isPasswordPolicyEnabled(user.getCompanyId())) {
+
 			return null;
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyLocalServiceImpl.java
@@ -244,10 +244,6 @@ public class PasswordPolicyLocalServiceImpl
 			long companyId, long[] organizationIds)
 		throws PortalException {
 
-		if (LDAPSettingsUtil.isPasswordPolicyEnabled(companyId)) {
-			return null;
-		}
-
 		if (ArrayUtil.isEmpty(organizationIds)) {
 			return getDefaultPasswordPolicy(companyId);
 		}

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -1211,8 +1211,15 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			emailAddress = emailAddressGenerator.generate(companyId, userId);
 		}
 
+		long ldapServerId = -1;
+
+		if (serviceContext != null) {
+			ldapServerId = GetterUtil.getLong(
+				serviceContext.getAttribute("ldapServerId"), ldapServerId);
+		}
+
 		validate(
-			companyId, userId, autoPassword, password1, password2,
+			companyId, ldapServerId, userId, autoPassword, password1, password2,
 			autoScreenName, screenName, emailAddress, null, firstName,
 			middleName, lastName, organizationIds, locale);
 
@@ -1270,12 +1277,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		user.setPasswordReset(_isPasswordReset(companyId));
 		user.setScreenName(screenName);
 		user.setEmailAddress(emailAddress);
-
-		Long ldapServerId = null;
-
-		if (serviceContext != null) {
-			ldapServerId = (Long)serviceContext.getAttribute("ldapServerId");
-		}
 
 		if (ldapServerId != null) {
 			user.setLdapServerId(ldapServerId);
@@ -4827,9 +4828,9 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			}
 
 			validate(
-				companyId, user.getUserId(), autoPassword, password1, password2,
-				autoScreenName, screenName, emailAddress, null, firstName,
-				middleName, lastName, null, locale);
+				companyId, 0, user.getUserId(), autoPassword, password1,
+				password2, autoScreenName, screenName, emailAddress, null,
+				firstName, middleName, lastName, null, locale);
 
 			if (!autoPassword &&
 				(Validator.isNull(password1) || Validator.isNull(password2))) {
@@ -7006,12 +7007,31 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		}
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #validatePassword(long, String, String)}
+	 */
+	@Deprecated
 	protected void validate(
 			long companyId, long userId, boolean autoPassword, String password1,
 			String password2, boolean autoScreenName, String screenName,
 			String emailAddress, String openId, String firstName,
 			String middleName, String lastName, long[] organizationIds,
 			Locale locale)
+		throws PortalException {
+
+		validate(
+			companyId, 0, userId, autoPassword, password1, password2,
+			autoScreenName, screenName, emailAddress, openId, firstName,
+			middleName, lastName, organizationIds, locale);
+	}
+
+	protected void validate(
+			long companyId, long ldapServerId, long userId,
+			boolean autoPassword, String password1, String password2,
+			boolean autoScreenName, String screenName, String emailAddress,
+			String openId, String firstName, String middleName, String lastName,
+			long[] organizationIds, Locale locale)
 		throws PortalException {
 
 		validateMaxUsers(companyId);
@@ -7021,11 +7041,17 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		}
 
 		if (!autoPassword) {
-			PasswordPolicy passwordPolicy =
-				_passwordPolicyLocalService.getDefaultPasswordPolicy(companyId);
+			PasswordPolicy passwordPolicy = null;
 
-			PwdToolkitUtil.validate(
-				companyId, 0, password1, password2, passwordPolicy);
+			if ((ldapServerId <= 0) ||
+				!LDAPSettingsUtil.isPasswordPolicyEnabled(companyId)) {
+
+				passwordPolicy =
+					_passwordPolicyLocalService.getDefaultPasswordPolicy(
+						companyId);
+			}
+
+			PwdToolkitUtil.validate(0, password1, password2, passwordPolicy);
 		}
 
 		validateEmailAddress(companyId, emailAddress);
@@ -7234,8 +7260,20 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		}
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #validatePassword(long, String, String)}
+	 */
+	@Deprecated
 	protected void validatePassword(
 			long companyId, long userId, String password1, String password2)
+		throws PortalException {
+
+		validatePassword(userId, password1, password2);
+	}
+
+	protected void validatePassword(
+			long userId, String password1, String password2)
 		throws PortalException {
 
 		if (Validator.isNull(password1) || Validator.isNull(password2)) {
@@ -7249,8 +7287,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		PasswordPolicy passwordPolicy =
 			_passwordPolicyLocalService.getPasswordPolicyByUserId(userId);
 
-		PwdToolkitUtil.validate(
-			companyId, userId, password1, password2, passwordPolicy);
+		PwdToolkitUtil.validate(userId, password1, password2, passwordPolicy);
 	}
 
 	protected void validateReminderQuery(

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -1274,17 +1274,19 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		}
 
 		user.setPasswordEncrypted(true);
-		user.setPasswordReset(_isPasswordReset(companyId));
-		user.setScreenName(screenName);
-		user.setEmailAddress(emailAddress);
 
-		if (ldapServerId != null) {
-			user.setLdapServerId(ldapServerId);
+		if ((ldapServerId <= 0) ||
+			!LDAPSettingsUtil.isPasswordPolicyEnabled(companyId)) {
+
+			user.setPasswordReset(_isPasswordReset(companyId));
 		}
 		else {
-			user.setLdapServerId(-1);
+			user.setPasswordReset(false);
 		}
 
+		user.setScreenName(screenName);
+		user.setEmailAddress(emailAddress);
+		user.setLdapServerId(ldapServerId);
 		user.setLanguageId(LocaleUtil.toLanguageId(locale));
 		user.setTimeZoneId(guestUser.getTimeZoneId());
 		user.setGreeting(greeting);
@@ -7455,7 +7457,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			PasswordPolicy passwordPolicy =
 				_passwordPolicyLocalService.getDefaultPasswordPolicy(companyId);
 
-			if ((passwordPolicy != null) && passwordPolicy.isChangeable() &&
+			if (passwordPolicy.isChangeable() &&
 				passwordPolicy.isChangeRequired()) {
 
 				return true;

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -1788,10 +1788,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 */
 	@Override
 	public void checkLockout(User user) throws PortalException {
-		if (LDAPSettingsUtil.isPasswordPolicyEnabled(user.getCompanyId())) {
-			return;
-		}
-
 		doCheckLockout(user, user.getPasswordPolicy());
 	}
 
@@ -1872,10 +1868,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	 */
 	@Override
 	public void checkPasswordExpired(User user) throws PortalException {
-		if (LDAPSettingsUtil.isPasswordPolicyEnabled(user.getCompanyId())) {
-			return;
-		}
-
 		doCheckPasswordExpired(user, user.getPasswordPolicy());
 	}
 
@@ -1903,7 +1895,9 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		if (autoPassword) {
 			String password = StringPool.BLANK;
 
-			if (LDAPSettingsUtil.isPasswordPolicyEnabled(user.getCompanyId())) {
+			if (LDAPSettingsUtil.isPasswordPolicyEnabled(user.getCompanyId()) &&
+				(user.getLdapServerId() > 0)) {
+
 				if (_log.isWarnEnabled()) {
 					_log.warn(
 						StringBundler.concat(
@@ -5278,7 +5272,9 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		catch (ModelListenerException modelListenerException) {
 			Throwable throwable = modelListenerException.getCause();
 
-			if (LDAPSettingsUtil.isPasswordPolicyEnabled(user.getCompanyId())) {
+			if (LDAPSettingsUtil.isPasswordPolicyEnabled(user.getCompanyId()) &&
+				(user.getLdapServerId() > 0)) {
+
 				String msg = GetterUtil.getString(throwable.getMessage());
 
 				String[] errorPasswordHistoryKeywords =
@@ -6238,7 +6234,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	protected User doCheckLockout(User user, PasswordPolicy passwordPolicy)
 		throws PortalException {
 
-		if (!passwordPolicy.isLockout()) {
+		if ((passwordPolicy == null) || !passwordPolicy.isLockout()) {
 			return user;
 		}
 
@@ -6273,7 +6269,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 		// Check if user should be forced to change password on first login
 
-		if (passwordPolicy.isChangeable() &&
+		if ((passwordPolicy != null) && passwordPolicy.isChangeable() &&
 			passwordPolicy.isChangeRequired() &&
 			(user.getLastLoginDate() == null)) {
 
@@ -6374,7 +6370,9 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 			// Let LDAP handle max failure event
 
-			if (!LDAPSettingsUtil.isPasswordPolicyEnabled(companyId)) {
+			if (!LDAPSettingsUtil.isPasswordPolicyEnabled(companyId) ||
+				(user.getLdapServerId() <= 0)) {
+
 				PasswordPolicy passwordPolicy = user.getPasswordPolicy();
 
 				user = userPersistence.fetchByPrimaryKey(user.getUserId());
@@ -7381,14 +7379,12 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		// Check password policy to see if the is account locked out or if the
 		// password is expired
 
-		if (!LDAPSettingsUtil.isPasswordPolicyEnabled(user.getCompanyId())) {
-			PasswordPolicy passwordPolicy = user.getPasswordPolicy();
+		PasswordPolicy passwordPolicy = user.getPasswordPolicy();
 
-			user = doCheckLockout(user, passwordPolicy);
+		user = doCheckLockout(user, passwordPolicy);
 
-			if (!PasswordModificationThreadLocal.isPasswordModified()) {
-				user = doCheckPasswordExpired(user, passwordPolicy);
-			}
+		if (!PasswordModificationThreadLocal.isPasswordModified()) {
+			user = doCheckPasswordExpired(user, passwordPolicy);
 		}
 
 		return user;


### PR DESCRIPTION
Rebased and resent from https://github.com/liferay-appsec/liferay-portal/pull/1979

Original message:

https://liferay.atlassian.net/browse/LPD-36309

> The main problem is password policies are never used if LDAP Password Policy is enabled. This includes "native" portal users which have no relation to an LDAP server.
> 
> The solution is to also check if the given user has an LDAP server ID value before returning a null password policy. There is also other logic surrounding password policies, such as assignment and creation/editing.
> 
> Please let me know if you have any questions, or if I should include anymore tests. Thanks!