### PR TITLE
LPD-41375 Exchange jodd.Paramo dependency with java.lang.reflect.Parameter

### DIFF
--- a/modules/apps/portal-remote/portal-remote-json-web-service-web/build.gradle
+++ b/modules/apps/portal-remote/portal-remote-json-web-service-web/build.gradle
@@ -1,6 +1,4 @@
 dependencies {
-	compileInclude group: "org.jodd", name: "jodd-proxetta", version: "6.0.0"
-
 	compileOnly group: "com.liferay", name: "jodd.util", version: "6.0.1.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/portal-remote/portal-remote-json-web-service-web/src/main/java/com/liferay/portal/remote/json/web/service/web/internal/util/MethodParametersResolverUtil.java
+++ b/modules/apps/portal-remote/portal-remote-json-web-service-web/src/main/java/com/liferay/portal/remote/json/web/service/web/internal/util/MethodParametersResolverUtil.java
@@ -11,10 +11,9 @@ import com.liferay.portal.kernel.util.MethodParameter;
 
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 
 import java.util.concurrent.ConcurrentMap;
-
-import jodd.paramo.Paramo;
 
 /**
  * @author Igor Spasic
@@ -34,15 +33,15 @@ public class MethodParametersResolverUtil {
 
 		Class<?>[] methodParameterTypes = method.getParameterTypes();
 
-		jodd.paramo.MethodParameter[] joddMethodParameters =
-			Paramo.resolveParameters(method);
+		Parameter[] parameters = method.getParameters();
 
-		methodParameters = new MethodParameter[joddMethodParameters.length];
+		methodParameters = new MethodParameter[parameters.length];
 
-		for (int i = 0; i < joddMethodParameters.length; i++) {
+		for (int i = 0; i < parameters.length; i++) {
 			methodParameters[i] = new MethodParameter(
-				classLoader, joddMethodParameters[i].getName(),
-				joddMethodParameters[i].getSignature(),
+				classLoader, parameters[i].getName(),
+				parameters[i].getParameterizedType(
+				).getTypeName(),
 				methodParameterTypes[i]);
 		}
 


### PR DESCRIPTION
[LPD-41375](https://liferay.atlassian.net/browse/LPD-41375)

Original pr  - https://github.com/liferay-appsec/liferay-portal/pull/2049

Original message:

> Please see https://liferay.atlassian.net/browse/LPP-56216. The customer uses Java21 on the portal and created a Service builder module, but during runtime, it does not compatible with JsonWS jodd.Paramo dependency. That jodd.paramo.MethodParameter would be replaced with java.lang.reflect.Parameter.