### PR TITLE
LPD-54453 - notification of password change should only send if user is already approved

### DIFF
--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
@@ -1424,11 +1424,19 @@ public class UserLocalServiceTest {
 			Assert.assertEquals(
 				WorkflowConstants.STATUS_APPROVED, user.getStatus());
 
+			ServiceContextThreadLocal.pushServiceContext(
+				ServiceContextTestUtil.getServiceContext(
+					user.getGroupId(), user.getUserId()));
+
+			_userLocalService.updatePassword(
+				user.getUserId(), "newpassword", "newpassword", false);
+
 			Assert.assertTrue(
 				MailServiceTestUtil.lastMailMessageContains(
-					"You recently created an account"));
+					"The request for a new password"));
 		}
 		finally {
+			ServiceContextThreadLocal.popServiceContext();
 			_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
 				workflowDefinitionLink);
 		}

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
@@ -37,7 +37,6 @@ import com.liferay.portal.kernel.model.TicketConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserConstants;
 import com.liferay.portal.kernel.model.UserGroup;
-import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.security.auth.Authenticator;
@@ -1372,11 +1371,10 @@ public class UserLocalServiceTest {
 	public void testUpdatePasswordNotificationUserNotApproved()
 		throws Exception {
 
-		WorkflowDefinitionLink workflowDefinitionLink =
-			_workflowDefinitionLinkLocalService.addWorkflowDefinitionLink(
-				TestPropsValues.getUserId(), TestPropsValues.getCompanyId(),
-				GroupConstants.DEFAULT_LIVE_GROUP_ID, User.class.getName(), 0,
-				0, "Single Approver", 1);
+		_workflowDefinitionLinkLocalService.addWorkflowDefinitionLink(
+			TestPropsValues.getUserId(), TestPropsValues.getCompanyId(),
+			GroupConstants.DEFAULT_LIVE_GROUP_ID, User.class.getName(), 0, 0,
+			"Single Approver", 1);
 
 		try {
 			User user = _userLocalService.addUserWithWorkflow(
@@ -1437,8 +1435,6 @@ public class UserLocalServiceTest {
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();
-			_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
-				workflowDefinitionLink);
 		}
 	}
 

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
@@ -10,7 +10,6 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.CharPool;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.audit.AuditMessage;
 import com.liferay.portal.kernel.bean.ClassLoaderBeanHandler;
@@ -1398,13 +1397,9 @@ public class UserLocalServiceTest {
 			_userLocalService.updatePassword(
 				user.getUserId(), "test2", "test2", false);
 
-			String updatePasswordMessage = StringBundler.concat(
-				"Dear " + user.getFirstName() + StringPool.SPACE +
-					user.getLastName() + StringPool.COMMA);
-
 			Assert.assertFalse(
 				MailServiceTestUtil.lastMailMessageContains(
-					updatePasswordMessage));
+					"The request for a new password"));
 
 			for (WorkflowTask workflowTask :
 					_workflowTaskManager.getWorkflowTasks(

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
@@ -1376,56 +1376,56 @@ public class UserLocalServiceTest {
 			GroupConstants.DEFAULT_LIVE_GROUP_ID, User.class.getName(), 0, 0,
 			"Single Approver", 1);
 
+		User user = _userLocalService.addUserWithWorkflow(
+			0, TestPropsValues.getCompanyId(), false, "test", "test", false,
+			RandomTestUtil.randomString(),
+			RandomTestUtil.randomString() + "@liferay.com", LocaleUtil.US,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), 0, 0, true, 1, 1, 1970,
+			StringPool.BLANK, UserConstants.TYPE_REGULAR, null, null, null,
+			null, true,
+			ServiceContextTestUtil.getServiceContext(
+				TestPropsValues.getCompanyId(), TestPropsValues.getGroupId(),
+				TestPropsValues.getUserId()));
+
+		Assert.assertNotEquals(
+			WorkflowConstants.STATUS_APPROVED, user.getStatus());
+
+		_userLocalService.updatePassword(
+			user.getUserId(), "test2", "test2", false);
+
+		Assert.assertFalse(
+			MailServiceTestUtil.lastMailMessageContains(
+				"The request for a new password"));
+
+		for (WorkflowTask workflowTask :
+				_workflowTaskManager.getWorkflowTasks(
+					TestPropsValues.getCompanyId(), false, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			workflowTask = _workflowTaskManager.assignWorkflowTaskToUser(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				workflowTask.getWorkflowTaskId(), TestPropsValues.getUserId(),
+				StringPool.BLANK, null, null);
+
+			workflowTask = _workflowTaskManager.completeWorkflowTask(
+				user.getCompanyId(), TestPropsValues.getUserId(),
+				workflowTask.getWorkflowTaskId(), Constants.APPROVE,
+				StringPool.BLANK, null);
+
+			Assert.assertTrue(workflowTask.isCompleted());
+		}
+
+		user = _userLocalService.getUser(user.getUserId());
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_APPROVED, user.getStatus());
+
+		ServiceContextThreadLocal.pushServiceContext(
+			ServiceContextTestUtil.getServiceContext(
+				user.getGroupId(), user.getUserId()));
+
 		try {
-			User user = _userLocalService.addUserWithWorkflow(
-				0, TestPropsValues.getCompanyId(), false, "test", "test", false,
-				RandomTestUtil.randomString(),
-				RandomTestUtil.randomString() + "@liferay.com", LocaleUtil.US,
-				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				RandomTestUtil.randomString(), 0, 0, true, 1, 1, 1970,
-				StringPool.BLANK, UserConstants.TYPE_REGULAR, null, null, null,
-				null, true,
-				ServiceContextTestUtil.getServiceContext(
-					TestPropsValues.getCompanyId(),
-					TestPropsValues.getGroupId(), TestPropsValues.getUserId()));
-
-			Assert.assertNotEquals(
-				WorkflowConstants.STATUS_APPROVED, user.getStatus());
-
-			_userLocalService.updatePassword(
-				user.getUserId(), "test2", "test2", false);
-
-			Assert.assertFalse(
-				MailServiceTestUtil.lastMailMessageContains(
-					"The request for a new password"));
-
-			for (WorkflowTask workflowTask :
-					_workflowTaskManager.getWorkflowTasks(
-						TestPropsValues.getCompanyId(), false,
-						QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
-
-				workflowTask = _workflowTaskManager.assignWorkflowTaskToUser(
-					TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-					workflowTask.getWorkflowTaskId(),
-					TestPropsValues.getUserId(), StringPool.BLANK, null, null);
-
-				workflowTask = _workflowTaskManager.completeWorkflowTask(
-					user.getCompanyId(), TestPropsValues.getUserId(),
-					workflowTask.getWorkflowTaskId(), Constants.APPROVE,
-					StringPool.BLANK, null);
-
-				Assert.assertTrue(workflowTask.isCompleted());
-			}
-
-			user = _userLocalService.getUser(user.getUserId());
-
-			Assert.assertEquals(
-				WorkflowConstants.STATUS_APPROVED, user.getStatus());
-
-			ServiceContextThreadLocal.pushServiceContext(
-				ServiceContextTestUtil.getServiceContext(
-					user.getGroupId(), user.getUserId()));
-
 			_userLocalService.updatePassword(
 				user.getUserId(), "newpassword", "newpassword", false);
 

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
@@ -10,6 +10,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.audit.AuditMessage;
 import com.liferay.portal.kernel.bean.ClassLoaderBeanHandler;
@@ -26,6 +27,7 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.PasswordPolicy;
 import com.liferay.portal.kernel.model.Role;
@@ -36,6 +38,7 @@ import com.liferay.portal.kernel.model.TicketConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserConstants;
 import com.liferay.portal.kernel.model.UserGroup;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.security.auth.Authenticator;
@@ -58,6 +61,7 @@ import com.liferay.portal.kernel.service.TicketLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
@@ -78,6 +82,7 @@ import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
@@ -90,16 +95,20 @@ import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.comparator.UserLastLoginDateComparator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowTask;
+import com.liferay.portal.kernel.workflow.WorkflowTaskManager;
 import com.liferay.portal.model.impl.UserImpl;
 import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
 import com.liferay.portal.security.ldap.test.util.configuration.LDAPAuthConfigurationProviderTemporarySwapper;
 import com.liferay.portal.service.impl.UserLocalServiceImpl;
 import com.liferay.portal.spring.aop.AopInvocationHandler;
+import com.liferay.portal.test.mail.MailServiceTestUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.test.rule.SynchronousMailTestRule;
 import com.liferay.portal.util.DigesterImpl;
 
 import java.sql.Connection;
@@ -139,7 +148,8 @@ public class UserLocalServiceTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new AggregateTestRule(
 			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE);
+			PermissionCheckerMethodTestRule.INSTANCE,
+			SynchronousMailTestRule.INSTANCE);
 
 	@BeforeClass
 	public static void setUpClass() throws Exception {
@@ -1360,6 +1370,76 @@ public class UserLocalServiceTest {
 	}
 
 	@Test
+	public void testUpdatePasswordNotificationUserNotApproved()
+		throws Exception {
+
+		WorkflowDefinitionLink workflowDefinitionLink =
+			_workflowDefinitionLinkLocalService.addWorkflowDefinitionLink(
+				TestPropsValues.getUserId(), TestPropsValues.getCompanyId(),
+				GroupConstants.DEFAULT_LIVE_GROUP_ID, User.class.getName(), 0,
+				0, "Single Approver", 1);
+
+		try {
+			User user = _userLocalService.addUserWithWorkflow(
+				0, TestPropsValues.getCompanyId(), false, "test", "test", false,
+				RandomTestUtil.randomString(),
+				RandomTestUtil.randomString() + "@liferay.com", LocaleUtil.US,
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), 0, 0, true, 1, 1, 1970,
+				StringPool.BLANK, UserConstants.TYPE_REGULAR, null, null, null,
+				null, true,
+				ServiceContextTestUtil.getServiceContext(
+					TestPropsValues.getCompanyId(),
+					TestPropsValues.getGroupId(), TestPropsValues.getUserId()));
+
+			Assert.assertNotEquals(
+				WorkflowConstants.STATUS_APPROVED, user.getStatus());
+
+			_userLocalService.updatePassword(
+				user.getUserId(), "test2", "test2", false);
+
+			String updatePasswordMessage = StringBundler.concat(
+				"Dear " + user.getFirstName() + StringPool.SPACE +
+					user.getLastName() + StringPool.COMMA);
+
+			Assert.assertFalse(
+				MailServiceTestUtil.lastMailMessageContains(
+					updatePasswordMessage));
+
+			for (WorkflowTask workflowTask :
+					_workflowTaskManager.getWorkflowTasks(
+						TestPropsValues.getCompanyId(), false,
+						QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
+
+				workflowTask = _workflowTaskManager.assignWorkflowTaskToUser(
+					TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+					workflowTask.getWorkflowTaskId(),
+					TestPropsValues.getUserId(), StringPool.BLANK, null, null);
+
+				workflowTask = _workflowTaskManager.completeWorkflowTask(
+					user.getCompanyId(), TestPropsValues.getUserId(),
+					workflowTask.getWorkflowTaskId(), Constants.APPROVE,
+					StringPool.BLANK, null);
+
+				Assert.assertTrue(workflowTask.isCompleted());
+			}
+
+			user = _userLocalService.getUser(user.getUserId());
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_APPROVED, user.getStatus());
+
+			Assert.assertTrue(
+				MailServiceTestUtil.lastMailMessageContains(
+					"You recently created an account"));
+		}
+		finally {
+			_workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
+				workflowDefinitionLink);
+		}
+	}
+
+	@Test
 	public void testUpdatePasswordWithModifiedAlgorithm() throws Exception {
 		try (AutoCloseable autoCloseable =
 				ReflectionTestUtil.setFieldValueWithAutoCloseable(
@@ -1799,6 +1879,13 @@ public class UserLocalServiceTest {
 	@Inject
 	private UserNotificationEventLocalService
 		_userNotificationEventLocalService;
+
+	@Inject
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
+
+	@Inject
+	private WorkflowTaskManager _workflowTaskManager;
 
 	private class TestAuditMessageProcessor implements AuditMessageProcessor {
 

--- a/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
+++ b/modules/apps/user/user-test/src/testIntegration/java/com/liferay/user/service/test/UserLocalServiceTest.java
@@ -1368,7 +1368,7 @@ public class UserLocalServiceTest {
 	}
 
 	@Test
-	public void testUpdatePasswordNotificationUserNotApproved()
+	public void testUpdatePasswordDoesNotNotifyUnapprovedUser()
 		throws Exception {
 
 		_workflowDefinitionLinkLocalService.addWorkflowDefinitionLink(

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -1970,6 +1970,14 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		else if (adminEmailUserAddedEnabled && sendEmail) {
 			notifyUser(user, serviceContext);
 		}
+
+		if (user.getPasswordModified()) {
+			user.setPasswordModified(false);
+
+			sendPasswordNotification(
+				user, user.getCompanyId(), user.getPassword(), null, null,
+				null, null, null, serviceContext);
+		}
 	}
 
 	/**
@@ -5194,7 +5202,9 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 				userId, modelListenerException);
 		}
 
-		if (!silentUpdate) {
+		if (!silentUpdate &&
+			user.getStatus() == WorkflowConstants.STATUS_APPROVED) {
+
 			user.setPasswordModified(false);
 
 			sendPasswordNotification(

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -1970,14 +1970,6 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		else if (adminEmailUserAddedEnabled && sendEmail) {
 			notifyUser(user, serviceContext);
 		}
-
-		if (user.getPasswordModified()) {
-			user.setPasswordModified(false);
-
-			sendPasswordNotification(
-				user, user.getCompanyId(), user.getPassword(), null, null, null,
-				null, null, serviceContext);
-		}
 	}
 
 	/**

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -1975,8 +1975,8 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			user.setPasswordModified(false);
 
 			sendPasswordNotification(
-				user, user.getCompanyId(), user.getPassword(), null, null,
-				null, null, null, serviceContext);
+				user, user.getCompanyId(), user.getPassword(), null, null, null,
+				null, null, serviceContext);
 		}
 	}
 
@@ -5203,7 +5203,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		}
 
 		if (!silentUpdate &&
-			user.getStatus() == WorkflowConstants.STATUS_APPROVED) {
+			(user.getStatus() == WorkflowConstants.STATUS_APPROVED)) {
 
 			user.setPasswordModified(false);
 


### PR DESCRIPTION
Original Comment:

> Hi @liferay-appsec ,
> 
> https://liferay.atlassian.net/browse/LPD-54453
> 
> The Commerce/USM team was recently made aware of an issue where a password change email could be sent to a user who is not yet approved. This would mean we'd be sending an email to someone who doesn't even have access to their account yet technically which could be confusing for the user in question.
> 
> We've made this pretty straightforward change where we only send the notification if the user is approved (and user's > default to approved if workflow is not enabled, as a note), but wanted to make sure this had your team's ok since passwords are more your guy's domain. Could you guys please take a look if the solution itself looks ok to you? Specifically, would it be ok for a hotfix since the LPP ticket is a FIRE ticket.
> 
> Thanks!
>
>CC: @brianikim