### PR TITLE
LPD-53920 Fix oAuth 2 integration tests

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-test/bnd.bnd
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/bnd.bnd
@@ -4,7 +4,12 @@ Bundle-Version: 1.0.0
 Import-Package:\
 	!javax.cache.*,\
 	\
+	!org.apache.abdera.*,\
+	!org.apache.cxf.aegis.*,\
+	\
 	!org.bouncycastle.*,\
+	\
+	!org.codehaus.jettison.*,\
 	\
 	!sun.net.www.protocol.http.*,\
 	\

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseClientTestCase.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseClientTestCase.java
@@ -675,7 +675,7 @@ public abstract class BaseClientTestCase {
 
 	private static Set<String> _originalRestrictedHeaderSet;
 	private static final Pattern _pAuthTokenPattern = Pattern.compile(
-		"Liferay.authToken\\s*=\\s*(['\"])(((?!\\1).)*)\\1;");
+		"authToken:\\s*(['\"])(((?!\\1).)*)\\1,");
 	private static Set<String> _restrictedHeaderSet;
 
 	private BundleActivator _bundleActivator;

--- a/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/PortalConfigurationCORSClientTest.java
+++ b/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/PortalConfigurationCORSClientTest.java
@@ -220,7 +220,7 @@ public class PortalConfigurationCORSClientTest extends BaseCORSClientTestCase {
 	}
 
 	private static final Pattern _pAuthTokenPattern = Pattern.compile(
-		"Liferay.authToken\\s*=\\s*(['\"])(((?!\\1).)*)\\1;");
+		"authToken:\\s*(['\"])(((?!\\1).)*)\\1,");
 
 	private String _pAuth;
 


### PR DESCRIPTION
Related issue: [LPD-53920](https://liferay.atlassian.net/browse/LPD-53920)

Now the authToken is displayed as:
`authToken: 'TLK9pVkk',` instead of `Liferay.authToken = 'TLK9pVkk';`