### PR TITLE
LPD-58396 Remove Poshi tests with Priority 3 and lower from acceptance - Security

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/CAS.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/CAS.testcase
@@ -16,7 +16,7 @@ definition {
 	@description = "LPS-126600 TC-2: Validate there is no CAS option under SSO category in Instance Settings."
 	@priority = 3
 	test AssertCASNotAvailableUnderInstanceSettings {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		task ("Go to SSO under instance settings") {
 			var baseURL = PropsUtil.get("portal.url");
@@ -34,7 +34,7 @@ definition {
 	@description = "LPS-126600 TC-1: Validate there is no CAS option under SSO category in System Settings."
 	@priority = 3
 	test AssertCASNotAvailableUnderSystemSettings {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		task ("Go to SSO under system settings") {
 			var baseURL = PropsUtil.get("portal.url");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/antisamy/AntiSamy.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/antisamy/AntiSamy.testcase
@@ -33,7 +33,7 @@ definition {
 	@priority = 3
 	test AntiSamyConfigXMLShouldBeConfigurableInPortal {
 		property antisamy.enabled = "true";
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -68,7 +68,7 @@ definition {
 	@description = "LPD-25553: AntiSamy Should be disabled without exceptions"
 	@priority = 3
 	test AntiSamyShouldBeDisabledWithoutExceptions {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -109,7 +109,7 @@ definition {
 	@priority = 3
 	test ModelSpecificAntiSamyRulesShouldWorkForModel {
 		property antisamy.enabled = "true";
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -223,7 +223,7 @@ definition {
 	@description = "LPD-25553: Assert AntiSamy is correctly disabled"
 	@priority = 3
 	test ScriptInWikiPortletShouldNotBeSanitizedWhenAntiSamyIsDisabled {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/ldap/LDAP.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/ldap/LDAP.testcase
@@ -29,7 +29,7 @@ definition {
 	@priority = 3
 	test AssertLDAPCredentialsDoesNotExposeInURL {
 		property apacheds.multiple.users.enabled = "true";
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
@@ -184,7 +184,7 @@ definition {
 		property app.server.types = "tomcat";
 		property database.types = "db2,hypersonic,mariadb,mysql,oracle,postgresql,sqlserver";
 		property environment.acceptance = "false";
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/xss/XSS.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/xss/XSS.testcase
@@ -2,6 +2,7 @@
 definition {
 
 	property ci.retries.disabled = "true";
+	property portal.acceptance = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "false";

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/xss/XSS.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/xss/XSS.testcase
@@ -158,7 +158,7 @@ definition {
 	@description = "This is a use case for LPS-90727. Assert no XSS vulnerability when modifying a specific URL from the control panel."
 	@priority = 3
 	test NoXSSVulnerabilityInControlPanel {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		task ("Go to Account Settings and save p_p_auth param from the URL") {
 			var portalURL = PropsUtil.get("portal.url");
@@ -496,7 +496,7 @@ definition {
 	@description = "This is a use case for LRQA-30154. View search results."
 	@priority = 3
 	test NoXSSVulnerabilityInSearchResults {
-		property portal.acceptance = "true";
+		property portal.acceptance = "false";
 
 		var siteName = '''<script>alert(123);</script>''';
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/xss/XSS.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/xss/XSS.testcase
@@ -31,7 +31,7 @@ definition {
 	}
 
 	@description = "This is a use case for LPS-45254. View URL validate."
-	@priority = 3
+	@priority = 4
 	test MaliciousURLScriptsAreNotValidated {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
@@ -64,7 +64,7 @@ definition {
 	}
 
 	@description = "This is a use case for LRQA-7595. Validate XSS vulnerabilities."
-	@priority = 3
+	@priority = 4
 	test MaliciousURLScriptsDoNotExecute {
 		task ("Visit malicious urls and request error message") {
 			var portalURL = PropsUtil.get("portal.url");
@@ -104,7 +104,7 @@ definition {
 	}
 
 	@description = "This is a use case for LPS-92264. Assert no XSS pop up in asset publisher content."
-	@priority = 3
+	@priority = 4
 	test NoXSSVulnerabilityInAssetPublisherContent {
 		task ("Add web content") {
 			JSONWebcontent.addWebContent(
@@ -152,10 +152,8 @@ definition {
 	}
 
 	@description = "This is a use case for LPS-90727. Assert no XSS vulnerability when modifying a specific URL from the control panel."
-	@priority = 3
+	@priority = 4
 	test NoXSSVulnerabilityInControlPanel {
-		property portal.acceptance = "false";
-
 		task ("Go to Account Settings and save p_p_auth param from the URL") {
 			var portalURL = PropsUtil.get("portal.url");
 
@@ -176,7 +174,7 @@ definition {
 	}
 
 	@description = "This is a use case for LPS-83273. View forms entry with XSS."
-	@priority = 3
+	@priority = 4
 	test NoXSSVulnerabilityInForms {
 		var formDescription = '''<script>alert(222)</script>''';
 		var formName = '''<script>alert(111)</script>''';
@@ -240,7 +238,7 @@ definition {
 	}
 
 	@description = "This is a use case for LPS-72807. View google analytics ID."
-	@priority = 3
+	@priority = 4
 	test NoXSSVulnerabilityInGoogleAnalyticsID {
 		task ("Edit google analytics Id successfully") {
 			Site.openSiteSettingsAdmin(siteURLKey = "guest");
@@ -254,7 +252,7 @@ definition {
 	}
 
 	@description = "This is a use case for LPS-113685"
-	@priority = 3
+	@priority = 4
 	test NoXSSVulnerabilityInGroovyScript {
 		property test.liferay.virtual.instance = "false";
 
@@ -276,7 +274,7 @@ definition {
 	}
 
 	@description = "This is a use case for LRQA-10563. View JSONWS."
-	@priority = 3
+	@priority = 4
 	test NoXSSVulnerabilityInJSONWS {
 		task ("Access JSONWS successfully") {
 			var portalURL = PropsUtil.get("portal.url");
@@ -288,7 +286,7 @@ definition {
 	}
 
 	@description = "This is a use case for LPS-59198. View LDAP."
-	@priority = 3
+	@priority = 4
 	test NoXSSVulnerabilityInLDAP {
 		task ("Add LDAP server successfully") {
 			PortalSettings.gotoConfiguration(
@@ -312,7 +310,7 @@ definition {
 	}
 
 	@description = "This is a use case for LRQA-10563. View liferay portlet list."
-	@priority = 3
+	@priority = 4
 	test NoXSSVulnerabilityInLiferayPortletList {
 		task ("Add public page") {
 			var portalURL = PropsUtil.get("portal.url");
@@ -347,7 +345,7 @@ definition {
 	}
 
 	@description = "This is a use case for LRQA-10472. View, look and feel."
-	@priority = 3
+	@priority = 4
 	test NoXSSVulnerabilityInLookAndFeel {
 		task ("Add public page") {
 			JSONLayout.addPublicLayout(
@@ -383,7 +381,7 @@ definition {
 	}
 
 	@description = "This is a use case for LPS-123822, LPS-127611 and LPS-133261. View Matomo."
-	@priority = 3
+	@priority = 4
 	test NoXSSVulnerabilityInMatomo {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
@@ -406,7 +404,7 @@ definition {
 	}
 
 	@description = "This is a use case for LRQA-10472. View Recycle bin."
-	@priority = 3
+	@priority = 4
 	test NoXSSVulnerabilityInRecycleBin {
 		var entryTitle = '''<script>alert(123);</script>''';
 
@@ -448,7 +446,7 @@ definition {
 	}
 
 	@description = "This is a use case for LPS-48990. View roles."
-	@priority = 3
+	@priority = 4
 	test NoXSSVulnerabilityInRoles {
 		task ("Add role") {
 			Role.openRolesAdmin();
@@ -490,10 +488,8 @@ definition {
 	}
 
 	@description = "This is a use case for LRQA-30154. View search results."
-	@priority = 3
+	@priority = 4
 	test NoXSSVulnerabilityInSearchResults {
-		property portal.acceptance = "false";
-
 		var siteName = '''<script>alert(123);</script>''';
 
 		task ("Add blank CP") {
@@ -523,7 +519,7 @@ definition {
 	}
 
 	@description = "This is a use case for LPS-71236 and LPS-71307. View web content."
-	@priority = 3
+	@priority = 4
 	test NoXSSVulnerabilityInWebContent {
 		task ("Given: A Web Content is created with a script in the title") {
 			JSONWebcontent.addWebContent(

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/xss/XSS.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/xss/XSS.testcase
@@ -2,9 +2,7 @@
 definition {
 
 	property ci.retries.disabled = "true";
-	property custom.properties = "feature.flag.LPD-35013=false";
-	property osgi.modules.includes = "wiki";
-	property portal.release = "false";
+	property portal.release = "true";
 	property portal.upstream = "true";
 	property test.assert.warning.exceptions = "false";
 	property testray.main.component.name = "XSS";
@@ -17,8 +15,6 @@ definition {
 		task ("Enable dynamic and manual selection") {
 			AssetPublisherPortlet.enableDynamicAndManualSelection();
 		}
-
-		WikiPortlet.enableWiki();
 	}
 
 	tearDown {
@@ -583,49 +579,6 @@ definition {
 			LexiconEntry.changeDisplayStyle(displayStyle = "cards");
 
 			AssertAlertNotPresent();
-		}
-	}
-
-	@description = "This is a use case for LPS-45254. View wiki."
-	@priority = 3
-	test NoXSSVulnerabilityInWiki {
-		task ("Edit user information") {
-			Navigator.openURL();
-
-			UserBar.gotoDropdownItem(dropdownItem = "Account Settings");
-
-			User.editUserInformation(
-				userFirstNameEdit = '''<script>alert(123);</script>''',
-				userLastNameEdit = '''<script>alert(123);</script>''',
-				userMiddleNameEdit = '''<script>alert(123);</script>''');
-		}
-
-		task ("Add CP to main wiki node") {
-			WikiNavigator.openWikiAdmin(siteURLKey = "guest");
-
-			JSONWiki.addWikiPage(
-				groupName = "Guest",
-				wikiNodeName = "Main",
-				wikiPageContent = "Wiki Page Content",
-				wikiPageName = "Wiki Page Title");
-		}
-
-		task ("Assert correct name showed") {
-			WikiNavigator.openToWikiPage(
-				siteURLKey = "guest",
-				wikiNodeName = "Main",
-				wikiPageTitle = "Wiki Page Title");
-
-			WikiPage.viewNotPresentInPageBody(elementValue = "XSS");
-		}
-
-		task ("Assert correct HTML source text") {
-			var actualScript = '''<script>alert(123);</script>''';
-			var escapedScript = '''&lt;script&gt;alert(123);&lt;/script&gt;''';
-
-			AssertHTMLSourceTextNotPresent(value1 = ${actualScript});
-
-			AssertHTMLSourceTextPresent(value1 = ${escapedScript});
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/WikiAdmin.testcase
@@ -452,4 +452,47 @@ definition {
 			wikiPageTitle = "Wiki Page Title2");
 	}
 
+	@description = "This is a use case for LPS-45254. View wiki."
+	@priority = 4
+	test NoXSSVulnerabilityInWiki {
+		task ("Edit user information") {
+			Navigator.openURL();
+
+			UserBar.gotoDropdownItem(dropdownItem = "Account Settings");
+
+			User.editUserInformation(
+				userFirstNameEdit = '''<script>alert(123);</script>''',
+				userLastNameEdit = '''<script>alert(123);</script>''',
+				userMiddleNameEdit = '''<script>alert(123);</script>''');
+		}
+
+		task ("Add CP to main wiki node") {
+			WikiNavigator.openWikiAdmin(siteURLKey = "guest");
+
+			JSONWiki.addWikiPage(
+				groupName = "Guest",
+				wikiNodeName = "Main",
+				wikiPageContent = "Wiki Page Content",
+				wikiPageName = "Wiki Page Title");
+		}
+
+		task ("Assert correct name showed") {
+			WikiNavigator.openToWikiPage(
+				siteURLKey = "guest",
+				wikiNodeName = "Main",
+				wikiPageTitle = "Wiki Page Title");
+
+			WikiPage.viewNotPresentInPageBody(elementValue = "XSS");
+		}
+
+		task ("Assert correct HTML source text") {
+			var actualScript = '''<script>alert(123);</script>''';
+			var escapedScript = '''&lt;script&gt;alert(123);&lt;/script&gt;''';
+
+			AssertHTMLSourceTextNotPresent(value1 = ${actualScript});
+
+			AssertHTMLSourceTextPresent(value1 = ${escapedScript});
+		}
+	}
+
 }


### PR DESCRIPTION
Hi team, Release team is looking to remove Poshi tests that are marked as priority 3 or lower from running on acceptance.
If you believe any of these tests should not be removed from acceptance, please let us know so we can update the priority and keep the test running on acceptance.
Thank you!