### PR TITLE
LPD-64004 When using the OAuth 2 Bearer Token flow, Liferay is not creating an access token bearing the user's identity (ScreenName in configuration)

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayJWTBearerGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayJWTBearerGrantHandler.java
@@ -330,6 +330,17 @@ public class LiferayJWTBearerGrantHandler extends BaseAccessTokenGrantHandler {
 				userSubject.setId(subject);
 				userSubject.setLogin(user.getScreenName());
 			}
+			else if (userAuthType.equals(CompanyConstants.AUTH_TYPE_SN)) {
+				User user = userLocalService.fetchUserByScreenName(
+					companyId, subject);
+
+				if (user == null) {
+					return null;
+				}
+
+				userSubject.setId(String.valueOf(user.getUserId()));
+				userSubject.setLogin(user.getScreenName());
+			}
 
 			Map<String, String> properties = userSubject.getProperties();
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/BaseTokenEndpointTestCase.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/BaseTokenEndpointTestCase.java
@@ -84,6 +84,10 @@ public abstract class BaseTokenEndpointTestCase extends BaseClientTestCase {
 				TEST_CLIENT_ID_5,
 				new ClientPasswordClientAuthentication(
 					TEST_CLIENT_ID_5, _TEST_CLIENT_SECRET));
+			clientAuthentications.put(
+				TEST_CLIENT_ID_6,
+				new ClientPasswordClientAuthentication(
+					TEST_CLIENT_ID_6, _TEST_CLIENT_SECRET));
 
 			createOAuth2ApplicationWithClientSecretPost(
 				user.getCompanyId(), user, TEST_CLIENT_ID_1,
@@ -118,6 +122,14 @@ public abstract class BaseTokenEndpointTestCase extends BaseClientTestCase {
 					"everything", "everything.read", "everything.write"));
 			createOAuth2ApplicationWithClientSecretPost(
 				user.getCompanyId(), user, TEST_CLIENT_ID_5,
+				_TEST_CLIENT_SECRET,
+				Arrays.asList(
+					GrantType.RESOURCE_OWNER_PASSWORD, GrantType.REFRESH_TOKEN,
+					GrantType.JWT_BEARER),
+				Arrays.asList(
+					"everything", "everything.read", "everything.write"));
+			createOAuth2ApplicationWithClientSecretPost(
+				user.getCompanyId(), user, TEST_CLIENT_ID_6,
 				_TEST_CLIENT_SECRET,
 				Arrays.asList(
 					GrantType.RESOURCE_OWNER_PASSWORD, GrantType.REFRESH_TOKEN,
@@ -178,6 +190,8 @@ public abstract class BaseTokenEndpointTestCase extends BaseClientTestCase {
 	protected static final String TEST_CLIENT_ID_4 = "test_client_id_4";
 
 	protected static final String TEST_CLIENT_ID_5 = "test_client_id_5";
+
+	protected static final String TEST_CLIENT_ID_6 = "test_client_id_6";
 
 	protected static final Map<String, ClientAuthentication>
 		clientAuthentications = new HashMap<>();

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/JWTAssertAuthorizationGrantTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/JWTAssertAuthorizationGrantTest.java
@@ -72,6 +72,31 @@ public class JWTAssertAuthorizationGrantTest
 	}
 
 	@Test
+	public void testGrantWithCorrectAudience3() throws Exception {
+		User user = UserTestUtil.getAdminUser(TestPropsValues.getCompanyId());
+
+		JWTAssertionAuthorizationGrant jwtAssertionAuthorizationGrant =
+			new JWTAssertionAuthorizationGrant(
+				TEST_CLIENT_ID_6, null, user.getScreenName(),
+				getTokenWebTarget());
+
+		String accessToken = getAccessToken(
+			jwtAssertionAuthorizationGrant,
+			clientAuthentications.get(TEST_CLIENT_ID_6));
+
+		Assert.assertTrue(Validator.isNotNull(accessToken));
+
+		String[] parts = accessToken.split("\\.");
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			new String(Base64.decode(parts[1])));
+
+		Assert.assertEquals(user.getUserId(), jsonObject.getLong("sub"));
+		Assert.assertEquals(
+			user.getScreenName(), jsonObject.getString("username"));
+	}
+
+	@Test
 	public void testGrantWithWrongAudience() throws Exception {
 		User user = UserTestUtil.getAdminUser(TestPropsValues.getCompanyId());
 
@@ -133,6 +158,17 @@ public class JWTAssertAuthorizationGrantTest
 					JWTAssertionUtil.JWKS
 				).put(
 					"oauth2.in.assertion.user.auth.type", "emailAddress"
+				).build());
+			createFactoryConfiguration(
+				"com.liferay.oauth2.provider.rest.internal.configuration." +
+					"OAuth2InAssertionConfiguration",
+				HashMapDictionaryBuilder.<String, Object>put(
+					"oauth2.in.assertion.issuer", TEST_CLIENT_ID_6
+				).put(
+					"oauth2.in.assertion.signature.json.web.key.set",
+					JWTAssertionUtil.JWKS
+				).put(
+					"oauth2.in.assertion.user.auth.type", "screenName"
 				).build());
 
 			super.prepareTest();


### PR DESCRIPTION

https://liferay.atlassian.net/browse/LPD-64004
- LPD-64004 create test to unveil non-treated case
- LPD-64004 add case to retrieve user from screenName if the inout assertion is configured that way
