### PR TITLE
LPD-48810 add preference to Login Portlet so its title show up after 73ab6be4cc12ea228c9acdad1464b5b443371cd7 was introduced

### DIFF
--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/LoginPortlet.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/LoginPortlet.java
@@ -38,6 +38,7 @@ import org.osgi.service.component.annotations.Reference;
 		"jakarta.portlet.init-param.view-template=/login.jsp",
 		"jakarta.portlet.name=" + LoginPortletKeys.LOGIN,
 		"jakarta.portlet.portlet-mode=text/html;config",
+		"jakarta.portlet.preferences=classpath:/META-INF/portlet-preferences/default-portlet-preferences.xml",
 		"jakarta.portlet.resource-bundle=content.Language",
 		"jakarta.portlet.security-role-ref=guest,power-user,user",
 		"jakarta.portlet.version=4.0"

--- a/modules/apps/login/login-web/src/main/resources/META-INF/portlet-preferences/default-portlet-preferences.xml
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/portlet-preferences/default-portlet-preferences.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+
+<portlet-preferences>
+	<preference>
+		<name>portletSetupPortletDecoratorId</name>
+		<value>borderless</value>
+	</preference>
+</portlet-preferences>


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-48810

Bringing back the Login portlet title after https://liferay.atlassian.net/browse/LPD-48216 was made

### Explanation

The fix works because if there is a `portletSetupPortletDecoratorId` portlet preference defined, the title will show up ([see](https://github.com/thiago-buarqque/liferay-portal/blob/20f62920fd5bbd8b84f0bdeaa2c9d08300e25192/portal-kernel/src/com/liferay/portal/kernel/theme/PortletDisplay.java#L465-L465))


#### Test

This is covered by [PasswordPolicies#CannotSetPasswordDuringAccountCreation](https://testray.liferay.com/#/project/35392/routines/922501/build/136340735/case-result/136343305/history?filter=%7B%22testrayRoutineIds%22%3A%5B922501%5D%7D&filterSchema=buildResultsHistory) (which is failing since the issue was introduced)