### PR TITLE
LPD-32210, LPD-32213, LPD-32214

### DIFF
--- a/modules/test/playwright/pages/instance-configuration-web/GeneralPage.ts
+++ b/modules/test/playwright/pages/instance-configuration-web/GeneralPage.ts
@@ -10,12 +10,14 @@ import {waitForAlert} from '../../utils/waitForAlert';
 export class GeneralPage {
 	readonly defaultLandingPageField: Locator;
 	readonly defaultLogoutPageField: Locator;
+	readonly homeUrlField: Locator;
 	readonly page: Page;
 	readonly saveButton: Locator;
 
 	constructor(page: Page) {
 		this.defaultLandingPageField = page.getByLabel('Default Landing Page');
 		this.defaultLogoutPageField = page.getByLabel('Default Logout Page');
+		this.homeUrlField = page.getByLabel('Home URL');
 		this.page = page;
 		this.saveButton = page
 			.getByRole('button', {name: 'Save'})
@@ -31,6 +33,13 @@ export class GeneralPage {
 
 	async editDefaultLogoutPage(defaultLogoutPage: string) {
 		await this.defaultLogoutPageField.fill(defaultLogoutPage);
+
+		await this.saveButton.click();
+		await waitForAlert(this.page);
+	}
+
+	async editHomeUrl(homeUrl: string) {
+		await this.homeUrlField.fill(homeUrl);
 
 		await this.saveButton.click();
 		await waitForAlert(this.page);

--- a/modules/test/playwright/pages/instance-configuration-web/GeneralPage.ts
+++ b/modules/test/playwright/pages/instance-configuration-web/GeneralPage.ts
@@ -8,16 +8,25 @@ import {Locator, Page} from '@playwright/test';
 import {waitForAlert} from '../../utils/waitForAlert';
 
 export class GeneralPage {
+	readonly defaultLandingPageField: Locator;
 	readonly defaultLogoutPageField: Locator;
 	readonly page: Page;
 	readonly saveButton: Locator;
 
 	constructor(page: Page) {
+		this.defaultLandingPageField = page.getByLabel('Default Landing Page');
 		this.defaultLogoutPageField = page.getByLabel('Default Logout Page');
 		this.page = page;
 		this.saveButton = page
 			.getByRole('button', {name: 'Save'})
 			.or(page.getByRole('button', {name: 'Update'}));
+	}
+
+	async editDefaultLandingPage(defaultLandingPage: string) {
+		await this.defaultLandingPageField.fill(defaultLandingPage);
+
+		await this.saveButton.click();
+		await waitForAlert(this.page);
 	}
 
 	async editDefaultLogoutPage(defaultLogoutPage: string) {

--- a/modules/test/playwright/pages/instance-configuration-web/GeneralPage.ts
+++ b/modules/test/playwright/pages/instance-configuration-web/GeneralPage.ts
@@ -44,4 +44,13 @@ export class GeneralPage {
 		await this.saveButton.click();
 		await waitForAlert(this.page);
 	}
+
+	async resetNavigationFields() {
+		await this.defaultLandingPageField.clear();
+		await this.defaultLogoutPageField.clear();
+		await this.homeUrlField.clear();
+
+		await this.saveButton.click();
+		await waitForAlert(this.page);
+	}
 }

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -1508,6 +1508,100 @@ test('LPD-32213 AC1 TC1 and TC5: Verify SP initiated SSO from a restricted resou
 	await waitForAlert(siteSettingsPage.page);
 });
 
+test('LPD-32213 AC1 TC2: Verify after successful SP initiated SSO with auth.forward.by.last.path=true, the user is redirected to the page SSO was initiated from, regardless of Default Landing Page or Home Url.', async ({
+	browser,
+}) => {
+	const idpAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_IDP_NAME,
+		'Identity Provider'
+	);
+
+	const spAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_SP_NAME,
+		'Service Provider'
+	);
+
+	await connectSpAndIdp(
+		idpAdminPage,
+		DEFAULT_IDP_NAME,
+		spAdminPage,
+		DEFAULT_SP_NAME
+	);
+
+	// Create a user on the IdP instance
+
+	const userAccount = await createUser(idpAdminPage, DEFAULT_IDP_NAME);
+
+	// Create a new page on the SP Instance to initiate SSO from
+
+	const pagesAdminPage = new PagesAdminPage(spAdminPage);
+
+	await pagesAdminPage.goto();
+
+	const pageTitle = getRandomString();
+
+	await pagesAdminPage.createNewPage({
+		name: pageTitle,
+	});
+
+	const spSsoPageUrl = DEFAULT_SP_URL + '/web/guest/' + pageTitle;
+
+	// Configure Default Landing Page on SP instance
+
+	await pagesAdminPage.goto();
+
+	const defaultLandingPageTitle = getRandomString();
+
+	await pagesAdminPage.createNewPage({
+		name: defaultLandingPageTitle,
+	});
+
+	const defaultLandingPagePath = '/web/guest/' + defaultLandingPageTitle;
+
+	// Configure Home Url on SP instance
+
+	await pagesAdminPage.goto();
+
+	const homeUrlPageTitle = getRandomString();
+
+	await pagesAdminPage.createNewPage({
+		name: homeUrlPageTitle,
+	});
+
+	const homeUrlPagePath = '/web/guest/' + homeUrlPageTitle;
+
+	// Configure Default Landing Page and Home Url
+
+	const instanceSettingsPage = new InstanceSettingsPage(spAdminPage);
+
+	await instanceSettingsPage.goToInstanceSetting(
+		'Instance Configuration',
+		'General',
+		false
+	);
+
+	const generalPage = new GeneralPage(instanceSettingsPage.page);
+
+	await generalPage.editDefaultLandingPage(defaultLandingPagePath);
+	await generalPage.editHomeUrl(homeUrlPagePath);
+
+	resetAfterTestGeneralPage.add(DEFAULT_SP_NAME);
+
+	// SP initiated SSO from specified page
+
+	const newPage = await performSpInitiatedSSO(
+		browser,
+		userAccount.emailAddress,
+		spSsoPageUrl
+	);
+
+	// Expect to be redirected back to page SSO was initiated from
+
+	expect(await newPage.url()).toContain(spSsoPageUrl);
+});
+
 test('SAML connection cannot be saved if a custom field value is used more than once', async ({
 	browser,
 }) => {

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -72,6 +72,8 @@ import {
 	createIdentityProviderVirtualInstance,
 	createServiceProviderVirtualInstance,
 	createUser,
+	deleteAfterTestProviderConnections,
+	deleteAfterTestVirtualInstances,
 	deleteVirtualInstance,
 	performSamlSafeLogin,
 	resetSamlConfiguration,
@@ -90,8 +92,6 @@ export const test = mergeTests(
 	virtualInstancesPagesTest
 );
 
-export const deleteAfterTestProviderConnections = new Set<string>();
-export const deleteAfterTestVirtualInstances = new Set<string>();
 const resetAfterTestGeneralPage = new Set<string>();
 
 test.afterAll(async ({browser}) => {

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -1289,6 +1289,94 @@ test('LPD-32210 AC1 TC4: Verify IdP initiated SSO with no redirection params/con
 	expect(await newPage.url()).toContain(idpNewPageUrl);
 });
 
+test('LPD-32210 AC1 TC5: Verify unsuccessful IdP initiated SSO with any redirection params/configs applied redirects user to current login page.', async ({
+	browser,
+}) => {
+	const idpAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_IDP_NAME,
+		'Identity Provider'
+	);
+
+	const spAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_SP_NAME,
+		'Service Provider'
+	);
+
+	await connectSpAndIdp(
+		idpAdminPage,
+		DEFAULT_IDP_NAME,
+		spAdminPage,
+		DEFAULT_SP_NAME
+	);
+
+	// Create new page on IdP Instance
+
+	const pagesAdminPage = new PagesAdminPage(idpAdminPage);
+
+	await pagesAdminPage.goto();
+
+	const pageTitle = getRandomString();
+
+	await pagesAdminPage.createNewPage({
+		name: pageTitle,
+	});
+
+	const idpNewPagePath = '/web/guest/' + pageTitle;
+
+	// Configure new page as the Default Landing Page
+
+	const instanceSettingsPage = new InstanceSettingsPage(idpAdminPage);
+
+	await instanceSettingsPage.goToInstanceSetting(
+		'Instance Configuration',
+		'General',
+		false
+	);
+
+	const generalPage = new GeneralPage(instanceSettingsPage.page);
+
+	await generalPage.editDefaultLandingPage(idpNewPagePath);
+
+	resetAfterTestGeneralPage.add(DEFAULT_IDP_NAME);
+
+	// Dynamically retrieve home URL
+
+	const newPage = await browser.newPage();
+
+	await newPage.goto(DEFAULT_IDP_URL + '/c/portal/layout');
+
+	const homeUrl = await newPage.url();
+
+	// Set new page as login redirect parameter
+
+	const loginPageParams =
+		'?p_p_id=com_liferay_login_web_portlet_LoginPortlet&' +
+		'p_p_state=maximized&' +
+		'_com_liferay_login_web_portlet_LoginPortlet_redirect=%2F' +
+		pageTitle;
+
+	// Execute unsuccessful IdP initiated SSO
+
+	await newPage.goto(homeUrl + loginPageParams);
+
+	await newPage.getByLabel('Email Address').fill('invalid@liferay.com');
+	await newPage.getByLabel('Password').fill('invalid');
+	await newPage.getByRole('button', {name: 'Sign In'}).click();
+	await newPage.waitForTimeout(5000);
+
+	// Verify unsuccessful authentication
+
+	await expect(await newPage.getByText('Error:')).toBeVisible();
+
+	// Verify user is not logged in and still on login portlet page
+
+	await expect(await newPage.getByLabel('Email Address')).toBeVisible();
+
+	await expect(await newPage.url()).toContain(homeUrl);
+});
+
 test('SAML connection cannot be saved if a custom field value is used more than once', async ({
 	browser,
 }) => {

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -33,11 +33,13 @@ import {ServiceProviderConnectionsPage} from '../../pages/saml-web/ServiceProvid
 import {SiteSettingsPage} from '../../pages/site-admin-web/SiteSettingsPage';
 import {EditUserPage} from '../../pages/users-admin-web/EditUserPage';
 import {UsersAndOrganizationsPage} from '../../pages/users-admin-web/UsersAndOrganizationsPage';
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {getRandomInt} from '../../utils/getRandomInt';
 import getRandomString from '../../utils/getRandomString';
 import performLogin, {performLogout} from '../../utils/performLogin';
 import {reloadUntilVisible} from '../../utils/reloadUntilVisible';
 import {waitForAlert} from '../../utils/waitForAlert';
+import {waitForLoading} from '../osb-faro-web/utils/loading';
 import {
 	TIdentityProvider,
 	configureIdentityProvider,
@@ -1375,6 +1377,123 @@ test('LPD-32210 AC1 TC5: Verify unsuccessful IdP initiated SSO with any redirect
 	await expect(await newPage.getByLabel('Email Address')).toBeVisible();
 
 	await expect(await newPage.url()).toContain(homeUrl);
+});
+
+test('LPD-32213 AC1 TC1: Verify SP initiated SSO from a restricted resource with prompt enabled redirects user back to resource after authentication.', async ({
+	browser,
+}) => {
+	const idpAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_IDP_NAME,
+		'Identity Provider'
+	);
+
+	const spAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_SP_NAME,
+		'Service Provider'
+	);
+
+	await connectSpAndIdp(
+		idpAdminPage,
+		DEFAULT_IDP_NAME,
+		spAdminPage,
+		DEFAULT_SP_NAME
+	);
+
+	// Create a user on the IdP instance
+
+	const userAccount = await createUser(idpAdminPage, DEFAULT_IDP_NAME);
+
+	// Create a new page on the SP Instance
+
+	const pagesAdminPage = new PagesAdminPage(spAdminPage);
+
+	await pagesAdminPage.goto();
+
+	const pageTitle = getRandomString();
+
+	await pagesAdminPage.createNewPage({
+		name: pageTitle,
+	});
+
+	// Remove guest view permission from new page
+
+	await pagesAdminPage.goto();
+
+	await pagesAdminPage.changePagesPermissions(
+		[pageTitle],
+		['guest_ACTION_VIEW']
+	);
+
+	const spNewPageUrl = DEFAULT_SP_URL + '/web/guest/' + pageTitle;
+
+	// Enable Prompt Enabled option
+
+	const siteSettingsPage = new SiteSettingsPage(spAdminPage);
+
+	await siteSettingsPage.goToSiteSetting('Login', 'Login');
+
+	await waitForLoading(siteSettingsPage.page);
+
+	await siteSettingsPage.page.getByLabel('Prompt Enabled').setChecked(true);
+
+	if (
+		await siteSettingsPage.page
+			.getByRole('button', {name: 'Save'})
+			.isVisible()
+	) {
+		await siteSettingsPage.page.getByRole('button', {name: 'Save'}).click();
+	}
+	else {
+		await siteSettingsPage.page
+			.getByRole('button', {name: 'Update'})
+			.click();
+	}
+
+	await waitForAlert(siteSettingsPage.page);
+
+	// Attempt to access resource as unauthenticated user
+
+	const newPage = await browser.newPage({
+		baseURL: DEFAULT_SP_URL,
+	});
+
+	await newPage.goto(spNewPageUrl);
+
+	// Verify redirected to IdP for authentication
+
+	await expect(await newPage.getByLabel('Email Address')).toBeVisible();
+
+	expect(await newPage.url()).toContain(DEFAULT_IDP_URL);
+
+	// Authenticate on IdP to finish SSO
+
+	await newPage.getByLabel('Email Address').fill(userAccount.emailAddress);
+	await newPage.getByLabel('Password').fill('test');
+	await newPage.getByRole('button', {name: 'Sign In'}).click();
+
+	// Verify user is logged in
+
+	await newPage.getByTitle('User Profile Menu').waitFor({timeout: 30 * 1000});
+
+	// Verify user is redirected back to restricted resource
+
+	expect(await newPage.url()).toContain(spNewPageUrl);
+
+	// Clear Prompt Enabled
+
+	await clickAndExpectToBeVisible({
+		autoClick: true,
+		target: siteSettingsPage.page.getByRole('link', {
+			name: 'Reset Default Values',
+		}),
+		trigger: siteSettingsPage.page.getByRole('button', {
+			name: 'Actions',
+		}),
+	});
+
+	await waitForAlert(siteSettingsPage.page);
 });
 
 test('SAML connection cannot be saved if a custom field value is used more than once', async ({

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -1161,6 +1161,77 @@ test('LPD-32210 AC1 TC2: Verify IdP initiated SSO with different instance redire
 	expect(await newPage.url()).toContain(DEFAULT_SP_URL);
 });
 
+test('LPD-32210 AC1 TC3: Verify IdP initiated SSO with a configured Default Landing Page redirects user properly.', async ({
+	browser,
+}) => {
+	const idpAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_IDP_NAME,
+		'Identity Provider'
+	);
+
+	const spAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_SP_NAME,
+		'Service Provider'
+	);
+
+	await connectSpAndIdp(
+		idpAdminPage,
+		DEFAULT_IDP_NAME,
+		spAdminPage,
+		DEFAULT_SP_NAME
+	);
+
+	// Create new page on IdP Instance
+
+	const pagesAdminPage = new PagesAdminPage(idpAdminPage);
+
+	await pagesAdminPage.goto();
+
+	const pageTitle = getRandomString();
+
+	await pagesAdminPage.createNewPage({
+		name: pageTitle,
+	});
+
+	const idpNewPagePath = '/web/guest/' + pageTitle;
+
+	// Configure new page as the Default Landing Page
+
+	const instanceSettingsPage = new InstanceSettingsPage(idpAdminPage);
+
+	await instanceSettingsPage.goToInstanceSetting(
+		'Instance Configuration',
+		'General',
+		false
+	);
+
+	const generalPage = new GeneralPage(instanceSettingsPage.page);
+
+	await generalPage.editDefaultLandingPage(idpNewPagePath);
+
+	resetAfterTestGeneralPage.add(DEFAULT_IDP_NAME);
+
+	// Create IdP User
+
+	const userAccount = await createUser(idpAdminPage, DEFAULT_IDP_NAME);
+
+	// IdP initiated SSO
+
+	const newPage = await browser.newPage();
+
+	await performLogin(newPage, userAccount.alternateName, DEFAULT_IDP_URL);
+
+	await newPage.getByTitle('User Profile Menu').waitFor({timeout: 30 * 1000});
+
+	// Expect to be redirected back to Default Landing Page configuration value
+
+	await newPage.waitForTimeout(5000);
+
+	expect(await newPage.url()).toContain(DEFAULT_IDP_URL + idpNewPagePath);
+});
+
 test('SAML connection cannot be saved if a custom field value is used more than once', async ({
 	browser,
 }) => {

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -90,6 +90,7 @@ export const test = mergeTests(
 
 export const deleteAfterTestProviderConnections = new Set<string>();
 export const deleteAfterTestVirtualInstances = new Set<string>();
+const resetAfterTestGeneralPage = new Set<string>();
 
 test.afterAll(async ({browser}) => {
 
@@ -116,6 +117,28 @@ test.afterAll(async ({browser}) => {
 
 test.afterEach(async ({browser}) => {
 	const defaultBaseUrl = liferayConfig.environment.baseUrl;
+
+	for (const instanceName of resetAfterTestGeneralPage) {
+		liferayConfig.environment.baseUrl = `http://${instanceName}:8080`;
+
+		// Reset general tab
+
+		const newPage = await performSamlSafeLogin(browser, instanceName);
+
+		const instanceSettingsPage = new InstanceSettingsPage(newPage);
+
+		await instanceSettingsPage.goToInstanceSetting(
+			'Instance Configuration',
+			'General',
+			false
+		);
+
+		const generalPage = new GeneralPage(instanceSettingsPage.page);
+
+		await generalPage.editDefaultLogoutPage('');
+
+		await newPage.close();
+	}
 
 	for (const instanceName of deleteAfterTestProviderConnections) {
 		liferayConfig.environment.baseUrl = `http://${instanceName}:8080`;
@@ -798,6 +821,8 @@ test('LPD-32189 AC1 TC1: Verify IdP initiated SLO redirects user to c/portal/sam
 	const generalPage = new GeneralPage(instanceSettingsPage.page);
 
 	await generalPage.editDefaultLogoutPage(idpNewPagePath);
+
+	resetAfterTestGeneralPage.add(DEFAULT_IDP_NAME);
 
 	// Create IdP User
 

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -1602,6 +1602,89 @@ test('LPD-32213 AC1 TC2: Verify after successful SP initiated SSO with auth.forw
 	expect(await newPage.url()).toContain(spSsoPageUrl);
 });
 
+test('LPD-32214 AC1 TC1: Verify SP initiated SLO logs user out of IdP and SP, then redirects back to Default Logout Page configuration value of SP.', async ({
+	browser,
+}) => {
+	const idpAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_IDP_NAME,
+		'Identity Provider'
+	);
+
+	const spAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_SP_NAME,
+		'Service Provider'
+	);
+
+	await connectSpAndIdp(
+		idpAdminPage,
+		DEFAULT_IDP_NAME,
+		spAdminPage,
+		DEFAULT_SP_NAME
+	);
+
+	// Create new page on SP Instance
+
+	const pagesAdminPage = new PagesAdminPage(spAdminPage);
+
+	await pagesAdminPage.goto();
+
+	const pageTitle = getRandomString();
+
+	await pagesAdminPage.createNewPage({
+		name: pageTitle,
+	});
+
+	const defaultLogoutPagePath = '/web/guest/' + pageTitle;
+
+	// Configure new page as the Default Logout Page
+
+	const instanceSettingsPage = new InstanceSettingsPage(spAdminPage);
+
+	await instanceSettingsPage.goToInstanceSetting(
+		'Instance Configuration',
+		'General',
+		false
+	);
+
+	const generalPage = new GeneralPage(instanceSettingsPage.page);
+
+	await generalPage.editDefaultLogoutPage(defaultLogoutPagePath);
+
+	resetAfterTestGeneralPage.add(DEFAULT_IDP_NAME);
+
+	// Create IdP User
+
+	const userAccount = await createUser(idpAdminPage, DEFAULT_IDP_NAME);
+
+	// SP initiated SSO
+
+	const newPage = await performSpInitiatedSSO(
+		browser,
+		userAccount.emailAddress,
+		DEFAULT_SP_URL
+	);
+
+	// SP initiated SLO
+
+	await performLogout(newPage);
+
+	// Expect to be redirected back to Default Logout Page configuration value
+
+	await newPage.waitForTimeout(5000);
+
+	expect(await newPage.url()).toContain(
+		DEFAULT_SP_URL + defaultLogoutPagePath
+	);
+
+	// Verify the IdP was also logged out
+
+	await newPage.goto(DEFAULT_IDP_URL);
+
+	expect(await newPage.getByRole('button', {name: 'Sign In'})).toBeVisible();
+});
+
 test('SAML connection cannot be saved if a custom field value is used more than once', async ({
 	browser,
 }) => {

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -139,6 +139,7 @@ test.afterEach(async ({browser}) => {
 
 		await generalPage.editDefaultLandingPage('');
 		await generalPage.editDefaultLogoutPage('');
+		await generalPage.editHomeUrl('');
 
 		await newPage.close();
 	}

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -1024,6 +1024,117 @@ test('LPD-32208 AC1 TC4: Verify SP initiated SSO with RelayState redirects user 
 	).toBeVisible();
 });
 
+test('LPD-32210 AC1 TC1: Verify IdP initiated SSO with same-site page redirect parameter redirects the user to designated page.', async ({
+	browser,
+}) => {
+	const idpAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_IDP_NAME,
+		'Identity Provider'
+	);
+
+	const spAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_SP_NAME,
+		'Service Provider'
+	);
+
+	await connectSpAndIdp(
+		idpAdminPage,
+		DEFAULT_IDP_NAME,
+		spAdminPage,
+		DEFAULT_SP_NAME
+	);
+
+	// Create a new page on the IdP Instance
+
+	const pagesAdminPage = new PagesAdminPage(idpAdminPage);
+
+	await pagesAdminPage.goto();
+
+	const pageTitle = getRandomString();
+
+	await pagesAdminPage.createNewPage({
+		name: pageTitle,
+	});
+
+	// Create new user in IdP instance
+
+	const userAccount = await createUser(idpAdminPage, DEFAULT_IDP_NAME);
+
+	// Execute IdP initiated SSO with redirect parameter
+
+	const pagePath = '/web/guest/' + pageTitle;
+
+	const newPage = await performSamlSafeLogin(
+		browser,
+		DEFAULT_IDP_NAME,
+		'?p_p_id=com_liferay_login_web_portlet_LoginPortlet&' +
+			'p_p_state=maximized&' +
+			'_com_liferay_login_web_portlet_LoginPortlet_redirect=' +
+			pagePath.replace('/', '%2F'),
+		'@liferay.com',
+		undefined,
+		userAccount.alternateName
+	);
+
+	// Verify we have been redirected and logged in
+
+	expect(await newPage.url()).toContain(DEFAULT_IDP_URL + pagePath);
+
+	await expect(await newPage.getByTitle('User Profile Menu')).toBeVisible();
+});
+
+test('LPD-32210 AC1 TC2: Verify IdP initiated SSO with different instance redirect parameter redirects the user to designated instance.', async ({
+	browser,
+}) => {
+	const idpAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_IDP_NAME,
+		'Identity Provider'
+	);
+
+	const spAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_SP_NAME,
+		'Service Provider'
+	);
+
+	await connectSpAndIdp(
+		idpAdminPage,
+		DEFAULT_IDP_NAME,
+		spAdminPage,
+		DEFAULT_SP_NAME
+	);
+
+	// Create new user in IdP instance
+
+	const userAccount = await createUser(idpAdminPage, DEFAULT_IDP_NAME);
+
+	// Execute IdP initiated SSO with redirect parameter
+
+	const newPage = await browser.newPage();
+
+	const escapedSpUrl = DEFAULT_SP_URL.replace('/', '%2F').replace(':', '%3A');
+
+	await newPage.goto(
+		DEFAULT_IDP_URL +
+			'?p_p_id=com_liferay_login_web_portlet_LoginPortlet&' +
+			'p_p_state=maximized&' +
+			'_com_liferay_login_web_portlet_LoginPortlet_redirect=' +
+			escapedSpUrl
+	);
+
+	await newPage.getByLabel('Email Address').fill(userAccount.emailAddress);
+	await newPage.getByLabel('Password').fill('test');
+	await newPage.getByRole('button', {name: 'Sign In'}).click();
+	await newPage.waitForTimeout(5000);
+
+	// Verify we have been redirected to SP instance
+
+	expect(await newPage.url()).toContain(DEFAULT_SP_URL);
+});
+
 test('SAML connection cannot be saved if a custom field value is used more than once', async ({
 	browser,
 }) => {

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -1573,6 +1573,7 @@ test('Verify IdP initiated SLO also logs out of authenticated SP when Require Au
 	const newPage = await performSamlSafeLogin(
 		browser,
 		DEFAULT_IDP_NAME,
+		undefined,
 		'@liferay.com',
 		false,
 		userAccount.alternateName

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -137,9 +137,7 @@ test.afterEach(async ({browser}) => {
 
 		const generalPage = new GeneralPage(instanceSettingsPage.page);
 
-		await generalPage.editDefaultLandingPage('');
-		await generalPage.editDefaultLogoutPage('');
-		await generalPage.editHomeUrl('');
+		await generalPage.resetNavigationFields();
 
 		await newPage.close();
 	}

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -135,6 +135,7 @@ test.afterEach(async ({browser}) => {
 
 		const generalPage = new GeneralPage(instanceSettingsPage.page);
 
+		await generalPage.editDefaultLandingPage('');
 		await generalPage.editDefaultLogoutPage('');
 
 		await newPage.close();

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -1232,6 +1232,63 @@ test('LPD-32210 AC1 TC3: Verify IdP initiated SSO with a configured Default Land
 	expect(await newPage.url()).toContain(DEFAULT_IDP_URL + idpNewPagePath);
 });
 
+test('LPD-32210 AC1 TC4: Verify IdP initiated SSO with no redirection params/configs applied redirects user to the page they initiated SSO from.', async ({
+	browser,
+}) => {
+	const idpAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_IDP_NAME,
+		'Identity Provider'
+	);
+
+	const spAdminPage = await configureVirtualInstanceForSaml(
+		browser,
+		DEFAULT_SP_NAME,
+		'Service Provider'
+	);
+
+	await connectSpAndIdp(
+		idpAdminPage,
+		DEFAULT_IDP_NAME,
+		spAdminPage,
+		DEFAULT_SP_NAME
+	);
+
+	// Create new page on IdP Instance
+
+	const pagesAdminPage = new PagesAdminPage(idpAdminPage);
+
+	await pagesAdminPage.goto();
+
+	const pageTitle = getRandomString();
+
+	await pagesAdminPage.createNewPage({
+		name: pageTitle,
+	});
+
+	const idpNewPageUrl = DEFAULT_IDP_URL + '/web/guest/' + pageTitle;
+
+	// Create IdP User
+
+	const userAccount = await createUser(idpAdminPage, DEFAULT_IDP_NAME);
+
+	// IdP initiated SSO from new page
+
+	const newPage = await browser.newPage();
+
+	await performLogin(newPage, userAccount.alternateName, idpNewPageUrl);
+
+	await newPage.waitForTimeout(5000);
+
+	// Verify user is logged in
+
+	expect(await newPage.getByTitle('User Profile Menu')).toBeVisible();
+
+	// Expect to be redirected back to page SSO was initiated from
+
+	expect(await newPage.url()).toContain(idpNewPageUrl);
+});
+
 test('SAML connection cannot be saved if a custom field value is used more than once', async ({
 	browser,
 }) => {

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -1379,7 +1379,7 @@ test('LPD-32210 AC1 TC5: Verify unsuccessful IdP initiated SSO with any redirect
 	await expect(await newPage.url()).toContain(homeUrl);
 });
 
-test('LPD-32213 AC1 TC1: Verify SP initiated SSO from a restricted resource with prompt enabled redirects user back to resource after authentication.', async ({
+test('LPD-32213 AC1 TC1 and TC5: Verify SP initiated SSO from a restricted resource with prompt enabled redirects user back to resource after authentication.', async ({
 	browser,
 }) => {
 	const idpAdminPage = await configureVirtualInstanceForSaml(
@@ -1467,7 +1467,20 @@ test('LPD-32213 AC1 TC1: Verify SP initiated SSO from a restricted resource with
 
 	expect(await newPage.url()).toContain(DEFAULT_IDP_URL);
 
-	// Authenticate on IdP to finish SSO
+	// Provide invalid credentials to test LPD-32213 TC4
+
+	await newPage.getByLabel('Email Address').fill(userAccount.emailAddress);
+	await newPage.getByLabel('Password').fill('invalid');
+	await newPage.getByRole('button', {name: 'Sign In'}).click();
+	await newPage.waitForTimeout(2000);
+
+	// Expect to remain unauthenticated on IdP
+
+	await expect(await newPage.getByLabel('Email Address')).toBeVisible();
+
+	expect(await newPage.url()).toContain(DEFAULT_IDP_URL);
+
+	// End TC4.  Successfully authenticate on IdP to finish SSO
 
 	await newPage.getByLabel('Email Address').fill(userAccount.emailAddress);
 	await newPage.getByLabel('Password').fill('test');

--- a/modules/test/playwright/tests/saml-web/utils/samlVirtualInstanceUtil.ts
+++ b/modules/test/playwright/tests/saml-web/utils/samlVirtualInstanceUtil.ts
@@ -148,7 +148,7 @@ export async function deleteVirtualInstance(name: string, page: Page) {
 export async function performSamlSafeLogin(
 	browser,
 	domain: string,
-	baseUrl = '?p_p_id=com_liferay_login_web_portlet_LoginPortlet&' +
+	baseUrl = '/web/guest?p_p_id=com_liferay_login_web_portlet_LoginPortlet&' +
 		'p_p_state=maximized',
 	mailId = domain !== 'localhost' ? `@${domain}.com` : undefined,
 	rememberMe = true,

--- a/modules/test/playwright/tests/saml-web/utils/samlVirtualInstanceUtil.ts
+++ b/modules/test/playwright/tests/saml-web/utils/samlVirtualInstanceUtil.ts
@@ -16,10 +16,6 @@ import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisibl
 import {getRandomInt} from '../../../utils/getRandomInt';
 import performLogin, {userData} from '../../../utils/performLogin';
 import {waitForAlert} from '../../../utils/waitForAlert';
-import {
-	deleteAfterTestProviderConnections,
-	deleteAfterTestVirtualInstances,
-} from '../saml.spec';
 import {connectSpAndIdp} from './samlProviderConnectionUtil';
 
 export const DEFAULT_IDP_NAME = 'www.able.com';
@@ -30,6 +26,8 @@ export const SECONDARY_IDP_NAME = 'www.charlie.com';
 export const SECONDARY_IDP_URL = `http://${SECONDARY_IDP_NAME}:8080`;
 export const SECONDARY_SP_NAME = 'www.dog.com';
 export const SECONDARY_SP_URL = `http://${SECONDARY_SP_NAME}:8080`;
+export const deleteAfterTestProviderConnections = new Set<string>();
+export const deleteAfterTestVirtualInstances = new Set<string>();
 
 export async function createCustomField(
 	adminPage: Page,

--- a/modules/test/playwright/tests/saml-web/utils/samlVirtualInstanceUtil.ts
+++ b/modules/test/playwright/tests/saml-web/utils/samlVirtualInstanceUtil.ts
@@ -150,6 +150,8 @@ export async function deleteVirtualInstance(name: string, page: Page) {
 export async function performSamlSafeLogin(
 	browser,
 	domain: string,
+	baseUrl = '?p_p_id=com_liferay_login_web_portlet_LoginPortlet&' +
+		'p_p_state=maximized',
 	mailId = domain !== 'localhost' ? `@${domain}.com` : undefined,
 	rememberMe = true,
 	screenName = 'test'
@@ -158,14 +160,7 @@ export async function performSamlSafeLogin(
 		baseURL: `http://${domain}:8080`,
 	});
 
-	await performLogin(
-		page,
-		screenName,
-		'?p_p_id=com_liferay_login_web_portlet_LoginPortlet&' +
-			'p_p_state=maximized',
-		mailId,
-		rememberMe
-	);
+	await performLogin(page, screenName, baseUrl, mailId, rememberMe);
 
 	return page;
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-32210
https://liferay.atlassian.net/browse/LPD-32213
https://liferay.atlassian.net/browse/LPD-32214

Resent from https://github.com/liferay-appsec/liferay-portal/pull/2118 with some changes excluded.

SP SSO redirection with `auth.forward.by.last.path=false` will actually redirect to `/c` in the [AutoLoginFilter](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/servlet/filters/autologin/AutoLoginFilter.java#L213-L215) class, which in turn will skip the login processes in the `SpSsoSamlPortalFilter`, [since the path does not match anymore](https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSsoSamlPortalFilter.java#L86).

So, this means redirection of SP SSO with `auth.forward.by.last.path=false` does not behave any differently from normal portal login redirection, so we should not need to add tests here.  It will be a good idea to add login tests with [LPD-44168](https://liferay.atlassian.net/browse/LPD-44168), which would also cover SP SSO.

Because of this, these three epics are now complete, so hopefully we can merge them soon.