### PR TITLE
LPD-26723

### DIFF
--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/servlet/profile/BaseProfile.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.opensaml.integration.internal.binding.SamlBinding;
 import com.liferay.saml.opensaml.integration.internal.binding.SamlBindingProvider;
@@ -420,6 +421,9 @@ public abstract class BaseProfile {
 				domain, httpServletRequest, httpServletResponse,
 				CookiesConstants.NAME_LOGIN);
 		}
+
+		httpServletRequest.removeAttribute(WebKeys.USER);
+		httpServletRequest.removeAttribute(WebKeys.USER_ID);
 
 		HttpSession httpSession = httpServletRequest.getSession();
 

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -34,7 +34,6 @@ import {UsersAndOrganizationsPage} from '../../pages/users-admin-web/UsersAndOrg
 import {getRandomInt} from '../../utils/getRandomInt';
 import getRandomString from '../../utils/getRandomString';
 import performLogin, {performLogout} from '../../utils/performLogin';
-import {reloadUntilVisible} from '../../utils/reloadUntilVisible';
 import {waitForAlert} from '../../utils/waitForAlert';
 import {
 	TIdentityProvider,
@@ -1327,11 +1326,6 @@ test('Verify IdP initiated SLO also logs out of authenticated SP when Require Au
 		name: 'Sign In',
 	});
 
-	await reloadUntilVisible({
-		myLocator: signInButton,
-		page: newPage,
-	});
-
 	expect(await signInButton).toBeVisible();
 });
 
@@ -1419,11 +1413,6 @@ test('Verify IdP initiated SLO logs out of multiple authenticated SPs.  See LPS-
 
 		const signInButton = await spIntancePage.getByRole('button', {
 			name: 'Sign In',
-		});
-
-		await reloadUntilVisible({
-			myLocator: signInButton,
-			page: spIntancePage,
 		});
 
 		expect(await signInButton).toBeVisible();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-26723

Also resolves [LPD-41188](https://liferay.atlassian.net/browse/LPD-41188)

Without my changes, when the user navigates back to the SP, [PortalImpl.getUser() will return the previously authenticated user](https://github.com/liferay/liferay-portal/blob/bd8371069d06f7c3738f40f1d92732529e6a4692/portal-impl/src/com/liferay/portal/util/PortalImpl.java#L5142-L5146), even after they have logged out.  This affects the portal in a few ways, the most noticible is in the [ServiceContextFactory class](https://github.com/liferay/liferay-portal/blob/bd8371069d06f7c3738f40f1d92732529e6a4692/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContextFactory.java#L207), where if we have a valid USER or USER_ID attribute, then [we set the ThemeDisplay to signedIn and give it the User Id](https://github.com/liferay/liferay-portal/blob/bd8371069d06f7c3738f40f1d92732529e6a4692/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContextFactory.java#L221-L222), which later on bites us, because [we set the signedIn value](https://github.com/liferay/liferay-portal/blob/bd8371069d06f7c3738f40f1d92732529e6a4692/portal-kernel/src/com/liferay/portal/kernel/service/ServiceContextFactory.java#L191) to true, and therefore [the initial check in login.jsp passes](https://github.com/liferay/liferay-portal/blob/bd8371069d06f7c3738f40f1d92732529e6a4692/modules/apps/login/login-web/src/main/resources/META-INF/resources/login.jsp#L11), rendering the user icon.

For tests, I've actually just removed some existing code which bypassed this issue.  I initially believed this to be a front-end bug, so I chose to workaround the tests, since it seemed trivial enough (the user is fully un-authenticated, just the icon shows up).  Please let me know if you have any questions, thanks!