### PR TITLE
LPD-50660

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilter.java
@@ -53,19 +53,18 @@ public class PasswordModifiedFilter extends BasePortalFilter {
 
 		String contextPath = PortalUtil.getPathContext();
 
-		String proxyPath = PortalUtil.getPathProxy();
+		if (Validator.isNotNull(contextPath)) {
+			String proxyPath = PortalUtil.getPathProxy();
 
-		if (Validator.isNotNull(contextPath) &&
-			Validator.isNotNull(proxyPath) &&
-			contextPath.startsWith(proxyPath)) {
+			if (Validator.isNotNull(proxyPath) &&
+				contextPath.startsWith(proxyPath)) {
 
-			contextPath = contextPath.substring(proxyPath.length());
-		}
+				contextPath = contextPath.substring(proxyPath.length());
+			}
 
-		if (Validator.isNotNull(contextPath) &&
-			!contextPath.equals(StringPool.SLASH)) {
-
-			requestURI = requestURI.substring(contextPath.length());
+			if (!contextPath.equals(StringPool.SLASH)) {
+				requestURI = requestURI.substring(contextPath.length());
+			}
 		}
 
 		return HttpComponentsUtil.removePathParameters(requestURI);

--- a/portal-impl/src/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilter.java
@@ -53,6 +53,15 @@ public class PasswordModifiedFilter extends BasePortalFilter {
 
 		String contextPath = PortalUtil.getPathContext();
 
+		String proxyPath = PortalUtil.getPathProxy();
+
+		if (Validator.isNotNull(contextPath) &&
+			Validator.isNotNull(proxyPath) &&
+			contextPath.startsWith(proxyPath)) {
+
+			contextPath = contextPath.substring(proxyPath.length());
+		}
+
 		if (Validator.isNotNull(contextPath) &&
 			!contextPath.equals(StringPool.SLASH)) {
 

--- a/portal-impl/test/unit/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilterTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilterTest.java
@@ -73,4 +73,52 @@ public class PasswordModifiedFilterTest {
 		);
 	}
 
+	@Test
+	public void testProcessFilterWithPortalProxyPath() throws Exception {
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(
+			new PortalImpl() {
+
+				@Override
+				public String getPathContext() {
+					return "/proxy/test";
+				}
+
+				@Override
+				public String getPathProxy() {
+					return "/proxy";
+				}
+
+			});
+
+		PasswordModifiedFilter passwordModifiedFilter =
+			new PasswordModifiedFilter();
+
+		FilterChain filterChain = Mockito.mock(FilterChain.class);
+
+		passwordModifiedFilter.processFilter(
+			new HttpServletRequestWrapper(
+				ProxyFactory.newDummyInstance(HttpServletRequest.class)) {
+
+				@Override
+				public String getContextPath() {
+					return "/c/bad/context/path";
+				}
+
+				@Override
+				public String getRequestURI() {
+					return "/test/path";
+				}
+
+			},
+			null, filterChain);
+
+		Mockito.verify(
+			filterChain
+		).doFilter(
+			Mockito.any(), Mockito.any()
+		);
+	}
+
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-50660
https://liferay.atlassian.net/browse/LPD-49295

This resolves a core-infra release blocker described in [LPD-50546](https://liferay.atlassian.net/browse/LPD-50546) by appending the original fix for [LPD-49295](https://liferay.atlassian.net/browse/LPD-49295).  The tests failing in the [release blocker](https://testray.liferay.com/#/testflow/153739650/subtasks/153740978?filter=%7B%7D&filterSchema=subtaskCaseResults) are now [passing on this PR](https://github.com/liferay-appsec/liferay-portal/pull/2223#issuecomment-2699630836) with my changes.  I previously included a commit which excluded all other test aside from the failing ones, but I have dropped that commit now.

In short, the test were failing because of the following error:

> ERROR [http-nio-8080-exec-3][PasswordModifiedFilter:55] java.lang.StringIndexOutOfBoundsException: Range [8, 1) out of bounds for length 1
> java.lang.StringIndexOutOfBoundsException: Range [8, 1) out of bounds for length 1

This error occurred on these specific Poshi tests because [the portal.proxy.path was set](https://github.com/liferay/liferay-portal/blob/master/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/deployment/PortalProxyPath.testcase#L5), and my original changes for LPD-49295 did not account for this.  You can see with my original changes, we simply returned the PortalImpl.getPathContext() value, which [may contain the portal.proxy.path value](https://github.com/liferay/liferay-portal/blob/4281f9b41f4c84911eaaf42439d4bf4905772f58/portal-impl/src/com/liferay/portal/util/PortalImpl.java#L346-L350).  Now we check if this value begins with `_pathProxy` (and substring it if it does) before attempting to substring the `contextPath`.