### PR TITLE
LPD-55701 SimpleCaptcha won't refresh if the same CAPTCHA is also present in a modal within the same page

### DIFF
--- a/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
+++ b/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
@@ -51,9 +51,11 @@ String url = (String)request.getAttribute("liferay-captcha:captcha:url");
 
 	<aui:script>
 		function <portlet:namespace />attachEvent() {
-			var refreshCaptcha = document.getElementById(
-				'<portlet:namespace />refreshCaptcha'
-			);
+			const modal = document.querySelector('.modal-body');
+
+			var refreshCaptcha = modal
+				? modal.querySelector('#<portlet:namespace />refreshCaptcha')
+				: document.getElementById('<portlet:namespace />refreshCaptcha');
 
 			if (refreshCaptcha && !refreshCaptcha.hasEventAttached) {
 				refreshCaptcha.hasEventAttached = true;
@@ -63,9 +65,9 @@ String url = (String)request.getAttribute("liferay-captcha:captcha:url");
 						'<%= HtmlUtil.escapeJS(url) %>'
 					);
 
-					var captcha = document.getElementById(
-						'<portlet:namespace />captcha'
-					);
+					var captcha = modal
+						? modal.querySelector('#<portlet:namespace />captcha')
+						: document.getElementById('<portlet:namespace />captcha');
 
 					if (captcha) {
 						captcha.setAttribute('src', url);


### PR DESCRIPTION
Related issue: [LPD-55701](https://liferay.atlassian.net/browse/LPD-55701)

No automatic tests possible, as this case comes from a customer customization error, can't be reproduced on a clean bundle.

To manually test this, please check the steps on the LPD link.