### PR TITLE
LPD-44960 Add functional test + SF fix of LPD-41420

### DIFF
--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/CreateAccountMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/CreateAccountMVCActionCommand.java
@@ -341,27 +341,7 @@ public class CreateAccountMVCActionCommand extends BaseMVCActionCommand {
 			}
 		}
 
-		if (Validator.isNull(PropsValues.COMPANY_SECURITY_STRANGERS_URL)) {
-			return;
-		}
-
-		try {
-			Layout layout = _layoutLocalService.getFriendlyURLLayout(
-				themeDisplay.getScopeGroupId(), false,
-				PropsValues.COMPANY_SECURITY_STRANGERS_URL);
-
-			String redirect = _portal.getLayoutURL(layout, themeDisplay);
-
-			sendRedirect(actionRequest, actionResponse, redirect);
-		}
-		catch (NoSuchLayoutException noSuchLayoutException) {
-
-			// LPS-52675
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(noSuchLayoutException);
-			}
-		}
+		_verifyStrangersURL(actionRequest, actionResponse, themeDisplay);
 	}
 
 	protected CaptchaConfiguration getCaptchaConfiguration()
@@ -583,6 +563,34 @@ public class CreateAccountMVCActionCommand extends BaseMVCActionCommand {
 
 		sendRedirect(
 			actionRequest, actionResponse, themeDisplay, user, password1);
+	}
+
+	private void _verifyStrangersURL(
+			ActionRequest actionRequest, ActionResponse actionResponse,
+			ThemeDisplay themeDisplay)
+		throws Exception {
+
+		if (Validator.isNull(PropsValues.COMPANY_SECURITY_STRANGERS_URL)) {
+			return;
+		}
+
+		try {
+			Layout layout = _layoutLocalService.getFriendlyURLLayout(
+				themeDisplay.getScopeGroupId(), false,
+				PropsValues.COMPANY_SECURITY_STRANGERS_URL);
+
+			String redirect = _portal.getLayoutURL(layout, themeDisplay);
+
+			sendRedirect(actionRequest, actionResponse, redirect);
+		}
+		catch (NoSuchLayoutException noSuchLayoutException) {
+
+			// LPS-52675
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(noSuchLayoutException);
+			}
+		}
 	}
 
 	private ActionRequest _wrapActionRequest(ActionRequest actionRequest)

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/CreateAccountMVCActionCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/CreateAccountMVCActionCommand.java
@@ -285,6 +285,11 @@ public class CreateAccountMVCActionCommand extends BaseMVCActionCommand {
 				sendRedirect(
 					actionRequest, actionResponse, themeDisplay, user,
 					user.getPasswordUnencrypted());
+
+				_verifyStrangersURL(
+					actionRequest, actionResponse, themeDisplay);
+
+				return;
 			}
 			else if (exception instanceof
 						UserScreenNameException.MustNotBeDuplicate) {

--- a/modules/test/playwright/fixtures/captchaConfigPageTest.ts
+++ b/modules/test/playwright/fixtures/captchaConfigPageTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {CaptchaConfigPage} from '../pages/captcha-web/CaptchaConfigPage';
+
+const captchaConfigPageTest = test.extend<{
+	captchaConfigPage: CaptchaConfigPage;
+}>({
+	captchaConfigPage: async ({page}, use) => {
+		await use(new CaptchaConfigPage(page));
+	},
+});
+
+export {captchaConfigPageTest};

--- a/modules/test/playwright/helpers/HeadlessCommerceAdminCatalogApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessCommerceAdminCatalogApiHelper.ts
@@ -612,25 +612,25 @@ export class HeadlessCommerceAdminCatalogApiHelper {
 	}
 
 	async postProductConfigurationList(
-        productConfigurationList: TProductConfigurationList
+		productConfigurationList: TProductConfigurationList
 	): Promise<TProductConfigurationList> {
-        productConfigurationList = await this.apiHelpers.post(
-            `${this.apiHelpers.baseUrl}${this.basePath}/product-configuration-lists?nestedFields=productConfigurations`,
-            {
-                data: {
-                    catalogId: getRandomInt(),
-                    name: getRandomString(),
-                    ...productConfigurationList,
-                },
-            }
-        );
+		productConfigurationList = await this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/product-configuration-lists?nestedFields=productConfigurations`,
+			{
+				data: {
+					catalogId: getRandomInt(),
+					name: getRandomString(),
+					...productConfigurationList,
+				},
+			}
+		);
 
-        if (this.apiHelpers instanceof DataApiHelpers) {
-            this.apiHelpers.data.push({
-                id: productConfigurationList.id,
-                type: 'productConfigurationList',
-            });
-        }
+		if (this.apiHelpers instanceof DataApiHelpers) {
+			this.apiHelpers.data.push({
+				id: productConfigurationList.id,
+				type: 'productConfigurationList',
+			});
+		}
 
 		return productConfigurationList;
 	}

--- a/modules/test/playwright/pages/captcha-web/CaptchaConfigPage.ts
+++ b/modules/test/playwright/pages/captcha-web/CaptchaConfigPage.ts
@@ -5,11 +5,13 @@
 
 import {Locator, Page, expect} from '@playwright/test';
 
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {waitForAlert} from '../../utils/waitForAlert';
 import {ApplicationsMenuPage} from '../product-navigation-applications-menu/ApplicationsMenuPage';
 
 export class CaptchaConfigPage {
 	readonly applicationsMenuPage: ApplicationsMenuPage;
+	readonly actions: Locator;
 	readonly captchaEngine: Locator;
 	readonly createAccountCaptchaEnabled: Locator;
 	readonly maxChallenges: Locator;
@@ -21,6 +23,7 @@ export class CaptchaConfigPage {
 	readonly reCaptchaPublicKey: Locator;
 	readonly reCaptchaScriptURL: Locator;
 	readonly reCaptchaVerifyURL: Locator;
+	readonly resetDefaultValues: Locator;
 	readonly saveButton: Locator;
 	readonly sendPasswordCaptchaEnabled: Locator;
 	readonly simpleCaptchaHeight: Locator;
@@ -29,6 +32,7 @@ export class CaptchaConfigPage {
 
 	constructor(page: Page) {
 		this.applicationsMenuPage = new ApplicationsMenuPage(page);
+		this.actions = page.getByRole('button', {name: 'Actions'});
 		this.captchaEngine = page.getByLabel('CAPTCHA Engine');
 		this.createAccountCaptchaEnabled = page.getByText(
 			'Create Account CAPTCHA Enabled'
@@ -46,6 +50,9 @@ export class CaptchaConfigPage {
 		this.reCaptchaPublicKey = page.getByLabel('reCAPTCHA Public Key');
 		this.reCaptchaScriptURL = page.getByLabel('reCAPTCHA Script URL');
 		this.reCaptchaVerifyURL = page.getByLabel('reCAPTCHA Verify URL');
+		this.resetDefaultValues = page.getByRole('link', {
+			name: 'Reset Default Values',
+		});
 		this.saveButton = page.getByRole('button', {name: 'Save'});
 		this.sendPasswordCaptchaEnabled = page.getByText(
 			'Send Password CAPTCHA Enabled'
@@ -60,49 +67,76 @@ export class CaptchaConfigPage {
 
 		await this.maxChallenges.fill('-1');
 
-		await this.disableCreateAccountCaptcha();
+		await this.disableCreateAccountCaptcha(false);
 
-		await this.disableSendPasswordCaptcha();
+		await this.disableSendPasswordCaptcha(false);
 
-		await this.disableMessageBoardsEditCategoryCaptcha();
+		await this.disableMessageBoardsEditCategoryCaptcha(false);
 
-		await this.disableMessageBoardsEditMessageCaptcha();
+		await this.disableMessageBoardsEditMessageCaptcha(false);
 
 		await this.saveConfiguration();
 	}
 
-	async disableCreateAccountCaptcha() {
+	async disableCreateAccountCaptcha(saveConfiguration: boolean = true) {
 		await this.createAccountCaptchaEnabled.uncheck();
 		await expect(this.createAccountCaptchaEnabled).not.toBeChecked();
+
+		if (saveConfiguration) {
+			await this.saveConfiguration();
+		}
 	}
 
-	async disableMessageBoardsEditCategoryCaptcha() {
+	async disableMessageBoardsEditCategoryCaptcha(
+		saveConfiguration: boolean = true
+	) {
 		await this.messageBoardsEditCategoryCaptchaEnabled.uncheck();
 		await expect(
 			this.messageBoardsEditCategoryCaptchaEnabled
 		).not.toBeChecked();
+
+		if (saveConfiguration) {
+			await this.saveConfiguration();
+		}
 	}
 
-	async disableMessageBoardsEditMessageCaptcha() {
+	async disableMessageBoardsEditMessageCaptcha(
+		saveConfiguration: boolean = true
+	) {
 		await this.messageBoardsEditMessageCaptchaEnabled.uncheck();
 		await expect(
 			this.messageBoardsEditMessageCaptchaEnabled
 		).not.toBeChecked();
+
+		if (saveConfiguration) {
+			await this.saveConfiguration();
+		}
 	}
 
-	async disableSendPasswordCaptcha() {
+	async disableSendPasswordCaptcha(saveConfiguration: boolean = true) {
 		await this.sendPasswordCaptchaEnabled.uncheck();
 		await expect(this.sendPasswordCaptchaEnabled).not.toBeChecked();
+
+		if (saveConfiguration) {
+			await this.saveConfiguration();
+		}
 	}
 
-	async enableReCaptcha(publicKey: string, privateKey: string) {
+	async enableReCaptcha(
+		publicKey: string,
+		privateKey: string,
+		saveConfiguration: boolean = true
+	) {
 		await this.captchaEngine.click();
-
 		await this.page.getByRole('option', {name: 'reCAPTCHA'}).click();
 
 		await this.reCaptchaPublicKey.fill(publicKey);
 
 		await this.reCaptchaPrivateKey.fill(privateKey);
+
+		if (saveConfiguration) {
+			await this.saveConfiguration();
+		}
 	}
 
 	async goTo() {
@@ -113,9 +147,28 @@ export class CaptchaConfigPage {
 		await this.sendPasswordCaptchaEnabled.waitFor();
 	}
 
+	async resetCaptchaConfiguration() {
+		if (await this.actions.isVisible()) {
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: this.resetDefaultValues,
+				trigger: this.actions,
+			});
+
+			await waitForAlert(this.page);
+
+			await this.saveConfiguration();
+		}
+	}
+
 	async saveConfiguration() {
 		if (await this.page.isVisible('button:has-text("Update")')) {
 			await this.updateButton.click();
+
+			await waitForAlert(
+				this.page,
+				`Success:Your request completed successfully.`
+			);
 
 			return;
 		}

--- a/modules/test/playwright/pages/captcha-web/CaptchaConfigPage.ts
+++ b/modules/test/playwright/pages/captcha-web/CaptchaConfigPage.ts
@@ -1,25 +1,25 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {Locator, Page} from '@playwright/test';
+import {Locator, Page, expect} from '@playwright/test';
 
 import {waitForAlert} from '../../utils/waitForAlert';
 import {ApplicationsMenuPage} from '../product-navigation-applications-menu/ApplicationsMenuPage';
 
 export class CaptchaConfigPage {
 	readonly applicationsMenuPage: ApplicationsMenuPage;
+	readonly captchaEngine: Locator;
 	readonly createAccountCaptchaEnabled: Locator;
 	readonly maxChallenges: Locator;
 	readonly messageBoardsEditCategoryCaptchaEnabled: Locator;
 	readonly messageBoardsEditMessageCaptchaEnabled: Locator;
-	readonly captchaEngine: Locator;
 	readonly page: Page;
-	readonly reCaptchaPublicKey: Locator;
-	readonly reCaptchaPrivateKey: Locator;
-	readonly reCaptchaScriptURL: Locator;
 	readonly reCaptchaNoScriptURL: Locator;
+	readonly reCaptchaPrivateKey: Locator;
+	readonly reCaptchaPublicKey: Locator;
+	readonly reCaptchaScriptURL: Locator;
 	readonly reCaptchaVerifyURL: Locator;
 	readonly saveButton: Locator;
 	readonly sendPasswordCaptchaEnabled: Locator;
@@ -29,6 +29,7 @@ export class CaptchaConfigPage {
 
 	constructor(page: Page) {
 		this.applicationsMenuPage = new ApplicationsMenuPage(page);
+		this.captchaEngine = page.getByLabel('CAPTCHA Engine');
 		this.createAccountCaptchaEnabled = page.getByText(
 			'Create Account CAPTCHA Enabled'
 		);
@@ -39,14 +40,13 @@ export class CaptchaConfigPage {
 		this.messageBoardsEditMessageCaptchaEnabled = page.getByLabel(
 			'Message Boards Edit Message'
 		);
-		this.captchaEngine = page.getByLabel('CAPTCHA Engine');
 		this.page = page;
-		this.reCaptchaPublicKey = page.getByLabel('reCAPTCHA Public Key');
-		this.reCaptchaPrivateKey = page.getByLabel('reCAPTCHA Private Key');
-		this.reCaptchaScriptURL = page.getByLabel('reCAPTCHA Script URL');
 		this.reCaptchaNoScriptURL = page.getByLabel('reCAPTCHA No Script URL');
-		this.saveButton = page.getByRole('button', {name: 'Save'});
+		this.reCaptchaPrivateKey = page.getByLabel('reCAPTCHA Private Key');
+		this.reCaptchaPublicKey = page.getByLabel('reCAPTCHA Public Key');
+		this.reCaptchaScriptURL = page.getByLabel('reCAPTCHA Script URL');
 		this.reCaptchaVerifyURL = page.getByLabel('reCAPTCHA Verify URL');
+		this.saveButton = page.getByRole('button', {name: 'Save'});
 		this.sendPasswordCaptchaEnabled = page.getByText(
 			'Send Password CAPTCHA Enabled'
 		);
@@ -55,32 +55,76 @@ export class CaptchaConfigPage {
 		this.updateButton = page.getByRole('button', {name: 'Update'});
 	}
 
+	async disableCaptcha() {
+		await this.goTo();
+
+		await this.maxChallenges.fill('-1');
+
+		await this.disableCreateAccountCaptcha();
+
+		await this.disableSendPasswordCaptcha();
+
+		await this.disableMessageBoardsEditCategoryCaptcha();
+
+		await this.disableMessageBoardsEditMessageCaptcha();
+
+		await this.saveConfiguration();
+	}
+
+	async disableCreateAccountCaptcha() {
+		await this.createAccountCaptchaEnabled.uncheck();
+		await expect(this.createAccountCaptchaEnabled).not.toBeChecked();
+	}
+
+	async disableMessageBoardsEditCategoryCaptcha() {
+		await this.messageBoardsEditCategoryCaptchaEnabled.uncheck();
+		await expect(
+			this.messageBoardsEditCategoryCaptchaEnabled
+		).not.toBeChecked();
+	}
+
+	async disableMessageBoardsEditMessageCaptcha() {
+		await this.messageBoardsEditMessageCaptchaEnabled.uncheck();
+		await expect(
+			this.messageBoardsEditMessageCaptchaEnabled
+		).not.toBeChecked();
+	}
+
+	async disableSendPasswordCaptcha() {
+		await this.sendPasswordCaptchaEnabled.uncheck();
+		await expect(this.sendPasswordCaptchaEnabled).not.toBeChecked();
+	}
+
+	async enableReCaptcha(publicKey: string, privateKey: string) {
+		await this.captchaEngine.click();
+
+		await this.page.getByRole('option', {name: 'reCAPTCHA'}).click();
+
+		await this.reCaptchaPublicKey.fill(publicKey);
+
+		await this.reCaptchaPrivateKey.fill(privateKey);
+	}
+
 	async goTo() {
 		await this.applicationsMenuPage.goToSystemSettings();
+
 		await this.page.getByRole('link', {name: 'Security Tools'}).click();
 
 		await this.sendPasswordCaptchaEnabled.waitFor();
 	}
 
-	async enableReCaptcha(publicKey: string, privateKey: string) {
-		await this.captchaEngine.click();
-		await this.page.getByRole('option', {name: 'reCAPTCHA'}).click();
-		await this.reCaptchaPublicKey.fill(publicKey);
-		await this.reCaptchaPrivateKey.fill(privateKey);
-		this.saveConfiguration();
-		await waitForAlert(
-			this.page,
-			`Success:Your request completed successfully.`
-		);
-	}
-
 	async saveConfiguration() {
 		if (await this.page.isVisible('button:has-text("Update")')) {
-			this.updateButton.click();
+			await this.updateButton.click();
 
 			return;
 		}
 
-		this.saveButton.click();
+		await this.saveButton.click();
+
+		await waitForAlert(
+			this.page,
+			`Success:Your request completed successfully.`
+		);
 	}
 }

--- a/modules/test/playwright/tests/captcha-web/recaptcha.spec.ts
+++ b/modules/test/playwright/tests/captcha-web/recaptcha.spec.ts
@@ -22,7 +22,6 @@ test('LPD-32888 Check reCaptcha has a label for textarea', async ({
 		reCaptchaConfig.publicKey,
 		reCaptchaConfig.privateKey
 	);
-	await captchaConfigPage.saveConfiguration();
 
 	await performLogout(page);
 	await page.goto(liferayConfig.environment.baseUrl);

--- a/modules/test/playwright/tests/captcha-web/recaptcha.spec.ts
+++ b/modules/test/playwright/tests/captcha-web/recaptcha.spec.ts
@@ -1,23 +1,28 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {expect, test} from '@playwright/test';
+import {expect, mergeTests} from '@playwright/test';
 
+import {captchaConfigPageTest} from '../../fixtures/captchaConfigPageTest';
+import {loginTest} from '../../fixtures/loginTest';
 import {liferayConfig} from '../../liferay.config';
-import {CaptchaConfigPage} from '../../pages/captcha-web/CaptchaConfigPage';
-import performLogin, {performLogout} from '../../utils/performLogin';
+import {performLogout} from '../../utils/performLogin';
 import {reCaptchaConfig} from './config';
 
-test('LPD-32888 Check reCaptcha has a label for textarea', async ({page}) => {
-	await performLogin(page, 'test');
-	const captchaConfigPage = new CaptchaConfigPage(page);
+export const test = mergeTests(loginTest(), captchaConfigPageTest);
+
+test('LPD-32888 Check reCaptcha has a label for textarea', async ({
+	captchaConfigPage,
+	page,
+}) => {
 	await captchaConfigPage.goTo();
 	await captchaConfigPage.enableReCaptcha(
 		reCaptchaConfig.publicKey,
 		reCaptchaConfig.privateKey
 	);
+	await captchaConfigPage.saveConfiguration();
 
 	await performLogout(page);
 	await page.goto(liferayConfig.environment.baseUrl);

--- a/modules/test/playwright/tests/login-web/createAccount.spec.ts
+++ b/modules/test/playwright/tests/login-web/createAccount.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {captchaConfigPageTest} from '../../fixtures/captchaConfigPageTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {liferayConfig} from '../../liferay.config';
+import getRandomString from '../../utils/getRandomString';
+import {performLogout} from '../../utils/performLogin';
+
+export const test = mergeTests(loginTest(), captchaConfigPageTest);
+
+test.describe('Duplicate account creation', () => {
+	test('Using already existing email address does not throw failure alert', async ({
+		captchaConfigPage,
+		page,
+	}) => {
+		await captchaConfigPage.goTo();
+
+		await captchaConfigPage.disableCreateAccountCaptcha();
+
+		await captchaConfigPage.saveConfiguration();
+
+		await performLogout(page);
+
+		await page.goto(liferayConfig.environment.baseUrl);
+
+		await page.getByRole('button', {name: 'Sign In'}).click();
+
+		await page.getByText('Create Account').click();
+
+		await page.getByLabel('Screen Name').fill(getRandomString());
+
+		await page.getByLabel('Email Address').fill('test@liferay.com');
+
+		await page.getByLabel('First Name').fill(getRandomString());
+
+		await page.getByLabel('Last Name').fill(getRandomString());
+
+		const password = getRandomString();
+
+		await page
+			.getByLabel('Password Required', {exact: true})
+			.fill(password);
+
+		await page.getByLabel('Reenter Password Required').fill(password);
+
+		await page.getByRole('button', {name: 'Save'}).click();
+
+		await page.waitForTimeout(1000);
+
+		await expect(
+			page.getByText('Error:Your request failed to complete.')
+		).toBeHidden({timeout: 500});
+	});
+});

--- a/modules/test/playwright/tests/login-web/createAccount.spec.ts
+++ b/modules/test/playwright/tests/login-web/createAccount.spec.ts
@@ -6,54 +6,148 @@
 import {expect, mergeTests} from '@playwright/test';
 
 import {captchaConfigPageTest} from '../../fixtures/captchaConfigPageTest';
+import {instanceSettingsPagesTest} from '../../fixtures/instanceSettingsPagesTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {liferayConfig} from '../../liferay.config';
 import getRandomString from '../../utils/getRandomString';
-import {performLogout} from '../../utils/performLogin';
+import performLogin, {performLogout} from '../../utils/performLogin';
 
-export const test = mergeTests(loginTest(), captchaConfigPageTest);
+export const test = mergeTests(
+	captchaConfigPageTest,
+	instanceSettingsPagesTest,
+	loginTest()
+);
 
-test.describe('Duplicate account creation', () => {
-	test('Using already existing email address does not throw failure alert', async ({
-		captchaConfigPage,
-		page,
-	}) => {
+test.beforeEach(
+	'Disable create account CAPTCHA',
+	async ({captchaConfigPage, page}) => {
+		await page.goto(liferayConfig.environment.baseUrl);
+
+		if (await page.getByRole('button', {name: 'Sign In'}).isVisible()) {
+			await performLogin(page, 'test');
+		}
+
 		await captchaConfigPage.goTo();
 
 		await captchaConfigPage.disableCreateAccountCaptcha();
+	}
+);
 
-		await captchaConfigPage.saveConfiguration();
-
-		await performLogout(page);
-
+test.afterEach(
+	'Reset CAPTCHA configuration',
+	async ({captchaConfigPage, page}) => {
 		await page.goto(liferayConfig.environment.baseUrl);
 
-		await page.getByRole('button', {name: 'Sign In'}).click();
+		if (await page.getByRole('button', {name: 'Sign In'}).isVisible()) {
+			await performLogin(page, 'test');
+		}
 
-		await page.getByText('Create Account').click();
+		await captchaConfigPage.goTo();
 
-		await page.getByLabel('Screen Name').fill(getRandomString());
+		await captchaConfigPage.resetCaptchaConfiguration();
 
-		await page.getByLabel('Email Address').fill('test@liferay.com');
+		await page.goto(liferayConfig.environment.baseUrl);
+	}
+);
 
-		await page.getByLabel('First Name').fill(getRandomString());
+test('LPD-44960 Create account using duplicate email address', async ({
+	page,
+}) => {
+	await performLogout(page);
 
-		await page.getByLabel('Last Name').fill(getRandomString());
+	await page.goto(liferayConfig.environment.baseUrl);
 
-		const password = getRandomString();
+	await page.getByRole('button', {name: 'Sign In'}).click();
 
-		await page
-			.getByLabel('Password Required', {exact: true})
-			.fill(password);
+	await page.getByText('Create Account').click();
 
-		await page.getByLabel('Reenter Password Required').fill(password);
+	await page.getByLabel('Screen Name').fill(getRandomString());
 
-		await page.getByRole('button', {name: 'Save'}).click();
+	await page.getByLabel('Email Address').fill('test@liferay.com');
 
-		await page.waitForTimeout(1000);
+	await page.getByLabel('First Name').fill(getRandomString());
 
-		await expect(
-			page.getByText('Error:Your request failed to complete.')
-		).toBeHidden({timeout: 500});
-	});
+	await page.getByLabel('Last Name').fill(getRandomString());
+
+	const password = getRandomString();
+
+	await page.getByLabel('Password Required', {exact: true}).fill(password);
+
+	await page.getByLabel('Reenter Password Required').fill(password);
+
+	await page.getByRole('button', {name: 'Save'}).click();
+
+	await expect(
+		page.getByText(
+			'Thank you for creating an account. Use your password to log in.'
+		)
+	).toBeVisible();
+
+	await expect(
+		page.getByText('Error:Your request failed to complete.')
+	).toBeHidden();
+});
+
+test('LPD-44960 Create account using duplicate email address with email address verification', async ({
+	instanceSettingsPage,
+	page,
+}) => {
+	await instanceSettingsPage.goToInstanceSetting(
+		'User Authentication',
+		'General'
+	);
+
+	const strangersVerify = page.getByText(
+		'Require strangers to verify their email address?'
+	);
+	await strangersVerify.check();
+	await expect(strangersVerify).toBeChecked();
+
+	await instanceSettingsPage.saveAndWaitForAlert();
+
+	await performLogout(page);
+
+	await page.goto(liferayConfig.environment.baseUrl);
+
+	await page.getByRole('button', {name: 'Sign In'}).click();
+
+	await page.getByText('Create Account').click();
+
+	await page.getByLabel('Screen Name').fill(getRandomString());
+
+	await page.getByLabel('Email Address').fill('test@liferay.com');
+
+	await page.getByLabel('First Name').fill(getRandomString());
+
+	await page.getByLabel('Last Name').fill(getRandomString());
+
+	const password = getRandomString();
+
+	await page.getByLabel('Password Required', {exact: true}).fill(password);
+
+	await page.getByLabel('Reenter Password Required').fill(password);
+
+	await page.getByRole('button', {name: 'Save'}).click();
+
+	await expect(
+		page.getByText(
+			'Thank you for creating an account. Your email verification code was sent to test@liferay.com. Use your password to log in.'
+		)
+	).toBeVisible();
+
+	await expect(
+		page.getByText('Error:Your request failed to complete.')
+	).toBeHidden();
+
+	await performLogin(page, 'test');
+
+	await instanceSettingsPage.goToInstanceSetting(
+		'User Authentication',
+		'General'
+	);
+
+	await strangersVerify.uncheck();
+	await expect(strangersVerify).not.toBeChecked();
+
+	await instanceSettingsPage.saveAndWaitForAlert();
 });


### PR DESCRIPTION
Previous PR: https://github.com/liferay-appsec/liferay-portal/pull/2156/

Related issue: https://liferay.atlassian.net/browse/LPD-44960

### **Context:** 
There was a change to prevent user enumeration([LPD-15723](https://liferay.atlassian.net/browse/LPD-15723)) where it changed the behavior to: when a user tries to create an account with a already existing email address, it shows the same toast as if created with a valid email address.

### **Issue:**
After these changes, when a duplicate account creation is attempted it now shows two toasts: a success one and a failure one. Showing the failure one leads to bad user experience and can bring back the user enumeration. 

### **Solution:**
This PR was created to remove the failure toast for when `UserEmailAddressException.MustNotBeDuplicate` is triggered when creating a new account.
