### PR TITLE
LPD-63540 RELEASE BLOCKER | LDAP System Configurations are Deleted After Upgrade Process

### DIFF
--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/ConfigurationDataCleanupPreupgradeProcessTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/data/cleanup/test/ConfigurationDataCleanupPreupgradeProcessTest.java
@@ -60,6 +60,10 @@ public class ConfigurationDataCleanupPreupgradeProcessTest
 	public void testUpgrade() throws Exception {
 		connection = DataAccess.getConnection();
 
+		_test(0, _getNonexistentCompanyId(), "companyId", "Company");
+
+		connection = DataAccess.getConnection();
+
 		_test(
 			TestPropsValues.getCompanyId(), _getNonexistentCompanyId(),
 			"companyId", "Company");

--- a/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ConfigurationDataCleanupPreupgradeProcess.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/data/cleanup/ConfigurationDataCleanupPreupgradeProcess.java
@@ -58,7 +58,7 @@ public class ConfigurationDataCleanupPreupgradeProcess
 
 				String configurationId = resultSet.getString("configurationId");
 
-				if (companyId != -1) {
+				if (companyId > 0) {
 					if (!ArrayUtil.contains(companyIds, companyId)) {
 						_deleteConfiguration(
 							configurationId, "companyId", "Company", companyId,


### PR DESCRIPTION
Related issue: [LPD-63540](https://liferay.atlassian.net/browse/LPD-63540)

when adding a system LDAP configuration, it will assign companyId=0(system) to it. Since companyID 0 is not present in the DB, it will delete it. we need to modify the current behavior to also accept companyId=0 configurations.

This should also fix LDAPUpgrade#ViewLDAPConfigurationAfterUpgrade73101

PS: this change has been reviewed by the @liferay-database-infra team.