### PR TITLE
LPD-51524 Enhancing the test coverage of OAuth 2 API access based validation on Scopes with LPD-41009 fix for database partition enabled

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeFinderTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeFinderTest.java
@@ -8,16 +8,23 @@ package com.liferay.oauth2.provider.client.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.internal.test.TestRunnablePostHandlingApplication;
+import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.scope.spi.scope.finder.ScopeFinder;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Dictionary;
+import java.util.List;
 
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
@@ -42,7 +49,7 @@ public class ScopeFinderTest extends BaseClientTestCase {
 		new LiferayIntegrationTestRule();
 
 	@Test
-	public void testUnavailableAssignedScopeAliases() {
+	public void testUnavailableAssignedScopeAliases() throws PortalException {
 		String token = getToken(
 			"oauthTestClientCredentials", null,
 			this::getClientCredentialsResponse, this::parseTokenString);
@@ -74,6 +81,44 @@ public class ScopeFinderTest extends BaseClientTestCase {
 			webTarget.request(),
 			getToken(
 				"oauthTestClientCredentials", null,
+				this::getClientCredentialsResponse, this::parseTokenString));
+
+		Assert.assertEquals(
+			403,
+			invocationBuilder.get(
+			).getStatus());
+
+		webTarget = getWebTarget();
+
+		webTarget = webTarget.path("o/captcha/v1.0/captcha/challenge");
+
+		invocationBuilder = authorize(
+			webTarget.request(),
+			getToken(
+				"oauthTestApplication", null,
+				this::getClientCredentialsResponse, this::parseTokenString));
+
+		Assert.assertEquals(
+			200,
+			invocationBuilder.get(
+			).getStatus());
+
+		List<String> scopeAliasess = new ArrayList<>();
+
+		scopeAliasess.add("Liferay.Captcha.REST.everything.write");
+
+		OAuth2Application oAuth2Application =
+			_oAuth2ApplicationLocalService.getOAuth2Application(
+				_oAuth2ApplicationId);
+
+		_oAuth2ApplicationLocalService.updateScopeAliases(
+			oAuth2Application.getUserId(), oAuth2Application.getUserName(),
+			_oAuth2ApplicationId, scopeAliasess);
+
+		invocationBuilder = authorize(
+			webTarget.request(),
+			getToken(
+				"oauthTestApplication", null,
 				this::getClientCredentialsResponse, this::parseTokenString));
 
 		Assert.assertEquals(
@@ -116,6 +161,20 @@ public class ScopeFinderTest extends BaseClientTestCase {
 				defaultCompanyId, user, "oauthTestClientCredentials",
 				Collections.singletonList(GrantType.CLIENT_CREDENTIALS),
 				Collections.singletonList("everything.read"));
+
+			OAuth2Application oAuth2Application = createOAuth2Application(
+				defaultCompanyId, user, "oauthTestApplication",
+				Collections.singletonList(
+					"Liferay.Captcha.REST.everything.read"));
+
+			_oAuth2ScopeGrantLocalService.createOAuth2ScopeGrant(
+				oAuth2Application.getCompanyId(),
+				oAuth2Application.getOAuth2ApplicationScopeAliasesId(),
+				"Liferay.Captcha.REST", "com.liferay.captcha.rest.impl", "GET",
+				Collections.singletonList(
+					"Liferay.Captcha.REST.everything.read"));
+
+			_oAuth2ApplicationId = oAuth2Application.getOAuth2ApplicationId();
 		}
 
 	}
@@ -124,5 +183,13 @@ public class ScopeFinderTest extends BaseClientTestCase {
 	protected BundleActivator getBundleActivator() {
 		return new ScopeFinderTestPreparatorBundleActivator();
 	}
+
+	private static long _oAuth2ApplicationId;
+
+	@Inject
+	private static OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
+
+	@Inject
+	private static OAuth2ScopeGrantLocalService _oAuth2ScopeGrantLocalService;
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeFinderTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeFinderTest.java
@@ -15,9 +15,9 @@ import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -153,17 +153,17 @@ public class ScopeFinderTest extends BaseClientTestCase {
 					() -> registerScopeFinder(scopeFinder, properties2)),
 				"annotated", properties1);
 
-			long defaultCompanyId = PortalUtil.getDefaultCompanyId();
+			long companyId = TestPropsValues.getCompanyId();
 
-			User user = UserTestUtil.getAdminUser(defaultCompanyId);
+			User user = UserTestUtil.getAdminUser(companyId);
 
 			createOAuth2Application(
-				defaultCompanyId, user, "oauthTestClientCredentials",
+				companyId, user, "oauthTestClientCredentials",
 				Collections.singletonList(GrantType.CLIENT_CREDENTIALS),
 				Collections.singletonList("everything.read"));
 
 			OAuth2Application oAuth2Application = createOAuth2Application(
-				defaultCompanyId, user, "oauthTestApplication",
+				companyId, user, "oauthTestApplication",
 				Collections.singletonList(
 					"Liferay.Captcha.REST.everything.read"));
 


### PR DESCRIPTION
Add new tests for this story [LPD-51524](https://liferay.atlassian.net/browse/LPD-51524)  including the [LPD-41009](https://liferay.atlassian.net/browse/LPD-41009)
