### PR TITLE
LPD-52797 Additional fixes

### DIFF
--- a/modules/apps/login/login-web-test/src/testIntegration/java/com/liferay/login/web/internal/portlet/action/test/ForgotPasswordMVCActionCommandTest.java
+++ b/modules/apps/login/login-web-test/src/testIntegration/java/com/liferay/login/web/internal/portlet/action/test/ForgotPasswordMVCActionCommandTest.java
@@ -73,9 +73,13 @@ public class ForgotPasswordMVCActionCommandTest {
 
 		_createUser(true, false);
 
-		List<Ticket> tickets = _processAction(true);
+		try (SafeCloseable safeCloseable =
+				_updateLDAPAuthConfigurationWithSafeCloseable(true)) {
 
-		Assert.assertTrue(tickets.isEmpty());
+			List<Ticket> tickets = _processAction();
+
+			Assert.assertTrue(tickets.isEmpty());
+		}
 	}
 
 	@Test
@@ -84,9 +88,13 @@ public class ForgotPasswordMVCActionCommandTest {
 
 		_createUser(true, false);
 
-		List<Ticket> tickets = _processAction(false);
+		try (SafeCloseable safeCloseable =
+				_updateLDAPAuthConfigurationWithSafeCloseable(false)) {
 
-		Assert.assertEquals(tickets.toString(), 1, tickets.size());
+			List<Ticket> tickets = _processAction();
+
+			Assert.assertEquals(tickets.toString(), 1, tickets.size());
+		}
 	}
 
 	@Test
@@ -95,9 +103,13 @@ public class ForgotPasswordMVCActionCommandTest {
 
 		_createUser(false, false);
 
-		List<Ticket> tickets = _processAction(true);
+		try (SafeCloseable safeCloseable =
+				_updateLDAPAuthConfigurationWithSafeCloseable(true)) {
 
-		Assert.assertEquals(tickets.toString(), 1, tickets.size());
+			List<Ticket> tickets = _processAction();
+
+			Assert.assertEquals(tickets.toString(), 1, tickets.size());
+		}
 	}
 
 	@Test
@@ -205,19 +217,7 @@ public class ForgotPasswordMVCActionCommandTest {
 		return mockLiferayPortletActionRequest;
 	}
 
-	private List<Ticket> _processAction(boolean passwordPolicyEnabled)
-		throws Exception {
-
-		Dictionary<String, Object> configurationProperties =
-			_ldapAuthConfigurationProvider.getConfigurationProperties(
-				_user.getCompanyId());
-
-		Object originalPasswordPolicyEnabled = configurationProperties.put(
-			"passwordPolicyEnabled", passwordPolicyEnabled);
-
-		_ldapAuthConfigurationProvider.updateProperties(
-			_user.getCompanyId(), configurationProperties);
-
+	private List<Ticket> _processAction() throws Exception {
 		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
 				new ConfigurationTemporarySwapper(
 					"com.liferay.captcha.configuration.CaptchaConfiguration",
@@ -247,18 +247,24 @@ public class ForgotPasswordMVCActionCommandTest {
 				_user.getCompanyId(), User.class.getName(), _user.getUserId(),
 				TicketConstants.TYPE_PASSWORD);
 		}
-		finally {
-			if (originalPasswordPolicyEnabled != null) {
-				configurationProperties.put(
-					"passwordPolicyEnabled", originalPasswordPolicyEnabled);
-			}
-			else {
-				configurationProperties.remove("passwordPolicyEnabled");
-			}
+	}
 
-			_ldapAuthConfigurationProvider.updateProperties(
-				_user.getCompanyId(), configurationProperties);
-		}
+	private SafeCloseable _updateLDAPAuthConfigurationWithSafeCloseable(
+		boolean passwordPolicyEnabled) {
+
+		long companyId = _user.getCompanyId();
+
+		Dictionary<String, Object> configurationProperties =
+			_ldapAuthConfigurationProvider.getConfigurationProperties(
+				companyId);
+
+		configurationProperties.put(
+			"passwordPolicyEnabled", passwordPolicyEnabled);
+
+		_ldapAuthConfigurationProvider.updateProperties(
+			companyId, configurationProperties);
+
+		return () -> _ldapAuthConfigurationProvider.delete(companyId);
 	}
 
 	@DeleteAfterTestRun

--- a/modules/apps/password-policy/password-policy-test/src/testIntegration/java/com/liferay/password/policy/service/test/PasswordPolicyLocalServiceTest.java
+++ b/modules/apps/password-policy/password-policy-test/src/testIntegration/java/com/liferay/password/policy/service/test/PasswordPolicyLocalServiceTest.java
@@ -23,7 +23,6 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
 import java.util.Dictionary;
 
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -43,11 +42,6 @@ public class PasswordPolicyLocalServiceTest {
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
 			PermissionCheckerMethodTestRule.INSTANCE);
-
-	@After
-	public void tearDown() throws Exception {
-		_ldapAuthConfigurationProvider.delete(TestPropsValues.getCompanyId());
-	}
 
 	@Test
 	public void testGetDefaultPasswordPolicyWithLDAPPasswordPolicy()
@@ -180,24 +174,13 @@ public class PasswordPolicyLocalServiceTest {
 			_ldapAuthConfigurationProvider.getConfigurationProperties(
 				companyId);
 
-		Object originalPasswordPolicyEnabled = configurationProperties.put(
+		configurationProperties.put(
 			"passwordPolicyEnabled", passwordPolicyEnabled);
 
 		_ldapAuthConfigurationProvider.updateProperties(
 			companyId, configurationProperties);
 
-		return () -> {
-			if (originalPasswordPolicyEnabled != null) {
-				configurationProperties.put(
-					"passwordPolicyEnabled", originalPasswordPolicyEnabled);
-			}
-			else {
-				configurationProperties.remove("passwordPolicyEnabled");
-			}
-
-			_ldapAuthConfigurationProvider.updateProperties(
-				companyId, configurationProperties);
-		};
+		return () -> _ldapAuthConfigurationProvider.delete(companyId);
 	}
 
 	@Inject(

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
@@ -1723,24 +1723,13 @@ public class UserLocalServiceTest {
 			_ldapAuthConfigurationProvider.getConfigurationProperties(
 				companyId);
 
-		Object originalPasswordPolicyEnabled = configurationProperties.put(
+		configurationProperties.put(
 			"passwordPolicyEnabled", passwordPolicyEnabled);
 
 		_ldapAuthConfigurationProvider.updateProperties(
 			companyId, configurationProperties);
 
-		return () -> {
-			if (originalPasswordPolicyEnabled != null) {
-				configurationProperties.put(
-					"passwordPolicyEnabled", originalPasswordPolicyEnabled);
-			}
-			else {
-				configurationProperties.remove("passwordPolicyEnabled");
-			}
-
-			_ldapAuthConfigurationProvider.updateProperties(
-				companyId, configurationProperties);
-		};
+		return () -> _ldapAuthConfigurationProvider.delete(companyId);
 	}
 
 	private SafeCloseable _updateSecurityWithSafeCloseable(


### PR DESCRIPTION
Related issue: [LPD-52797](https://liferay.atlassian.net/browse/LPD-52797)

When using a `LDAPAuthConfiguration` it should be deleted after the test run or else it can leave leftovers which could affect other tests that uses the same configuration. (e.g.: `LDAPPropertiesUpgradeProcessTest` expects the configuration to be null)