### PR TITLE
LPD-49295

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilter.java
@@ -51,7 +51,7 @@ public class PasswordModifiedFilter extends BasePortalFilter {
 	private String _getRequestPath(HttpServletRequest httpServletRequest) {
 		String requestURI = httpServletRequest.getRequestURI();
 
-		String contextPath = httpServletRequest.getContextPath();
+		String contextPath = PortalUtil.getPathContext();
 
 		if (Validator.isNotNull(contextPath) &&
 			!contextPath.equals(StringPool.SLASH)) {

--- a/portal-impl/test/unit/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilterTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilterTest.java
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.servlet.filters.password.modified;
+
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.ProxyFactory;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portal.util.PortalImpl;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Christopher Kian
+ */
+public class PasswordModifiedFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testDoFilter() throws IOException, ServletException {
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(new PortalImpl());
+
+		PasswordModifiedFilter passwordModifiedFilter =
+			new PasswordModifiedFilter();
+
+		passwordModifiedFilter.doFilter(
+			new HttpServletRequestWrapper(
+				ProxyFactory.newDummyInstance(HttpServletRequest.class)) {
+
+				@Override
+				public String getContextPath() {
+					return "/c/bad/context/path";
+				}
+
+				@Override
+				public String getRequestURI() {
+					return "/c/portal/status";
+				}
+
+			},
+			null, ProxyFactory.newDummyInstance(FilterChain.class));
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-49295

This doesn't test the bug functionally, but it does directly test the filter, specifically gathering the context path from `PortalImpl` instead of the `httpServletRequest`.

If you have any doubts about the fix or test, please let me know, thanks!