### PR TITLE
LPD-47223, LPD-47428

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -6,9 +6,13 @@
 package com.liferay.portal.security.ldap.internal.exportimport;
 
 import com.liferay.expando.kernel.model.ExpandoBridge;
+import com.liferay.expando.kernel.model.ExpandoColumn;
 import com.liferay.expando.kernel.model.ExpandoColumnConstants;
+import com.liferay.expando.kernel.model.ExpandoTable;
 import com.liferay.expando.kernel.model.ExpandoTableConstants;
 import com.liferay.expando.kernel.model.ExpandoValue;
+import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
+import com.liferay.expando.kernel.service.ExpandoTableLocalService;
 import com.liferay.expando.kernel.service.ExpandoValueLocalService;
 import com.liferay.expando.util.ExpandoConverterUtil;
 import com.liferay.petra.string.StringBundler;
@@ -37,6 +41,7 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.exportimport.UserGroupImportTransactionThreadLocal;
 import com.liferay.portal.kernel.security.ldap.AttributesTransformer;
 import com.liferay.portal.kernel.security.ldap.LDAPSettings;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -55,6 +60,7 @@ import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PwdGenerator;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.exportimport.UserImporter;
 import com.liferay.portal.security.ldap.ContactConverterKeys;
@@ -914,6 +920,45 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			role.getRoleId(), new long[] {group.getGroupId()});
 	}
 
+	private long _getExpandoColumnId() throws Exception {
+		if (_expandoColumn == null) {
+			_expandoColumn = _expandoColumnLocalService.fetchColumn(
+				_expandoTable.getTableId(), "ldapServerId");
+
+			if (_expandoColumn == null) {
+				_expandoColumn = _expandoColumnLocalService.addColumn(
+					_expandoTable.getTableId(), "ldapServerId",
+					ExpandoColumnConstants.LONG);
+
+				UnicodeProperties unicodeProperties =
+					_expandoColumn.getTypeSettingsProperties();
+
+				unicodeProperties.setProperty(
+					ExpandoColumnConstants.INDEX_TYPE,
+					String.valueOf(ExpandoColumnConstants.INDEX_TYPE_KEYWORD));
+				unicodeProperties.setProperty(
+					ExpandoColumnConstants.PROPERTY_HIDDEN,
+					Boolean.TRUE.toString());
+			}
+		}
+
+		return _expandoColumn.getColumnId();
+	}
+
+	private long _getExpandoTableId(long companyId) throws Exception {
+		if (_expandoTable == null) {
+			_expandoTable = _expandoTableLocalService.getTable(
+				companyId, UserGroup.class.getName(), "LDAP");
+
+			if (_expandoTable == null) {
+				_expandoTable = _expandoTableLocalService.addTable(
+					companyId, UserGroup.class.getName(), "LDAP");
+			}
+		}
+
+		return _expandoTable.getTableId();
+	}
+
 	private LDAPImportContext _getLDAPImportContext(
 		long companyId, Properties contactExpandoMappings,
 		Properties contactMappings, Properties groupMappings,
@@ -1174,6 +1219,12 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			}
 		}
 
+		_expandoValueLocalService.addValue(
+			_classNameLocalService.getClassNameId(UserGroup.class),
+			_getExpandoTableId(ldapImportContext.getCompanyId()),
+			_getExpandoColumnId(), userGroupId,
+			String.valueOf(ldapImportContext.getLdapServerId()));
+
 		if (_log.isDebugEnabled()) {
 			_log.debug(
 				StringBundler.concat(
@@ -1298,7 +1349,9 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			}
 		}
 
-		_updateUserUserGroups(user.getUserId(), newUserGroupIds);
+		_updateUserUserGroups(
+			ldapImportContext.getLdapServerId(), user.getUserId(),
+			newUserGroupIds);
 	}
 
 	private User _importUser(
@@ -1972,7 +2025,8 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 		return password;
 	}
 
-	private void _updateUserUserGroups(long userId, Set<Long> userGroupIds)
+	private void _updateUserUserGroups(
+			long ldapServerId, long userId, Set<Long> userGroupIds)
 		throws Exception {
 
 		List<Long> deleteUserGroupIds = new ArrayList<>();
@@ -1987,7 +2041,16 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 					userGroupIds.remove(userGroupId);
 				}
 				else {
-					deleteUserGroupIds.add(userGroupId);
+					ExpandoValue expandoValue =
+						_expandoValueLocalService.getValue(
+							_getExpandoTableId(userGroup.getCompanyId()),
+							_getExpandoColumnId(), userGroupId);
+
+					if ((expandoValue != null) &&
+						(expandoValue.getLong() == ldapServerId)) {
+
+						deleteUserGroupIds.add(userGroupId);
+					}
 				}
 			}
 		}
@@ -2035,9 +2098,21 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 	private BeanProperties _beanProperties;
 
 	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
 	private CompanyLocalService _companyLocalService;
 
 	private String _companySecurityAuthType;
+	private ExpandoColumn _expandoColumn;
+
+	@Reference
+	private ExpandoColumnLocalService _expandoColumnLocalService;
+
+	private ExpandoTable _expandoTable;
+
+	@Reference
+	private ExpandoTableLocalService _expandoTableLocalService;
 
 	@Reference
 	private ExpandoValueLocalService _expandoValueLocalService;

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -947,8 +947,9 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 
 	private long _getExpandoTableId(long companyId) throws Exception {
 		if (_expandoTable == null) {
-			_expandoTable = _expandoTableLocalService.getTable(
-				companyId, UserGroup.class.getName(), "LDAP");
+			_expandoTable = _expandoTableLocalService.fetchTable(
+				companyId,
+				_classNameLocalService.getClassNameId(UserGroup.class), "LDAP");
 
 			if (_expandoTable == null) {
 				_expandoTable = _expandoTableLocalService.addTable(

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -933,8 +933,18 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			userExpandoMappings, userMappings);
 	}
 
-	private ExpandoColumn _getOrCreateExpandoColumn(ExpandoTable expandoTable)
+	private ExpandoColumn _getOrCreateExpandoColumn(long companyId)
 		throws Exception {
+
+		ExpandoTable expandoTable = _expandoTableLocalService.fetchTable(
+			companyId, _classNameLocalService.getClassNameId(UserGroup.class),
+			ExpandoTableConstants.DEFAULT_TABLE_NAME);
+
+		if (expandoTable == null) {
+			expandoTable = _expandoTableLocalService.addTable(
+				companyId, UserGroup.class.getName(),
+				ExpandoTableConstants.DEFAULT_TABLE_NAME);
+		}
 
 		ExpandoColumn expandoColumn = _expandoColumnLocalService.fetchColumn(
 			expandoTable.getTableId(), "ldapServerId");
@@ -961,22 +971,6 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 		}
 
 		return expandoColumn;
-	}
-
-	private ExpandoTable _getOrCreateExpandoTable(long companyId)
-		throws Exception {
-
-		ExpandoTable expandoTable = _expandoTableLocalService.fetchTable(
-			companyId, _classNameLocalService.getClassNameId(UserGroup.class),
-			ExpandoTableConstants.DEFAULT_TABLE_NAME);
-
-		if (expandoTable == null) {
-			expandoTable = _expandoTableLocalService.addTable(
-				companyId, UserGroup.class.getName(),
-				ExpandoTableConstants.DEFAULT_TABLE_NAME);
-		}
-
-		return expandoTable;
 	}
 
 	private Attribute _getUsers(
@@ -1226,15 +1220,13 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			}
 		}
 
-		ExpandoTable expandoTable = _getOrCreateExpandoTable(
+		ExpandoColumn expandoColumn = _getOrCreateExpandoColumn(
 			ldapImportContext.getCompanyId());
-
-		ExpandoColumn expandoColumn = _getOrCreateExpandoColumn(expandoTable);
 
 		_expandoValueLocalService.addValue(
 			_classNameLocalService.getClassNameId(UserGroup.class),
-			expandoTable.getTableId(), expandoColumn.getColumnId(), userGroupId,
-			String.valueOf(ldapImportContext.getLdapServerId()));
+			expandoColumn.getTableId(), expandoColumn.getColumnId(),
+			userGroupId, String.valueOf(ldapImportContext.getLdapServerId()));
 
 		if (_log.isDebugEnabled()) {
 			_log.debug(
@@ -2052,15 +2044,12 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 					userGroupIds.remove(userGroupId);
 				}
 				else {
-					ExpandoTable expandoTable = _getOrCreateExpandoTable(
-						userGroup.getCompanyId());
-
 					ExpandoColumn expandoColumn = _getOrCreateExpandoColumn(
-						expandoTable);
+						userGroup.getCompanyId());
 
 					ExpandoValue expandoValue =
 						_expandoValueLocalService.getValue(
-							expandoTable.getTableId(),
+							expandoColumn.getTableId(),
 							expandoColumn.getColumnId(), userGroupId);
 
 					if ((expandoValue != null) &&

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -953,6 +953,11 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			unicodeProperties.setProperty(
 				ExpandoColumnConstants.PROPERTY_HIDDEN,
 				Boolean.TRUE.toString());
+
+			expandoColumn.setTypeSettingsProperties(unicodeProperties);
+
+			expandoColumn = _expandoColumnLocalService.updateExpandoColumn(
+				expandoColumn);
 		}
 
 		return expandoColumn;
@@ -963,11 +968,12 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 
 		ExpandoTable expandoTable = _expandoTableLocalService.fetchTable(
 			companyId, _classNameLocalService.getClassNameId(UserGroup.class),
-			"LDAP");
+			ExpandoTableConstants.DEFAULT_TABLE_NAME);
 
 		if (expandoTable == null) {
 			expandoTable = _expandoTableLocalService.addTable(
-				companyId, UserGroup.class.getName(), "LDAP");
+				companyId, UserGroup.class.getName(),
+				ExpandoTableConstants.DEFAULT_TABLE_NAME);
 		}
 
 		return expandoTable;

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -1353,8 +1353,8 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 		}
 
 		_updateUserUserGroups(
-			ldapImportContext.getLdapServerId(), user.getUserId(),
-			newUserGroupIds);
+			ldapImportContext.getLdapServerId(), newUserGroupIds,
+			user.getUserId());
 	}
 
 	private User _importUser(
@@ -2029,7 +2029,7 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 	}
 
 	private void _updateUserUserGroups(
-			long ldapServerId, long userId, Set<Long> userGroupIds)
+			long ldapServerId, Set<Long> userGroupIds, long userId)
 		throws Exception {
 
 		List<Long> deleteUserGroupIds = new ArrayList<>();

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -920,44 +920,42 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			role.getRoleId(), new long[] {group.getGroupId()});
 	}
 
