### PR TITLE
LPD-55409 Reset CSP configuration via GoGo Shell

### DIFF
--- a/modules/apps/portal-security/portal-security-content-security-policy-test/build.gradle
+++ b/modules/apps/portal-security/portal-security-content-security-policy-test/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-security:portal-security-content-security-policy")
+	testIntegrationImplementation project(":apps:static:osgi:osgi-util")
 	testIntegrationImplementation project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/portal-security/portal-security-content-security-policy-test/build.gradle
+++ b/modules/apps/portal-security/portal-security-content-security-policy-test/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-security:portal-security-content-security-policy")
+	testIntegrationImplementation project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/portal-security/portal-security-content-security-policy-test/src/testIntegration/java/com/liferay/portal/security/content/security/policy/test/CSPOSGiCommandsTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy-test/src/testIntegration/java/com/liferay/portal/security/content/security/policy/test/CSPOSGiCommandsTest.java
@@ -6,16 +6,19 @@
 package com.liferay.portal.security.content.security.policy.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.osgi.util.osgi.commands.OSGiCommands;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
@@ -23,14 +26,15 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import java.lang.reflect.Method;
 
+import java.util.Dictionary;
+import java.util.Map;
+
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import org.osgi.service.cm.Configuration;
 import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
@@ -45,133 +49,122 @@ public class CSPOSGiCommandsTest {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@Before
-	public void setUp() throws Exception {
-		_company = CompanyTestUtil.addCompany();
-		_group = GroupTestUtil.addGroup();
-	}
-
 	@Test
-	public void testResettingCSPConfigurationsViaGoGoShell() throws Exception {
-		_contentSecurityPolicyConfiguration =
-			_configurationAdmin.getConfiguration(
-				_CLASS_NAME, StringPool.QUESTION);
+	public void testResetContentSecurityPolicyConfiguration() throws Exception {
+		Company company = CompanyTestUtil.addCompany(false);
 
-		ConfigurationTestUtil.saveConfiguration(
-			_contentSecurityPolicyConfiguration,
+		_testResetContentSecurityPolicyConfiguration(
+			company.getCompanyId(),
 			HashMapDictionaryBuilder.<String, Object>put(
-				"enabled", false
-			).put(
-				"excludedPaths", "/api"
-			).put(
-				"policy", "script-src 'unsafe-inline';"
-			).build());
+				"companyId", company.getCompanyId()
+			).build(),
+			ExtendedObjectClassDefinition.Scope.COMPANY);
 
-		_resetSystemConfiguration();
+		Group group = GroupTestUtil.addGroup();
 
-		_assertConfigurationIsDeleted(
-			ExtendedObjectClassDefinition.Scope.SYSTEM, 0L, false);
+		_testResetContentSecurityPolicyConfiguration(
+			group.getGroupId(),
+			HashMapDictionaryBuilder.<String, Object>put(
+				"groupId", group.getGroupId()
+			).build(),
+			ExtendedObjectClassDefinition.Scope.GROUP);
 
-		_createScopedConfiguration("companyId", _company.getCompanyId());
-
-		_resetCompanyConfiguration(String.valueOf(_company.getCompanyId()));
-
-		_assertConfigurationIsDeleted(
-			ExtendedObjectClassDefinition.Scope.COMPANY,
-			_company.getCompanyId(), true);
-
-		_createScopedConfiguration("groupId", _group.getGroupId());
-
-		_resetGroupConfiguration(String.valueOf(_group.getGroupId()));
-
-		_assertConfigurationIsDeleted(
-			ExtendedObjectClassDefinition.Scope.GROUP, _group.getGroupId(),
-			true);
+		_testResetContentSecurityPolicyConfiguration(
+			CompanyConstants.SYSTEM, new HashMapDictionary<>(),
+			ExtendedObjectClassDefinition.Scope.SYSTEM);
 	}
 
-	private void _assertConfigurationIsDeleted(
-			ExtendedObjectClassDefinition.Scope property, long propertyId,
-			boolean propertyFiltered)
+	private void _createConfiguration(
+			Dictionary<String, Object> properties,
+			ExtendedObjectClassDefinition.Scope scope)
 		throws Exception {
 
-		String filterString;
+		properties = HashMapDictionaryBuilder.<String, Object>putAll(
+			properties
+		).put(
+			"enabled", false
+		).put(
+			"excludedPaths", "/api"
+		).put(
+			"policy", "script-src 'unsafe-inline';"
+		).build();
 
-		if (propertyFiltered) {
-			filterString = StringBundler.concat(
-				"(&(service.factoryPid=", _CLASS_NAME, ".scoped)(",
-				property.getPropertyKey(), "=", propertyId, "))");
+		if (scope.equals(ExtendedObjectClassDefinition.Scope.SYSTEM)) {
+			ConfigurationTestUtil.saveConfiguration(
+				_configurationAdmin.getConfiguration(
+					_CLASS_NAME, StringPool.QUESTION),
+				properties);
+
+			return;
+		}
+
+		ConfigurationTestUtil.createFactoryConfiguration(
+			_CLASS_NAME + ".scoped", properties);
+	}
+
+	private void _resetConfiguration(
+			long id, ExtendedObjectClassDefinition.Scope scope)
+		throws Exception {
+
+		Class<?> clazz = _osgiCommands.getClass();
+
+		Method method = null;
+		Object[] arguments = null;
+
+		if (scope.equals(ExtendedObjectClassDefinition.Scope.SYSTEM)) {
+			method = clazz.getMethod(_functionNames.get(scope));
 		}
 		else {
+			method = clazz.getMethod(_functionNames.get(scope), long.class);
+			arguments = new Object[] {id};
+		}
+
+		method.invoke(_osgiCommands, arguments);
+	}
+
+	private void _testResetContentSecurityPolicyConfiguration(
+			long id, Dictionary<String, Object> properties,
+			ExtendedObjectClassDefinition.Scope scope)
+		throws Exception {
+
+		_createConfiguration(properties, scope);
+
+		_resetConfiguration(id, scope);
+
+		String filterString = null;
+
+		if (scope.equals(ExtendedObjectClassDefinition.Scope.SYSTEM)) {
 			filterString = StringBundler.concat(
 				"(&(service.pid=", _CLASS_NAME, "))");
 		}
+		else {
+			filterString = StringBundler.concat(
+				"(&(service.factoryPid=", _CLASS_NAME, ".scoped)(",
+				scope.getPropertyKey(), "=", id, "))");
+		}
 
-		Configuration[] configurations = _configurationAdmin.listConfigurations(
-			filterString);
-
-		Assert.assertNull(configurations);
-	}
-
-	private void _createScopedConfiguration(String property, long propertyId)
-		throws Exception {
-
-		ConfigurationTestUtil.createFactoryConfiguration(
-			_CLASS_NAME + ".scoped",
-			HashMapDictionaryBuilder.<String, Object>put(
-				property, propertyId
-			).put(
-				"enabled", false
-			).put(
-				"excludedPaths", "/api"
-			).put(
-				"policy", "script-src 'unsafe-inline';"
-			).build());
-	}
-
-	private void _resetCompanyConfiguration(String companyId) throws Exception {
-		_runWithId("resetCompanyConfiguration", companyId);
-	}
-
-	private void _resetGroupConfiguration(String groupId) throws Exception {
-		_runWithId("resetGroupConfiguration", groupId);
-	}
-
-	private void _resetSystemConfiguration() throws Exception {
-		_run("resetSystemConfiguration");
-	}
-
-	private void _run(String functionName) throws Exception {
-		Class<?> clazz = _cspOSGiCommands.getClass();
-
-		Method method = clazz.getMethod(functionName);
-
-		method.invoke(_cspOSGiCommands);
-	}
-
-	private void _runWithId(String functionName, String id) throws Exception {
-		Class<?> clazz = _cspOSGiCommands.getClass();
-
-		Method method = clazz.getMethod(functionName, String.class);
-
-		method.invoke(_cspOSGiCommands, id);
+		Assert.assertNull(_configurationAdmin.listConfigurations(filterString));
 	}
 
 	private static final String _CLASS_NAME =
 		"com.liferay.portal.security.content.security.policy.internal." +
 			"configuration.ContentSecurityPolicyConfiguration";
 
-	@Inject(filter = "osgi.command.scope=csp", type = Inject.NoType.class)
-	private static Object _cspOSGiCommands;
-
-	@DeleteAfterTestRun
-	private Company _company;
+	@Inject(filter = "osgi.command.scope=csp")
+	private static OSGiCommands _osgiCommands;
 
 	@Inject
 	private ConfigurationAdmin _configurationAdmin;
 
-	private Configuration _contentSecurityPolicyConfiguration;
-
-	@DeleteAfterTestRun
-	private Group _group;
+	private final Map<ExtendedObjectClassDefinition.Scope, String>
+		_functionNames = HashMapBuilder.put(
+			ExtendedObjectClassDefinition.Scope.COMPANY,
+			"resetCompanyConfiguration"
+		).put(
+			ExtendedObjectClassDefinition.Scope.GROUP, "resetGroupConfiguration"
+		).put(
+			ExtendedObjectClassDefinition.Scope.SYSTEM,
+			"resetSystemConfiguration"
+		).build();
 
 }

--- a/modules/apps/portal-security/portal-security-content-security-policy-test/src/testIntegration/java/com/liferay/portal/security/content/security/policy/test/CSPOSGiCommandsTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy-test/src/testIntegration/java/com/liferay/portal/security/content/security/policy/test/CSPOSGiCommandsTest.java
@@ -1,0 +1,177 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.content.security.policy.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.lang.reflect.Method;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author Jorge García Jiménez
+ */
+@FeatureFlag("LPS-134060")
+@RunWith(Arquillian.class)
+public class CSPOSGiCommandsTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_company = CompanyTestUtil.addCompany();
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testResettingCSPConfigurationsViaGoGoShell() throws Exception {
+		_contentSecurityPolicyConfiguration =
+			_configurationAdmin.getConfiguration(
+				_CLASS_NAME, StringPool.QUESTION);
+
+		ConfigurationTestUtil.saveConfiguration(
+			_contentSecurityPolicyConfiguration,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"enabled", false
+			).put(
+				"excludedPaths", "/api"
+			).put(
+				"policy", "script-src 'unsafe-inline';"
+			).build());
+
+		_resetSystemConfiguration();
+
+		_assertConfigurationIsDeleted(
+			ExtendedObjectClassDefinition.Scope.SYSTEM, 0L, false);
+
+		_createScopedConfiguration("companyId", _company.getCompanyId());
+
+		_resetCompanyConfiguration(String.valueOf(_company.getCompanyId()));
+
+		_assertConfigurationIsDeleted(
+			ExtendedObjectClassDefinition.Scope.COMPANY,
+			_company.getCompanyId(), true);
+
+		_createScopedConfiguration("groupId", _group.getGroupId());
+
+		_resetGroupConfiguration(String.valueOf(_group.getGroupId()));
+
+		_assertConfigurationIsDeleted(
+			ExtendedObjectClassDefinition.Scope.GROUP, _group.getGroupId(),
+			true);
+	}
+
+	private void _assertConfigurationIsDeleted(
+			ExtendedObjectClassDefinition.Scope property, long propertyId,
+			boolean propertyFiltered)
+		throws Exception {
+
+		String filterString;
+
+		if (propertyFiltered) {
+			filterString = StringBundler.concat(
+				"(&(service.factoryPid=", _CLASS_NAME, ".scoped)(",
+				property.getPropertyKey(), "=", propertyId, "))");
+		}
+		else {
+			filterString = StringBundler.concat(
+				"(&(service.pid=", _CLASS_NAME, "))");
+		}
+
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			filterString);
+
+		Assert.assertNull(configurations);
+	}
+
+	private void _createScopedConfiguration(String property, long propertyId)
+		throws Exception {
+
+		ConfigurationTestUtil.createFactoryConfiguration(
+			_CLASS_NAME + ".scoped",
+			HashMapDictionaryBuilder.<String, Object>put(
+				property, propertyId
+			).put(
+				"enabled", false
+			).put(
+				"excludedPaths", "/api"
+			).put(
+				"policy", "script-src 'unsafe-inline';"
+			).build());
+	}
+
+	private void _resetCompanyConfiguration(String companyId) throws Exception {
+		_runWithId("resetCompanyConfiguration", companyId);
+	}
+
+	private void _resetGroupConfiguration(String groupId) throws Exception {
+		_runWithId("resetGroupConfiguration", groupId);
+	}
+
+	private void _resetSystemConfiguration() throws Exception {
+		_run("resetSystemConfiguration");
+	}
+
+	private void _run(String functionName) throws Exception {
+		Class<?> clazz = _cspOSGiCommands.getClass();
+
+		Method method = clazz.getMethod(functionName);
+
+		method.invoke(_cspOSGiCommands);
+	}
+
+	private void _runWithId(String functionName, String id) throws Exception {
+		Class<?> clazz = _cspOSGiCommands.getClass();
+
+		Method method = clazz.getMethod(functionName, String.class);
+
+		method.invoke(_cspOSGiCommands, id);
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.portal.security.content.security.policy.internal." +
+			"configuration.ContentSecurityPolicyConfiguration";
+
+	@Inject(filter = "osgi.command.scope=csp", type = Inject.NoType.class)
+	private static Object _cspOSGiCommands;
+
+	@DeleteAfterTestRun
+	private Company _company;
+
+	@Inject
+	private ConfigurationAdmin _configurationAdmin;
+
+	private Configuration _contentSecurityPolicyConfiguration;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+}

