### PR TITLE
LPD-40224

### DIFF
--- a/modules/apps/bean-portlet/bean-portlet-extension-api/bnd.bnd
+++ b/modules/apps/bean-portlet/bean-portlet-extension-api/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Bean Portlet Extension API
 Bundle-SymbolicName: com.liferay.bean.portlet.extension.api
-Bundle-Version: 2.0.8
+Bundle-Version: 2.1.0
 Export-Package: com.liferay.bean.portlet.extension

--- a/modules/apps/bean-portlet/bean-portlet-extension-api/src/main/java/com/liferay/bean/portlet/extension/CSRFLiferayPortletURL.java
+++ b/modules/apps/bean-portlet/bean-portlet-extension-api/src/main/java/com/liferay/bean/portlet/extension/CSRFLiferayPortletURL.java
@@ -288,6 +288,11 @@ public class CSRFLiferayPortletURL implements LiferayPortletURL {
 	}
 
 	@Override
+	public void setUseNamespace(boolean namespace) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public void setWindowState(WindowState windowState) {
 		throw new UnsupportedOperationException();
 	}

--- a/modules/apps/bean-portlet/bean-portlet-extension-api/src/main/resources/com/liferay/bean/portlet/extension/packageinfo
+++ b/modules/apps/bean-portlet/bean-portlet-extension-api/src/main/resources/com/liferay/bean/portlet/extension/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleConfigurationDisplayContext.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/display/context/KBArticleConfigurationDisplayContext.java
@@ -72,8 +72,8 @@ public class KBArticleConfigurationDisplayContext {
 		PortletURL portletURL = ActionURLTag.doTag(
 			PortletRequest.ACTION_PHASE, null, null, null, null, null, null,
 			null, null, LayoutConstants.DEFAULT_PLID,
-			LayoutConstants.DEFAULT_PLID, null, null, null, 0, 0, true, null,
-			null, _httpServletRequest);
+			LayoutConstants.DEFAULT_PLID, null, null, null, 0, 0, null, true,
+			null, null, _httpServletRequest);
 
 		return portletURL.toString();
 	}

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/display/context/AuditDisplayContext.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/display/context/AuditDisplayContext.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.portlet.PortletURLUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.CalendarFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -71,7 +72,7 @@ public class AuditDisplayContext {
 			return _className;
 		}
 
-		_className = ParamUtil.getString(_httpServletRequest, "className");
+		_className = _getRenderParamWithOrWithoutNamespace("className");
 
 		return _className;
 	}
@@ -81,7 +82,7 @@ public class AuditDisplayContext {
 			return _classPK;
 		}
 
-		_classPK = ParamUtil.getString(_httpServletRequest, "classPK");
+		_classPK = _getRenderParamWithOrWithoutNamespace("classPK");
 
 		return _classPK;
 	}
@@ -91,7 +92,7 @@ public class AuditDisplayContext {
 			return _clientHost;
 		}
 
-		_clientHost = ParamUtil.getString(_httpServletRequest, "clientHost");
+		_clientHost = _getRenderParamWithOrWithoutNamespace("clientHost");
 
 		return _clientHost;
 	}
@@ -101,7 +102,7 @@ public class AuditDisplayContext {
 			return _clientIP;
 		}
 
-		_clientIP = ParamUtil.getString(_httpServletRequest, "clientIP");
+		_clientIP = _getRenderParamWithOrWithoutNamespace("clientIP");
 
 		return _clientIP;
 	}
@@ -177,7 +178,7 @@ public class AuditDisplayContext {
 			return _eventType;
 		}
 
-		_eventType = ParamUtil.getString(_httpServletRequest, "eventType");
+		_eventType = _getRenderParamWithOrWithoutNamespace("eventType");
 
 		return _eventType;
 	}
@@ -187,9 +188,20 @@ public class AuditDisplayContext {
 			return _groupId;
 		}
 
