### PR TITLE
LPD-50543 Keep only CentOS environment on MFA Poshi tests

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/multi-factor-authentication/MultiFactorAuthentication.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/multi-factor-authentication/MultiFactorAuthentication.testcase
@@ -898,7 +898,7 @@ definition {
 		property custom.properties = "jsonws.web.service.paths.excludes=";
 		property database.types = "hypersonic,mariadb,mysql,oracle,postgresql,sqlserver";
 		property environment.acceptance = "true";
-		property operating.system.types = "alpine,amazonlinux,centos,debian,fedora,orcllinux,osx,redhat,rockylinux,solaris,suse,ubuntu,windows";
+		property operating.system.types = "centos";
 		property osgi.module.configuration.file.names = "com.liferay.multi.factor.authentication.email.otp.configuration.MFAEmailOTPConfiguration.config";
 		property osgi.module.configurations = "emailFromAddress=\"test@liferay.com\"${line.separator}emailFromName=\"Joe\ Bloggs\"";
 		property portal.acceptance = "true";
@@ -952,7 +952,7 @@ definition {
 		property custom.properties = "jsonws.web.service.paths.excludes=";
 		property database.types = "hypersonic,mariadb,mysql,oracle,postgresql,sqlserver";
 		property environment.acceptance = "true";
-		property operating.system.types = "alpine,amazonlinux,centos,debian,fedora,orcllinux,osx,redhat,rockylinux,solaris,suse,ubuntu,windows";
+		property operating.system.types = "centos";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -1011,7 +1011,7 @@ definition {
 		property custom.properties = "jsonws.web.service.paths.excludes=";
 		property database.types = "hypersonic,mariadb,mysql,oracle,postgresql,sqlserver";
 		property environment.acceptance = "true";
-		property operating.system.types = "alpine,amazonlinux,centos,debian,fedora,orcllinux,osx,redhat,rockylinux,solaris,suse,ubuntu,windows";
+		property operating.system.types = "centos";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 


### PR DESCRIPTION
Related issue: [LPD-50543](https://liferay.atlassian.net/browse/LPD-50543)

These tests are failing on Debian 12 due to MockMock not being configured in that environment. The team decided that these tests should only run on CentOS since different OSs wouldn't impact on it.

The `operating.system.types` property was added(with all supported OS types) to all tests that have `property environment.acceptance = "true";` on this ticket: [LRCI-3217](https://liferay.atlassian.net/browse/LRCI-3217)