### PR TITLE
LPD-48610

### DIFF
--- a/modules/test/playwright/pages/login-web/LoginInstanceSettingsPage.ts
+++ b/modules/test/playwright/pages/login-web/LoginInstanceSettingsPage.ts
@@ -5,6 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
+import {waitForLoading} from '../../tests/osb-faro-web/utils/loading';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {waitForAlert} from '../../utils/waitForAlert';
 import {InstanceSettingsPage} from '../configuration-admin-web/InstanceSettingsPage';
@@ -22,10 +23,10 @@ export class LoginInstanceSettingsPage {
 
 	async goto() {
 		await this.instanceSettingsPage.goToInstanceSetting('Login', 'Login');
+		await waitForLoading(this.page);
 	}
 
 	async enableLoginPrompt() {
-		await this.page.getByRole('menuitem', {name: 'Login'}).waitFor();
 		await this.page.getByLabel('Prompt Enabled').check();
 		await this.saveButton.click();
 		await waitForAlert(this.page);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-48610

Here's a detailed rundown of how this issue can occur:
1. utilityPage.spec.ts line 103: `await loginInstanceSettingsPage.goto()`.  This line goes to Instance Settings > Login AND THEN ALSO clicks the 'Login' tab
2. However, the 'Login' tab is the default and only tab for the 'Login' instance settings category, so therefore the page is navigated to twice.  First when clicking 'Login' from Instance settings, and second when clicking the 'Login' tab.
3. The `instanceSettingsPage.goToInstanceSetting()` method should not be adjusted, since this is used in several tests and it is doing it's job correctly.
4. Further, we should continue to navigate to the 'Login' tab, since it's possible we add a new tab in the future with an alpha lower than 'Login', which would break the current tests.
5. utilityPage.spec.ts line 104: `await loginInstanceSettingsPage.enableLoginPrompt()`.  Once the Playwright test sees the 'Login' menuitem, it instantly checks the prompt enabled box and saves the configuration
6. If step 5 takes place before the second navigation to the 'Login' tab is completed, it's possible the 'check' is lost.

High-level rundown:
1. portal navigates to Instance settings > Login
2. Page is loaded
3. Portal navigates to the 'Login' tab
4. Playwright sees the 'Login' tab is loaded and continues
5. Playwright checks 'Prompt Enabled'
6. Playwright saves the configuration
7. Sometime during steps 5 and/or 6, the page reloads the 'Login' tab
8. The configuration is not actually saved.

Solution: Include the `waitForLoading` utility, so the page is complete loaded before modifying the configuration.  ~~This is not needed for the `resetLoginPrompt()` method, since this method uses the `clickAndExpectToBeVisible()` util, which will wait until the button is present before clicking, then wait for a `success` prompt.~~ Actually it failed for reset too, [see this link](https://ffd13d3474c78f763a26363ada1c25cea54d093aedc974c155eb16b-apidata.googleusercontent.com/download/storage/v1/b/testray-results/o/2025-04%2Ftest-1-37%2Ftest-portal-acceptance-pullrequest(master)%2F21627%2Fplaywright-js-tomcat90-postgresql163%2F4%2F0%2Fplaywright-report%2Findex.html?jk=AbSFce6IfX5VLXlDfgJBWiHkG_WgmCFyY4ASKWEvfSglw8cJpiQXlMXxzh5jpF3kIM5D-ash2FiaW2ytvQqOZjGXFiftka8yw8lJpMPwGmzmZEzNuFilSY4RuHelTiQSaJm1AheXjR5bP0NyVvMLifpEuhlF7D7tOY4iDW3rxr7Fxfcdj67GgC_u0wzCAfabwEjXacCsuGsvSSz1zK2ZfQWT-z_oIjZ0x1vLaRRWgM3y3SCgZkGfPTM2zzawTollFlNDxXfjEUcTkU2SufF_11FgNyLNiNEJTdRQtyP-YA_YOiFuXBtJh7frWUDLeb1hpoo1Ul4tCYIPX-Hr2ReFRmlBg0evQiH8RTx0YQno4CS4YvEWkw9q8zWsy8rTCpqFKkZeWzXjagTTzw_6teui9I_BtD-N2y6VszYr-3hiYEjeOHI5cbiC5Yi-y8X1x3_Fu-eff-8S2HgOdjtaDL_-gDlhxOvb_Nu4X7ykQPcnKT5OWEAOuG6NSLp-plS2bjswvRq9uAm3bUx-pX15VxysqmyimNp-ohmLPaOYpxVU7KcNh8GJIDvgEMNpy9KOd54dNX-bwId880GjBvQkaFPza_Vhl4JGGZhN5CTS3v77spMSilV6tTYrOdni4NyrEkAimB8hB39MWgRbDNvjARK8qGtRU0GN5WJSYcDYTEAlKka6Ndk6VWVHXpiLzOblaZn40mmYSCH6YMUBfzeh9nwQ2jTylJIVzOO7pHj0IPcMndi8_5SJ2lzukUFaNsjff9CqjR7T0itU7yYgGMkh30s2RARI9cemZe1aGu92BKhDIVaZXFs6tnuw4OuCZOGwiy-EcjBCcRur9xbqXjWjIYMZCUBFtK6LpkiTxKUqPmxPsHzRDCxBc3h5COqFbx8YnwPT7_0OUsRJyUaFNApBz-LmGm1YyZH2Ovz_Gi-8Oo3xGvTjn7Bm8dxAZIQ7SnZYk-gP5bi0fzAvG8ANavYoEzyen_5Lld0XZu1m8IqzTB_u4RpLqPNuOyWzp6Sf9r-osr29TOGQWGrc_EfxfG4pcx8YyZZbng9vfaAsc7YMHDaFdVsEpT7mZsxq14mqjFQGIUB9F8PWCruG29b5cDfWCNbSaqPl-LGmy_vDoFRNV5P9B8V4KACkUMYyBe8lTvT0q1alyqQWbXEURZIq8mT7PnB-1Y4Ze2MFCUH559xSxqNllKyQdUUXUmY09k11x_Or4voij3KTyJ4vdlnye06f-9R6eq4RCRtIxU5SpwQhmKITKW51R2ZhsDuoH6ZdushC4YGCox8es5jHTMTMX3bsjpRM04wekl_Ikhy6MGhfRddij5-069XfM9p7km2aYDy2tQ&isca=1#?testId=f7fb5a9f43ff79c0eec9-50d4cd1c9f0df52c6d66).