-		_groupId = ParamUtil.getInteger(_httpServletRequest, "groupId");
+		_groupId = GetterUtil.getInteger(
+			_getRenderParamWithOrWithoutNamespace("groupId"));
 
 		return _groupId;
+	}
+
+	public String getKeywords() {
+		if (_keywords != null) {
+			return _keywords;
+		}
+
+		_keywords = _getRenderParamWithOrWithoutNamespace("keywords");
+
+		return _keywords;
 	}
 
 	public SearchContainer<AuditEvent> getSearchContainer() throws Exception {
@@ -216,7 +228,7 @@ public class AuditDisplayContext {
 			range[1] = _searchContainer.getEnd();
 		}
 
-		if (displayTerms.isAdvancedSearch()) {
+		if (isAdvancedSearch()) {
 			Date endDate = PortalUtil.getDate(
 				getEndDateMonth(), getEndDateDay(), getEndDateYear(),
 				(getEndDateAmPm() != Calendar.PM) ? getEndDateHour() :
@@ -235,17 +247,17 @@ public class AuditDisplayContext {
 					getUserName(), startDate, endDate, getEventType(),
 					getClassName(), getClassPK(), getClientHost(),
 					getClientIP(), getServerName(), getServerPort(), null,
-					displayTerms.isAndOperator(), range[0], range[1],
+					isAndOperator(), range[0], range[1],
 					new AuditEventCreateDateComparator()),
 				AuditEventManagerUtil.getAuditEventsCount(
 					_themeDisplay.getCompanyId(), getGroupId(), getUserId(),
 					getUserName(), startDate, endDate, getEventType(),
 					getClassName(), getClassPK(), getClientHost(),
 					getClientIP(), getServerName(), getServerPort(), null,
-					displayTerms.isAndOperator()));
+					isAndOperator()));
 		}
 		else {
-			String keywords = displayTerms.getKeywords();
+			String keywords = getKeywords();
 
 			String number =
 				Validator.isNumber(keywords) ? keywords : String.valueOf(0);
@@ -272,7 +284,7 @@ public class AuditDisplayContext {
 			return _serverName;
 		}
 
-		_serverName = ParamUtil.getString(_httpServletRequest, "serverName");
+		_serverName = _getRenderParamWithOrWithoutNamespace("serverName");
 
 		return _serverName;
 	}
@@ -282,7 +294,8 @@ public class AuditDisplayContext {
 			return _serverPort;
 		}
 
-		_serverPort = ParamUtil.getInteger(_httpServletRequest, "serverPort");
+		_serverPort = GetterUtil.getInteger(
+			_getRenderParamWithOrWithoutNamespace("serverPort"));
 
 		return _serverPort;
 	}
@@ -358,7 +371,8 @@ public class AuditDisplayContext {
 			return _userId;
 		}
 
-		_userId = ParamUtil.getLong(_httpServletRequest, "userId");
+		_userId = GetterUtil.getLong(
+			_getRenderParamWithOrWithoutNamespace("userId"));
 
 		return _userId;
 	}
@@ -368,9 +382,19 @@ public class AuditDisplayContext {
 			return _userName;
 		}
 
-		_userName = ParamUtil.getString(_httpServletRequest, "userName");
+		_userName = _getRenderParamWithOrWithoutNamespace("userName");
 
 		return _userName;
