### PR TITLE
LPD-1407 it is defined the css file in the portlet property but it does not exist and are in hidden category

### DIFF
--- a/modules/apps/oauth-client/oauth-client-admin-web/src/main/java/com/liferay/oauth/client/admin/web/internal/portlet/OAuthClientAdminPortlet.java
+++ b/modules/apps/oauth-client/oauth-client-admin-web/src/main/java/com/liferay/oauth/client/admin/web/internal/portlet/OAuthClientAdminPortlet.java
@@ -18,7 +18,6 @@ import org.osgi.service.component.annotations.Component;
 @Component(
 	property = {
 		"com.liferay.portlet.display-category=category.hidden",
-		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.preferences-company-wide=true",
 		"javax.portlet.display-name=OAuth Client Administration",
 		"javax.portlet.init-param.portlet-title-based-navigation=true",

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/java/com/liferay/multi/factor/authentication/email/otp/web/internal/portlet/MFAEmailOTPVerifyPortlet.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/java/com/liferay/multi/factor/authentication/email/otp/web/internal/portlet/MFAEmailOTPVerifyPortlet.java
@@ -27,7 +27,6 @@ import org.osgi.service.component.annotations.Deactivate;
 		"com.liferay.portlet.application-type=full-page-application",
 		"com.liferay.portlet.css-class-wrapper=portlet-mfa-email-otp-verify",
 		"com.liferay.portlet.display-category=category.hidden",
-		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.preferences-company-wide=true",
 		"javax.portlet.display-name=Multi Factor Authentication Email One-Time Password Verify",
 		"javax.portlet.init-param.mvc-command-names-default-views=/mfa_email_otp_verify/verify",

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/MFAVerifyPortlet.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/MFAVerifyPortlet.java
@@ -27,7 +27,6 @@ import org.osgi.service.component.annotations.Deactivate;
 		"com.liferay.portlet.application-type=full-page-application",
 		"com.liferay.portlet.css-class-wrapper=portlet-mfa-verify",
 		"com.liferay.portlet.display-category=category.hidden",
-		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.preferences-company-wide=true",
 		"javax.portlet.display-name=Multi Factor Authentication Verify",
 		"javax.portlet.init-param.mvc-command-names-default-views=/mfa_verify/view",


### PR DESCRIPTION
[LPD-1407](https://liferay.atlassian.net/browse/LPD-1407)

The problem  is because in the [MFAVerifyPortlet portlet is defined the property to set the css file](https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-web/src/main/java/com/liferay/multi/factor/authentication/web/internal/portlet/MFAVerifyPortlet.java#L30), but that file does not exit.

How the portlets are hidden, we have removed the property instead of create the css file. 

Based on the LPP we have seen the same problen in other of our portlets:
 * MFAEmailOTPVerifyPortlet
 * OAuthClientAdminPortlet
 * MFAEmailOTPVerifyPortlet
