### PR TITLE
LPD-47223

### DIFF
--- a/modules/test/playwright/tests/portal-security-ldap/env/set_up.sh
+++ b/modules/test/playwright/tests/portal-security-ldap/env/set_up.sh
@@ -20,10 +20,10 @@ function ldap_set_up {
 
 	local dependencies_dir_name=${CURRENT_DIR_NAME}/../dependencies
 
-	execute_command ldapadd -cx -D "cn=admin,dc=example,dc=com" -f ${dependencies_dir_name}/addGroups.ldif -w "secret"
-	execute_command ldapadd -cx -D "cn=admin,dc=example,dc=com" -f ${dependencies_dir_name}/addUsers.ldif -w "secret"
-	execute_command ldapadd -cx -D "cn=admin,dc=example,dc=com" -f ${dependencies_dir_name}/admin.ldif -w "secret"
 	execute_command ldapadd -cx -D "cn=admin,dc=example,dc=com" -f ${dependencies_dir_name}/exampleCompany.ldif -w "secret"
+	execute_command ldapadd -cx -D "cn=admin,dc=example,dc=com" -f ${dependencies_dir_name}/admin.ldif -w "secret"
+	execute_command ldapadd -cx -D "cn=admin,dc=example,dc=com" -f ${dependencies_dir_name}/addUsers.ldif -w "secret"
+	execute_command ldapadd -cx -D "cn=admin,dc=example,dc=com" -f ${dependencies_dir_name}/addGroups.ldif -w "secret"
 }
 
 function main {

--- a/modules/test/playwright/tests/portal-security-ldap/env/tear_down.sh
+++ b/modules/test/playwright/tests/portal-security-ldap/env/tear_down.sh
@@ -6,11 +6,11 @@ echo CURRENT_DIR_NAME=${CURRENT_DIR_NAME}
 
 source ${CURRENT_DIR_NAME}/../../../env/common.sh
 
-DEPENDENCIES_DIR_NAME=${CURRENT_DIR_NAME}/../dependencies
-
 function ldap_tear_down {
-	ldapdelete -cx -D "cn=admin,dc=example,dc=com" -f ${DEPENDENCIES_DIR_NAME}/removeGroups.ldif -w "secret"
-	ldapdelete -cx -D "cn=admin,dc=example,dc=com" -f ${DEPENDENCIES_DIR_NAME}/removeUsers.ldif -w "secret"
+	local dependencies_dir_name=${CURRENT_DIR_NAME}/../dependencies
+
+	ldapdelete -cx -D "cn=admin,dc=example,dc=com" -f ${dependencies_dir_name}/removeGroups.ldif -w "secret"
+	ldapdelete -cx -D "cn=admin,dc=example,dc=com" -f ${dependencies_dir_name}/removeUsers.ldif -w "secret"
 
 	kill -INT `cat /usr/local/var/run/slapd.pid`
 }


### PR DESCRIPTION
Adjusting the order of LDIF addition, otherwise the follow errors occur:
```
     [exec] adding new entry "cn=ldapgroup1,dc=example,dc=com"
     [exec] 
     [exec] adding new entry "cn=ldapgroup2,dc=example,dc=com"
     [exec] 
     [exec] adding new entry "cn=ldapgroup3,dc=example,dc=com"
     [exec] 
     [exec] adding new entry "cn=ldapgroup3modified,dc=example,dc=com"
     [exec] 
     [exec] adding new entry "cn=ldapgroup4a,dc=example,dc=com"
     [exec] 
     [exec] adding new entry "cn=ldapgroup4b,dc=example,dc=com"
     [exec] 
     [exec] Command "ldapadd -cx -D cn=admin,dc=example,dc=com -f /opt/dev/projects/github/liferay-portal/modules/test/playwright/tests/portal-security-ldap/env/../dependencies/addGroups.ldif -w secret" failed with exit code 0.
     [exec] adding new entry "cn=ldapuser1,dc=example,dc=com"
     [exec] 
     [exec] adding new entry "cn=ldapuser2,dc=example,dc=com"
     [exec] 
     [exec] adding new entry "cn=ldapuser3,dc=example,dc=com"
     [exec] 
     [exec] adding new entry "cn=ldapuser3modified,dc=example,dc=com"
     [exec] 
     [exec] adding new entry "cn=ldapuser4,dc=example,dc=com"
     [exec] 
     [exec] adding new entry "cn=ldapuser4a,dc=example,dc=com"
     [exec] 
     [exec] adding new entry "cn=ldapuser4ab,dc=example,dc=com"
     [exec] 
     [exec] Command "ldapadd -cx -D cn=admin,dc=example,dc=com -f /opt/dev/projects/github/liferay-portal/modules/test/playwright/tests/portal-security-ldap/env/../dependencies/addUsers.ldif -w secret" failed with exit code 0.
     [exec] adding new entry "cn=admin,dc=example,dc=com"
     [exec] 
     [exec] Command "ldapadd -cx -D cn=admin,dc=example,dc=com -f /opt/dev/projects/github/liferay-portal/modules/test/playwright/tests/portal-security-ldap/env/../dependencies/admin.ldif -w secret" failed with exit code 0.
     [exec] adding new entry "dc=example,dc=com"
     [exec] 
     [exec] ldap_add: No such object (32)
     [exec] ldap_add: No such object (32)
     [exec] ldap_add: No such object (32)
     [exec] ldap_add: No such object (32)
     [exec] ldap_add: No such object (32)
     [exec] ldap_add: No such object (32)
     [exec] ldap_add: No such object (32)
     [exec] ldap_add: No such object (32)
     [exec] ldap_add: No such object (32)
     [exec] ldap_add: No such object (32)
     [exec] ldap_add: No such object (32)
     [exec] ldap_add: No such object (32)
     [exec] ldap_add: No such object (32)
     [exec] ldap_add: No such object (32)
```

Also adding a small SF change to make `set_up.sh` and `tear_down.sh` consistent.