+	}
+
+	public boolean isAdvancedSearch() {
+		return GetterUtil.getBoolean(
+			_getRenderParamWithOrWithoutNamespace("advancedSearch"));
+	}
+
+	public boolean isAndOperator() {
+		return GetterUtil.getBoolean(
+			_getRenderParamWithOrWithoutNamespace("andOperator"));
 	}
 
 	public void setPaging(boolean paging) {
@@ -398,6 +422,8 @@ public class AuditDisplayContext {
 				PortletURLUtil.getCurrent(
 					_liferayPortletRequest, _liferayPortletResponse),
 				_liferayPortletResponse)
+		).setKeywords(
+			getKeywords()
 		).setParameter(
 			PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE + "endDateAmPm",
 			getEndDateAmPm()
@@ -435,6 +461,10 @@ public class AuditDisplayContext {
 			PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE + "startDateYear",
 			getStartDateYear()
 		).setParameter(
+			"advancedSearch", isAdvancedSearch()
+		).setParameter(
+			"andOperator", isAndOperator()
+		).setParameter(
 			"className", getClassName()
 		).setParameter(
 			"classPK", getClassPK()
@@ -459,6 +489,13 @@ public class AuditDisplayContext {
 		return _portletURL;
 	}
 
+	private String _getRenderParamWithOrWithoutNamespace(String param) {
+		return ParamUtil.getString(
+			(HttpServletRequest)_servletRequestWrapper.getRequest(),
+			PortletQName.PRIVATE_RENDER_PARAMETER_NAMESPACE + param,
+			ParamUtil.getString(_httpServletRequest, param));
+	}
+
 	private String _className;
 	private String _classPK;
 	private String _clientHost;
@@ -472,6 +509,7 @@ public class AuditDisplayContext {
 	private String _eventType;
 	private Integer _groupId;
 	private final HttpServletRequest _httpServletRequest;
+	private String _keywords;
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
 	private boolean _paging = true;

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/display/context/AuditDisplayContext.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/display/context/AuditDisplayContext.java
@@ -197,7 +197,8 @@ public class AuditDisplayContext {
 			return _searchContainer;
 		}
 
-		DisplayTerms displayTerms = new DisplayTerms(_liferayPortletRequest);
+		DisplayTerms displayTerms = new DisplayTerms(
+			(HttpServletRequest)_servletRequestWrapper.getRequest());
 
 		_searchContainer = new SearchContainer(
 			_liferayPortletRequest, displayTerms, null,
@@ -384,10 +385,7 @@ public class AuditDisplayContext {
 			PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE + param,
 			ParamUtil.getInteger(
 				(HttpServletRequest)_servletRequestWrapper.getRequest(), param,
-				ParamUtil.getInteger(
-					(HttpServletRequest)_servletRequestWrapper.getRequest(),
-					_liferayPortletResponse.getNamespace() + param,
-					defaultValue)));
+				defaultValue));
 	}
 
 	private PortletURL _getPortletURL() throws Exception {

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/display/context/AuditDisplayContext.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/display/context/AuditDisplayContext.java
@@ -384,7 +384,10 @@ public class AuditDisplayContext {
 			PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE + param,
 			ParamUtil.getInteger(
 				(HttpServletRequest)_servletRequestWrapper.getRequest(), param,
-				defaultValue));
+				ParamUtil.getInteger(
+					(HttpServletRequest)_servletRequestWrapper.getRequest(),
+					_liferayPortletResponse.getNamespace() + param,
+					defaultValue)));
 	}
 
 	private PortletURL _getPortletURL() throws Exception {

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/configuration/icon/export_audit_events.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/configuration/icon/export_audit_events.jsp
@@ -7,7 +7,7 @@
 
 <%@ include file="/init.jsp" %>
 
-<liferay-portlet:resourceURL id="/audit/export_audit_events" var="exportURL">
+<liferay-portlet:resourceURL id="/audit/export_audit_events" useNamespace="<%= false %>" var="exportURL">
 	<portlet:param name="endDateAmPm" value="<%= String.valueOf(auditDisplayContext.getEndDateAmPm()) %>" />
 	<portlet:param name="endDateDay" value="<%= String.valueOf(auditDisplayContext.getEndDateDay()) %>" />
 	<portlet:param name="endDateHour" value="<%= String.valueOf(auditDisplayContext.getEndDateHour()) %>" />

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/configuration/icon/export_audit_events.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/configuration/icon/export_audit_events.jsp
@@ -8,18 +8,29 @@
 <%@ include file="/init.jsp" %>
 
 <liferay-portlet:resourceURL id="/audit/export_audit_events" useNamespace="<%= false %>" var="exportURL">
+	<portlet:param name="className" value="<%= String.valueOf(auditDisplayContext.getClassName()) %>" />
+	<portlet:param name="classPK" value="<%= String.valueOf(auditDisplayContext.getClassPK()) %>" />
+	<portlet:param name="clientHost" value="<%= String.valueOf(auditDisplayContext.getClientHost()) %>" />
+	<portlet:param name="clientIP" value="<%= String.valueOf(auditDisplayContext.getClientIP()) %>" />
 	<portlet:param name="endDateAmPm" value="<%= String.valueOf(auditDisplayContext.getEndDateAmPm()) %>" />
 	<portlet:param name="endDateDay" value="<%= String.valueOf(auditDisplayContext.getEndDateDay()) %>" />
 	<portlet:param name="endDateHour" value="<%= String.valueOf(auditDisplayContext.getEndDateHour()) %>" />
 	<portlet:param name="endDateMinute" value="<%= String.valueOf(auditDisplayContext.getEndDateMinute()) %>" />
 	<portlet:param name="endDateMonth" value="<%= String.valueOf(auditDisplayContext.getEndDateMonth()) %>" />
 	<portlet:param name="endDateYear" value="<%= String.valueOf(auditDisplayContext.getEndDateYear()) %>" />
+	<portlet:param name="eventType" value="<%= String.valueOf(auditDisplayContext.getEventType()) %>" />
+	<portlet:param name="groupId" value="<%= String.valueOf(auditDisplayContext.getGroupId()) %>" />
+	<portlet:param name="keywords" value="<%= String.valueOf(auditDisplayContext.getKeywords()) %>" />
+	<portlet:param name="serverName" value="<%= String.valueOf(auditDisplayContext.getServerName()) %>" />
+	<portlet:param name="serverPort" value="<%= String.valueOf(auditDisplayContext.getServerPort()) %>" />
 	<portlet:param name="startDateAmPm" value="<%= String.valueOf(auditDisplayContext.getStartDateAmPm()) %>" />
 	<portlet:param name="startDateDay" value="<%= String.valueOf(auditDisplayContext.getStartDateDay()) %>" />
 	<portlet:param name="startDateHour" value="<%= String.valueOf(auditDisplayContext.getStartDateHour()) %>" />
 	<portlet:param name="startDateMinute" value="<%= String.valueOf(auditDisplayContext.getStartDateMinute()) %>" />
 	<portlet:param name="startDateMonth" value="<%= String.valueOf(auditDisplayContext.getStartDateMonth()) %>" />
 	<portlet:param name="startDateYear" value="<%= String.valueOf(auditDisplayContext.getStartDateYear()) %>" />
+	<portlet:param name="userId" value="<%= String.valueOf(auditDisplayContext.getUserId()) %>" />
+	<portlet:param name="userName" value="<%= String.valueOf(auditDisplayContext.getUserName()) %>" />
 </liferay-portlet:resourceURL>
 
 <aui:script>

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/configuration/icon/export_audit_events.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/configuration/icon/export_audit_events.jsp
@@ -7,7 +7,20 @@
 
 <%@ include file="/init.jsp" %>
 
-<liferay-portlet:resourceURL id="/audit/export_audit_events" var="exportURL" />
+<liferay-portlet:resourceURL id="/audit/export_audit_events" var="exportURL">
+	<portlet:param name="endDateAmPm" value="<%= String.valueOf(auditDisplayContext.getEndDateAmPm()) %>" />
+	<portlet:param name="endDateDay" value="<%= String.valueOf(auditDisplayContext.getEndDateDay()) %>" />
+	<portlet:param name="endDateHour" value="<%= String.valueOf(auditDisplayContext.getEndDateHour()) %>" />
+	<portlet:param name="endDateMinute" value="<%= String.valueOf(auditDisplayContext.getEndDateMinute()) %>" />
+	<portlet:param name="endDateMonth" value="<%= String.valueOf(auditDisplayContext.getEndDateMonth()) %>" />
+	<portlet:param name="endDateYear" value="<%= String.valueOf(auditDisplayContext.getEndDateYear()) %>" />
+	<portlet:param name="startDateAmPm" value="<%= String.valueOf(auditDisplayContext.getStartDateAmPm()) %>" />
+	<portlet:param name="startDateDay" value="<%= String.valueOf(auditDisplayContext.getStartDateDay()) %>" />
+	<portlet:param name="startDateHour" value="<%= String.valueOf(auditDisplayContext.getStartDateHour()) %>" />
+	<portlet:param name="startDateMinute" value="<%= String.valueOf(auditDisplayContext.getStartDateMinute()) %>" />
+	<portlet:param name="startDateMonth" value="<%= String.valueOf(auditDisplayContext.getStartDateMonth()) %>" />
+	<portlet:param name="startDateYear" value="<%= String.valueOf(auditDisplayContext.getStartDateYear()) %>" />
+</liferay-portlet:resourceURL>
 
 <aui:script>
 	Liferay.Util.setPortletConfigurationIconAction(

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/event_search.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/event_search.jsp
@@ -8,8 +8,6 @@
 <%@ include file="/init.jsp" %>
 
 <%
-AuditDisplayContext auditDisplayContext = (AuditDisplayContext)request.getAttribute(AuditDisplayContext.class.getName());
-
 SearchContainer<?> searchContainer = (SearchContainer<?>)request.getAttribute("liferay-ui:search:searchContainer");
 %>
 

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/init.jsp
@@ -37,3 +37,7 @@ page import="com.liferay.portal.security.audit.web.internal.display.context.Audi
 <liferay-theme:defineObjects />
 
 <portlet:defineObjects />
+
+<%
+AuditDisplayContext auditDisplayContext = new AuditDisplayContext(request, liferayPortletRequest, liferayPortletResponse, timeZone);
+%>

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/view.jsp
@@ -12,13 +12,6 @@
 <clay:container-fluid
 	cssClass="container-view"
 >
-
-	<%
-	AuditDisplayContext auditDisplayContext = new AuditDisplayContext(request, liferayPortletRequest, liferayPortletResponse, timeZone);
-
-	request.setAttribute(AuditDisplayContext.class.getName(), auditDisplayContext);
-	%>
-
 	<aui:form action="<%= searchURL %>" method="get" name="fm">
 		<liferay-portlet:renderURLParams varImpl="searchURL" />
 

--- a/portal-impl/src/com/liferay/portlet/internal/PortletURLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/internal/PortletURLImpl.java
@@ -813,6 +813,13 @@ public class PortletURLImpl
 		clearCache();
 	}
 
+	@Override
+	public void setUseNamespace(boolean namespace) {
+		_useNamespace = namespace;
+
+		clearCache();
+	}
+
 	public void setWindowState(String windowState) throws WindowStateException {
 		setWindowState(WindowStateFactory.getWindowState(windowState));
 	}
@@ -1341,7 +1348,7 @@ public class PortletURLImpl
 
 		if (!name.startsWith(PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE) &&
 			!name.startsWith(namespace) &&
-			!PortalUtil.isReservedParameter(name)) {
+			!PortalUtil.isReservedParameter(name) && _useNamespace) {
 
 			if (_encodedNamespace == null) {
 				_encodedNamespace = URLCodec.encodeURL(namespace);
@@ -1766,6 +1773,7 @@ public class PortletURLImpl
 	private String _resourceID;
 	private boolean _secure;
 	private String _toString;
+	private boolean _useNamespace = true;
 	private boolean _windowStateRestoreCurrentView;
 	private String _windowStateString;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/LiferayPortletURL.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/LiferayPortletURL.java
@@ -293,6 +293,8 @@ public interface LiferayPortletURL
 
 	public void setRemovedParameterNames(Set<String> removedParamNames);
 
+	public void setUseNamespace(boolean namespace);
+
 	/**
 	 * Sets whether this portlet restores to the current view when toggling
 	 * between maximized and normal states.

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/LiferayPortletURLWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/LiferayPortletURLWrapper.java
@@ -197,6 +197,11 @@ public class LiferayPortletURLWrapper
 	}
 
 	@Override
+	public void setUseNamespace(boolean namespace) {
+		_liferayPortletURL.setUseNamespace(namespace);
+	}
+
+	@Override
 	public void setWindowStateRestoreCurrentView(
 		boolean windowStateRestoreCurrentView) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 30.1.0
+version 30.2.0

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 24.6.1
+Bundle-Version: 24.7.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/kernel/test/portlet/MockLiferayPortletURL.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/portlet/MockLiferayPortletURL.java
@@ -274,6 +274,10 @@ public class MockLiferayPortletURL implements LiferayPortletURL, RenderURL {
 	}
 
 	@Override
+	public void setUseNamespace(boolean namespace) {
+	}
+
+	@Override
 	public void setWindowState(WindowState windowState)
 		throws WindowStateException {
 	}

--- a/portal-test/src/com/liferay/portal/kernel/test/portlet/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/portal-test/src/com/liferay/portlet/test/packageinfo
+++ b/portal-test/src/com/liferay/portlet/test/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/util-taglib/bnd.bnd
+++ b/util-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 25.2.0
+Bundle-Version: 26.0.0
 Export-Package:\
 	com.liferay.alloy.taglib.*;version="3.0.0",\
 	com.liferay.taglib.*

--- a/util-taglib/src/META-INF/liferay-portlet-ext.tld
+++ b/util-taglib/src/META-INF/liferay-portlet-ext.tld
@@ -114,6 +114,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>useNamespace</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>var</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
@@ -458,6 +463,11 @@
 		</attribute>
 		<attribute>
 			<name>secure</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
+			<name>useNamespace</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>

--- a/util-taglib/src/com/liferay/taglib/portlet/ActionURLTag.java
+++ b/util-taglib/src/com/liferay/taglib/portlet/ActionURLTag.java
@@ -50,8 +50,8 @@ public class ActionURLTag
 			Boolean escapeXml, String name, String resourceID,
 			String cacheability, long plid, long refererPlid,
 			String portletName, Boolean anchor, Boolean encrypt,
-			long doAsGroupId, long doAsUserId, Boolean portletConfiguration,
-			Map<String, String[]> parameterMap,
+			long doAsGroupId, long doAsUserId, Boolean useNamespace,
+			Boolean portletConfiguration, Map<String, String[]> parameterMap,
 			Set<String> removedParameterNames,
 			HttpServletRequest httpServletRequest)
 		throws Exception {
@@ -131,6 +131,10 @@ public class ActionURLTag
 
 		if (doAsUserId > 0) {
 			liferayPortletURL.setDoAsUserId(doAsUserId);
+		}
+
+		if (useNamespace != null) {
+			liferayPortletURL.setUseNamespace(useNamespace);
 		}
 
 		String settingsScope = null;
@@ -217,8 +221,8 @@ public class ActionURLTag
 				getLifecycle(), _windowState, _portletMode, _secure,
 				_copyCurrentRenderParameters, _escapeXml, _name, _resourceID,
 				_cacheability, _plid, _refererPlid, _portletName, _anchor,
-				_encrypt, _doAsGroupId, _doAsUserId, _portletConfiguration,
-				getParams(), getRemovedParameterNames(),
+				_encrypt, _doAsGroupId, _doAsUserId, _useNamespace,
+				_portletConfiguration, getParams(), getRemovedParameterNames(),
 				(HttpServletRequest)pageContext.getRequest());
 
 			if (Validator.isNotNull(_var)) {
@@ -321,6 +325,10 @@ public class ActionURLTag
 		_secure = Boolean.valueOf(secure);
 	}
 
+	public void setUseNamespace(boolean namespace) {
+		_useNamespace = namespace;
+	}
+
 	public void setVar(String var) {
 		_var = var;
 	}
@@ -401,6 +409,7 @@ public class ActionURLTag
 	private long _refererPlid = LayoutConstants.DEFAULT_PLID;
 	private String _resourceID;
 	private Boolean _secure;
+	private Boolean _useNamespace;
 	private String _var;
 	private String _varImpl;
 	private String _windowState;

--- a/util-taglib/src/com/liferay/taglib/portlet/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/portlet/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 10.0.0

--- a/util-taglib/src/com/liferay/taglib/util/DummyVelocityTaglib.java
+++ b/util-taglib/src/com/liferay/taglib/util/DummyVelocityTaglib.java
@@ -36,7 +36,8 @@ public class DummyVelocityTaglib implements VelocityTaglib {
 		Boolean copyCurrentRenderParameters, Boolean escapeXml, String name,
 		long plid, long refererPlid, String portletName, Boolean anchor,
 		Boolean encrypt, long doAsGroupId, long doAsUserId,
-		Boolean portletConfiguration, String queryString) {
+		Boolean useNamespace, Boolean portletConfiguration,
+		String queryString) {
 
 		return null;
 	}
@@ -156,8 +157,8 @@ public class DummyVelocityTaglib implements VelocityTaglib {
 		String windowState, String portletMode, Boolean secure,
 		Boolean copyCurrentRenderParameters, Boolean escapeXml, long plid,
 		long refererPlid, String portletName, Boolean anchor, Boolean encrypt,
-		long doAsGroupId, long doAsUserId, Boolean portletConfiguration,
-		String queryString) {
+		long doAsGroupId, long doAsUserId, Boolean useNamespace,
+		Boolean portletConfiguration, String queryString) {
 
 		return null;
 	}

--- a/util-taglib/src/com/liferay/taglib/util/VelocityTaglib.java
+++ b/util-taglib/src/com/liferay/taglib/util/VelocityTaglib.java
@@ -33,7 +33,8 @@ public interface VelocityTaglib {
 			Boolean copyCurrentRenderParameters, Boolean escapeXml, String name,
 			long plid, long refererPlid, String portletName, Boolean anchor,
 			Boolean encrypt, long doAsGroupId, long doAsUserId,
-			Boolean portletConfiguration, String queryString)
+			Boolean useNamespace, Boolean portletConfiguration,
+			String queryString)
 		throws Exception;
 
 	public String actionURL(
@@ -106,7 +107,8 @@ public interface VelocityTaglib {
 			Boolean copyCurrentRenderParameters, Boolean escapeXml, long plid,
 			long refererPlid, String portletName, Boolean anchor,
 			Boolean encrypt, long doAsGroupId, long doAsUserId,
-			Boolean portletConfiguration, String queryString)
+			Boolean useNamespace, Boolean portletConfiguration,
+			String queryString)
 		throws Exception;
 
 	public String renderURL(

--- a/util-taglib/src/com/liferay/taglib/util/VelocityTaglibImpl.java
+++ b/util-taglib/src/com/liferay/taglib/util/VelocityTaglibImpl.java
@@ -94,7 +94,8 @@ public class VelocityTaglibImpl implements VelocityTaglib {
 			Boolean copyCurrentRenderParameters, Boolean escapeXml, String name,
 			long plid, long refererPlid, String portletName, Boolean anchor,
 			Boolean encrypt, long doAsGroupId, long doAsUserId,
-			Boolean portletConfiguration, String queryString)
+			Boolean useNamespace, Boolean portletConfiguration,
+			String queryString)
 		throws Exception {
 
 		String resourceID = null;
@@ -107,8 +108,8 @@ public class VelocityTaglibImpl implements VelocityTaglib {
 			PortletRequest.ACTION_PHASE, windowState, portletMode, secure,
 			copyCurrentRenderParameters, escapeXml, name, resourceID,
 			cacheability, plid, refererPlid, portletName, anchor, encrypt,
-			doAsGroupId, doAsUserId, portletConfiguration, parameterMap,
-			removedParameterNames, _httpServletRequest);
+			doAsGroupId, doAsUserId, useNamespace, portletConfiguration,
+			parameterMap, removedParameterNames, _httpServletRequest);
 
 		return portletURL.toString();
 	}
@@ -128,12 +129,14 @@ public class VelocityTaglibImpl implements VelocityTaglib {
 		Boolean encrypt = null;
 		long doAsGroupId = 0;
 		long doAsUserId = 0;
+		Boolean useNamespace = null;
 		Boolean portletConfiguration = null;
 
 		return actionURL(
 			windowState, portletMode, secure, copyCurrentRenderParameters,
 			escapeXml, name, plid, refererPlid, portletName, anchor, encrypt,
-			doAsGroupId, doAsUserId, portletConfiguration, queryString);
+			doAsGroupId, doAsUserId, portletConfiguration, useNamespace,
+			queryString);
 	}
 
 	@Override
@@ -358,7 +361,8 @@ public class VelocityTaglibImpl implements VelocityTaglib {
 			Boolean copyCurrentRenderParameters, Boolean escapeXml, long plid,
 			long refererPlid, String portletName, Boolean anchor,
 			Boolean encrypt, long doAsGroupId, long doAsUserId,
-			Boolean portletConfiguration, String queryString)
+			Boolean useNamespace, Boolean portletConfiguration,
+			String queryString)
 		throws Exception {
 
 		String name = null;
@@ -372,8 +376,8 @@ public class VelocityTaglibImpl implements VelocityTaglib {
 			PortletRequest.RENDER_PHASE, windowState, portletMode, secure,
 			copyCurrentRenderParameters, escapeXml, name, resourceID,
 			cacheability, plid, refererPlid, portletName, anchor, encrypt,
-			doAsGroupId, doAsUserId, portletConfiguration, parameterMap,
-			removedParameterNames, _httpServletRequest);
+			doAsGroupId, doAsUserId, useNamespace, portletConfiguration,
+			parameterMap, removedParameterNames, _httpServletRequest);
 
 		return portletURL.toString();
 	}
@@ -392,12 +396,14 @@ public class VelocityTaglibImpl implements VelocityTaglib {
 		Boolean encrypt = null;
 		long doAsGroupId = 0;
 		long doAsUserId = 0;
+		Boolean useNamespace = null;
 		Boolean portletConfiguration = null;
 
 		return renderURL(
 			windowState, portletMode, secure, copyCurrentRenderParameters,
 			escapeXml, plid, referPlid, portletName, anchor, encrypt,
-			doAsGroupId, doAsUserId, portletConfiguration, queryString);
+			doAsGroupId, doAsUserId, useNamespace, portletConfiguration,
+			queryString);
 	}
 
 	@Override

--- a/util-taglib/src/com/liferay/taglib/util/packageinfo
+++ b/util-taglib/src/com/liferay/taglib/util/packageinfo
@@ -1,1 +1,1 @@
-version 14.0.0
+version 15.0.0


### PR DESCRIPTION
Changes look good @daiazius, but see my final commit.  I've also rebased the branch.

Please verify my changes look fine, and once CI passes, we can forward to Stian, thanks!

Original message:

> Ticket: https://liferay.atlassian.net/browse/LPD-40224
> 
> Hi, this problem was happening because when the portlet namespace was removed from the date parameters, the resourceURL tag stopped returning these parameters because it needs a namespace.
> 
> I solved this by moving the auditDisplayContext to init.jsp and using it to put these parameters back in the exportURL and making _getParamWithOrWithoutNamespace() accept the portlet namespace.