-	private long _getExpandoColumnId() throws Exception {
-		if (_expandoColumn == null) {
-			_expandoColumn = _expandoColumnLocalService.fetchColumn(
-				_expandoTable.getTableId(), "ldapServerId");
+	private ExpandoColumn _getExpandoColumn(ExpandoTable expandoTable)
+		throws Exception {
 
-			if (_expandoColumn == null) {
-				_expandoColumn = _expandoColumnLocalService.addColumn(
-					_expandoTable.getTableId(), "ldapServerId",
-					ExpandoColumnConstants.LONG);
+		ExpandoColumn expandoColumn = _expandoColumnLocalService.fetchColumn(
+			expandoTable.getTableId(), "ldapServerId");
 
-				UnicodeProperties unicodeProperties =
-					_expandoColumn.getTypeSettingsProperties();
+		if (expandoColumn == null) {
+			expandoColumn = _expandoColumnLocalService.addColumn(
+				expandoTable.getTableId(), "ldapServerId",
+				ExpandoColumnConstants.LONG);
 
-				unicodeProperties.setProperty(
-					ExpandoColumnConstants.INDEX_TYPE,
-					String.valueOf(ExpandoColumnConstants.INDEX_TYPE_KEYWORD));
-				unicodeProperties.setProperty(
-					ExpandoColumnConstants.PROPERTY_HIDDEN,
-					Boolean.TRUE.toString());
-			}
+			UnicodeProperties unicodeProperties =
+				expandoColumn.getTypeSettingsProperties();
+
+			unicodeProperties.setProperty(
+				ExpandoColumnConstants.INDEX_TYPE,
+				String.valueOf(ExpandoColumnConstants.INDEX_TYPE_KEYWORD));
+			unicodeProperties.setProperty(
+				ExpandoColumnConstants.PROPERTY_HIDDEN,
+				Boolean.TRUE.toString());
 		}
 
-		return _expandoColumn.getColumnId();
+		return expandoColumn;
 	}
 
-	private long _getExpandoTableId(long companyId) throws Exception {
-		if (_expandoTable == null) {
-			_expandoTable = _expandoTableLocalService.fetchTable(
-				companyId,
-				_classNameLocalService.getClassNameId(UserGroup.class), "LDAP");
+	private ExpandoTable _getExpandoTable(long companyId) throws Exception {
+		ExpandoTable expandoTable = _expandoTableLocalService.fetchTable(
+			companyId, _classNameLocalService.getClassNameId(UserGroup.class),
+			"LDAP");
 
-			if (_expandoTable == null) {
-				_expandoTable = _expandoTableLocalService.addTable(
-					companyId, UserGroup.class.getName(), "LDAP");
-			}
+		if (expandoTable == null) {
+			expandoTable = _expandoTableLocalService.addTable(
+				companyId, UserGroup.class.getName(), "LDAP");
 		}
 
-		return _expandoTable.getTableId();
+		return expandoTable;
 	}
 
 	private LDAPImportContext _getLDAPImportContext(
@@ -1220,10 +1218,14 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			}
 		}
 
+		ExpandoTable expandoTable = _getExpandoTable(
+			ldapImportContext.getCompanyId());
+
+		ExpandoColumn expandoColumn = _getExpandoColumn(expandoTable);
+
 		_expandoValueLocalService.addValue(
 			_classNameLocalService.getClassNameId(UserGroup.class),
-			_getExpandoTableId(ldapImportContext.getCompanyId()),
-			_getExpandoColumnId(), userGroupId,
+			expandoTable.getTableId(), expandoColumn.getColumnId(), userGroupId,
 			String.valueOf(ldapImportContext.getLdapServerId()));
 
 		if (_log.isDebugEnabled()) {
@@ -2042,10 +2044,16 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 					userGroupIds.remove(userGroupId);
 				}
 				else {
+					ExpandoTable expandoTable = _getExpandoTable(
+						userGroup.getCompanyId());
+
+					ExpandoColumn expandoColumn = _getExpandoColumn(
+						expandoTable);
+
 					ExpandoValue expandoValue =
 						_expandoValueLocalService.getValue(
-							_getExpandoTableId(userGroup.getCompanyId()),
-							_getExpandoColumnId(), userGroupId);
+							expandoTable.getTableId(),
+							expandoColumn.getColumnId(), userGroupId);
 
 					if ((expandoValue != null) &&
 						(expandoValue.getLong() == ldapServerId)) {
@@ -2105,12 +2113,9 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 	private CompanyLocalService _companyLocalService;
 
 	private String _companySecurityAuthType;
-	private ExpandoColumn _expandoColumn;
 
 	@Reference
 	private ExpandoColumnLocalService _expandoColumnLocalService;
-
-	private ExpandoTable _expandoTable;
 
 	@Reference
 	private ExpandoTableLocalService _expandoTableLocalService;

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -920,7 +920,20 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			role.getRoleId(), new long[] {group.getGroupId()});
 	}
 
-	private ExpandoColumn _getExpandoColumn(ExpandoTable expandoTable)
+	private LDAPImportContext _getLDAPImportContext(
+		long companyId, Properties contactExpandoMappings,
+		Properties contactMappings, Properties groupMappings,
+		SafeLdapContext safeLdapContext, long ldapServerId,
+		Set<String> ldapUserIgnoreAttributes, Properties userExpandoMappings,
+		Properties userMappings) {
+
+		return new LDAPImportContext(
+			companyId, contactExpandoMappings, contactMappings, groupMappings,
+			safeLdapContext, ldapServerId, ldapUserIgnoreAttributes,
+			userExpandoMappings, userMappings);
+	}
+
+	private ExpandoColumn _getOrCreateExpandoColumn(ExpandoTable expandoTable)
 		throws Exception {
 
 		ExpandoColumn expandoColumn = _expandoColumnLocalService.fetchColumn(
@@ -945,7 +958,9 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 		return expandoColumn;
 	}
 
-	private ExpandoTable _getExpandoTable(long companyId) throws Exception {
+	private ExpandoTable _getOrCreateExpandoTable(long companyId)
+		throws Exception {
+
 		ExpandoTable expandoTable = _expandoTableLocalService.fetchTable(
 			companyId, _classNameLocalService.getClassNameId(UserGroup.class),
 			"LDAP");
@@ -956,19 +971,6 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 		}
 
 		return expandoTable;
-	}
-
-	private LDAPImportContext _getLDAPImportContext(
-		long companyId, Properties contactExpandoMappings,
-		Properties contactMappings, Properties groupMappings,
-		SafeLdapContext safeLdapContext, long ldapServerId,
-		Set<String> ldapUserIgnoreAttributes, Properties userExpandoMappings,
-		Properties userMappings) {
-
-		return new LDAPImportContext(
-			companyId, contactExpandoMappings, contactMappings, groupMappings,
-			safeLdapContext, ldapServerId, ldapUserIgnoreAttributes,
-			userExpandoMappings, userMappings);
 	}
 
 	private Attribute _getUsers(
@@ -1218,10 +1220,10 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			}
 		}
 
-		ExpandoTable expandoTable = _getExpandoTable(
+		ExpandoTable expandoTable = _getOrCreateExpandoTable(
 			ldapImportContext.getCompanyId());
 
-		ExpandoColumn expandoColumn = _getExpandoColumn(expandoTable);
+		ExpandoColumn expandoColumn = _getOrCreateExpandoColumn(expandoTable);
 
 		_expandoValueLocalService.addValue(
 			_classNameLocalService.getClassNameId(UserGroup.class),
@@ -2044,10 +2046,10 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 					userGroupIds.remove(userGroupId);
 				}
 				else {
-					ExpandoTable expandoTable = _getExpandoTable(
+					ExpandoTable expandoTable = _getOrCreateExpandoTable(
 						userGroup.getCompanyId());
 
-					ExpandoColumn expandoColumn = _getExpandoColumn(
+					ExpandoColumn expandoColumn = _getOrCreateExpandoColumn(
 						expandoTable);
 
 					ExpandoValue expandoValue =

--- a/modules/test/playwright/fixtures/ldapConfigurationPagesTest.ts
+++ b/modules/test/playwright/fixtures/ldapConfigurationPagesTest.ts
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import test from '@playwright/test';
+
+import {LdapConfigurationPage} from '../pages/portal-security-ldap/LdapConfigurationPage';
+import {LdapServerPage} from '../pages/portal-security-ldap/LdapServerPage';
+
+const ldapConfigurationPagesTest = test.extend<{
+	ldapConfigurationPage: LdapConfigurationPage;
+	ldapServerPage: LdapServerPage;
+}>({
+	ldapConfigurationPage: async ({page}, use) => {
+		await use(new LdapConfigurationPage(page));
+	},
+	ldapServerPage: async ({page}, use) => {
+		await use(new LdapServerPage(page));
+	},
+});
+
+export {ldapConfigurationPagesTest};

--- a/modules/test/playwright/helpers/LdapConfigurationHelper.ts
+++ b/modules/test/playwright/helpers/LdapConfigurationHelper.ts
@@ -1,0 +1,98 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const DEFAULT_LDAP_CONFIGURATION_VALUES = {
+	autogenerateUserPasswordOnImport: false,
+	createRolePerGroupOnImport: false,
+	defaultUserPassword: 'test',
+	enableExport: false,
+	enableGroupCacheOnImport: true,
+	enableGroupExport: true,
+	enableImport: false,
+	enableImportOnStartup: false,
+	enableUserPasswordOnImport: true,
+	enabled: false,
+	importInterval: 10,
+	importMethod: 'User',
+	importUserSyncStrategy: 'Auth Type',
+	lockExpirationTime: 86400000,
+	method: 'Bind',
+	passwordEncryptionAlgorithm: 'None',
+	required: false,
+	userLdapPasswordPolicy: false,
+};
+
+export type TLdapConfiguration = {
+	autogenerateUserPasswordOnImport?: boolean;
+	createRolePerGroupOnImport?: boolean;
+	defaultUserPassword?: string;
+	enableExport?: boolean;
+	enableGroupCacheOnImport?: boolean;
+	enableGroupExport?: boolean;
+	enableImport?: boolean;
+	enableImportOnStartup?: boolean;
+	enableUserPasswordOnImport?: boolean;
+	enabled?: boolean;
+	importInterval?: number;
+	importMethod?: string | 'Group' | 'User';
+	importUserSyncStrategy?: string | 'Auth Type' | 'UUID';
+	lockExpirationTime?: number;
+	method?: string | 'Bind' | 'Password Compare';
+	passwordEncryptionAlgorithm?:
+		| string
+		| 'BCRYPT'
+		| 'MD2'
+		| 'MD5'
+		| 'None'
+		| 'SHA'
+		| 'SHA-256'
+		| 'SHA-384'
+		| 'SSHA'
+		| 'UFC-CRYPT';
+	required?: boolean;
+	userLdapPasswordPolicy?: boolean;
+};
+
+export type TLdapServer = {
+	authenticationSearchFilter?: string;
+	baseDn?: string;
+	baseProviderUrl?: string;
+	clockSkew?: number;
+	credentials?: string;
+	customContactMapping?: string;
+	customUserMapping?: string;
+	defaultValues?:
+		| 'Apache Directory Server'
+		| 'Fedora Directory Server'
+		| 'Microsoft Active Directory Server'
+		| 'Novell eDirectory'
+		| 'OpenLDAP'
+		| 'other Directory Server';
+	description?: string;
+	emailAddress?: string;
+	firstName?: string;
+	fullName?: string;
+	group?: string;
+	groupDefaultObjectClasses?: string;
+	groupName?: string;
+	groupsDn?: string;
+	ignoreUserSearchFilterForAuthentication?: boolean;
+	importSearchFilterGroup?: string;
+	importSearchFilterUser?: string;
+	jobTitle?: string;
+	lastName?: string;
+	middleName?: string;
+	password?: string;
+	portrait?: string;
+	principal?: string;
+	screenName?: string;
+	serverName: string;
+	status?: string;
+	user?: string;
+	userDefaultObjectClasses?: string;
+	userIgnoreAttributes?: string;
+	usersDn?: string;
+	uuid?: string;
+};

--- a/modules/test/playwright/pages/portal-security-ldap/LdapConfigurationPage.ts
+++ b/modules/test/playwright/pages/portal-security-ldap/LdapConfigurationPage.ts
@@ -1,0 +1,274 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {
+	DEFAULT_LDAP_CONFIGURATION_VALUES,
+	TLdapConfiguration,
+} from '../../helpers/LdapConfigurationHelper';
+import {waitForAlert} from '../../utils/waitForAlert';
+import {InstanceSettingsPage} from '../configuration-admin-web/InstanceSettingsPage';
+
+export class LdapConfigurationPage {
+	readonly addLdapServerButton: Locator;
+	readonly autogenerateUserPasswordOnImport: Locator;
+	readonly createRolePerGroupOnImport: Locator;
+	readonly defaultUserPassword: Locator;
+	readonly enableExport: Locator;
+	readonly enableGroupCacheOnImport: Locator;
+	readonly enableGroupExport: Locator;
+	readonly enableImport: Locator;
+	readonly enableImportOnStartup: Locator;
+	readonly enableUserPasswordOnImport: Locator;
+	readonly enabled: Locator;
+	readonly importInterval: Locator;
+	readonly importMethod: Locator;
+	readonly importUserSyncStrategy: Locator;
+	readonly instanceSettingsPage: InstanceSettingsPage;
+	readonly lockExpirationTime: Locator;
+	readonly method: Locator;
+	readonly page: Page;
+	readonly passwordEncryptionAlgorithm: Locator;
+	readonly required: Locator;
+	readonly resetDefaultValues: Locator;
+	readonly saveButton: Locator;
+	readonly useLdapPasswordPolicy: Locator;
+
+	constructor(page: Page) {
+		this.addLdapServerButton = page.getByRole('button', {name: 'Add'});
+		this.autogenerateUserPasswordOnImport = page.getByText(
+			'Autogenerate User Password on Import'
+		);
+		this.createRolePerGroupOnImport = page.getByText(
+			'Create Role per Group on Import'
+		);
+		this.defaultUserPassword = page.getByLabel('Default User Password');
+		this.enableExport = page.getByText('Enable Export');
+		this.enableGroupCacheOnImport = page.getByText(
+			'Enable Group Cache on Import'
+		);
+		this.enableGroupExport = page.getByText('Enable Group Export');
+		this.enableImport = page.getByText('Enable Import').first();
+		this.enableImportOnStartup = page.getByText('Enable Import on Startup');
+		this.enableUserPasswordOnImport = page.getByText(
+			'Enable User Password on Import'
+		);
+
+		this.enabled = page.getByText('Enabled', {exact: true});
+		this.importInterval = page.getByLabel('Import Interval');
+		this.importMethod = page.getByLabel('Import Method');
+		this.importUserSyncStrategy = page.getByLabel(
+			'Import User Sync Strategy'
+		);
+		this.instanceSettingsPage = new InstanceSettingsPage(page);
+		this.lockExpirationTime = page.getByLabel('Lock Expiration Time');
+		this.method = page.getByLabel('Method');
+		this.page = page;
+		this.passwordEncryptionAlgorithm = page.getByLabel(
+			'Password Encryption Algorithm'
+		);
+		this.required = page.getByText('Required');
+		this.resetDefaultValues = page.getByText('Reset Default Values');
+		this.saveButton = page.getByRole('button', {name: 'Save'});
+		this.useLdapPasswordPolicy = page.getByText('Use LDAP Password Policy');
+	}
+
+	async addLdapServer(forceReload = true) {
+		await this.goToServersTab(forceReload);
+
+		await this.addLdapServerButton.click();
+	}
+
+	async goTo() {
+		await this.instanceSettingsPage.goToInstanceSetting(
+			'LDAP',
+			'General',
+			false
+		);
+
+		await this.enabled.waitFor();
+	}
+
+	async goToServersTab(forceReload = true) {
+		if (forceReload) {
+			await this.goTo();
+		}
+
+		await this.page.getByRole('menuitem', {name: 'Servers'}).click();
+
+		await this.addLdapServerButton.waitFor();
+	}
+
+	async resetLdapConfiguration() {
+		await this.goTo();
+
+		const defaultLdapConfiguration: TLdapConfiguration = {
+			...DEFAULT_LDAP_CONFIGURATION_VALUES,
+		};
+
+		await this.updateLDAPGeneralConfiguration(defaultLdapConfiguration);
+
+		await this.updateLDAPExportConfiguration(defaultLdapConfiguration);
+
+		await this.updateLDAPImportConfiguration(defaultLdapConfiguration);
+	}
+
+	async updateLDAPConfiguration(
+		ldapConfiguration: TLdapConfiguration,
+		forceReload = true
+	) {
+		if (forceReload) {
+			await this.goTo();
+		}
+
+		await this.updateLDAPGeneralConfiguration(ldapConfiguration);
+
+		await this.updateLDAPExportConfiguration(ldapConfiguration);
+
+		await this.updateLDAPImportConfiguration(ldapConfiguration);
+	}
+
+	async updateLDAPExportConfiguration(ldapConfiguration: TLdapConfiguration) {
+		await this.page.getByRole('menuitem', {name: 'Export'}).click();
+
+		await this.enableExport.waitFor();
+
+		if (ldapConfiguration.enableExport !== undefined) {
+			await this.enableExport.setChecked(ldapConfiguration.enableExport);
+		}
+
+		if (ldapConfiguration.enableGroupExport !== undefined) {
+			await this.enableGroupExport.setChecked(
+				ldapConfiguration.enableGroupExport
+			);
+		}
+
+		await this.saveButton.click();
+
+		await waitForAlert(
+			this.page,
+			`Success:Your request completed successfully.`
+		);
+	}
+
+	async updateLDAPGeneralConfiguration(
+		ldapConfiguration: TLdapConfiguration
+	) {
+		if (await this.enabled.isHidden()) {
+			await this.page.getByRole('menuitem', {name: 'General'}).click();
+		}
+
+		await this.enabled.waitFor();
+
+		if (ldapConfiguration.enabled !== undefined) {
+			await this.enabled.setChecked(ldapConfiguration.enabled);
+		}
+
+		if (ldapConfiguration.method) {
+			await this.method.selectOption(ldapConfiguration.method);
+		}
+
+		if (ldapConfiguration.passwordEncryptionAlgorithm) {
+			await this.passwordEncryptionAlgorithm.selectOption(
+				ldapConfiguration.passwordEncryptionAlgorithm
+			);
+		}
+
+		if (ldapConfiguration.required !== undefined) {
+			await this.required.setChecked(ldapConfiguration.required);
+		}
+
+		if (ldapConfiguration.userLdapPasswordPolicy !== undefined) {
+			await this.useLdapPasswordPolicy.setChecked(
+				ldapConfiguration.userLdapPasswordPolicy
+			);
+		}
+
+		await this.saveButton.click();
+
+		await waitForAlert(
+			this.page,
+			`Success:Your request completed successfully.`
+		);
+	}
+
+	async updateLDAPImportConfiguration(ldapConfiguration: TLdapConfiguration) {
+		await this.page.getByRole('menuitem', {name: 'Import'}).click();
+
+		await this.enableImport.waitFor();
+
+		if (ldapConfiguration.autogenerateUserPasswordOnImport !== undefined) {
+			await this.autogenerateUserPasswordOnImport.setChecked(
+				ldapConfiguration.autogenerateUserPasswordOnImport
+			);
+		}
+
+		if (ldapConfiguration.createRolePerGroupOnImport !== undefined) {
+			await this.createRolePerGroupOnImport.setChecked(
+				ldapConfiguration.createRolePerGroupOnImport
+			);
+		}
+
+		if (ldapConfiguration.defaultUserPassword) {
+			await this.defaultUserPassword.fill(
+				ldapConfiguration.defaultUserPassword
+			);
+		}
+
+		if (ldapConfiguration.enableGroupCacheOnImport !== undefined) {
+			await this.enableGroupCacheOnImport.setChecked(
+				ldapConfiguration.enableGroupCacheOnImport
+			);
+		}
+
+		if (ldapConfiguration.enableImport !== undefined) {
+			await this.enableImport.setChecked(ldapConfiguration.enableImport);
+		}
+
+		if (ldapConfiguration.enableImportOnStartup !== undefined) {
+			await this.enableImportOnStartup.setChecked(
+				ldapConfiguration.enableImportOnStartup
+			);
+		}
+
+		if (ldapConfiguration.enableUserPasswordOnImport !== undefined) {
+			await this.enableUserPasswordOnImport.setChecked(
+				ldapConfiguration.enableUserPasswordOnImport
+			);
+		}
+
+		if (ldapConfiguration.importInterval) {
+			await this.importInterval.fill(
+				ldapConfiguration.importInterval.toString()
+			);
+		}
+
+		if (ldapConfiguration.importMethod) {
+			await this.importMethod.selectOption(
+				ldapConfiguration.importMethod
+			);
+		}
+
+		if (ldapConfiguration.importUserSyncStrategy) {
+			await this.importUserSyncStrategy.selectOption(
+				ldapConfiguration.importUserSyncStrategy
+			);
+		}
+
+		if (ldapConfiguration.lockExpirationTime) {
+			await this.lockExpirationTime.fill(
+				ldapConfiguration.lockExpirationTime.toString()
+			);
+		}
+
+		await this.saveButton.click();
+
+		await waitForAlert(
+			this.page,
+			`Success:Your request completed successfully.`
+		);
+	}
+}

--- a/modules/test/playwright/pages/portal-security-ldap/LdapServerPage.ts
+++ b/modules/test/playwright/pages/portal-security-ldap/LdapServerPage.ts
@@ -1,0 +1,322 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+import {TLdapServer} from '../../helpers/LdapConfigurationHelper';
+import {waitForAlert} from '../../utils/waitForAlert';
+import {LdapConfigurationPage} from './LdapConfigurationPage';
+
+export class LdapServerPage {
+	readonly authenticationSearchFilter: Locator;
+	readonly baseDn: Locator;
+	readonly baseProviderUrl: Locator;
+	readonly cancelButton: Locator;
+	readonly clockSkew: Locator;
+	readonly closeButton: Locator;
+	readonly credentials: Locator;
+	readonly customContactMapping: Locator;
+	readonly customUserMapping: Locator;
+	readonly description: Locator;
+	readonly emailAddress: Locator;
+	readonly firstName: Locator;
+	readonly fullName: Locator;
+	readonly group: Locator;
+	readonly groupDefaultObjectClasses: Locator;
+	readonly groupName: Locator;
+	readonly groupsDn: Locator;
+	readonly ignoreUserSearchFilterForAuthentication: Locator;
+	readonly importSearchFilterGroup: Locator;
+	readonly importSearchFilterUser: Locator;
+	readonly jobTitle: Locator;
+	readonly lastName: Locator;
+	readonly ldapConfigurationPage: LdapConfigurationPage;
+	readonly middleName: Locator;
+	readonly page: Page;
+	readonly password: Locator;
+	readonly portrait: Locator;
+	readonly principal: Locator;
+	readonly saveButton: Locator;
+	readonly screenName: Locator;
+	readonly serverName: Locator;
+	readonly status: Locator;
+	readonly testLdapConnection: Locator;
+	readonly testLdapGroups: Locator;
+	readonly testLdapUsers: Locator;
+	readonly user: Locator;
+	readonly userDefaultObjectClasses: Locator;
+	readonly userIgnoreAttributes: Locator;
+	readonly usersDn: Locator;
+	readonly uuid: Locator;
+
+	constructor(page: Page) {
+		this.authenticationSearchFilter = page.getByLabel(
+			'Authentication Search Filter'
+		);
+		this.baseDn = page.getByLabel('Base DN The LDAP Base');
+		this.baseProviderUrl = page.getByLabel('Base Provider URL The LDAP');
+		this.cancelButton = page.getByRole('button', {name: 'Cancel'});
+		this.clockSkew = page.getByLabel('Clock Skew The system time');
+		this.closeButton = page.getByLabel('close');
+		this.credentials = page.getByLabel('Credentials');
+		this.customContactMapping = page.getByLabel('Custom Contact Mapping');
+		this.customUserMapping = page.getByLabel('Custom User Mapping');
+		this.description = page.getByLabel('Description');
+		this.emailAddress = page.getByLabel('Email Address');
+		this.firstName = page.getByLabel('First Name', {exact: true});
+		this.fullName = page.getByLabel('Full Name');
+		this.group = page.getByLabel('Group', {exact: true});
+		this.groupDefaultObjectClasses = page.getByLabel(
+			'Group Default Object Classes'
+		);
+		this.groupName = page.getByLabel('Group Name');
+		this.groupsDn = page.getByLabel('Groups DN');
+		this.ignoreUserSearchFilterForAuthentication = page.getByLabel(
+			'Ignore User Search Filter'
+		);
+		this.importSearchFilterGroup = page
+			.getByText('Groups Import Search Filter')
+			.getByLabel('Import Search Filter');
+		this.importSearchFilterUser = page
+			.getByText('Users Authentication Search')
+			.getByLabel('Import Search Filter');
+		this.jobTitle = page.getByLabel('Job Title');
+		this.lastName = page.getByLabel('Last Name', {exact: true});
+		this.ldapConfigurationPage = new LdapConfigurationPage(page);
+		this.middleName = page.getByLabel('Middle Name');
+		this.page = page;
+		this.password = page.getByLabel('Password');
+		this.portrait = page.getByLabel('Portrait');
+		this.principal = page.getByLabel('Principal');
+		this.saveButton = page.getByRole('button', {name: 'Save'});
+		this.screenName = page.getByLabel('Screen Name');
+		this.serverName = page.getByLabel('Server Name');
+		this.status = page.getByLabel('Status');
+		this.testLdapConnection = page.getByRole('button', {
+			name: 'Test LDAP Connection',
+		});
+		this.testLdapGroups = page.getByRole('button', {
+			name: 'Test LDAP Groups',
+		});
+		this.testLdapUsers = page.getByRole('button', {
+			name: 'Test LDAP Users',
+		});
+		this.user = page.getByLabel('User', {exact: true});
+		this.userDefaultObjectClasses = page.getByLabel(
+			'User Default Object Classes'
+		);
+		this.userIgnoreAttributes = page.getByLabel('User Ignore Attributes');
+		this.usersDn = page.getByLabel('Users DN');
+		this.uuid = page.getByLabel('UUID');
+	}
+
+	async addLdapServer(ldapServer: TLdapServer, forceReload = true) {
+		await this.ldapConfigurationPage.addLdapServer(forceReload);
+
+		await this.populateLdapServerValues(ldapServer);
+
+		await this.saveButton.click();
+
+		await waitForAlert(
+			this.page,
+			`Success:Your request completed successfully.`
+		);
+	}
+
+	async deleteLdapServer(serverName: string, forceReload = true) {
+		if (forceReload) {
+			await this.ldapConfigurationPage.goToServersTab();
+		}
+
+		this.page.once('dialog', async (dialog) => {
+			dialog.accept();
+		});
+
+		await this.ldapConfigurationPage.page
+			.getByRole('row', {name: serverName})
+			.locator('div')
+			.getByTitle('Delete')
+			.click();
+
+		await waitForAlert(
+			this.page,
+			`Success:Your request completed successfully.`
+		);
+	}
+
+	async deleteLdapServers(forceReload = true) {
+		if (forceReload) {
+			await this.ldapConfigurationPage.goToServersTab();
+		}
+
+		const ldapServerDeleteButton = await this.ldapConfigurationPage.page
+			.getByRole('link', {name: 'Delete'})
+			.first();
+
+		while (await ldapServerDeleteButton.isVisible()) {
+			this.page.once('dialog', async (dialog) => {
+				dialog.accept();
+			});
+
+			await ldapServerDeleteButton.click();
+
+			await waitForAlert(
+				this.page,
+				`Success:Your request completed successfully.`
+			);
+		}
+	}
+
+	async editLdapServer(
+		ldapServer: TLdapServer,
+		existingServerName = ldapServer.serverName,
+		forceReload = true
+	) {
+		await this.viewLdapServer(existingServerName, forceReload);
+
+		await this.populateLdapServerValues(ldapServer);
+
+		await this.saveButton.click();
+
+		await waitForAlert(
+			this.page,
+			`Success:Your request completed successfully.`
+		);
+	}
+
+	async populateLdapServerValues(ldapServer: TLdapServer) {
+		await this.serverName.waitFor();
+
+		if (ldapServer.defaultValues) {
+			await this.page.getByLabel(ldapServer.defaultValues).click();
+		}
+		if (ldapServer.authenticationSearchFilter) {
+			await this.authenticationSearchFilter.fill(
+				ldapServer.authenticationSearchFilter
+			);
+		}
+		if (ldapServer.baseDn) {
+			await this.baseDn.fill(ldapServer.baseDn);
+		}
+		if (ldapServer.baseProviderUrl) {
+			await this.baseProviderUrl.fill(ldapServer.baseProviderUrl);
+		}
+		if (ldapServer.clockSkew) {
+			await this.clockSkew.fill(ldapServer.clockSkew.toString());
+		}
+		if (ldapServer.credentials) {
+			await this.credentials.fill(ldapServer.credentials);
+		}
+		if (ldapServer.customContactMapping) {
+			await this.customContactMapping.fill(
+				ldapServer.customContactMapping
+			);
+		}
+		if (ldapServer.customUserMapping) {
+			await this.customUserMapping.fill(ldapServer.customUserMapping);
+		}
+		if (ldapServer.description) {
+			await this.description.fill(ldapServer.description);
+		}
+		if (ldapServer.emailAddress) {
+			await this.emailAddress.fill(ldapServer.emailAddress);
+		}
+		if (ldapServer.firstName) {
+			await this.firstName.fill(ldapServer.firstName);
+		}
+		if (ldapServer.fullName) {
+			await this.fullName.fill(ldapServer.fullName);
+		}
+		if (ldapServer.group) {
+			await this.group.fill(ldapServer.group);
+		}
+		if (ldapServer.groupDefaultObjectClasses) {
+			await this.groupDefaultObjectClasses.fill(
+				ldapServer.groupDefaultObjectClasses
+			);
+		}
+		if (ldapServer.groupName) {
+			await this.groupName.fill(ldapServer.groupName);
+		}
+		if (ldapServer.groupsDn) {
+			await this.groupsDn.fill(ldapServer.groupsDn);
+		}
+		if (ldapServer.ignoreUserSearchFilterForAuthentication !== undefined) {
+			await this.ignoreUserSearchFilterForAuthentication.setChecked(
+				ldapServer.ignoreUserSearchFilterForAuthentication
+			);
+		}
+		if (ldapServer.importSearchFilterGroup) {
+			await this.importSearchFilterGroup.fill(
+				ldapServer.importSearchFilterGroup
+			);
+		}
+		if (ldapServer.importSearchFilterUser) {
+			await this.importSearchFilterUser.fill(
+				ldapServer.importSearchFilterUser
+			);
+		}
+		if (ldapServer.jobTitle) {
+			await this.jobTitle.fill(ldapServer.jobTitle);
+		}
+		if (ldapServer.lastName) {
+			await this.lastName.fill(ldapServer.lastName);
+		}
+		if (ldapServer.middleName) {
+			await this.middleName.fill(ldapServer.middleName);
+		}
+		if (ldapServer.password) {
+			await this.password.fill(ldapServer.password);
+		}
+		if (ldapServer.portrait) {
+			await this.portrait.fill(ldapServer.portrait);
+		}
+		if (ldapServer.principal) {
+			await this.principal.fill(ldapServer.principal);
+		}
+		if (ldapServer.screenName) {
+			await this.screenName.fill(ldapServer.screenName);
+		}
+
+		await this.serverName.fill(ldapServer.serverName);
+
+		if (ldapServer.status) {
+			await this.status.fill(ldapServer.status);
+		}
+		if (ldapServer.user) {
+			await this.user.fill(ldapServer.user);
+		}
+		if (ldapServer.userDefaultObjectClasses) {
+			await this.userDefaultObjectClasses.fill(
+				ldapServer.userDefaultObjectClasses
+			);
+		}
+		if (ldapServer.userIgnoreAttributes) {
+			await this.userIgnoreAttributes.fill(
+				ldapServer.userIgnoreAttributes
+			);
+		}
+		if (ldapServer.usersDn) {
+			await this.usersDn.fill(ldapServer.usersDn);
+		}
+		if (ldapServer.uuid) {
+			await this.uuid.fill(ldapServer.uuid);
+		}
+	}
+
+	async viewLdapServer(serverName: string, forceReload = true) {
+		if (forceReload) {
+			await this.ldapConfigurationPage.goToServersTab();
+		}
+
+		await this.ldapConfigurationPage.page
+			.getByRole('row', {name: serverName})
+			.locator('div')
+			.getByTitle('Edit')
+			.click();
+
+		await this.serverName.waitFor();
+	}
+}

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -90,6 +90,7 @@ import {config as portalSearchAdminWebConfig} from './tests/portal-search-admin-
 import {config as portalSearchWebConfig} from './tests/portal-search-web/config';
 import {config as portalSecurityAuditWebConfig} from './tests/portal-security-audit-web/config';
 import {config as portalSecurityContentSecurityPolicyConfig} from './tests/portal-security-content-security-policy/config';
+import {config as portalSecurityLdapConfig} from './tests/portal-security-ldap/config';
 import {config as portalSecurityScriptManagementWebConfig} from './tests/portal-security-script-management-web/config';
 import {config as portalSecurityServiceAccessPolicyService} from './tests/portal-security-service-access-policy-service/config';
 import {config as portalToolsRestBuilderTestImpl} from './tests/portal-tools-rest-builder-test-impl/config';
@@ -229,6 +230,7 @@ export default defineConfig({
 		portalSearchWebConfig,
 		portalSecurityAuditWebConfig,
 		portalSecurityContentSecurityPolicyConfig,
+		portalSecurityLdapConfig,
 		portalSecurityScriptManagementWebConfig,
 		portalSecurityServiceAccessPolicyService,
 		portalToolsRestBuilderTestImpl,

--- a/modules/test/playwright/tests/portal-security-ldap/config.ts
+++ b/modules/test/playwright/tests/portal-security-ldap/config.ts
@@ -1,0 +1,10 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'portal-security-ldap',
+	testDir: 'tests/portal-security-ldap',
+	timeout: 180 * 1000,
+};

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/addGroups.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/addGroups.ldif
@@ -1,0 +1,12 @@
+cn: ldapgroup1
+dn: cn=ldapgroup1,dc=example,dc=com
+objectClass: groupOfUniqueNames
+objectClass: top
+uniqueMember: cn=ldapuser1,dc=example,dc=com
+
+cn: ldapgroup2
+dn: cn=ldapgroup2,dc=example,dc=com
+objectClass: groupOfUniqueNames
+objectClass: top
+uniqueMember: cn=ldapuser1,dc=example,dc=com
+uniqueMember: cn=ldapuser2,dc=example,dc=com

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/addGroups.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/addGroups.ldif
@@ -10,3 +10,15 @@ objectClass: groupOfUniqueNames
 objectClass: top
 uniqueMember: cn=ldapuser1,dc=example,dc=com
 uniqueMember: cn=ldapuser2,dc=example,dc=com
+
+cn: ldapgroup3
+dn: cn=ldapgroup3,dc=example,dc=com
+objectClass: groupOfUniqueNames
+objectClass: top
+uniqueMember: cn=ldapuser3,dc=example,dc=com
+
+cn: ldapgroup3modified
+dn: cn=ldapgroup3modified,dc=example,dc=com
+objectClass: groupOfUniqueNames
+objectClass: top
+uniqueMember: cn=ldapuser3modified,dc=example,dc=com

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/addGroups.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/addGroups.ldif
@@ -22,3 +22,16 @@ dn: cn=ldapgroup3modified,dc=example,dc=com
 objectClass: groupOfUniqueNames
 objectClass: top
 uniqueMember: cn=ldapuser3modified,dc=example,dc=com
+
+cn: ldapgroup4a
+dn: cn=ldapgroup4a,dc=example,dc=com
+objectClass: groupOfUniqueNames
+objectClass: top
+uniqueMember: cn=ldapuser4a,dc=example,dc=com
+uniqueMember: cn=ldapuser4ab,dc=example,dc=com
+
+cn: ldapgroup4b
+dn: cn=ldapgroup4b,dc=example,dc=com
+objectClass: groupOfUniqueNames
+objectClass: top
+uniqueMember: cn=ldapuser4ab,dc=example,dc=com

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/addUserToGroup.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/addUserToGroup.ldif
@@ -1,0 +1,4 @@
+dn: cn=ldapgroup4a,dc=example,dc=com
+add: uniqueMember
+changetype: modify
+uniqueMember: cn=ldapuser4,dc=example,dc=com

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/addUsers.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/addUsers.ldif
@@ -1,0 +1,17 @@
+cn: ldapuser1
+dn: cn=ldapuser1,dc=example,dc=com
+givenName: first
+mail: ldapuser1@liferay.com
+objectClass: inetOrgPerson
+objectClass: top
+sn: last
+userPassword: test
+
+cn: ldapuser2
+dn: cn=ldapuser2,dc=example,dc=com
+givenName: first
+mail: ldapuser2@liferay.com
+objectClass: inetOrgPerson
+objectClass: top
+sn: last
+userPassword: test

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/addUsers.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/addUsers.ldif
@@ -15,3 +15,21 @@ objectClass: inetOrgPerson
 objectClass: top
 sn: last
 userPassword: test
+
+cn: ldapuser3
+dn: cn=ldapuser3,dc=example,dc=com
+givenName: first
+mail: ldapuser3@liferay.com
+objectClass: inetOrgPerson
+objectClass: top
+sn: last
+userPassword: test
+
+cn: ldapuser3modified
+dn: cn=ldapuser3modified,dc=example,dc=com
+givenName: firstmodified
+mail: ldapuser3@liferay.com
+objectClass: inetOrgPerson
+objectClass: top
+sn: lastmodified
+userPassword: testmodified

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/addUsers.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/addUsers.ldif
@@ -33,3 +33,30 @@ objectClass: inetOrgPerson
 objectClass: top
 sn: lastmodified
 userPassword: testmodified
+
+cn: ldapuser4
+dn: cn=ldapuser4,dc=example,dc=com
+givenName: first
+mail: ldapuser4@liferay.com
+objectClass: inetOrgPerson
+objectClass: top
+sn: last
+userPassword: test
+
+cn: ldapuser4a
+dn: cn=ldapuser4a,dc=example,dc=com
+givenName: first4a
+mail: ldapuser4@liferay.com
+objectClass: inetOrgPerson
+objectClass: top
+sn: last4a
+userPassword: test
+
+cn: ldapuser4ab
+dn: cn=ldapuser4ab,dc=example,dc=com
+givenName: first4ab
+mail: ldapuser4@liferay.com
+objectClass: inetOrgPerson
+objectClass: top
+sn: last4ab
+userPassword: test

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/admin.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/admin.ldif
@@ -1,0 +1,3 @@
+cn: admin
+dn: cn=admin,dc=example,dc=com
+objectclass: organizationalRole

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/exampleCompany.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/exampleCompany.ldif
@@ -1,0 +1,5 @@
+dc: example
+dn: dc=example,dc=com
+o: Example Company
+objectclass: dcObject
+objectclass: organization

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/removeGroups.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/removeGroups.ldif
@@ -1,2 +1,4 @@
 cn=ldapgroup1,dc=example,dc=com
-cn=ldapgroup2,dc=example,dc=com,
+cn=ldapgroup2,dc=example,dc=com
+cn=ldapgroup3,dc=example,dc=com
+cn=ldapgroup3modified,dc=example,dc=com,

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/removeGroups.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/removeGroups.ldif
@@ -1,0 +1,2 @@
+cn=ldapgroup1,dc=example,dc=com
+cn=ldapgroup2,dc=example,dc=com

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/removeGroups.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/removeGroups.ldif
@@ -1,4 +1,6 @@
 cn=ldapgroup1,dc=example,dc=com
 cn=ldapgroup2,dc=example,dc=com
 cn=ldapgroup3,dc=example,dc=com
-cn=ldapgroup3modified,dc=example,dc=com,
+cn=ldapgroup3modified,dc=example,dc=com
+cn=ldapgroup4a,dc=example,dc=com
+cn=ldapgroup4b,dc=example,dc=com,

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/removeGroups.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/removeGroups.ldif
@@ -1,2 +1,2 @@
 cn=ldapgroup1,dc=example,dc=com
-cn=ldapgroup2,dc=example,dc=com
+cn=ldapgroup2,dc=example,dc=com,

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/removeUsers.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/removeUsers.ldif
@@ -1,0 +1,2 @@
+cn=ldapuser1,dc=example,dc=com
+cn=ldapuser2,dc=example,dc=com

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/removeUsers.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/removeUsers.ldif
@@ -1,2 +1,4 @@
 cn=ldapuser1,dc=example,dc=com
-cn=ldapuser2,dc=example,dc=com,
+cn=ldapuser2,dc=example,dc=com
+cn=ldapuser3,dc=example,dc=com
+cn=ldapuser3modified,dc=example,dc=com,

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/removeUsers.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/removeUsers.ldif
@@ -1,4 +1,7 @@
 cn=ldapuser1,dc=example,dc=com
 cn=ldapuser2,dc=example,dc=com
 cn=ldapuser3,dc=example,dc=com
-cn=ldapuser3modified,dc=example,dc=com,
+cn=ldapuser3modified,dc=example,dc=com
+cn=ldapuser4,dc=example,dc=com
+cn=ldapuser4a,dc=example,dc=com
+cn=ldapuser4ab,dc=example,dc=com,

--- a/modules/test/playwright/tests/portal-security-ldap/dependencies/removeUsers.ldif
+++ b/modules/test/playwright/tests/portal-security-ldap/dependencies/removeUsers.ldif
@@ -1,2 +1,2 @@
 cn=ldapuser1,dc=example,dc=com
-cn=ldapuser2,dc=example,dc=com
+cn=ldapuser2,dc=example,dc=com,

--- a/modules/test/playwright/tests/portal-security-ldap/env/osgi/configs/com.liferay.captcha.configuration.CaptchaConfiguration.config
+++ b/modules/test/playwright/tests/portal-security-ldap/env/osgi/configs/com.liferay.captcha.configuration.CaptchaConfiguration.config
@@ -1,0 +1,1 @@
+maxChallenges="-1"

--- a/modules/test/playwright/tests/portal-security-ldap/env/portal-ext.properties
+++ b/modules/test/playwright/tests/portal-security-ldap/env/portal-ext.properties
@@ -1,0 +1,1 @@
+captcha.enforce.disabled=true

--- a/modules/test/playwright/tests/portal-security-ldap/env/set_up.sh
+++ b/modules/test/playwright/tests/portal-security-ldap/env/set_up.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
+
+echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
+
+source ${CURRENT_DIR_NAME}/../../../env/common.sh
+
+DEPENDENCIES_DIR_NAME=${CURRENT_DIR_NAME}/../dependencies
+
+echo DEPENDENCIES_DIR_NAME=${DEPENDENCIES_DIR_NAME}
+
+function echo_command_output {
+	if [ $? -ne 0 ]
+	 then
+		echo "Command failed with exit status $?"
+	else
+		echo "Command succeeded"
+	fi
+}
+
+function ldap_set_up {
+	echo "Starting slapd:"
+	/usr/local/libexec/slapd -F /usr/local/etc/slapd.d
+
+	echo_command_output
+
+	ldapadd -cx -D "cn=admin,dc=example,dc=com" -f ${DEPENDENCIES_DIR_NAME}/exampleCompany.ldif -w "secret"
+
+	echo_command_output
+
+	ldapadd -cx -D "cn=admin,dc=example,dc=com" -f ${DEPENDENCIES_DIR_NAME}/admin.ldif -w "secret"
+
+	echo_command_output
+
+	ldapadd -cx -D "cn=admin,dc=example,dc=com" -f ${DEPENDENCIES_DIR_NAME}/addUsers.ldif -w "secret"
+
+	echo_command_output
+
+	ldapadd -cx -D "cn=admin,dc=example,dc=com" -f ${DEPENDENCIES_DIR_NAME}/addGroups.ldif -w "secret"
+
+	echo_command_output
+}
+
+function main {
+	default_set_up
+
+	ldap_set_up
+}
+
+main "${@}"

--- a/modules/test/playwright/tests/portal-security-ldap/env/tear_down.sh
+++ b/modules/test/playwright/tests/portal-security-ldap/env/tear_down.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+CURRENT_DIR_NAME=$(dirname ${BASH_SOURCE[0]})
+
+echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
+
+source ${CURRENT_DIR_NAME}/../../../env/common.sh
+
+DEPENDENCIES_DIR_NAME=${CURRENT_DIR_NAME}/../dependencies
+
+echo DEPENDENCIES_DIR_NAME=${DEPENDENCIES_DIR_NAME}
+
+function main {
+	default_tear_down
+
+	ldap_tear_down
+}
+
+function ldap_tear_down {
+	ldapdelete -cx -D "cn=admin,dc=example,dc=com" -f ${DEPENDENCIES_DIR_NAME}/removeGroups.ldif -w "secret"
+	ldapdelete -cx -D "cn=admin,dc=example,dc=com" -f ${DEPENDENCIES_DIR_NAME}/removeUsers.ldif -w "secret"
+
+	kill -INT `cat /usr/local/var/run/slapd.pid`
+}
+
+main "${@}"

--- a/modules/test/playwright/tests/portal-security-ldap/ldap.spec.ts
+++ b/modules/test/playwright/tests/portal-security-ldap/ldap.spec.ts
@@ -38,6 +38,8 @@ export const test = mergeTests(
 
 const LDAP_GROUP_1 = 'ldapgroup1';
 const LDAP_GROUP_2 = 'ldapgroup2';
+const LDAP_GROUP_3 = 'ldapgroup3';
+const LDAP_GROUP_3_MODIFIED = 'ldapgroup3modified';
 
 const LDAP_USER_1: TUserAccount = {
 	alternateName: 'ldapuser1',
@@ -53,6 +55,22 @@ const LDAP_USER_2: TUserAccount = {
 	familyName: 'last',
 	givenName: 'first',
 	password: 'test',
+};
+
+const LDAP_USER_3: TUserAccount = {
+	alternateName: 'ldapuser3',
+	emailAddress: 'ldapuser3@liferay.com',
+	familyName: 'last',
+	givenName: 'first',
+	password: 'test',
+};
+
+const LDAP_USER_3_MODIFIED: TUserAccount = {
+	alternateName: 'ldapuser3modified',
+	emailAddress: 'ldapuser3@liferay.com',
+	familyName: 'lastmodified',
+	givenName: 'firstmodified',
+	password: 'testmodified',
 };
 
 test.afterAll(async ({browser}) => {
@@ -83,7 +101,12 @@ test.afterEach(
 		});
 
 		await test.step('Delete LDAP users from portal if present', async () => {
-			for (const ldapUser of [LDAP_USER_1, LDAP_USER_2]) {
+			for (const ldapUser of [
+				LDAP_USER_1,
+				LDAP_USER_2,
+				LDAP_USER_3,
+				LDAP_USER_3_MODIFIED,
+			]) {
 				const user =
 					await apiHelpers.headlessAdminUser.getUserAccountByEmailAddress(
 						ldapUser.emailAddress
@@ -130,15 +153,27 @@ test.afterEach(
 
 test.beforeAll(async () => {
 
-	// Add LDAP user info to userData so we can authenticate via performLogin
+	// Add LDAP user info to userData so we can authenticate via performLogin or
+	// performLoginViaApi
 
-	for (const ldapUser of [LDAP_USER_1, LDAP_USER_2]) {
+	for (const ldapUser of [LDAP_USER_1, LDAP_USER_2, LDAP_USER_3]) {
 		userData[ldapUser.alternateName] = {
 			name: ldapUser.givenName,
-			password: 'test',
+			password: ldapUser.password,
 			surname: ldapUser.familyName,
 		};
 	}
+
+	// The modified user is a special case, because it uses the existing email
+	// address, but the data and credentials are different.  We can workaround
+	// the performLogin constraints by using the email as the key, and passing
+	// in a blank 'domain' argument.
+
+	userData[LDAP_USER_3_MODIFIED.emailAddress] = {
+		name: LDAP_USER_3_MODIFIED.givenName,
+		password: LDAP_USER_3_MODIFIED.password,
+		surname: LDAP_USER_3_MODIFIED.familyName,
+	};
 });
 
 test.beforeEach(async ({browser}) => {
@@ -267,6 +302,144 @@ test('LPD-47223 AC1 TC1: Verify LDAP import via authentication imports user attr
 				name: LDAP_GROUP_2,
 			})
 		).toBeVisible();
+	});
+});
+
+test('LPD-47223 AC2 TC2: Verify LDAP bulk import updates user information and membership', async ({
+	browser,
+	editUserPage,
+	ldapConfigurationPage,
+	ldapServerPage,
+	usersAndOrganizationsPage,
+}) => {
+	const ldapServer: TLdapServer = {
+		authenticationSearchFilter: `(&(mail=@email_address@)(cn=${LDAP_USER_3.alternateName}))`,
+		defaultValues: 'OpenLDAP',
+		ignoreUserSearchFilterForAuthentication: false,
+		importSearchFilterUser: `(&(objectClass=inetOrgPerson)(cn=${LDAP_USER_3.alternateName}))`,
+		principal: 'cn=admin,dc=example,dc=com',
+		serverName: getRandomString(),
+	};
+
+	await test.step('Add LDAP server', async () => {
+		await ldapServerPage.addLdapServer(ldapServer);
+	});
+
+	await testAndExpectLdapEntries(
+		'user',
+		[LDAP_USER_3.alternateName],
+		ldapServer.serverName,
+		ldapServerPage,
+		true,
+		[LDAP_USER_3_MODIFIED.alternateName]
+	);
+
+	await invokeLdapImport(ldapConfigurationPage.page);
+
+	await test.step('Assert user data and membership was imported correctly', async () => {
+		await usersAndOrganizationsPage.goToUsers(false);
+
+		await (
+			await usersAndOrganizationsPage.usersTableRowLink(
+				LDAP_USER_3.alternateName
+			)
+		).click();
+
+		await expect(editUserPage.emailAddressInput).toHaveValue(
+			LDAP_USER_3.emailAddress
+		);
+
+		await expect(editUserPage.firstNameInput).toHaveValue(
+			LDAP_USER_3.givenName
+		);
+
+		await expect(editUserPage.lastNameInput).toHaveValue(
+			LDAP_USER_3.familyName
+		);
+
+		await expect(editUserPage.screenNameInput).toHaveValue(
+			LDAP_USER_3.alternateName
+		);
+
+		await editUserPage.membershipsLink.click();
+
+		await expect(
+			await editUserPage.page.getByRole('cell', {
+				exact: true,
+				name: LDAP_GROUP_3,
+			})
+		).toBeVisible();
+
+		await expect(
+			await editUserPage.page.getByRole('cell', {
+				exact: true,
+				name: LDAP_GROUP_3_MODIFIED,
+			})
+		).not.toBeVisible();
+	});
+
+	await test.step('Change user data and memberships on LDAP server by adjusting import filter, since we cannot modify LDAP server from playwright test.  The email will stay the same, so the portal will think the user was actually updated in LDAP.', async () => {
+		ldapServer.authenticationSearchFilter = `(&(mail=@email_address@)(cn=${LDAP_USER_3_MODIFIED.alternateName}))`;
+		ldapServer.importSearchFilterUser = `(&(objectClass=inetOrgPerson)(cn=${LDAP_USER_3_MODIFIED.alternateName}))`;
+
+		await ldapServerPage.editLdapServer(ldapServer);
+	});
+
+	await invokeLdapImport(ldapServerPage.page);
+
+	await test.step('Assert user data and membership was updated correctly', async () => {
+		await usersAndOrganizationsPage.goToUsers(false);
+
+		await expect(
+			await usersAndOrganizationsPage.usersTableCell(
+				LDAP_USER_3.alternateName
+			)
+		).toBeHidden();
+
+		await (
+			await usersAndOrganizationsPage.usersTableRowLink(
+				LDAP_USER_3_MODIFIED.alternateName
+			)
+		).click();
+
+		await expect(editUserPage.firstNameInput).toHaveValue(
+			LDAP_USER_3_MODIFIED.givenName
+		);
+
+		await expect(editUserPage.lastNameInput).toHaveValue(
+			LDAP_USER_3_MODIFIED.familyName
+		);
+
+		await expect(editUserPage.screenNameInput).toHaveValue(
+			LDAP_USER_3_MODIFIED.alternateName
+		);
+
+		await editUserPage.membershipsLink.click();
+
+		await expect(
+			await editUserPage.page.getByRole('cell', {
+				exact: true,
+				name: LDAP_GROUP_3,
+			})
+		).not.toBeVisible();
+
+		await expect(
+			await editUserPage.page.getByRole('cell', {
+				exact: true,
+				name: LDAP_GROUP_3_MODIFIED,
+			})
+		).toBeVisible();
+	});
+
+	await test.step('Assert user password updated correctly', async () => {
+		const page = await browser.newPage();
+
+		await performLogin(
+			page,
+			LDAP_USER_3_MODIFIED.emailAddress,
+			undefined,
+			''
+		);
 	});
 });
 

--- a/modules/test/playwright/tests/portal-security-ldap/ldap.spec.ts
+++ b/modules/test/playwright/tests/portal-security-ldap/ldap.spec.ts
@@ -40,6 +40,8 @@ const LDAP_GROUP_1 = 'ldapgroup1';
 const LDAP_GROUP_2 = 'ldapgroup2';
 const LDAP_GROUP_3 = 'ldapgroup3';
 const LDAP_GROUP_3_MODIFIED = 'ldapgroup3modified';
+const LDAP_GROUP_4_A = 'ldapgroup4a';
+const LDAP_GROUP_4_B = 'ldapgroup4b';
 
 const LDAP_USER_1: TUserAccount = {
 	alternateName: 'ldapuser1',
@@ -71,6 +73,30 @@ const LDAP_USER_3_MODIFIED: TUserAccount = {
 	familyName: 'lastmodified',
 	givenName: 'firstmodified',
 	password: 'testmodified',
+};
+
+const LDAP_USER_4: TUserAccount = {
+	alternateName: 'ldapuser4',
+	emailAddress: 'ldapuser4@liferay.com',
+	familyName: 'last',
+	givenName: 'first',
+	password: 'test',
+};
+
+const LDAP_USER_4_A: TUserAccount = {
+	alternateName: 'ldapuser4a',
+	emailAddress: 'ldapuser4@liferay.com',
+	familyName: 'last4a',
+	givenName: 'first4a',
+	password: 'test',
+};
+
+const LDAP_USER_4_AB: TUserAccount = {
+	alternateName: 'ldapuser4ab',
+	emailAddress: 'ldapuser4@liferay.com',
+	familyName: 'last4ab',
+	givenName: 'first4ab',
+	password: 'test',
 };
 
 test.afterAll(async ({browser}) => {
@@ -106,6 +132,9 @@ test.afterEach(
 				LDAP_USER_2,
 				LDAP_USER_3,
 				LDAP_USER_3_MODIFIED,
+				LDAP_USER_4,
+				LDAP_USER_4_A,
+				LDAP_USER_4_AB,
 			]) {
 				const user =
 					await apiHelpers.headlessAdminUser.getUserAccountByEmailAddress(
@@ -156,7 +185,12 @@ test.beforeAll(async () => {
 	// Add LDAP user info to userData so we can authenticate via performLogin or
 	// performLoginViaApi
 
-	for (const ldapUser of [LDAP_USER_1, LDAP_USER_2, LDAP_USER_3]) {
+	for (const ldapUser of [
+		LDAP_USER_1,
+		LDAP_USER_2,
+		LDAP_USER_3,
+		LDAP_USER_4,
+	]) {
 		userData[ldapUser.alternateName] = {
 			name: ldapUser.givenName,
 			password: ldapUser.password,
@@ -169,11 +203,13 @@ test.beforeAll(async () => {
 	// the performLogin constraints by using the email as the key, and passing
 	// in a blank 'domain' argument.
 
-	userData[LDAP_USER_3_MODIFIED.emailAddress] = {
-		name: LDAP_USER_3_MODIFIED.givenName,
-		password: LDAP_USER_3_MODIFIED.password,
-		surname: LDAP_USER_3_MODIFIED.familyName,
-	};
+	for (const modifiedLdapUser of [LDAP_USER_3_MODIFIED, LDAP_USER_4_A]) {
+		userData[modifiedLdapUser.emailAddress] = {
+			name: modifiedLdapUser.givenName,
+			password: modifiedLdapUser.password,
+			surname: modifiedLdapUser.familyName,
+		};
+	}
 });
 
 test.beforeEach(async ({browser}) => {
@@ -440,6 +476,155 @@ test('LPD-47223 AC2 TC2: Verify LDAP bulk import updates user information and me
 			undefined,
 			''
 		);
+	});
+});
+
+test('LPD-47223 AC3 TC3: Verify LDAP import via authentication with multiple matching LDAP servers imports/updates only user groups for the first matching LDAP server', async ({
+	browser,
+	editUserPage,
+	ldapConfigurationPage,
+	ldapServerPage,
+	usersAndOrganizationsPage,
+}) => {
+	const ldapServerA: TLdapServer = {
+		authenticationSearchFilter: `(&(mail=@email_address@)(cn=${LDAP_USER_4_AB.alternateName}))`,
+		defaultValues: 'OpenLDAP',
+		ignoreUserSearchFilterForAuthentication: false,
+		importSearchFilterGroup: `(&(objectClass=groupOfUniqueNames)(cn=${LDAP_GROUP_4_A}))`,
+		importSearchFilterUser: `(&(objectClass=inetOrgPerson)(cn=${LDAP_USER_4_AB.alternateName}))`,
+		principal: 'cn=admin,dc=example,dc=com',
+		serverName: getRandomString(),
+	};
+
+	const ldapServerB = JSON.parse(JSON.stringify(ldapServerA));
+
+	ldapServerB.importSearchFilterGroup = `(&(objectClass=groupOfUniqueNames)(cn=${LDAP_GROUP_4_B}))`;
+	ldapServerB.serverName = getRandomString();
+
+	await test.step('Add the same LDAP server twice, but adjust the group import search filter so each entry adds a different group', async () => {
+		await test.step('Add first LDAP server', async () => {
+			await ldapServerPage.addLdapServer(ldapServerA);
+		});
+
+		await testAndExpectLdapEntries(
+			'group',
+			[LDAP_GROUP_4_A],
+			ldapServerA.serverName,
+			ldapServerPage,
+			undefined,
+			[LDAP_GROUP_4_B]
+		);
+
+		await testAndExpectLdapEntries(
+			'user',
+			[LDAP_USER_4_AB.alternateName],
+			ldapServerA.serverName,
+			ldapServerPage,
+			true,
+			[LDAP_USER_4.alternateName, LDAP_USER_4_A.alternateName]
+		);
+
+		await test.step('Add second LDAP server', async () => {
+			await ldapServerPage.addLdapServer(ldapServerB, false);
+		});
+
+		await testAndExpectLdapEntries(
+			'group',
+			[LDAP_GROUP_4_B],
+			ldapServerB.serverName,
+			ldapServerPage,
+			undefined,
+			[LDAP_GROUP_4_A]
+		);
+
+		await testAndExpectLdapEntries(
+			'user',
+			[LDAP_USER_4_AB.alternateName],
+			ldapServerB.serverName,
+			ldapServerPage,
+			undefined,
+			[LDAP_USER_4.alternateName, LDAP_USER_4_A.alternateName]
+		);
+	});
+
+	await invokeLdapImport(ldapConfigurationPage.page);
+
+	await test.step(`Assert ${LDAP_USER_4_AB.alternateName} was imported`, async () => {
+		await usersAndOrganizationsPage.goToUsers(false);
+
+		await expect(
+			await usersAndOrganizationsPage.usersTableCell(
+				LDAP_USER_4_AB.alternateName
+			)
+		).toBeVisible();
+	});
+
+	await test.step(`Assert ${LDAP_USER_4_AB.alternateName} is a member of both groups`, async () => {
+		await (
+			await usersAndOrganizationsPage.usersTableRowLink(
+				LDAP_USER_4_AB.alternateName
+			)
+		).click();
+
+		await editUserPage.membershipsLink.click();
+
+		await expect(
+			await editUserPage.page.getByRole('cell', {
+				exact: true,
+				name: LDAP_GROUP_4_A,
+			})
+		).toBeVisible();
+
+		await expect(
+			await editUserPage.page.getByRole('cell', {
+				exact: true,
+				name: LDAP_GROUP_4_B,
+			})
+		).toBeVisible();
+	});
+
+	await test.step('Change memberships on LDAP server by adjusting import filter, since we cannot modify LDAP server from playwright test.  The email will stay the same, so the portal will think the user was actually removed from the groups on the LDAP server.', async () => {
+		ldapServerA.authenticationSearchFilter = `(&(mail=@email_address@)(cn=${LDAP_USER_4.alternateName}))`;
+		ldapServerA.importSearchFilterUser = `(&(objectClass=inetOrgPerson)(cn=${LDAP_USER_4.alternateName}))`;
+
+		await ldapServerPage.editLdapServer(ldapServerA);
+
+		ldapServerB.authenticationSearchFilter = `(&(mail=@email_address@)(cn=${LDAP_USER_4.alternateName}))`;
+		ldapServerB.importSearchFilterUser = `(&(objectClass=inetOrgPerson)(cn=${LDAP_USER_4.alternateName}))`;
+
+		await ldapServerPage.editLdapServer(ldapServerB);
+	});
+
+	await test.step(`Authenticate with ${LDAP_USER_4.alternateName}, triggering an import from LDAP server A only`, async () => {
+		const page = await browser.newPage();
+
+		await performLogin(page, LDAP_USER_4.alternateName);
+	});
+
+	await test.step(`Assert membership was revoked only for the first server's group`, async () => {
+		await usersAndOrganizationsPage.goToUsers(false);
+
+		await (
+			await usersAndOrganizationsPage.usersTableRowLink(
+				LDAP_USER_4.alternateName
+			)
+		).click();
+
+		await editUserPage.membershipsLink.click();
+
+		await expect(
+			await editUserPage.page.getByRole('cell', {
+				exact: true,
+				name: LDAP_GROUP_4_A,
+			})
+		).toBeHidden();
+
+		await expect(
+			await editUserPage.page.getByRole('cell', {
+				exact: true,
+				name: LDAP_GROUP_4_B,
+			})
+		).toBeVisible();
 	});
 });
 

--- a/modules/test/playwright/tests/portal-security-ldap/ldap.spec.ts
+++ b/modules/test/playwright/tests/portal-security-ldap/ldap.spec.ts
@@ -479,7 +479,7 @@ test('LPD-47223 AC2 TC2: Verify LDAP bulk import updates user information and me
 	});
 });
 
-test('LPD-47223 AC3 TC3: Verify LDAP import via authentication with multiple matching LDAP servers imports/updates only user groups for the first matching LDAP server', async ({
+test('LPD-47223 AC3 TC3 and AC3 TC4: Verify LDAP import via authentication with multiple matching LDAP servers imports/updates only user groups for the first matching LDAP server', async ({
 	browser,
 	editUserPage,
 	ldapConfigurationPage,
@@ -625,6 +625,123 @@ test('LPD-47223 AC3 TC3: Verify LDAP import via authentication with multiple mat
 				name: LDAP_GROUP_4_B,
 			})
 		).toBeVisible();
+	});
+
+	await test.step('LPD-47223 AC3 TC3 End, AC3 TC4 Start: Verify if second ldap server is the first to match during authentication, only changes from that server will be reflected', async () => {
+		await test.step('Update first LDAP server so it no longer matches any users', async () => {
+			ldapServerA.authenticationSearchFilter =
+				'(&(mail=@email_address@)(cn=fakeuser))';
+			ldapServerA.importSearchFilterUser =
+				'(&(objectClass=inetOrgPerson)(cn=fakeuser))';
+
+			await ldapServerPage.editLdapServer(ldapServerA);
+
+			await testAndExpectLdapEntries(
+				'group',
+				[LDAP_GROUP_4_A],
+				ldapServerA.serverName,
+				ldapServerPage,
+				undefined,
+				[LDAP_GROUP_4_B]
+			);
+
+			await testAndExpectLdapEntries(
+				'user',
+				[],
+				ldapServerA.serverName,
+				ldapServerPage,
+				true
+			);
+		});
+
+		await test.step(`Authenticate with ${LDAP_USER_4.alternateName}, triggering an import from LDAP server B only`, async () => {
+			const page = await browser.newPage();
+
+			await performLogin(page, LDAP_USER_4.alternateName);
+		});
+
+		await test.step(`Assert membership was revoked for the second LDAP server's group`, async () => {
+			await usersAndOrganizationsPage.goToUsers(false);
+
+			await (
+				await usersAndOrganizationsPage.usersTableRowLink(
+					LDAP_USER_4.alternateName
+				)
+			).click();
+
+			await editUserPage.membershipsLink.click();
+
+			await expect(
+				await editUserPage.page.getByRole('cell', {
+					exact: true,
+					name: LDAP_GROUP_4_A,
+				})
+			).toBeHidden();
+
+			await expect(
+				await editUserPage.page.getByRole('cell', {
+					exact: true,
+					name: LDAP_GROUP_4_B,
+				})
+			).toBeHidden();
+		});
+
+		await test.step(`Update second LDAP server so it now matches the user with ${LDAP_GROUP_4_A} membership`, async () => {
+			ldapServerB.authenticationSearchFilter = `(&(mail=@email_address@)(cn=${LDAP_USER_4_A.alternateName}))`;
+			ldapServerB.importSearchFilterUser = `(&(objectClass=inetOrgPerson)(cn=${LDAP_USER_4_A.alternateName}))`;
+
+			await ldapServerPage.editLdapServer(ldapServerB);
+
+			await testAndExpectLdapEntries(
+				'group',
+				[LDAP_GROUP_4_B],
+				ldapServerB.serverName,
+				ldapServerPage,
+				undefined,
+				[LDAP_GROUP_4_A]
+			);
+
+			await testAndExpectLdapEntries(
+				'user',
+				[LDAP_USER_4_A.alternateName],
+				ldapServerB.serverName,
+				ldapServerPage,
+				true,
+				[LDAP_USER_4.alternateName, LDAP_USER_4_AB.alternateName]
+			);
+		});
+
+		await test.step(`Authenticate with ${LDAP_USER_4_A.alternateName}, triggering an import from LDAP server B only`, async () => {
+			const page = await browser.newPage();
+
+			await performLogin(page, LDAP_USER_4_A.emailAddress, undefined, '');
+		});
+
+		await test.step(`Assert membership was not added for the first LDAP server's group`, async () => {
+			await usersAndOrganizationsPage.goToUsers(false);
+
+			await (
+				await usersAndOrganizationsPage.usersTableRowLink(
+					LDAP_USER_4_A.alternateName
+				)
+			).click();
+
+			await editUserPage.membershipsLink.click();
+
+			await expect(
+				await editUserPage.page.getByRole('cell', {
+					exact: true,
+					name: LDAP_GROUP_4_A,
+				})
+			).toBeHidden();
+
+			await expect(
+				await editUserPage.page.getByRole('cell', {
+					exact: true,
+					name: LDAP_GROUP_4_B,
+				})
+			).toBeHidden();
+		});
 	});
 });
 

--- a/modules/test/playwright/tests/portal-security-ldap/ldap.spec.ts
+++ b/modules/test/playwright/tests/portal-security-ldap/ldap.spec.ts
@@ -421,7 +421,7 @@ test('LPD-47223 AC2 TC2: Verify LDAP bulk import updates user information and me
 		await ldapServerPage.editLdapServer(ldapServer);
 	});
 
-	await invokeLdapImport(ldapServerPage.page);
+	await invokeLdapImport(ldapServerPage.page, ldapServer);
 
 	await test.step('Assert user data and membership was updated correctly', async () => {
 		await usersAndOrganizationsPage.goToUsers(false);
@@ -595,6 +595,8 @@ test('LPD-47223 AC3 TC3 and AC3 TC4: Verify LDAP import via authentication with 
 		await ldapServerPage.editLdapServer(ldapServerB);
 	});
 
+	await updateLdapServerCustomMapping(ldapServerA, ldapServerPage.page);
+
 	await test.step(`Authenticate with ${LDAP_USER_4.alternateName}, triggering an import from LDAP server A only`, async () => {
 		const page = await browser.newPage();
 
@@ -654,6 +656,8 @@ test('LPD-47223 AC3 TC3 and AC3 TC4: Verify LDAP import via authentication with 
 			);
 		});
 
+		await updateLdapServerCustomMapping(ldapServerB, ldapServerPage.page);
+
 		await test.step(`Authenticate with ${LDAP_USER_4.alternateName}, triggering an import from LDAP server B only`, async () => {
 			const page = await browser.newPage();
 
@@ -710,6 +714,8 @@ test('LPD-47223 AC3 TC3 and AC3 TC4: Verify LDAP import via authentication with 
 				[LDAP_USER_4.alternateName, LDAP_USER_4_AB.alternateName]
 			);
 		});
+
+		await updateLdapServerCustomMapping(ldapServerB, ldapServerPage.page);
 
 		await test.step(`Authenticate with ${LDAP_USER_4_A.alternateName}, triggering an import from LDAP server B only`, async () => {
 			const page = await browser.newPage();
@@ -954,7 +960,11 @@ test('smoke: Add LDAP server, verify connection, users, and groups are mapped pr
 	});
 });
 
-async function invokeLdapImport(page: Page) {
+async function invokeLdapImport(page: Page, ldapServer?: TLdapServer) {
+	if (ldapServer) {
+		await updateLdapServerCustomMapping(ldapServer, page);
+	}
+
 	await test.step('Manually trigger bulk import', async () => {
 		const applicationsMenuPage = new ApplicationsMenuPage(page);
 
@@ -1062,4 +1072,17 @@ async function resetLdapImportSystemSettings(
 
 		await waitForAlert(systemSettingsPage.page);
 	}
+}
+
+async function updateLdapServerCustomMapping(
+	ldapServer: TLdapServer,
+	page: Page
+) {
+	await test.step(`Update LDAP server '${ldapServer.serverName}' custom mapping to allow full reimport of user(s).`, async () => {
+		ldapServer.customUserMapping = getRandomString();
+
+		const ldapServerPage = new LdapServerPage(page);
+
+		await ldapServerPage.editLdapServer(ldapServer);
+	});
 }

--- a/modules/test/playwright/tests/portal-security-ldap/ldap.spec.ts
+++ b/modules/test/playwright/tests/portal-security-ldap/ldap.spec.ts
@@ -159,6 +159,117 @@ test.beforeEach(async ({browser}) => {
 	});
 });
 
+test('LPD-47223 AC1 TC1: Verify LDAP import via authentication imports user attributes and user groups, but only for the user being authenticated', async ({
+	browser,
+	editUserPage,
+	ldapServerPage,
+	userGroupsPage,
+	usersAndOrganizationsPage,
+}) => {
+	const ldapServer: TLdapServer = {
+		defaultValues: 'OpenLDAP',
+		principal: 'cn=admin,dc=example,dc=com',
+		serverName: getRandomString(),
+	};
+
+	await test.step('Add LDAP server', async () => {
+		await ldapServerPage.addLdapServer(ldapServer);
+	});
+
+	await testAndExpectLdapEntries(
+		'group',
+		[LDAP_GROUP_1, LDAP_GROUP_2],
+		ldapServer.serverName,
+		ldapServerPage
+	);
+
+	await testAndExpectLdapEntries(
+		'user',
+		[LDAP_USER_1.alternateName, LDAP_USER_2.alternateName],
+		ldapServer.serverName,
+		ldapServerPage,
+		true
+	);
+
+	await test.step(`Authenticate with ${LDAP_USER_2.alternateName}`, async () => {
+		const page = await browser.newPage();
+
+		await performLogin(page, LDAP_USER_2.alternateName);
+	});
+
+	await test.step(`Assert only ${LDAP_USER_2.alternateName} was imported`, async () => {
+		await usersAndOrganizationsPage.goToUsers(false);
+
+		await expect(
+			await usersAndOrganizationsPage.usersTableCell(
+				LDAP_USER_1.alternateName
+			)
+		).toBeHidden();
+
+		await expect(
+			await usersAndOrganizationsPage.usersTableCell(
+				LDAP_USER_2.alternateName
+			)
+		).toBeVisible();
+	});
+
+	await test.step('Assert user data was imported correctly', async () => {
+		await (
+			await usersAndOrganizationsPage.usersTableRowLink(
+				LDAP_USER_2.alternateName
+			)
+		).click();
+
+		await expect(editUserPage.emailAddressInput).toHaveValue(
+			LDAP_USER_2.emailAddress
+		);
+
+		await expect(editUserPage.firstNameInput).toHaveValue(
+			LDAP_USER_2.givenName
+		);
+
+		await expect(editUserPage.lastNameInput).toHaveValue(
+			LDAP_USER_2.familyName
+		);
+
+		await expect(editUserPage.screenNameInput).toHaveValue(
+			LDAP_USER_2.alternateName
+		);
+	});
+
+	await test.step('Assert user membership data was imported correctly', async () => {
+		await editUserPage.membershipsLink.click();
+
+		await expect(
+			(
+				await editUserPage.membershipsUserGroupsTableRow(
+					0,
+					LDAP_GROUP_2,
+					true
+				)
+			).row
+		).toBeVisible();
+	});
+
+	await test.step(`Assert only ${LDAP_GROUP_2} was imported`, async () => {
+		await userGroupsPage.goto();
+
+		await expect(
+			await userGroupsPage.page.getByRole('cell', {
+				exact: true,
+				name: LDAP_GROUP_1,
+			})
+		).toBeHidden();
+
+		await expect(
+			await userGroupsPage.page.getByRole('cell', {
+				exact: true,
+				name: LDAP_GROUP_2,
+			})
+		).toBeVisible();
+	});
+});
+
 test('LPD-47428: Verify a single LDAP user can belong to multiple User Groups imported from LDAP', async ({
 	browser,
 	editUserPage,

--- a/modules/test/playwright/tests/portal-security-ldap/ldap.spec.ts
+++ b/modules/test/playwright/tests/portal-security-ldap/ldap.spec.ts
@@ -1,0 +1,479 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page, expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {instanceSettingsPagesTest} from '../../fixtures/instanceSettingsPagesTest';
+import {ldapConfigurationPagesTest} from '../../fixtures/ldapConfigurationPagesTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {systemSettingsPageTest} from '../../fixtures/systemSettingsPageTest';
+import {userGroupsPageTest} from '../../fixtures/userGroupsPageTest';
+import {usersAndOrganizationsPagesTest} from '../../fixtures/usersAndOrganizationsPagesTest';
+import {
+	TLdapConfiguration,
+	TLdapServer,
+} from '../../helpers/LdapConfigurationHelper';
+import {SystemSettingsPage} from '../../pages/configuration-admin-web/SystemSettingsPage';
+import {LdapConfigurationPage} from '../../pages/portal-security-ldap/LdapConfigurationPage';
+import {LdapServerPage} from '../../pages/portal-security-ldap/LdapServerPage';
+import {ApplicationsMenuPage} from '../../pages/product-navigation-applications-menu/ApplicationsMenuPage';
+import {ServerAdministrationPage} from '../../pages/server-admin-web/ServerAdministrationPage';
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
+import getRandomString from '../../utils/getRandomString';
+import performLogin, {userData} from '../../utils/performLogin';
+import {waitForAlert} from '../../utils/waitForAlert';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	loginTest(),
+	instanceSettingsPagesTest,
+	ldapConfigurationPagesTest,
+	systemSettingsPageTest,
+	usersAndOrganizationsPagesTest,
+	userGroupsPageTest
+);
+
+const LDAP_GROUP_1 = 'ldapgroup1';
+const LDAP_GROUP_2 = 'ldapgroup2';
+
+const LDAP_USER_1: TUserAccount = {
+	alternateName: 'ldapuser1',
+	emailAddress: 'ldapuser1@liferay.com',
+	familyName: 'last',
+	givenName: 'first',
+	password: 'test',
+};
+
+const LDAP_USER_2: TUserAccount = {
+	alternateName: 'ldapuser2',
+	emailAddress: 'ldapuser2@liferay.com',
+	familyName: 'last',
+	givenName: 'first',
+	password: 'test',
+};
+
+test.afterAll(async ({browser}) => {
+	const page = await browser.newPage();
+
+	await performLogin(page, 'test');
+
+	const systemSettingsPage = new SystemSettingsPage(page);
+
+	await test.step('Reset System Settings LDAP configuration', async () => {
+		await resetLdapImportSystemSettings(systemSettingsPage);
+	});
+});
+
+test.afterEach(
+	async ({
+		apiHelpers,
+		ldapConfigurationPage,
+		ldapServerPage,
+		userGroupsPage,
+	}) => {
+		await test.step('Delete LDAP servers from portal', async () => {
+			await ldapServerPage.deleteLdapServers();
+		});
+
+		await test.step('Reset LDAP Instance Settings', async () => {
+			await ldapConfigurationPage.resetLdapConfiguration();
+		});
+
+		await test.step('Delete LDAP users from portal if present', async () => {
+			for (const ldapUser of [LDAP_USER_1, LDAP_USER_2]) {
+				const user =
+					await apiHelpers.headlessAdminUser.getUserAccountByEmailAddress(
+						ldapUser.emailAddress
+					);
+
+				if (user.id !== undefined) {
+					await apiHelpers.headlessAdminUser.deleteUserAccount(
+						Number(user.id)
+					);
+				}
+			}
+		});
+
+		await test.step('Delete LDAP groups from portal if present', async () => {
+			await userGroupsPage.goto();
+
+			const selectAllCheckbox = userGroupsPage.page.getByLabel(
+				'Select All Items on the Page'
+			);
+
+			await selectAllCheckbox.waitFor();
+
+			await userGroupsPage.page.waitForTimeout(1000);
+
+			if (await selectAllCheckbox.isEnabled()) {
+				await selectAllCheckbox.click();
+
+				userGroupsPage.page.once('dialog', async (dialog) => {
+					dialog.accept();
+				});
+
+				await userGroupsPage.page
+					.getByRole('button', {name: 'Delete'})
+					.click();
+
+				await waitForAlert(
+					userGroupsPage.page,
+					`Success:Your request completed successfully.`
+				);
+			}
+		});
+	}
+);
+
+test.beforeAll(async () => {
+
+	// Add LDAP user info to userData so we can authenticate via performLogin
+
+	for (const ldapUser of [LDAP_USER_1, LDAP_USER_2]) {
+		userData[ldapUser.alternateName] = {
+			name: ldapUser.givenName,
+			password: 'test',
+			surname: ldapUser.familyName,
+		};
+	}
+});
+
+test.beforeEach(async ({browser}) => {
+	await test.step('Enable LDAP, but prevent bulk import.  We can manually trigger bulk import via groovy script instead of waiting the import interval.', async () => {
+		const page = await browser.newPage();
+
+		await performLogin(page, 'test');
+
+		const ldapConfigurationPage = new LdapConfigurationPage(page);
+
+		const ldapConfiguration: TLdapConfiguration = {
+			enableImport: true,
+			enabled: true,
+			importInterval: 0,
+		};
+
+		await ldapConfigurationPage.updateLDAPConfiguration(ldapConfiguration);
+	});
+});
+
+test('LPD-47428: Verify a single LDAP user can belong to multiple User Groups imported from LDAP', async ({
+	browser,
+	editUserPage,
+	ldapConfigurationPage,
+	ldapServerPage,
+	usersAndOrganizationsPage,
+}) => {
+	const ldapServer1: TLdapServer = {
+		defaultValues: 'OpenLDAP',
+		importSearchFilterGroup: `(&(objectClass=groupOfUniqueNames)(cn=${LDAP_GROUP_1}))`,
+		principal: 'cn=admin,dc=example,dc=com',
+		serverName: getRandomString(),
+	};
+
+	const ldapServer2: TLdapServer = {
+		defaultValues: 'OpenLDAP',
+		importSearchFilterGroup: `(&(objectClass=groupOfUniqueNames)(cn=${LDAP_GROUP_2}))`,
+		principal: 'cn=admin,dc=example,dc=com',
+		serverName: getRandomString(),
+	};
+
+	await test.step('Add the same LDAP server twice, but adjust the group import search filter so each entry adds a different group', async () => {
+		await test.step('Add first LDAP server', async () => {
+			await ldapServerPage.addLdapServer(ldapServer1);
+		});
+
+		await testAndExpectLdapEntries(
+			'group',
+			[LDAP_GROUP_1],
+			ldapServer1.serverName,
+			ldapServerPage,
+			true,
+			[LDAP_GROUP_2]
+		);
+
+		await test.step('Add second LDAP server', async () => {
+			await ldapServerPage.addLdapServer(ldapServer2, false);
+		});
+
+		await testAndExpectLdapEntries(
+			'group',
+			[LDAP_GROUP_2],
+			ldapServer2.serverName,
+			ldapServerPage,
+			undefined,
+			[LDAP_GROUP_1]
+		);
+	});
+
+	await test.step(`Change LDAP Import Method to 'Group'`, async () => {
+		const ldapConfiguration: TLdapConfiguration = {
+			importMethod: 'Group',
+		};
+
+		await ldapConfigurationPage.updateLDAPConfiguration(ldapConfiguration);
+	});
+
+	await invokeLdapImport(ldapConfigurationPage.page);
+
+	await test.step('View User Groups associated with the LDAP user, and verify they were correctly imported', async () => {
+		await usersAndOrganizationsPage.goToUsers(false);
+
+		await (
+			await usersAndOrganizationsPage.usersTableRowLink(
+				LDAP_USER_1.alternateName
+			)
+		).click();
+
+		await editUserPage.membershipsLink.click();
+
+		await expect(
+			(
+				await editUserPage.membershipsUserGroupsTableRow(
+					0,
+					LDAP_GROUP_1,
+					true
+				)
+			).row
+		).toBeVisible();
+
+		await expect(
+			(
+				await editUserPage.membershipsUserGroupsTableRow(
+					0,
+					LDAP_GROUP_2,
+					true
+				)
+			).row
+		).toBeVisible();
+	});
+
+	await test.step('Attempt login with ldap user, but use incorrect password.  This reproduces the bug described in LPD-47428.', async () => {
+		const page = await browser.newPage();
+
+		await page.goto('/');
+
+		await page.getByRole('button', {name: 'Sign In'}).last().click();
+
+		await page.getByLabel('Email Address').fill(LDAP_USER_1.emailAddress);
+		await page.getByLabel('Password').fill('badPassword');
+
+		await page.getByRole('button', {name: 'Sign In'}).last().click();
+
+		await waitForAlert(page, 'Error:Authentication failed', {
+			autoClose: false,
+			type: 'danger',
+		});
+	});
+
+	await test.step('Verify both User Groups are still associated with the LDAP user.', async () => {
+		await editUserPage.page.reload();
+
+		await expect(
+			(
+				await editUserPage.membershipsUserGroupsTableRow(
+					0,
+					LDAP_GROUP_1,
+					true
+				)
+			).row
+		).toBeVisible();
+
+		await expect(
+			(
+				await editUserPage.membershipsUserGroupsTableRow(
+					0,
+					LDAP_GROUP_2,
+					true
+				)
+			).row
+		).toBeVisible();
+	});
+});
+
+test('smoke: Add LDAP server, verify connection, users, and groups are mapped properly, edit LDAP server, then delete LDAP server', async ({
+	ldapConfigurationPage,
+	ldapServerPage,
+}) => {
+	const serverName = getRandomString();
+
+	const ldapServer: TLdapServer = {
+		defaultValues: 'OpenLDAP',
+		principal: 'cn=admin,dc=example,dc=com',
+		serverName,
+	};
+
+	await test.step('Add LDAP Server', async () => {
+		await ldapServerPage.addLdapServer(ldapServer);
+	});
+
+	await test.step('Test LDAP Server connections', async () => {
+		await ldapServerPage.viewLdapServer(serverName, false);
+
+		await ldapServerPage.testLdapConnection.click();
+
+		await expect(
+			await ldapServerPage.page.getByText(
+				'Liferay has successfully connected to the LDAP server'
+			)
+		).toBeVisible();
+
+		await ldapServerPage.closeButton.click();
+
+		await ldapServerPage.testLdapUsers.click();
+
+		await expect(
+			await ldapServerPage.page.getByText(
+				'A subset of users has been displayed for you to review'
+			)
+		).toBeVisible();
+
+		await ldapServerPage.closeButton.click();
+
+		await ldapServerPage.testLdapGroups.click();
+
+		await expect(
+			await ldapServerPage.page.getByText(
+				'A subset of groups has been displayed for you to review'
+			)
+		).toBeVisible();
+
+		await ldapServerPage.closeButton.click();
+
+		await ldapServerPage.cancelButton.click();
+	});
+
+	await test.step('Edit LDAP Server by changing server name', async () => {
+		ldapServer.serverName = 'newServerName';
+
+		await ldapServerPage.editLdapServer(ldapServer, serverName, false);
+
+		await expect(
+			await ldapConfigurationPage.page.getByRole('row', {
+				name: 'newServerName',
+			})
+		).toBeVisible();
+	});
+
+	await test.step('Delete LDAP server', async () => {
+		await ldapServerPage.deleteLdapServer('newServerName', false);
+
+		await expect(
+			await ldapConfigurationPage.page.getByRole('row', {
+				name: 'newServerName',
+			})
+		).toBeHidden();
+	});
+});
+
+async function invokeLdapImport(page: Page) {
+	await test.step('Manually trigger bulk import', async () => {
+		const applicationsMenuPage = new ApplicationsMenuPage(page);
+
+		await applicationsMenuPage.goToServerAdministration();
+
+		const script = `
+			import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+			import com.liferay.portal.security.ldap.exportimport.LDAPUserImporter;
+			import org.osgi.framework.BundleContext;
+			BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+			def ldapUserImporter = bundleContext.getService(bundleContext.getServiceReference(LDAPUserImporter.class));
+			ldapUserImporter.importUsers();
+		`;
+
+		const serverAdministrationPage = new ServerAdministrationPage(page);
+
+		await serverAdministrationPage.executeScript(script);
+	});
+}
+
+async function testAndExpectLdapEntries(
+	entryType: 'group' | 'user',
+	expectedVisibleEntries: string[],
+	ldapServerName: string,
+	ldapServerPage: LdapServerPage,
+	clickCancel = false,
+	expectedNotVisibleEntriess?: string[]
+) {
+	await ldapServerPage.viewLdapServer(ldapServerName, true);
+
+	if (entryType === 'group') {
+		await ldapServerPage.testLdapGroups.click();
+	}
+	else {
+		await ldapServerPage.testLdapUsers.click();
+	}
+
+	if (expectedVisibleEntries.length <= 0) {
+		await test.step(`Verify LDAP server test displays no ${entryType}s`, async () => {
+			await expect(
+				await ldapServerPage.page.getByText(
+					`No ${entryType}s were found`
+				)
+			).toBeVisible();
+		});
+	}
+	else {
+		await test.step(`Verify LDAP server test ${entryType}s displays ${expectedVisibleEntries.join(
+			', '
+		)}`, async () => {
+			for (const expectedVisibleEntry of expectedVisibleEntries) {
+				await expect(
+					await ldapServerPage.page.getByRole('cell', {
+						exact: true,
+						name: expectedVisibleEntry,
+					})
+				).toBeVisible();
+			}
+		});
+	}
+
+	if (expectedNotVisibleEntriess) {
+		await test.step(`Verify LDAP server test ${entryType}s does not display ${expectedNotVisibleEntriess.join(
+			', '
+		)}`, async () => {
+			for (const expectedNotVisibleEntry of expectedNotVisibleEntriess) {
+				await expect(
+					await ldapServerPage.page.getByRole('cell', {
+						exact: true,
+						name: expectedNotVisibleEntry,
+					})
+				).not.toBeVisible();
+			}
+		});
+	}
+
+	await ldapServerPage.closeButton.click();
+
+	if (clickCancel) {
+		await ldapServerPage.cancelButton.click();
+	}
+}
+
+async function resetLdapImportSystemSettings(
+	systemSettingsPage: SystemSettingsPage
+) {
+	await systemSettingsPage.goToSystemSetting('LDAP', 'Import');
+
+	await systemSettingsPage.page.getByLabel('Import Interval').waitFor();
+
+	if (
+		await systemSettingsPage.page
+			.getByRole('button', {name: 'Actions'})
+			.isVisible()
+	) {
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: systemSettingsPage.page.getByRole('menuitem', {
+				name: 'Reset Default Values',
+			}),
+			trigger: systemSettingsPage.page.getByRole('button', {
+				name: 'Actions',
+			}),
+		});
+
+		await waitForAlert(systemSettingsPage.page);
+	}
+}

--- a/modules/test/playwright/tests/portal-security-ldap/test.properties
+++ b/modules/test/playwright/tests/portal-security-ldap/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=LDAP


### PR DESCRIPTION
Resent from https://github.com/liferay-appsec/liferay-portal/pull/2254 and https://github.com/brianchandotcom/liferay-portal/pull/160043

https://liferay.atlassian.net/browse/LPD-47223
https://liferay.atlassian.net/browse/LPD-47428

Both tickets have been combined with their commit history squashed in an understandable way.  Here is the original exploded commit history: https://github.com/ChrisKian/liferay-portal/compare/f78541c1d2ff80c8b07430aadff44cd27e9cf879...LPD-47428-3-exploded

Since we are unable to modify users on the LDAP server while our playwright test runs, I've had to workaround this issue by having multiple LDAP users with the same email, and the "updated" one is selected via import/authentication filter.  This only applies to TC2, TC3, and TC4.

This workaround also created another issue, where the "new" LDAP user would not be imported due to a modified date which was exactly the same, since all LDAP users are imported with the same modify date value.  In order to workaround **_this_** issue, I simply edit the LDAP Server connection configuration to include a dummy custom user mapping.  This "tricks" the portal into believing there may be a user update via custom mapping, thus the LDAP user is fully reimported.