--- a/modules/apps/portal-security/portal-security-content-security-policy/build.gradle
+++ b/modules/apps/portal-security/portal-security-content-security-policy/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
+	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-reflect")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/osgi/commands/CSPOSGiCommands.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/osgi/commands/CSPOSGiCommands.java
@@ -1,0 +1,89 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.content.security.policy.internal.osgi.commands;
+
+import com.liferay.osgi.util.osgi.commands.OSGiCommands;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.security.content.security.policy.internal.configuration.ContentSecurityPolicyConfiguration;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jorge García Jiménez
+ */
+@Component(
+	property = {
+		"osgi.command.function=resetCompanyConfiguration",
+		"osgi.command.function=resetGroupConfiguration",
+		"osgi.command.function=resetSystemConfiguration",
+		"osgi.command.scope=csp"
+	},
+	service = OSGiCommands.class
+)
+public class CSPOSGiCommands implements OSGiCommands {
+
+	public void resetCompanyConfiguration(String companyId)
+		throws ConfigurationException {
+
+		ContentSecurityPolicyConfiguration contentSecurityPolicyConfiguration =
+			_configurationProvider.getCompanyConfiguration(
+				ContentSecurityPolicyConfiguration.class,
+				GetterUtil.getLong(companyId));
+
+		if (contentSecurityPolicyConfiguration != null) {
+			_configurationProvider.deleteCompanyConfiguration(
+				ContentSecurityPolicyConfiguration.class,
+				GetterUtil.getLong(companyId));
+		}
+	}
+
+	public void resetGroupConfiguration(String groupId)
+		throws ConfigurationException {
+
+		ContentSecurityPolicyConfiguration contentSecurityPolicyConfiguration =
+			_configurationProvider.getGroupConfiguration(
+				ContentSecurityPolicyConfiguration.class,
+				GetterUtil.getLong(groupId));
+
+		if (contentSecurityPolicyConfiguration != null) {
+			_configurationProvider.deleteGroupConfiguration(
+				ContentSecurityPolicyConfiguration.class,
+				GetterUtil.getLong(groupId));
+		}
+	}
+
+	public void resetSystemConfiguration() throws ConfigurationException {
+		ContentSecurityPolicyConfiguration contentSecurityPolicyConfiguration =
+			_configurationProvider.getSystemConfiguration(
+				ContentSecurityPolicyConfiguration.class);
+
+		if (contentSecurityPolicyConfiguration != null) {
+			_configurationProvider.deleteSystemConfiguration(
+				ContentSecurityPolicyConfiguration.class);
+		}
+	}
+
+	@Activate
+	@Modified
+	protected void activate() throws Exception {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				CompanyThreadLocal.getNonsystemCompanyId(), "LPS-134060")) {
+
+			throw new UnsupportedOperationException();
+		}
+	}
+
+	@Reference
+	private ConfigurationProvider _configurationProvider;
+
+}

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/osgi/commands/CSPOSGiCommands.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/osgi/commands/CSPOSGiCommands.java
@@ -40,11 +40,18 @@ public class CSPOSGiCommands implements OSGiCommands {
 				ContentSecurityPolicyConfiguration.class,
 				GetterUtil.getLong(companyId));
 
