### PR TITLE
LPD-43608 [POC]Make captcha impl configurable

### DIFF
--- a/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/configuration/CaptchaConfiguration.java
+++ b/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/configuration/CaptchaConfiguration.java
@@ -51,11 +51,6 @@ public interface CaptchaConfiguration {
 	@Meta.AD(
 		deflt = "com.liferay.captcha.simplecaptcha.SimpleCaptchaImpl",
 		description = "captcha-engine-help", name = "captcha-engine",
-		optionLabels = {"SimpleCaptcha", "reCAPTCHA"},
-		optionValues = {
-			"com.liferay.captcha.simplecaptcha.SimpleCaptchaImpl",
-			"com.liferay.captcha.recaptcha.ReCaptchaImpl"
-		},
 		required = false
 	)
 	public String captchaEngine();

--- a/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/hcaptcha/HCaptchaImpl.java
+++ b/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/hcaptcha/HCaptchaImpl.java
@@ -1,0 +1,191 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.captcha.hcaptcha;
+
+import com.liferay.captcha.simplecaptcha.SimpleCaptchaImpl;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.captcha.Captcha;
+import com.liferay.portal.kernel.captcha.CaptchaConfigurationException;
+import com.liferay.portal.kernel.captcha.CaptchaException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.io.IOException;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Tagnaouti Boubker
+ * @author Jorge Ferrer
+ * @author Brian Wing Shun Chan
+ * @author Daniel Sanz
+ * @author Manuele Castro
+ */
+@Component(
+	configurationPid = "com.liferay.captcha.configuration.CaptchaConfiguration",
+	property = "captcha.engine.impl=com.liferay.captcha.hcaptcha.HCaptchaImpl",
+	service = Captcha.class
+)
+public class HCaptchaImpl extends SimpleCaptchaImpl {
+
+	@Override
+	public String getTaglibPath() {
+		return _TAGLIB_PATH;
+	}
+
+	@Override
+	public void serveImage(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public void serveImage(
+		ResourceRequest resourceRequest, ResourceResponse resourceResponse) {
+
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected boolean validateChallenge(HttpServletRequest httpServletRequest)
+		throws CaptchaException {
+
+		String hCaptchaResponse = ParamUtil.getString(
+			httpServletRequest, "h-captcha-response");
+
+		while (Validator.isBlank(hCaptchaResponse) &&
+			   (httpServletRequest instanceof HttpServletRequestWrapper)) {
+
+			HttpServletRequestWrapper httpServletRequestWrapper =
+				(HttpServletRequestWrapper)httpServletRequest;
+
+			httpServletRequest =
+				(HttpServletRequest)httpServletRequestWrapper.getRequest();
+
+			hCaptchaResponse = ParamUtil.getString(
+				httpServletRequest, "h-captcha-response");
+		}
+
+		if (Validator.isBlank(hCaptchaResponse)) {
+			_log.error(
+				"CAPTCHA text is null. User " +
+					httpServletRequest.getRemoteUser() +
+						" may be trying to circumvent the CAPTCHA.");
+
+			throw new CaptchaException();
+		}
+
+		Http.Options options = new Http.Options();
+
+		options.setLocation("https://api.hcaptcha.com/siteverify");
+
+		try {
+			options.addPart("secret", "ES_d946c657db1b4ef6bf30775ed7e7d0d1");
+		}
+		catch (SystemException systemException) {
+			_log.error(systemException);
+		}
+
+		options.addPart("remoteip", httpServletRequest.getRemoteAddr());
+		options.addPart("response", hCaptchaResponse);
+		options.setPost(true);
+
+		String content = null;
+
+		try {
+			content = HttpUtil.URLtoString(options);
+		}
+		catch (IOException ioException) {
+			_log.error(ioException);
+
+			throw new CaptchaConfigurationException();
+		}
+
+		if (content == null) {
+			_log.error("hCaptcha did not return a result");
+
+			throw new CaptchaConfigurationException();
+		}
+
+		try {
+			JSONObject jsonObject = _jsonFactory.createJSONObject(content);
+
+			String success = jsonObject.getString("success");
+
+			if (StringUtil.equalsIgnoreCase(success, "true")) {
+				return true;
+			}
+
+			JSONArray jsonArray = jsonObject.getJSONArray("error-codes");
+
+			if ((jsonArray == null) || (jsonArray.length() == 0)) {
+				_log.error("hCaptcha encountered an error");
+
+				throw new CaptchaConfigurationException();
+			}
+
+			StringBundler sb = new StringBundler((jsonArray.length() * 2) - 1);
+
+			for (int i = 0; i < jsonArray.length(); i++) {
+				sb.append(jsonArray.getString(i));
+
+				if (i < (jsonArray.length() - 1)) {
+					sb.append(StringPool.COMMA_AND_SPACE);
+				}
+			}
+
+			_log.error("hCaptcha encountered an error: " + sb.toString());
+
+			throw new CaptchaConfigurationException();
+		}
+		catch (JSONException jsonException) {
+			_log.error(
+				"hCaptcha did not return a valid result: " + content,
+				jsonException);
+
+			throw new CaptchaConfigurationException();
+		}
+	}
+
+	@Override
+	protected boolean validateChallenge(PortletRequest portletRequest)
+		throws CaptchaException {
+
+		return validateChallenge(
+			PortalUtil.getHttpServletRequest(portletRequest));
+	}
+
+	private static final String _TAGLIB_PATH = "/captcha/hcaptcha.jsp";
+
+	private static final Log _log = LogFactoryUtil.getLog(HCaptchaImpl.class);
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+}

--- a/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/hcaptcha.jsp
+++ b/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/hcaptcha.jsp
@@ -1,0 +1,30 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/captcha/init.jsp" %>
+
+<%
+String errorMessage = (String)request.getAttribute("liferay-captcha:captcha:errorMessage");
+%>
+
+<c:if test="<%= captchaEnabled %>">
+	<aui:script src='<%= HtmlUtil.escapeAttribute("https://js.hcaptcha.com/1/api.js") + "?hl=" + HtmlUtil.escapeAttribute(locale.getLanguage()) %>' type="text/javascript"></aui:script>
+
+	<label class="hidden" for="h-captcha-response">hCaptcha</label>
+
+	<div class="h-captcha" data-sitekey="<%= HtmlUtil.escapeAttribute("fa0cbf4c-adf4-4d96-98d0-442209e4658a") %>"></div>
+
+	<c:if test="<%= Validator.isNotNull(errorMessage) %>">
+		<p class="font-weight-semi-bold mt-1 text-danger" id="<portlet:namespace />h-captcha-response-error">
+			<clay:icon
+				symbol="info-circle"
+			/>
+
+			<span><%= errorMessage %></span>
+		</p>
+	</c:if>
+</c:if>


### PR DESCRIPTION
Jira ticket: [LPD-43608](https://liferay.atlassian.net/browse/LPD-43608)

## What
Introduce a flexible Captcha configuration allowing integration with additional third-party engines.

## Why
Currently, Liferay offers limited Captcha options. Expanding this functionality addresses a growing demand from customers.

## How
Since there are several Captcha engines available on the market, one solution for this would be to make the current captcha configuration customizable, so the client can add their own implementation. This POC shows how this could be achievable by showing a use case of [hCaptcha](https://docs.hcaptcha.com/). 

The user only needs to add a new Component that implements the [Captcha](portal-kernel/src/com/liferay/portal/kernel/captcha/Captcha.java) interface. 