### PR TITLE
LPD-44278

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/util/HtmlUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/HtmlUtil.java
@@ -401,12 +401,8 @@ public class HtmlUtil {
 
 		link = StringUtil.trim(link);
 
-		if (link.indexOf(StringPool.COLON) == 10) {
-			String protocol = StringUtil.toLowerCase(link.substring(0, 10));
-
-			if (protocol.equals("javascript")) {
-				link = StringUtil.replaceFirst(link, CharPool.COLON, "%3a");
-			}
+		if (link.contains("javascript:")) {
+			link = StringUtil.replaceFirst(link, CharPool.COLON, "%3a");
 		}
 
 		return link;

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/HtmlUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/HtmlUtilTest.java
@@ -165,6 +165,10 @@ public class HtmlUtilTest {
 			"javascript%3a//localhost:800/123%0aalert(document.domain)",
 			HtmlUtil.escapeJSLink(
 				"\tjavascript://localhost:800/123%0aalert(document.domain)"));
+		Assert.assertEquals(
+			"%00javascript%3a//localhost:800/123%0aalert(document.domain)",
+			HtmlUtil.escapeJSLink(
+				"%00javascript://localhost:800/123%0aalert(document.domain)"));
 	}
 
 	@Test


### PR DESCRIPTION
Related issue: [LPD-44278](https://liferay.atlassian.net/browse/LPD-44278)

The issue was reported to happen on `referer_js.jsp` and `forward_js.jsp` where the escapeJSLink could be exploited by injecting a null byte before the `javascript:` statement.

To fix this, I refactored the code to just catch up if there's any `javascript:` statement on the link, instead of expecting a fixed index for it.