### PR TITLE
LPD-48907 Add missing components tests to the security suite

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -7235,14 +7235,11 @@
     # Security
     #
 
+    modules.includes[js-unit][security]=${security.testing.modules}
+
     modules.includes[modules-semantic-versioning][security]=${security.testing.modules}
 
-    modules.includes.private[modules-semantic-versioning][security]=\
-        ${security.testing.modules},\
-        dxp/apps/antivirus/**,\
-        dxp/apps/multi-factor-authentication/**,\
-        dxp/apps/saml/**,\
-        dxp/apps/scim/**
+    modules.includes.private[modules-semantic-versioning][security]=${security.testing.modules}
 
     modules.includes.public[modules-semantic-versioning][security]=${security.testing.modules}
 
@@ -7266,20 +7263,31 @@
         apps/oauth-client/**,\
         apps/oauth2-provider/**,\
         apps/password-policies-admin/**,\
+        apps/portal-crypto-hash/**,\
+        apps/portal-remote/**,\
         apps/portal-security/**,\
         apps/portal-security-audit/**,\
         apps/portal-security-sso/**,\
-        apps/portal-settings/**
+        apps/portal-settings/**,\
+        dxp/apps/antivirus/**,\
+        dxp/apps/multi-factor-authentication/**,\
+        dxp/apps/saml/**,\
+        dxp/apps/scim/**
 
     test.batch.class.names.includes[security]=\
         **/antivirus-async-store-test/**/*Test.java,\
+        **/captcha/**/*Test.java,\
         **/cookies/**/*Test.java,\
+        **/login/**/*Test.java,\
         **/multi-factor-authentication/**/*Test.java,\
         **/oauth-client/**/*Test.java,\
         **/oauth2-provider/**/*Test.java,\
         **/password-policies-admin/**/*Test.java,\
+        **/password-policy/**/*Test.java,\
         **/portal-crypto-hash/**/*Test.java,\
-        **/portal-remote-cors-test/**/*Test.java,\
+        **/portal-json-web-service-client/**/*Test.java,\
+        **/portal-kernel-jsonwebservice-test/**/*Test.java,\
+        **/portal-remote/**/*Test.java,\
         **/portal-security/**/*Test.java,\
         **/portal-security-audit/**/*Test.java,\
         **/portal-security-ldap-api/**/*Test.java,\


### PR DESCRIPTION
Related issue: [LPD-48907](https://liferay.atlassian.net/browse/LPD-48907)

This is a first PR to start the maintenance plan of the security suite. I'm adding the missing component tests that are currently not running. The next step will be to rename/reassign the components. 

This is important so that we can keep track of all of our tests. 

You can check the current document related to this changes here: [Google Document](https://docs.google.com/document/d/10tqEiX5fKj24Ndi84YkViywtzRC-EHCvuwD4m_9gZUc/edit?tab=t.0)