### PR TITLE
LPD-44960

### DIFF
--- a/modules/apps/login/login-web-test/src/testIntegration/java/com/liferay/login/web/internal/portlet/action/test/CreateAccountMVCActionCommandTest.java
+++ b/modules/apps/login/login-web-test/src/testIntegration/java/com/liferay/login/web/internal/portlet/action/test/CreateAccountMVCActionCommandTest.java
@@ -1,0 +1,143 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.login.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.servlet.PortletServlet;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Manuele Castro
+ */
+@RunWith(Arquillian.class)
+public class CreateAccountMVCActionCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_guestUser = UserLocalServiceUtil.getUser(
+			UserLocalServiceUtil.getGuestUserId(
+				TestPropsValues.getCompanyId()));
+	}
+
+	@Test
+	public void testAddUserWithDuplicateEmailAddress() throws Exception {
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest();
+
+		PermissionChecker oldPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(_guestUser));
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					"com.liferay.captcha.configuration.CaptchaConfiguration",
+					HashMapDictionaryBuilder.<String, Object>put(
+						"createAccountCaptchaEnabled", false
+					).build())) {
+
+			_mvcActionCommand.processAction(
+				mockLiferayPortletActionRequest,
+				new MockLiferayPortletActionResponse());
+
+			Assert.assertEquals(
+				"",
+				ParamUtil.getString(
+					mockLiferayPortletActionRequest, "sessionErrors"));
+		}
+		finally {
+			PermissionThreadLocal.setPermissionChecker(oldPermissionChecker);
+		}
+	}
+
+	private MockLiferayPortletActionRequest
+			_getMockLiferayPortletActionRequest()
+		throws Exception {
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		String password = RandomTestUtil.randomString();
+
+		User user = TestPropsValues.getUser();
+
+		mockLiferayPortletActionRequest.addParameter(Constants.CMD, "add");
+		mockLiferayPortletActionRequest.addParameter(
+			"emailAddress", user.getEmailAddress());
+		mockLiferayPortletActionRequest.addParameter(
+			"firstName", RandomTestUtil.randomString());
+		mockLiferayPortletActionRequest.addParameter(
+			"lastName", RandomTestUtil.randomString());
+		mockLiferayPortletActionRequest.addParameter("password1", password);
+		mockLiferayPortletActionRequest.addParameter("password2", password);
+		mockLiferayPortletActionRequest.addParameter(
+			"screenName", RandomTestUtil.randomString());
+
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			CompanyLocalServiceUtil.fetchCompany(
+				TestPropsValues.getCompanyId()));
+		themeDisplay.setUser(_guestUser);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		mockLiferayPortletActionRequest.setAttribute(
+			PortletServlet.PORTLET_SERVLET_REQUEST, mockHttpServletRequest);
+
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		return mockLiferayPortletActionRequest;
+	}
+
+	private static User _guestUser;
+
+	@Inject(
+		filter = "mvc.command.name=/login/create_account",
+		type = MVCActionCommand.class
+	)
+	private MVCActionCommand _mvcActionCommand;
+
+}

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/CreateAccountMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/CreateAccountMVCActionCommand.java
@@ -306,32 +306,31 @@ public class CreateAccountMVCActionCommand extends BaseMVCActionCommand {
 						"mvcPath", "/update_account.jsp");
 				}
 			}
-
-			if (exception instanceof AddressCityException ||
-				exception instanceof AddressStreetException ||
-				exception instanceof AddressZipException ||
-				exception instanceof CaptchaException ||
-				exception instanceof CompanyMaxUsersException ||
-				exception instanceof ContactBirthdayException ||
-				exception instanceof ContactNameException ||
-				exception instanceof DuplicateOpenIdException ||
-				exception instanceof EmailAddressException ||
-				exception instanceof GroupFriendlyURLException ||
-				exception instanceof NoSuchCountryException ||
-				exception instanceof NoSuchListTypeException ||
-				exception instanceof NoSuchOrganizationException ||
-				exception instanceof NoSuchRegionException ||
-				exception instanceof OrganizationParentException ||
-				exception instanceof PhoneNumberException ||
-				exception instanceof RequiredFieldException ||
-				exception instanceof RequiredUserException ||
-				exception instanceof TermsOfUseException ||
-				exception instanceof UserEmailAddressException ||
-				exception instanceof UserIdException ||
-				exception instanceof UserPasswordException ||
-				exception instanceof UserScreenNameException ||
-				exception instanceof UserSmsException ||
-				exception instanceof WebsiteURLException) {
+			else if (exception instanceof AddressCityException ||
+					 exception instanceof AddressStreetException ||
+					 exception instanceof AddressZipException ||
+					 exception instanceof CaptchaException ||
+					 exception instanceof CompanyMaxUsersException ||
+					 exception instanceof ContactBirthdayException ||
+					 exception instanceof ContactNameException ||
+					 exception instanceof DuplicateOpenIdException ||
+					 exception instanceof EmailAddressException ||
+					 exception instanceof GroupFriendlyURLException ||
+					 exception instanceof NoSuchCountryException ||
+					 exception instanceof NoSuchListTypeException ||
+					 exception instanceof NoSuchOrganizationException ||
+					 exception instanceof NoSuchRegionException ||
+					 exception instanceof OrganizationParentException ||
+					 exception instanceof PhoneNumberException ||
+					 exception instanceof RequiredFieldException ||
+					 exception instanceof RequiredUserException ||
+					 exception instanceof TermsOfUseException ||
+					 exception instanceof UserEmailAddressException ||
+					 exception instanceof UserIdException ||
+					 exception instanceof UserPasswordException ||
+					 exception instanceof UserScreenNameException ||
+					 exception instanceof UserSmsException ||
+					 exception instanceof WebsiteURLException) {
 
 				SessionErrors.add(
 					actionRequest, exception.getClass(), exception);


### PR DESCRIPTION
Related issue: [LPD-44960](https://liferay.atlassian.net/browse/LPD-44960)

### **Context:** 
There was a change to prevent user enumeration([LPD-15723](https://liferay.atlassian.net/browse/LPD-15723)) where it changed the behavior to: when a user tries to create an account with a already existing email address, it shows the same toast as if created with a valid email address.

### **Issue:**
After these changes, when a duplicate account creation is attempted it now shows two toasts: a success one and a failure one. Showing the failure one leads to bad user experience and can bring back the user enumeration. 

### **Solution:**
This PR was created to remove the failure toast for when `UserEmailAddressException.MustNotBeDuplicate` is triggered when creating a new account.