### PR TITLE
LPD-39334 Add new ci:test:security-playwright suite

### DIFF
--- a/ci.properties
+++ b/ci.properties
@@ -168,6 +168,7 @@ ci.test.available.suites=\
     search-solr-as,\
     search-solr-db,\
     security,\
+    security-playwright,\
     service-builder,\
     setup-wizard,\
     sf,\
@@ -353,6 +354,7 @@ ci.test.suite.description[search-solr]=Test search tests with the Solr 8 search 
 ci.test.suite.description[search-solr-as]=Test search tests with the Solr 8 search engine on different application servers.
 ci.test.suite.description[search-solr-db]=Test search tests with the Solr 8 search engine on different databases.
 ci.test.suite.description[security]=Test security tests.
+ci.test.suite.description[security-playwright]=Test security playwright tests.
 ci.test.suite.description[service-builder]=Test Service Builder tests.
 ci.test.suite.description[setup-wizard]=Test Setup Wizard tests.
 ci.test.suite.description[sf]=Test source formatter.

--- a/test.properties
+++ b/test.properties
@@ -9175,13 +9175,38 @@
     # Security
     #
 
-    playwright.projects.includes[playwright-js-tomcat90-mysql57][security]=\
+    modules.includes[modules-semantic-versioning][security]=${security.testing.modules}
+
+    modules.includes.private[modules-semantic-versioning][security]=\
+        ${security.testing.modules},\
+        dxp/apps/antivirus/**,\
+        dxp/apps/multi-factor-authentication/**,\
+        dxp/apps/saml/**,\
+        dxp/apps/scim/**
+
+    modules.includes.public[modules-semantic-versioning][security]=${security.testing.modules}
+
+    playwright.projects.includes[playwright-js-tomcat90-mysql57][security]=${security.playwright.projects}
+
+    security.playwright.projects=\
         cookies-banner-web,\
         login-web,\
         openid-link,\
         portal-security-service-access-policy-service,\
         saml-web,\
         scim-configuration-web
+
+    security.testing.modules=\
+        apps/captcha/**,\
+        apps/cookies/**,\
+        apps/login/**,\
+        apps/oauth-client/**,\
+        apps/oauth2-provider/**,\
+        apps/password-policies-admin/**,\
+        apps/portal-security/**,\
+        apps/portal-security-audit/**,\
+        apps/portal-security-sso/**,\
+        apps/portal-settings/**
 
     test.batch.class.names.includes[security]=\
         **/antivirus-async-store-test/**/*Test.java,\
@@ -9241,6 +9266,17 @@
             (testray.main.component.name ~ "Upgrades Security") OR \
             (testray.main.component.name ~ "XSS")\
         )
+
+    #
+    # Security Playwright
+    #
+
+    playwright.projects.includes[playwright-js-tomcat90-mysql57][security-playwright]=${security.playwright.projects}
+
+    test.batch.dist.app.servers[security-playwright]=tomcat
+
+    test.batch.names[security-playwright]=\
+        playwright-js-tomcat90-mysql57
 
     #
     # Service Builder


### PR DESCRIPTION
Related ticket: [LPD-39334](https://liferay.atlassian.net/browse/LPD-39334)

As requested, I'm adding a new CI suite, for running only playwright tests from Application Security components.