### PR TITLE
LPD-26723

### DIFF
--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSessionTerminationSamlPortalFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSessionTerminationSamlPortalFilter.java
@@ -7,6 +7,7 @@ package com.liferay.saml.internal.servlet.filter;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.util.PortalInstances;
 import com.liferay.saml.helper.SamlHttpRequestHelper;
 import com.liferay.saml.persistence.model.SamlSpSession;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
@@ -27,8 +28,8 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"after-filter=Virtual Host Filter", "before-filter=Session Id Filter",
-		"dispatcher=FORWARD", "dispatcher=REQUEST",
+		"before-filter=Absolute Redirects Filter", "dispatcher=FORWARD",
+		"dispatcher=REQUEST",
 		"init-param.url-regex-ignore-pattern=^/html/.+\\.(css|gif|html|ico|jpg|js|png)(\\?.*)?$",
 		"servlet-context-name=",
 		"servlet-filter-name=SP Session Termination SAML Portal Filter",
@@ -49,6 +50,10 @@ public class SpSessionTerminationSamlPortalFilter extends BaseSamlPortalFilter {
 	public boolean isFilterEnabled(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {
+
+		if (httpServletRequest.getAttribute("COMPANY_ID") == null) {
+			PortalInstances.getCompanyId(httpServletRequest);
+		}
 
 		if (_samlProviderConfigurationHelper.isEnabled() &&
 			(httpServletRequest.getSession(false) != null)) {

--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSessionTerminationSamlPortalFilter.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/servlet/filter/SpSessionTerminationSamlPortalFilter.java
@@ -7,6 +7,7 @@ package com.liferay.saml.internal.servlet.filter;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.PortalInstances;
 import com.liferay.saml.helper.SamlHttpRequestHelper;
 import com.liferay.saml.persistence.model.SamlSpSession;
@@ -51,7 +52,7 @@ public class SpSessionTerminationSamlPortalFilter extends BaseSamlPortalFilter {
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {
 
-		if (httpServletRequest.getAttribute("COMPANY_ID") == null) {
+		if (httpServletRequest.getAttribute(WebKeys.COMPANY_ID) == null) {
 			PortalInstances.getCompanyId(httpServletRequest);
 		}
 

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -36,7 +36,6 @@ import {UsersAndOrganizationsPage} from '../../pages/users-admin-web/UsersAndOrg
 import {getRandomInt} from '../../utils/getRandomInt';
 import getRandomString from '../../utils/getRandomString';
 import performLogin, {performLogout} from '../../utils/performLogin';
-import {reloadUntilVisible} from '../../utils/reloadUntilVisible';
 import {waitForAlert} from '../../utils/waitForAlert';
 import {
 	TIdentityProvider,
@@ -1604,11 +1603,6 @@ test('Verify IdP initiated SLO also logs out of authenticated SP when Require Au
 		name: 'Sign In',
 	});
 
-	await reloadUntilVisible({
-		myLocator: signInButton,
-		page: newPage,
-	});
-
 	expect(await signInButton).toBeVisible();
 });
 
@@ -1696,11 +1690,6 @@ test('Verify IdP initiated SLO logs out of multiple authenticated SPs.  See LPS-
 
 		const signInButton = await spIntancePage.getByRole('button', {
 			name: 'Sign In',
-		});
-
-		await reloadUntilVisible({
-			myLocator: signInButton,
-			page: spIntancePage,
 		});
 
 		expect(await signInButton).toBeVisible();


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-26723

For most SAML filters, they should come after the `AbsoluteRedirectsFilter`, which intiializes the `CompanyThreadLocal` with the current companyId based off the virtual host provided.  However, with the `SpSessionTerminationSamlPortalFilter`, we run into a problem where the `AbsoluteRedirectsFilter` has reinitialized a session before the `SpSessionTerminationSamlPortalFilter` has a chance to properly destroy it.  This leads to certain user related data still being present, thus the initial request after IdP SLO shows the user icon instead of the Sign in Button (more explanation on [my initial PR](https://github.com/liferay-appsec/liferay-portal/pull/2082)).

So, the solution I came up with is to have the `SpSessionTerminationSamlPortalFilter` come before the `AbsoluteRedirectsFilter`, but to populate `CompanyThreadLocal.getCompanyId()` if it isn't already present.

Lastly, I did not add any new tests, because this behavior was previously found in existing tests, and explicitly accounted for.  I've removed the `reloadUntilVisible` method calls, so now the bug is no longer being worked-around.  This can be easily tested by reverting the bug fix, but keeping the test changes from this PR.