### PR TITLE
LPD-48249 Upgrade tests should have the property p********s.encryption.algorithm.legacy set

### DIFF
--- a/modules/apps/account/account-test/src/testFunctional/tests/AccountUpgrade.testcase
+++ b/modules/apps/account/account-test/src/testFunctional/tests/AccountUpgrade.testcase
@@ -1,6 +1,7 @@
 @component-name = "portal-commerce"
 definition {
 
+	property custom.properties = "passwords.encryption.algorithm.legacy=PBKDF2WithHmacSHA1/160/128000";
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver";
 	property portal.release = "true";
 	property portal.upstream = "true";
@@ -461,7 +462,7 @@ definition {
 	@description = "This is a use case for LPS-179688. TC-2 and TC-3: Verify login.create.account.allow.custom.password parameter is completely ignored from now on."
 	@priority = 5
 	test ViewCreatePasswordParameterIsIgnoredAfterUpgrade71103 {
-		property custom.properties = "login.create.account.allow.custom.password=false";
+		property custom.properties = "login.create.account.allow.custom.password=false${line.separator}passwords.encryption.algorithm.legacy=PBKDF2WithHmacSHA1/160/128000";
 		property data.archive.type = "data-archive-create-account-disable-password";
 		property database.types = "db2,mysql,oracle,postgresql,sqlserver";
 		property portal.version = "7.1.10.3";

--- a/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptorUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptorUtil.java
@@ -84,8 +84,15 @@ public class PasswordEncryptorUtil {
 			String encryptedPassword)
 		throws PwdEncryptorException {
 
+		String encryptedPasswordAlgorithm = _getEncryptedPasswordAlgorithm(
+			encryptedPassword);
+
+		if (Validator.isNull(encryptedPasswordAlgorithm)) {
+			return null;
+		}
+
 		PasswordEncryptor passwordEncryptor = _getPasswordEncryptor(
-			_getEncryptedPasswordAlgorithm(encryptedPassword));
+			encryptedPasswordAlgorithm);
 
 		return passwordEncryptor.getEncryptedPasswordAlgorithmSettings(
 			encryptedPassword);

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/upgrades/OAuth2Upgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/upgrades/OAuth2Upgrade.testcase
@@ -2,6 +2,7 @@
 definition {
 
 	property ci.retries.disabled = "true";
+	property custom.properties = "passwords.encryption.algorithm.legacy=PBKDF2WithHmacSHA1/160/128000";
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver";
 	property portal.release = "true";
 	property portal.upstream = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/OrganizationUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/OrganizationUpgrade.testcase
@@ -1,6 +1,7 @@
 @component-name = "portal-commerce"
 definition {
 
+	property custom.properties = "passwords.encryption.algorithm.legacy=PBKDF2WithHmacSHA1/160/128000";
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver";
 	property portal.release = "true";
 	property portal.upstream = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalConfigurationUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/PortalConfigurationUpgrade.testcase
@@ -1,7 +1,7 @@
 @component-name = "portal-core-infra"
 definition {
 
-	property custom.properties = "layout.user.access.via.plid.enabled=true";
+	property custom.properties = "layout.user.access.via.plid.enabled=true${line.separator}passwords.encryption.algorithm.legacy=PBKDF2WithHmacSHA1/160/128000";
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver";
 	property portal.release = "true";
 	property portal.smoke.upgrades = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UserUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/upgrades/UserUpgrade.testcase
@@ -1,6 +1,7 @@
 @component-name = "portal-commerce"
 definition {
 
+	property custom.properties = "passwords.encryption.algorithm.legacy=PBKDF2WithHmacSHA1/160/128000";
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver";
 	property portal.release = "true";
 	property portal.upstream = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAMLUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAMLUpgrade.testcase
@@ -2,6 +2,7 @@
 definition {
 
 	property ci.retries.disabled = "true";
+	property custom.properties = "passwords.encryption.algorithm.legacy=PBKDF2WithHmacSHA1/160/128000";
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver";
 	property dummy.socket.proxy.disabled = "true";
 	property portal.release = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/upgrades/ExportImportUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/exportimport/upgrades/ExportImportUpgrade.testcase
@@ -2,6 +2,7 @@
 definition {
 
 	property ci.retries.disabled = "true";
+	property custom.properties = "passwords.encryption.algorithm.legacy=PBKDF2WithHmacSHA1/160/128000";
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver";
 	property portal.release = "true";
 	property portal.upstream = "true";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/sitetemplates/upgrades/SitetemplatesUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/sitetemplates/upgrades/SitetemplatesUpgrade.testcase
@@ -2,6 +2,7 @@
 definition {
 
 	property ci.retries.disabled = "true";
+	property custom.properties = "passwords.encryption.algorithm.legacy=PBKDF2WithHmacSHA1/160/128000";
 	property database.types = "db2,mariadb,mysql,oracle,postgresql,sqlserver";
 	property portal.release = "true";
 	property portal.upstream = "true";
@@ -68,7 +69,7 @@ definition {
 	@description = "This is a use case for LPS-174465 and LPS-174471. TC-8 Verify that the exclamation mark are present after upgrade."
 	@priority = 3
 	test ExclamationMarkPresentAfterUpgrade701016 {
-		property custom.properties = "feature.flag.LPS-174417=true";
+		property custom.properties = "feature.flag.LPS-174417=true${line.separator}passwords.encryption.algorithm.legacy=PBKDF2WithHmacSHA1/160/128000";
 		property data.archive.type = "data-archive-page-with-collision";
 		property portal.version = "7.0.10.16";
 


### PR DESCRIPTION
Related issue: [LPD-48249](https://liferay.atlassian.net/browse/LPD-48249)

after [LPD-43072](https://liferay.atlassian.net/browse/LPD-43072) was merged, there’s now the need to set the property `passwords.encryption.algorithm.legacy` when performing an upgrade, so I’ve updated the affected tests with this property.