### PR TITLE
[RELEASE BLOCKER] LPD-61148 Users who are already registered are unable to login trough OIDC after upgrade process

### DIFF
--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OIDCUserInfoProcessor.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/OIDCUserInfoProcessor.java
@@ -646,7 +646,11 @@ public class OIDCUserInfoProcessor {
 			userGroupIds.add(userGroup.getUserGroupId());
 		}
 
-		return ArrayUtil.toLongArray(userGroupIds);
+		if (userGroupIds != null) {
+			return ArrayUtil.toLongArray(userGroupIds);
+		}
+
+		return null;
 	}
 
 	private boolean _isMale(


### PR DESCRIPTION
Related issue: [LPD-61148](https://liferay.atlassian.net/browse/LPD-61148)

This fix is covered by [OpenIDConnectUpgrade#ViewClientUserInfoAfterUpgrade7413U45](https://testray.liferay.com/web/testray#/project/35392/routines/82964/build/261549195/case-result/261597087) and it should pass for it to be forwarded