-		if (contentSecurityPolicyConfiguration != null) {
-			_configurationProvider.deleteCompanyConfiguration(
-				ContentSecurityPolicyConfiguration.class,
-				GetterUtil.getLong(companyId));
+		if (contentSecurityPolicyConfiguration == null) {
+			System.out.println(
+				"There is no company level " +
+					"ContentSecurityPolicyConfiguration for companyId " +
+						companyId);
+
+			return;
 		}
+
+		_configurationProvider.deleteCompanyConfiguration(
+			ContentSecurityPolicyConfiguration.class,
+			GetterUtil.getLong(companyId));
 	}
 
 	public void resetGroupConfiguration(String groupId)
@@ -55,11 +62,17 @@ public class CSPOSGiCommands implements OSGiCommands {
 				ContentSecurityPolicyConfiguration.class,
 				GetterUtil.getLong(groupId));
 
-		if (contentSecurityPolicyConfiguration != null) {
-			_configurationProvider.deleteGroupConfiguration(
-				ContentSecurityPolicyConfiguration.class,
-				GetterUtil.getLong(groupId));
+		if (contentSecurityPolicyConfiguration == null) {
+			System.out.println(
+				"There is no group level ContentSecurityPolicyConfiguration " +
+					"for groupId " + groupId);
+
+			return;
 		}
+
+		_configurationProvider.deleteGroupConfiguration(
+			ContentSecurityPolicyConfiguration.class,
+			GetterUtil.getLong(groupId));
 	}
 
 	public void resetSystemConfiguration() throws ConfigurationException {
@@ -67,10 +80,15 @@ public class CSPOSGiCommands implements OSGiCommands {
 			_configurationProvider.getSystemConfiguration(
 				ContentSecurityPolicyConfiguration.class);
 
-		if (contentSecurityPolicyConfiguration != null) {
-			_configurationProvider.deleteSystemConfiguration(
-				ContentSecurityPolicyConfiguration.class);
+		if (contentSecurityPolicyConfiguration == null) {
+			System.out.println(
+				"There is no system level ContentSecurityPolicyConfiguration");
+
+			return;
 		}
+
+		_configurationProvider.deleteSystemConfiguration(
+			ContentSecurityPolicyConfiguration.class);
 	}
 
 	@Activate

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/osgi/commands/CSPOSGiCommands.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/osgi/commands/CSPOSGiCommands.java
@@ -10,7 +10,6 @@ import com.liferay.portal.configuration.module.configuration.ConfigurationProvid
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.security.content.security.policy.internal.configuration.ContentSecurityPolicyConfiguration;
 
 import org.osgi.service.component.annotations.Activate;
@@ -32,13 +31,12 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class CSPOSGiCommands implements OSGiCommands {
 
-	public void resetCompanyConfiguration(String companyId)
+	public void resetCompanyConfiguration(long companyId)
 		throws ConfigurationException {
 
 		ContentSecurityPolicyConfiguration contentSecurityPolicyConfiguration =
 			_configurationProvider.getCompanyConfiguration(
-				ContentSecurityPolicyConfiguration.class,
-				GetterUtil.getLong(companyId));
+				ContentSecurityPolicyConfiguration.class, companyId);
 
 		if (contentSecurityPolicyConfiguration == null) {
 			System.out.println(
@@ -50,17 +48,15 @@ public class CSPOSGiCommands implements OSGiCommands {
 		}
 
 		_configurationProvider.deleteCompanyConfiguration(
-			ContentSecurityPolicyConfiguration.class,
-			GetterUtil.getLong(companyId));
+			ContentSecurityPolicyConfiguration.class, companyId);
 	}
 
-	public void resetGroupConfiguration(String groupId)
+	public void resetGroupConfiguration(long groupId)
 		throws ConfigurationException {
 
 		ContentSecurityPolicyConfiguration contentSecurityPolicyConfiguration =
 			_configurationProvider.getGroupConfiguration(
-				ContentSecurityPolicyConfiguration.class,
-				GetterUtil.getLong(groupId));
+				ContentSecurityPolicyConfiguration.class, groupId);
 
 		if (contentSecurityPolicyConfiguration == null) {
 			System.out.println(
@@ -71,8 +67,7 @@ public class CSPOSGiCommands implements OSGiCommands {
 		}
 
 		_configurationProvider.deleteGroupConfiguration(
-			ContentSecurityPolicyConfiguration.class,
-			GetterUtil.getLong(groupId));
+			ContentSecurityPolicyConfiguration.class, groupId);
 	}
 
 	public void resetSystemConfiguration() throws ConfigurationException {


### PR DESCRIPTION
story: https://liferay.atlassian.net/browse/LPD-55409
Three new GoGo Shell commands are created to reset csp configurations that could be faulty and prevent dxp from working, e.g. when using an unsupported content-security-policy.
