### PR TITLE
LPD-47655

### DIFF
--- a/modules/apps/portal-remote/portal-remote-soap-extender-test/src/testIntegration/java/com/liferay/portal/remote/soap/extender/test/ConfigurationAdminBundleActivator.java
+++ b/modules/apps/portal-remote/portal-remote-soap-extender-test/src/testIntegration/java/com/liferay/portal/remote/soap/extender/test/ConfigurationAdminBundleActivator.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.remote.soap.extender.test;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 
 import java.util.Dictionary;
 import java.util.Hashtable;
@@ -47,7 +48,7 @@ public class ConfigurationAdminBundleActivator implements BundleActivator {
 			_jaxWsApiConfiguration = configurationAdmin.getConfiguration(
 				"com.liferay.portal.remote.soap.extender.internal." +
 					"configuration.JaxWsApiConfiguration",
-				null);
+				StringPool.QUESTION);
 
 			_jaxWsApiConfigurationProperties =
 				_jaxWsApiConfiguration.getProperties();

--- a/modules/apps/portal-remote/portal-remote-soap-extender-test/src/testIntegration/java/com/liferay/portal/remote/soap/extender/test/JaxWsApiHandlerRegistrationTest.java
+++ b/modules/apps/portal-remote/portal-remote-soap-extender-test/src/testIntegration/java/com/liferay/portal/remote/soap/extender/test/JaxWsApiHandlerRegistrationTest.java
@@ -11,7 +11,6 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,7 +28,6 @@ public class JaxWsApiHandlerRegistrationTest extends BaseJaxWsTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Ignore
 	@Test
 	public void testHandlerIsRegistered() throws Exception {
 		String greeting = getGreeting(

--- a/modules/apps/portal-remote/portal-remote-soap-extender-test/src/testIntegration/java/com/liferay/portal/remote/soap/extender/test/JaxWsApiRegistrationTest.java
+++ b/modules/apps/portal-remote/portal-remote-soap-extender-test/src/testIntegration/java/com/liferay/portal/remote/soap/extender/test/JaxWsApiRegistrationTest.java
@@ -11,7 +11,6 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,7 +28,6 @@ public class JaxWsApiRegistrationTest extends BaseJaxWsTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Ignore
 	@Test
 	public void testGreeter() throws Exception {
 		Assert.assertEquals(

--- a/modules/apps/portal-remote/portal-remote-soap-extender-test/src/testIntegration/java/com/liferay/portal/remote/soap/extender/test/JaxWsComponentRegistrationTest.java
+++ b/modules/apps/portal-remote/portal-remote-soap-extender-test/src/testIntegration/java/com/liferay/portal/remote/soap/extender/test/JaxWsComponentRegistrationTest.java
@@ -14,7 +14,6 @@ import java.net.URL;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,7 +31,6 @@ public class JaxWsComponentRegistrationTest extends BaseJaxWsTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Ignore
 	@Test
 	public void testIsRegistered() throws Exception {
 		Assert.assertEquals(
@@ -40,7 +38,6 @@ public class JaxWsComponentRegistrationTest extends BaseJaxWsTestCase {
 			getGreeting("http://localhost:8080/o/soap-test/greeter?wsdl"));
 	}
 
-	@Ignore
 	@Test(expected = Exception.class)
 	public void testServiceListIsUnavailable() throws Exception {
 		URL url = new URL("http://localhost:8080/o/soap-test/services");


### PR DESCRIPTION
Related issue: [LPD-47655](https://liferay.atlassian.net/browse/LPD-47655)

Test started failing after [LPD-41740](https://liferay.atlassian.net/browse/LPD-41740) was merged. I also took the chance to remove some related tests from quarantine and moved them to Security team/suite. (before they were under Core Infra/Portal Services)

:warning: **Still need to confirm if all modules under portal-remote/ are from AppSec otherwise we'll need to modify `test.properties`**

see: 
![image](https://github.com/user-attachments/assets/d5fe69eb-3398-4b00-b0ca-3dbefed86bb0)  

![image](https://github.com/user-attachments/assets/6b522f3f-9e14-4f79-a75a-0315ed6fd1de)

