### PR TITLE
LPD-61657 Enable download permissions for attachment fields

### DIFF
--- a/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
+++ b/modules/apps/batch-planner/batch-planner-test/src/testIntegration/java/com/liferay/batch/planner/batch/engine/broker/test/BatchEngineBrokerTest.java
@@ -795,8 +795,8 @@ public class BatchEngineBrokerTest {
 		String template = StreamUtil.toString(_getInputStream(templateName));
 
 		Link link = LinkUtil.toLink(
-			_dlAppService, dlFileEntry, _dlURLHelper, groupId,
-			objectDefinitionERC, objectEntryERC, _portal);
+			_dlAppService, dlFileEntry, _dlURLHelper, groupId, true,
+			objectDefinitionERC, objectEntryERC, null, _portal);
 
 		template = StringUtil.replace(
 			template,
@@ -925,8 +925,8 @@ public class BatchEngineBrokerTest {
 
 		Link link = LinkUtil.toLink(
 			_dlAppService, dlFileEntry, _dlURLHelper,
-			GetterUtil.getLong(groupId), objectDefinitionERC, objectEntryERC,
-			_portal);
+			GetterUtil.getLong(groupId), true, objectDefinitionERC,
+			objectEntryERC, null, _portal);
 
 		String scopeKey = null;
 
@@ -1175,7 +1175,7 @@ public class BatchEngineBrokerTest {
 
 		ObjectDefinition objectDefinition =
 			_objectDefinitionLocalService.addCustomObjectDefinition(
-				user.getUserId(), 0, null, false, true, false, true, false,
+				user.getUserId(), 0, null, false, true, false, true, true,
 				false, false, false, false, null,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				name, null, null,

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java
@@ -175,7 +175,7 @@ public class SharedAssetDTOConverter
 
 	private FileEntry _getFileEntry(
 		ObjectDefinition objectDefinition, ObjectEntry objectEntry,
-		long fileEntryId) {
+		long fileEntryId, String objectFieldName) {
 
 		FileEntry fileEntry = new FileEntry();
 
@@ -196,7 +196,8 @@ public class SharedAssetDTOConverter
 					_dlAppService, dlFileEntry, _dlURLHelper,
 					objectEntry.getGroupId(),
 					objectDefinition.getExternalReferenceCode(),
-					objectEntry.getExternalReferenceCode(), _portal)));
+					objectEntry.getExternalReferenceCode(), _portal,
+					objectFieldName)));
 		fileEntry.setName(dlFileEntry::getFileName);
 		fileEntry.setThumbnailURL(
 			() -> {
@@ -260,7 +261,7 @@ public class SharedAssetDTOConverter
 				if (serializable instanceof Long) {
 					return _getFileEntry(
 						objectDefinition, objectEntry,
-						GetterUtil.getLong(serializable));
+						GetterUtil.getLong(serializable), objectFieldName);
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/dto/v1_0/converter/SharedAssetDTOConverter.java
@@ -23,12 +23,17 @@ import com.liferay.object.model.ObjectField;
 import com.liferay.object.rest.dto.v1_0.util.LinkUtil;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.service.ObjectEntryService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -195,9 +200,12 @@ public class SharedAssetDTOConverter
 				LinkUtil.toLink(
 					_dlAppService, dlFileEntry, _dlURLHelper,
 					objectEntry.getGroupId(),
+					_hasDownloadPermission(
+						fileEntryId, objectDefinition, objectEntry,
+						objectFieldName),
 					objectDefinition.getExternalReferenceCode(),
-					objectEntry.getExternalReferenceCode(), _portal,
-					objectFieldName)));
+					objectEntry.getExternalReferenceCode(), objectFieldName,
+					_portal)));
 		fileEntry.setName(dlFileEntry::getFileName);
 		fileEntry.setThumbnailURL(
 			() -> {
@@ -341,6 +349,36 @@ public class SharedAssetDTOConverter
 		return fileEntry.getMimeType();
 	}
 
+	private boolean _hasDownloadPermission(
+			long fileEntryId, ObjectDefinition objectDefinition,
+			ObjectEntry objectEntry, String objectFieldName)
+		throws PortalException {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				objectDefinition.getCompanyId(), "LPD-17564")) {
+
+			return true;
+		}
+
+		PermissionChecker permissionChecker =
+			GuestOrUserUtil.getPermissionChecker();
+
+		if (permissionChecker.hasPermission(
+				objectEntry.getGroupId(), DLFileEntry.class.getName(),
+				fileEntryId, ActionKeys.DOWNLOAD) &&
+			_objectEntryService.hasModelResourcePermission(
+				objectDefinition.getObjectDefinitionId(),
+				objectEntry.getObjectEntryId(),
+				ObjectFieldConstants.
+					ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX +
+						objectFieldName)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		SharedAssetDTOConverter.class);
 
@@ -367,6 +405,9 @@ public class SharedAssetDTOConverter
 
 	@Reference
 	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private ObjectEntryService _objectEntryService;
 
 	@Reference
 	private ObjectFieldLocalService _objectFieldLocalService;

--- a/modules/apps/object/object-api/build.gradle
+++ b/modules/apps/object/object-api/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	compileOnly project(":apps:frontend-data-set:frontend-data-set-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:list-type:list-type-api")
+	compileOnly project(":apps:portal-language:portal-language-override-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:static:osgi:osgi-util")

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectFieldConstants.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/constants/ObjectFieldConstants.java
@@ -10,6 +10,9 @@ package com.liferay.object.constants;
  */
 public class ObjectFieldConstants {
 
+	public static final String ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX =
+		"download_";
+
 	public static final String BUSINESS_TYPE_AGGREGATION = "Aggregation";
 
 	public static final String BUSINESS_TYPE_ASSIGNEE = "Assignee";

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
@@ -137,7 +137,8 @@ public class ObjectDefinitionResourcePermissionUtil {
 
 		for (ObjectField objectField : attachmentObjectFields) {
 			objectFieldPermissionKeys = StringBundler.concat(
-				objectFieldPermissionKeys, "<action-key>objectField.",
+				objectFieldPermissionKeys, "<action-key>",
+				ObjectFieldConstants.ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX,
 				objectField.getName(), "</action-key>");
 		}
 

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
@@ -18,16 +18,21 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
+import com.liferay.portal.language.override.service.PLOEntryLocalService;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -37,18 +42,20 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ObjectDefinitionResourcePermissionUtil {
 
 	public static void populateResourceActions(
-			List<ObjectField> attachmentObjectFields,
+			List<ObjectField> attachmentObjectFields, Language language,
 			ObjectActionLocalService objectActionLocalService,
 			ObjectDefinition objectDefinition,
 			ObjectFieldLocalService objectFieldLocalService,
+			PLOEntryLocalService ploEntryLocalService,
 			PortletLocalService portletLocalService,
 			ResourceActions resourceActions,
 			List<ObjectAction> standaloneObjectActions)
 		throws Exception {
 
 		Document document = _readDocument(
-			attachmentObjectFields, objectActionLocalService, objectDefinition,
-			objectFieldLocalService, standaloneObjectActions);
+			attachmentObjectFields, language, objectActionLocalService,
+			objectDefinition, objectFieldLocalService, ploEntryLocalService,
+			standaloneObjectActions);
 
 		try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
 				objectDefinition.getCompanyId())) {
@@ -84,13 +91,38 @@ public class ObjectDefinitionResourcePermissionUtil {
 
 		if (document == null) {
 			document = _readDocument(
-				null, objectActionLocalService, objectDefinition,
-				objectFieldLocalService, null);
+				null, null, objectActionLocalService, objectDefinition,
+				objectFieldLocalService, null, null);
 		}
 
 		resourceActions.removeModelResources(document);
 
 		resourceActions.removePortletResources(document);
+	}
+
+	private static void _addOrUpdateObjectFieldResourceActionPLOEntries(
+			Language language, ObjectField objectField,
+			PLOEntryLocalService ploEntryLocalService)
+		throws Exception {
+
+		if ((language == null) || (ploEntryLocalService == null)) {
+			return;
+		}
+
+		for (Locale locale : language.getAvailableLocales()) {
+			String languageId = LocaleUtil.toLanguageId(locale);
+
+			ploEntryLocalService.addOrUpdatePLOEntry(
+				objectField.getCompanyId(), objectField.getUserId(),
+				StringBundler.concat(
+					"action.",
+					ObjectFieldConstants.
+						ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX,
+					objectField.getName()),
+				languageId,
+				LanguageUtil.format(
+					locale, "download-x", objectField.getLabel(locale)));
+		}
 	}
 
 	private static String _getObjectActionPermissionKeys(
@@ -119,8 +151,11 @@ public class ObjectDefinitionResourcePermissionUtil {
 	}
 
 	private static String _getObjectFieldPermissionKeys(
-		List<ObjectField> attachmentObjectFields, long objectDefinitionId,
-		ObjectFieldLocalService objectFieldLocalService) {
+			List<ObjectField> attachmentObjectFields, Language language,
+			long objectDefinitionId,
+			ObjectFieldLocalService objectFieldLocalService,
+			PLOEntryLocalService ploEntryLocalService)
+		throws Exception {
 
 		if (attachmentObjectFields == null) {
 			if (objectFieldLocalService == null) {
@@ -136,6 +171,9 @@ public class ObjectDefinitionResourcePermissionUtil {
 		String objectFieldPermissionKeys = StringPool.BLANK;
 
 		for (ObjectField objectField : attachmentObjectFields) {
+			_addOrUpdateObjectFieldResourceActionPLOEntries(
+				language, objectField, ploEntryLocalService);
+
 			objectFieldPermissionKeys = StringBundler.concat(
 				objectFieldPermissionKeys, "<action-key>",
 				ObjectFieldConstants.ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX,
@@ -186,10 +224,11 @@ public class ObjectDefinitionResourcePermissionUtil {
 	}
 
 	private static Document _readDocument(
-			List<ObjectField> attachmentObjectFields,
+			List<ObjectField> attachmentObjectFields, Language language,
 			ObjectActionLocalService objectActionLocalService,
 			ObjectDefinition objectDefinition,
 			ObjectFieldLocalService objectFieldLocalService,
+			PLOEntryLocalService ploEntryLocalService,
 			List<ObjectAction> standaloneObjectActions)
 		throws Exception {
 
@@ -198,8 +237,9 @@ public class ObjectDefinitionResourcePermissionUtil {
 			standaloneObjectActions);
 
 		String objectFieldPermissionKeys = _getObjectFieldPermissionKeys(
-			attachmentObjectFields, objectDefinition.getObjectDefinitionId(),
-			objectFieldLocalService);
+			attachmentObjectFields, language,
+			objectDefinition.getObjectDefinitionId(), objectFieldLocalService,
+			ploEntryLocalService);
 
 		String resourceActionsFileName =
 			"resource-actions/resource-actions.xml.tpl";

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
@@ -236,10 +236,16 @@ public class ObjectDefinitionResourcePermissionUtil {
 			objectActionLocalService, objectDefinition.getObjectDefinitionId(),
 			standaloneObjectActions);
 
-		String objectFieldPermissionKeys = _getObjectFieldPermissionKeys(
-			attachmentObjectFields, language,
-			objectDefinition.getObjectDefinitionId(), objectFieldLocalService,
-			ploEntryLocalService);
+		String objectFieldPermissionKeys = StringPool.BLANK;
+
+		if (FeatureFlagManagerUtil.isEnabled(
+				objectDefinition.getCompanyId(), "LPD-17564")) {
+
+			objectFieldPermissionKeys = _getObjectFieldPermissionKeys(
+				attachmentObjectFields, language,
+				objectDefinition.getObjectDefinitionId(),
+				objectFieldLocalService, ploEntryLocalService);
+		}
 
 		String resourceActionsFileName =
 			"resource-actions/resource-actions.xml.tpl";

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/definition/security/permission/resource/util/ObjectDefinitionResourcePermissionUtil.java
@@ -8,9 +8,12 @@ package com.liferay.object.definition.security.permission.resource.util;
 import com.liferay.object.constants.ObjectActionKeys;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.service.ObjectActionLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -34,16 +37,18 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ObjectDefinitionResourcePermissionUtil {
 
 	public static void populateResourceActions(
+			List<ObjectField> attachmentObjectFields,
 			ObjectActionLocalService objectActionLocalService,
 			ObjectDefinition objectDefinition,
+			ObjectFieldLocalService objectFieldLocalService,
 			PortletLocalService portletLocalService,
 			ResourceActions resourceActions,
 			List<ObjectAction> standaloneObjectActions)
 		throws Exception {
 
 		Document document = _readDocument(
-			objectActionLocalService, objectDefinition,
-			standaloneObjectActions);
+			attachmentObjectFields, objectActionLocalService, objectDefinition,
+			objectFieldLocalService, standaloneObjectActions);
 
 		try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
 				objectDefinition.getCompanyId())) {
@@ -69,7 +74,9 @@ public class ObjectDefinitionResourcePermissionUtil {
 
 	public static void removeResourceActions(
 			ObjectActionLocalService objectActionLocalService,
-			ObjectDefinition objectDefinition, ResourceActions resourceActions)
+			ObjectDefinition objectDefinition,
+			ObjectFieldLocalService objectFieldLocalService,
+			ResourceActions resourceActions)
 		throws Exception {
 
 		Document document = _objectDefinitionResourceActionDocumentsMap.remove(
@@ -77,7 +84,8 @@ public class ObjectDefinitionResourcePermissionUtil {
 
 		if (document == null) {
 			document = _readDocument(
-				objectActionLocalService, objectDefinition, null);
+				null, objectActionLocalService, objectDefinition,
+				objectFieldLocalService, null);
 		}
 
 		resourceActions.removeModelResources(document);
@@ -89,13 +97,17 @@ public class ObjectDefinitionResourcePermissionUtil {
 		ObjectActionLocalService objectActionLocalService,
 		long objectDefinitionId, List<ObjectAction> standaloneObjectActions) {
 
-		String objectActionPermissionKeys = StringPool.BLANK;
-
 		if (standaloneObjectActions == null) {
+			if (objectActionLocalService == null) {
+				return null;
+			}
+
 			standaloneObjectActions = objectActionLocalService.getObjectActions(
 				objectDefinitionId,
 				ObjectActionTriggerConstants.KEY_STANDALONE);
 		}
+
+		String objectActionPermissionKeys = StringPool.BLANK;
 
 		for (ObjectAction objectAction : standaloneObjectActions) {
 			objectActionPermissionKeys = StringBundler.concat(
@@ -104,6 +116,32 @@ public class ObjectDefinitionResourcePermissionUtil {
 		}
 
 		return objectActionPermissionKeys;
+	}
+
+	private static String _getObjectFieldPermissionKeys(
+		List<ObjectField> attachmentObjectFields, long objectDefinitionId,
+		ObjectFieldLocalService objectFieldLocalService) {
+
+		if (attachmentObjectFields == null) {
+			if (objectFieldLocalService == null) {
+				return null;
+			}
+
+			attachmentObjectFields =
+				objectFieldLocalService.getObjectFieldsByBusinessType(
+					objectDefinitionId,
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT);
+		}
+
+		String objectFieldPermissionKeys = StringPool.BLANK;
+
+		for (ObjectField objectField : attachmentObjectFields) {
+			objectFieldPermissionKeys = StringBundler.concat(
+				objectFieldPermissionKeys, "<action-key>objectField.",
+				objectField.getName(), "</action-key>");
+		}
+
+		return objectFieldPermissionKeys;
 	}
 
 	private static String _getPermissionsGuestUnsupported(
@@ -147,14 +185,20 @@ public class ObjectDefinitionResourcePermissionUtil {
 	}
 
 	private static Document _readDocument(
+			List<ObjectField> attachmentObjectFields,
 			ObjectActionLocalService objectActionLocalService,
 			ObjectDefinition objectDefinition,
+			ObjectFieldLocalService objectFieldLocalService,
 			List<ObjectAction> standaloneObjectActions)
 		throws Exception {
 
 		String objectActionPermissionKeys = _getObjectActionPermissionKeys(
 			objectActionLocalService, objectDefinition.getObjectDefinitionId(),
 			standaloneObjectActions);
+
+		String objectFieldPermissionKeys = _getObjectFieldPermissionKeys(
+			attachmentObjectFields, objectDefinition.getObjectDefinitionId(),
+			objectFieldLocalService);
 
 		String resourceActionsFileName =
 			"resource-actions/resource-actions.xml.tpl";
@@ -184,7 +228,7 @@ public class ObjectDefinitionResourcePermissionUtil {
 					_getPermissionsGuestUnsupported(objectDefinition) +
 						objectActionPermissionKeys,
 					_getPermissionsSupports(objectDefinition) +
-						objectActionPermissionKeys,
+						objectActionPermissionKeys + objectFieldPermissionKeys,
 					objectDefinition.getPortletId(),
 					objectDefinition.getResourceName()
 				}));

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
@@ -25,6 +25,7 @@ import com.liferay.object.service.ObjectFieldLocalServiceUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -213,7 +214,10 @@ public class ObjectFieldUtil {
 			downloadURL, "objectEntryExternalReferenceCode",
 			objectEntryExternalReferenceCode);
 
-		if (Validator.isNotNull(objectFieldName)) {
+		if (Validator.isNotNull(objectFieldName) &&
+			FeatureFlagManagerUtil.isEnabled(
+				fileEntry.getCompanyId(), "LPD-17564")) {
+
 			downloadURL = HttpComponentsUtil.addParameter(
 				downloadURL, "objectFieldActionId",
 				ObjectFieldConstants.

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
@@ -216,7 +216,9 @@ public class ObjectFieldUtil {
 		if (Validator.isNotNull(objectFieldName)) {
 			downloadURL = HttpComponentsUtil.addParameter(
 				downloadURL, "objectFieldActionId",
-				"objectField." + objectFieldName);
+				ObjectFieldConstants.
+					ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX +
+						objectFieldName);
 		}
 
 		return downloadURL;

--- a/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
+++ b/modules/apps/object/object-api/src/main/java/com/liferay/object/field/util/ObjectFieldUtil.java
@@ -186,7 +186,8 @@ public class ObjectFieldUtil {
 	public static String getAttachmentDownloadURL(
 			DLURLHelper dlURLHelper, FileEntry fileEntry, long groupId,
 			String objectDefinitionExternalReferenceCode,
-			String objectEntryExternalReferenceCode, ThemeDisplay themeDisplay)
+			String objectEntryExternalReferenceCode, ThemeDisplay themeDisplay,
+			String objectFieldName)
 		throws PortalException {
 
 		String downloadURL = dlURLHelper.getDownloadURL(
@@ -211,6 +212,12 @@ public class ObjectFieldUtil {
 		downloadURL = HttpComponentsUtil.addParameter(
 			downloadURL, "objectEntryExternalReferenceCode",
 			objectEntryExternalReferenceCode);
+
+		if (Validator.isNotNull(objectFieldName)) {
+			downloadURL = HttpComponentsUtil.addParameter(
+				downloadURL, "objectFieldActionId",
+				"objectField." + objectFieldName);
+		}
 
 		return downloadURL;
 	}

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/definition/security/permission/resource/util/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/definition/security/permission/resource/util/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 3.0.0

--- a/modules/apps/object/object-api/src/main/resources/com/liferay/object/field/util/packageinfo
+++ b/modules/apps/object/object-api/src/main/resources/com/liferay/object/field/util/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/attachment/AttachmentDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/attachment/AttachmentDDMFormFieldTemplateContextContributor.java
@@ -223,7 +223,7 @@ public class AttachmentDDMFormFieldTemplateContextContributor
 						GetterUtil.getString(
 							ddmFormField.getProperty(
 								"objectEntryExternalReferenceCode")),
-						themeDisplay);
+						themeDisplay, ddmFormField.getName());
 				}
 			).put(
 				"title", fileEntry.getFileName()

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/attachment/AttachmentDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/attachment/AttachmentDDMFormFieldTemplateContextContributor.java
@@ -17,10 +17,15 @@ import com.liferay.item.selector.ItemSelector;
 import com.liferay.item.selector.criteria.FileEntryItemSelectorReturnType;
 import com.liferay.item.selector.criteria.file.criterion.FileItemSelectorCriterion;
 import com.liferay.object.configuration.ObjectConfiguration;
+import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.dynamic.data.mapping.form.field.type.constants.ObjectDDMFormFieldTypeConstants;
 import com.liferay.object.field.attachment.AttachmentManager;
 import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -34,6 +39,9 @@ import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.configuration.UploadServletRequestConfigurationProvider;
@@ -204,6 +212,16 @@ public class AttachmentDDMFormFieldTemplateContextContributor
 		try {
 			FileEntry fileEntry = _dlAppLocalService.getFileEntry(value);
 
+			String objectDefinitionERC = GetterUtil.getString(
+				ddmFormField.getProperty(
+					"objectDefinitionExternalReferenceCode"));
+
+			String objectEntryERC = GetterUtil.getString(
+				ddmFormField.getProperty("objectEntryExternalReferenceCode"));
+
+			long groupId = GetterUtil.getLong(
+				ddmFormField.getProperty("groupId"));
+
 			return HashMapBuilder.put(
 				"contentURL",
 				() -> {
@@ -215,15 +233,22 @@ public class AttachmentDDMFormFieldTemplateContextContributor
 					}
 
 					return ObjectFieldUtil.getAttachmentDownloadURL(
-						_dlURLHelper, fileEntry,
-						GetterUtil.getLong(ddmFormField.getProperty("groupId")),
-						GetterUtil.getString(
-							ddmFormField.getProperty(
-								"objectDefinitionExternalReferenceCode")),
-						GetterUtil.getString(
-							ddmFormField.getProperty(
-								"objectEntryExternalReferenceCode")),
-						themeDisplay, ddmFormField.getName());
+						_dlURLHelper, fileEntry, groupId, objectDefinitionERC,
+						objectEntryERC, themeDisplay, ddmFormField.getName());
+				}
+			).put(
+				"downloadPermission",
+				() -> {
+					if (Validator.isNull(objectDefinitionERC) ||
+						Validator.isNull(objectEntryERC)) {
+
+						return Boolean.FALSE.toString();
+					}
+
+					return _hasAttachmentDownloadPermission(
+						fileEntry, groupId, objectDefinitionERC, objectEntryERC,
+						ddmFormField.getName(),
+						_getPermissionChecker(themeDisplay));
 				}
 			).put(
 				"title", fileEntry.getFileName()
@@ -275,6 +300,17 @@ public class AttachmentDDMFormFieldTemplateContextContributor
 				_groupLocalService.fetchGroup(groupId), groupId,
 				portletNamespace + "selectAttachmentEntry",
 				fileItemSelectorCriterion));
+	}
+
+	private PermissionChecker _getPermissionChecker(ThemeDisplay themeDisplay) {
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (permissionChecker == null) {
+			permissionChecker = themeDisplay.getPermissionChecker();
+		}
+
+		return permissionChecker;
 	}
 
 	private String _getURL(
@@ -329,6 +365,49 @@ public class AttachmentDDMFormFieldTemplateContextContributor
 		return ddmFormFieldRenderingContext.getValue();
 	}
 
+	private String _hasAttachmentDownloadPermission(
+		FileEntry fileEntry, long groupId, String objectDefinitionERC,
+		String objectEntryERC, String objectFieldName,
+		PermissionChecker permissionChecker) {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				fileEntry.getCompanyId(), "LPD-17564")) {
+
+			return Boolean.TRUE.toString();
+		}
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					objectDefinitionERC, fileEntry.getCompanyId());
+
+		ObjectEntry objectEntry = _objectEntryLocalService.fetchObjectEntry(
+			objectEntryERC, groupId, objectDefinition.getObjectDefinitionId());
+
+		try {
+			if (fileEntry.containsPermission(
+					permissionChecker, ActionKeys.DOWNLOAD) &&
+				permissionChecker.hasPermission(
+					groupId, objectDefinition.getClassName(),
+					objectEntry.getObjectEntryId(),
+					ObjectFieldConstants.
+						ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX +
+							objectFieldName)) {
+
+				return Boolean.TRUE.toString();
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return Boolean.FALSE.toString();
+		}
+
+		return Boolean.FALSE.toString();
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		AttachmentDDMFormFieldTemplateContextContributor.class);
 
@@ -354,6 +433,12 @@ public class AttachmentDDMFormFieldTemplateContextContributor
 	private Language _language;
 
 	private volatile ObjectConfiguration _objectConfiguration;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
 
 	@Reference
 	private UploadServletRequestConfigurationProvider

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/Attachment.scss
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/Attachment.scss
@@ -30,34 +30,27 @@
 		gap: #{$gapTitleValue};
 		padding-top: #{$paddingTopTitle};
 
-		&:focus-within,
-		&:hover {
-			.lfr-objects__attachment-download {
-				color: black;
-				display: unset;
-				margin-bottom: #{$marginBottom};
-				margin-left: #{$marginLeft};
-				margin-right: #{$marginRight};
-			}
+		.lfr-objects__attachment-delete {
+			display: unset;
+			margin-bottom: #{$marginBottom};
+			margin-left: #{$marginLeft};
+			margin-right: #{$marginRight};
+		}
+
+		.lfr-objects__attachment-download {
+			display: unset;
+			margin-bottom: #{$marginBottom};
+			margin-left: #{$marginLeft};
 		}
 	}
 }
 
 .lfr-objects__attachment {
-	@include attachment(flex, 1rem, 1rem, 0, 0, 1rem, 0, 0);
+	@include attachment(flex, 1rem, 1rem, 0, 0, 5px, 0, 5px);
 }
 
 .col-ddm .col-md-4 {
 	.lfr-objects__attachment {
-		@include attachment(
-			block,
-			1rem,
-			0.2rem,
-			1rem,
-			5px,
-			0.5rem,
-			0.3rem,
-			0.5rem
-		);
+		@include attachment(block, 1rem, 0.2rem, 1rem, 5px, 0, 0.3rem, 0.5rem);
 	}
 }

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/Attachment.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/Attachment.tsx
@@ -23,6 +23,7 @@ export interface AttachmentProps
 	extends AttachmentBaseProps<string | LocalizedValue<string>> {
 	contentURL?: string;
 	deleteURL?: string;
+	downloadPermission?: string;
 	fieldName: string;
 	fileEntryProperties: AttachmentFile | LocalizedValue<AttachmentFile>;
 	localizedObjectField: boolean;
@@ -33,6 +34,7 @@ export interface AttachmentProps
 export default function Attachment({
 	contentURL,
 	deleteURL,
+	downloadPermission,
 	fileEntryProperties,
 	localizedObjectField,
 	onChange,
@@ -51,8 +53,8 @@ export default function Attachment({
 		if (Liferay.FeatureFlags['LPD-32050']) {
 			return fileEntryProperties;
 		}
-		else if (contentURL && title) {
-			return {contentURL, title};
+		else if (contentURL && downloadPermission && title) {
+			return {contentURL, downloadPermission, title};
 		}
 
 		return null;

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/AttachmentBase.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/AttachmentBase.tsx
@@ -21,6 +21,7 @@ import type {LocalizedValue} from 'dynamic-data-mapping-form-field-type';
 
 export type AttachmentFile = {
 	contentURL: string;
+	downloadPermission: string;
 	fileEntryId: string;
 	title: string;
 };
@@ -91,6 +92,7 @@ export default function AttachmentBase({
 			onAttachmentChange(
 				{
 					contentURL: selectedItemValue.url,
+					downloadPermission: 'true',
 					fileEntryId: selectedItemValue.fileEntryId,
 					title: selectedItemValue.title,
 				},
@@ -137,6 +139,7 @@ export default function AttachmentBase({
 					onAttachmentChange(
 						{
 							contentURL: file.contentURL,
+							downloadPermission: 'true',
 							fileEntryId: file.fileEntryId,
 							title: file.title,
 						},

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/FileContainer.tsx
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/js/Attachment/FileContainer.tsx
@@ -4,7 +4,6 @@
  */
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
-import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import React from 'react';
 
@@ -35,23 +34,38 @@ export default function FileContainer({
 					<ClayButton
 						displayType="unstyled"
 						onClick={() => {
-							window.open(attachment.contentURL, '_blank');
+							if (attachment.downloadPermission === 'true') {
+								window.open(attachment.contentURL, '_blank');
+							}
 						}}
 					>
 						{attachment.title}
 					</ClayButton>
 
-					{Liferay.ThemeDisplay.isSignedIn() && (
-						<a
-							className="lfr-objects__attachment-download"
-							href={attachment.contentURL}
-						>
-							<ClayIcon symbol="download" />
-						</a>
-					)}
+					{Liferay.ThemeDisplay.isSignedIn() &&
+						attachment.downloadPermission === 'true' && (
+							<div className="lfr-objects__attachment-download">
+								<ClayButtonWithIcon
+									aria-label={Liferay.Language.get(
+										'download'
+									)}
+									borderless
+									displayType="secondary"
+									monospaced
+									onClick={() =>
+										window.open(
+											attachment.contentURL,
+											'_blank'
+										)
+									}
+									symbol="download"
+									title={Liferay.Language.get('download')}
+								/>
+							</div>
+						)}
 
-					{!readOnly && (
-						<>
+					{!readOnly && attachment.title && (
+						<div className="lfr-objects__attachment-delete">
 							<ClayButtonWithIcon
 								aria-label={Liferay.Language.get('delete')}
 								borderless
@@ -61,7 +75,7 @@ export default function FileContainer({
 								symbol="times-circle-full"
 								title={Liferay.Language.get('delete')}
 							/>
-						</>
+						</div>
 					)}
 				</div>
 			</>

--- a/modules/apps/object/object-rest-api/bnd.bnd
+++ b/modules/apps/object/object-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Object REST API
 Bundle-SymbolicName: com.liferay.object.rest.api
-Bundle-Version: 28.1.1
+Bundle-Version: 29.0.0
 Export-Package:\
 	com.liferay.object.rest.dto.v1_0,\
 	com.liferay.object.rest.dto.v1_0.util,\

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/util/LinkUtil.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/util/LinkUtil.java
@@ -24,7 +24,8 @@ public class LinkUtil {
 		DLAppService dlAppService, DLFileEntry dlFileEntry,
 		DLURLHelper dlURLHelper, long groupId,
 		String objectDefinitionExternalReferenceCode,
-		String objectEntryExternalReferenceCode, Portal portal) {
+		String objectEntryExternalReferenceCode, Portal portal,
+		String objectFieldName) {
 
 		return new Link() {
 			{
@@ -36,7 +37,8 @@ public class LinkUtil {
 								dlAppService.getFileEntry(
 									dlFileEntry.getFileEntryId()),
 								groupId, objectDefinitionExternalReferenceCode,
-								objectEntryExternalReferenceCode, null);
+								objectEntryExternalReferenceCode, null,
+								objectFieldName);
 						}
 						catch (Exception exception) {
 							if (_log.isWarnEnabled()) {

--- a/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/util/LinkUtil.java
+++ b/modules/apps/object/object-rest-api/src/main/java/com/liferay/object/rest/dto/v1_0/util/LinkUtil.java
@@ -22,27 +22,30 @@ public class LinkUtil {
 
 	public static Link toLink(
 		DLAppService dlAppService, DLFileEntry dlFileEntry,
-		DLURLHelper dlURLHelper, long groupId,
+		DLURLHelper dlURLHelper, long groupId, boolean hasDownloadPermission,
 		String objectDefinitionExternalReferenceCode,
-		String objectEntryExternalReferenceCode, Portal portal,
-		String objectFieldName) {
+		String objectEntryExternalReferenceCode, String objectFieldName,
+		Portal portal) {
 
 		return new Link() {
 			{
 				setHref(
 					() -> {
-						try {
-							return ObjectFieldUtil.getAttachmentDownloadURL(
-								dlURLHelper,
-								dlAppService.getFileEntry(
-									dlFileEntry.getFileEntryId()),
-								groupId, objectDefinitionExternalReferenceCode,
-								objectEntryExternalReferenceCode, null,
-								objectFieldName);
-						}
-						catch (Exception exception) {
-							if (_log.isWarnEnabled()) {
-								_log.warn(exception);
+						if (hasDownloadPermission) {
+							try {
+								return ObjectFieldUtil.getAttachmentDownloadURL(
+									dlURLHelper,
+									dlAppService.getFileEntry(
+										dlFileEntry.getFileEntryId()),
+									groupId,
+									objectDefinitionExternalReferenceCode,
+									objectEntryExternalReferenceCode, null,
+									objectFieldName);
+							}
+							catch (Exception exception) {
+								if (_log.isWarnEnabled()) {
+									_log.warn(exception);
+								}
 							}
 						}
 

--- a/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/util/packageinfo
+++ b/modules/apps/object/object-rest-api/src/main/resources/com/liferay/object/rest/dto/v1_0/util/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 5.0.0

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -81,6 +81,9 @@ import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileVersion;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.PermissionService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
@@ -816,9 +819,12 @@ public class ObjectEntryDTOConverter
 			() -> LinkUtil.toLink(
 				_dlAppService, dlFileEntry, _dlURLHelper,
 				objectEntry.getGroupId(),
+				_hasDownloadPermission(
+					fileEntryId, objectDefinition, objectEntry,
+					objectFieldName),
 				objectDefinition.getExternalReferenceCode(),
-				objectEntry.getExternalReferenceCode(), _portal,
-				objectFieldName));
+				objectEntry.getExternalReferenceCode(), objectFieldName,
+				_portal));
 		fileEntry.setMetadata(
 			() -> NestedFieldsSupplier.supply(
 				objectFieldName + ".metadata",
@@ -1225,6 +1231,37 @@ public class ObjectEntryDTOConverter
 		}
 
 		return serializable;
+	}
+
+	private boolean _hasDownloadPermission(
+			long fileEntryId, ObjectDefinition objectDefinition,
+			com.liferay.object.model.ObjectEntry objectEntry,
+			String objectFieldName)
+		throws PortalException {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				objectDefinition.getCompanyId(), "LPD-17564")) {
+
+			return true;
+		}
+
+		PermissionChecker permissionChecker =
+			GuestOrUserUtil.getPermissionChecker();
+
+		if (permissionChecker.hasPermission(
+				objectEntry.getGroupId(), DLFileEntry.class.getName(),
+				fileEntryId, ActionKeys.DOWNLOAD) &&
+			_objectEntryService.hasModelResourcePermission(
+				objectDefinition.getObjectDefinitionId(),
+				objectEntry.getObjectEntryId(),
+				ObjectFieldConstants.
+					ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX +
+						objectFieldName)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _hasRootModelHierarchyNestedField() {

--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -817,7 +817,8 @@ public class ObjectEntryDTOConverter
 				_dlAppService, dlFileEntry, _dlURLHelper,
 				objectEntry.getGroupId(),
 				objectDefinition.getExternalReferenceCode(),
-				objectEntry.getExternalReferenceCode(), _portal));
+				objectEntry.getExternalReferenceCode(), _portal,
+				objectFieldName));
 		fileEntry.setMetadata(
 			() -> NestedFieldsSupplier.supply(
 				objectFieldName + ".metadata",

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -75,6 +75,7 @@ import com.liferay.portal.db.partition.util.DBPartitionUtil;
 import com.liferay.portal.kernel.defaultpermissions.resource.PortalDefaultPermissionsModelResource;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionLogic;
@@ -142,7 +143,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			dynamicQueryBatchIndexingActionableFactory,
 		GroupLocalService groupLocalService,
 		KaleoDefinitionLocalService kaleoDefinitionLocalService,
-		ListTypeLocalService listTypeLocalService,
+		Language language, ListTypeLocalService listTypeLocalService,
 		ObjectActionLocalService objectActionLocalService,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		ObjectDefinitionSettingLocalService objectDefinitionSettingLocalService,
@@ -179,6 +180,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			dynamicQueryBatchIndexingActionableFactory;
 		_groupLocalService = groupLocalService;
 		_kaleoDefinitionLocalService = kaleoDefinitionLocalService;
+		_language = language;
 		_listTypeLocalService = listTypeLocalService;
 		_objectActionLocalService = objectActionLocalService;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
@@ -296,9 +298,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 		try {
 			ObjectDefinitionResourcePermissionUtil.populateResourceActions(
-				attachmentObjectFields, _objectActionLocalService,
+				attachmentObjectFields, _language, _objectActionLocalService,
 				objectDefinition, _objectFieldLocalService,
-				_portletLocalService, _resourceActions,
+				_ploEntryLocalService, _portletLocalService, _resourceActions,
 				standaloneObjectActions);
 		}
 		catch (Exception exception) {
@@ -677,6 +679,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		_dynamicQueryBatchIndexingActionableFactory;
 	private final GroupLocalService _groupLocalService;
 	private final KaleoDefinitionLocalService _kaleoDefinitionLocalService;
+	private final Language _language;
 	private final ListTypeLocalService _listTypeLocalService;
 	private final ObjectActionLocalService _objectActionLocalService;
 	private final ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -15,6 +15,7 @@ import com.liferay.notification.term.evaluator.NotificationTermEvaluator;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectDefinitionConstants;
 import com.liferay.object.constants.ObjectDefinitionSettingConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.definition.security.permission.resource.util.ObjectDefinitionResourcePermissionUtil;
 import com.liferay.object.definition.tree.util.ObjectDefinitionTreeUtil;
 import com.liferay.object.deployer.ObjectDefinitionDeployer;
@@ -44,6 +45,7 @@ import com.liferay.object.internal.workflow.ObjectEntryWorkflowHandler;
 import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectLayout;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.related.models.ObjectRelatedModelsPredicateProvider;
@@ -247,6 +249,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			serviceRegistrationsMap.put(
 				DBPartitionUtil.getPartitionKey(objectDefinitionId),
 				_deploy(
+					_objectFieldLocalService.getObjectFieldsByBusinessType(
+						objectDefinitionId,
+						ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT),
 					objectDefinition,
 					objectLayoutsMap.getOrDefault(
 						objectDefinitionId, Collections.emptyList()),
@@ -262,7 +267,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	public List<ServiceRegistration<?>> deploy(
 		ObjectDefinition objectDefinition) {
 
-		return _deploy(objectDefinition, null, null, null);
+		return _deploy(null, objectDefinition, null, null, null);
 	}
 
 	@Override
@@ -280,6 +285,7 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 	}
 
 	private List<ServiceRegistration<?>> _deploy(
+		List<ObjectField> attachmentObjectFields,
 		ObjectDefinition objectDefinition, List<ObjectLayout> objectLayouts,
 		Map<Long, List<ObjectRelationship>> objectRelationshipsMap,
 		List<ObjectAction> standaloneObjectActions) {
@@ -290,7 +296,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 
 		try {
 			ObjectDefinitionResourcePermissionUtil.populateResourceActions(
-				_objectActionLocalService, objectDefinition,
+				attachmentObjectFields, _objectActionLocalService,
+				objectDefinition, _objectFieldLocalService,
 				_portletLocalService, _resourceActions,
 				standaloneObjectActions);
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/feature/flag/ObjectFieldFeatureFlagListener.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/feature/flag/ObjectFieldFeatureFlagListener.java
@@ -1,0 +1,183 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.feature.flag;
+
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.definition.security.permission.resource.util.ObjectDefinitionResourcePermissionUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectFieldLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagListener;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.security.permission.ResourceActions;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.language.override.service.PLOEntryLocalService;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Manuele Castro
+ */
+@Component(
+	property = "feature.flag.key=LPD-17564", service = FeatureFlagListener.class
+)
+public class ObjectFieldFeatureFlagListener implements FeatureFlagListener {
+
+	@Override
+	public void onValue(
+		long companyId, String featureFlagKey, boolean enabled) {
+
+		if (Objects.equals(featureFlagKey, "LPD-17564")) {
+			List<ObjectDefinition> objectDefinitions =
+				_objectDefinitionLocalService.getObjectDefinitions(
+					companyId, WorkflowConstants.STATUS_APPROVED);
+
+			for (ObjectDefinition objectDefinition : objectDefinitions) {
+				List<ObjectField> objectFields =
+					_objectFieldLocalService.getObjectFieldsByBusinessType(
+						objectDefinition.getObjectDefinitionId(),
+						ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT);
+
+				for (ObjectField objectField : objectFields) {
+					String actionId =
+						ObjectFieldConstants.
+							ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX +
+								objectField.getName();
+
+					if (enabled) {
+						ResourceAction resourceAction =
+							_resourceActionLocalService.fetchResourceAction(
+								objectDefinition.getClassName(), actionId);
+
+						if (resourceAction != null) {
+							continue;
+						}
+
+						try {
+							ObjectDefinitionResourcePermissionUtil.
+								populateResourceActions(
+									Collections.singletonList(objectField),
+									_language, null, objectDefinition,
+									_objectFieldLocalService,
+									_ploEntryLocalService, _portletLocalService,
+									_resourceActions, null);
+
+							_addOrUpdateObjectFieldResourceActionPLOEntries(
+								objectField);
+
+							_updateResourcePermissions(
+								objectDefinition, objectField);
+						}
+						catch (Exception exception) {
+							_log.error(exception);
+						}
+					}
+					else {
+						_resourceActions.removeModelResource(
+							objectDefinition.getClassName(), actionId);
+
+						_ploEntryLocalService.deletePLOEntries(
+							objectField.getCompanyId(), "action." + actionId);
+					}
+				}
+			}
+		}
+	}
+
+	private void _addOrUpdateObjectFieldResourceActionPLOEntries(
+			ObjectField objectField)
+		throws PortalException {
+
+		for (Locale locale : _language.getAvailableLocales()) {
+			String languageId = LocaleUtil.toLanguageId(locale);
+
+			_ploEntryLocalService.addOrUpdatePLOEntry(
+				objectField.getCompanyId(), objectField.getUserId(),
+				StringBundler.concat(
+					"action.",
+					ObjectFieldConstants.
+						ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX,
+					objectField.getName()),
+				languageId,
+				LanguageUtil.format(
+					locale, "download-x", objectField.getLabel(locale)));
+		}
+	}
+
+	private void _updateResourcePermissions(
+			ObjectDefinition objectDefinition, ObjectField objectField)
+		throws PortalException {
+
+		List<ResourcePermission> resourcePermissions =
+			_resourcePermissionLocalService.getResourcePermissions(
+				objectDefinition.getCompanyId(),
+				objectDefinition.getClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL);
+
+		for (ResourcePermission resourcePermission : resourcePermissions) {
+			String objectFieldActionId =
+				ObjectFieldConstants.
+					ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX +
+						objectField.getName();
+
+			if (!resourcePermission.hasActionId(objectFieldActionId) &&
+				resourcePermission.isViewActionId()) {
+
+				resourcePermission.addResourceAction(objectFieldActionId);
+
+				_resourcePermissionLocalService.updateResourcePermission(
+					resourcePermission);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ObjectFieldFeatureFlagListener.class);
+
+	@Reference
+	private Language _language;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectFieldLocalService _objectFieldLocalService;
+
+	@Reference
+	private PLOEntryLocalService _ploEntryLocalService;
+
+	@Reference
+	private PortletLocalService _portletLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourceActions _resourceActions;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
@@ -141,6 +141,8 @@ public class ObjectEntryModelResourcePermission
 
 		if ((objectEntry.getRootObjectEntryId() != 0) &&
 			!_isObjectActionName(
+				actionId, objectEntry.getObjectDefinitionId()) &&
+			!_isObjectFieldName(
 				actionId, objectEntry.getObjectDefinitionId())) {
 
 			ObjectEntry rootObjectEntry =
@@ -378,6 +380,27 @@ public class ObjectEntryModelResourcePermission
 					ObjectActionTriggerConstants.KEY_STANDALONE)) {
 
 			if (Objects.equals(objectAction.getName(), actionId)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private boolean _isObjectFieldName(
+		String actionId, long objectDefinitionId) {
+
+		for (ObjectField objectField :
+				_objectFieldLocalService.getObjectFieldsByBusinessType(
+					objectDefinitionId,
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+
+			if (Objects.equals(
+					ObjectFieldConstants.
+						ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX +
+							objectField.getName(),
+					actionId)) {
+
 				return true;
 			}
 		}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/security/permission/resource/ObjectEntryModelResourcePermission.java
@@ -143,7 +143,8 @@ public class ObjectEntryModelResourcePermission
 			!_isObjectActionName(
 				actionId, objectEntry.getObjectDefinitionId()) &&
 			!_isObjectFieldName(
-				actionId, objectEntry.getObjectDefinitionId())) {
+				actionId, objectEntry.getCompanyId(),
+				objectEntry.getObjectDefinitionId())) {
 
 			ObjectEntry rootObjectEntry =
 				_objectEntryLocalService.fetchObjectEntry(
@@ -388,7 +389,11 @@ public class ObjectEntryModelResourcePermission
 	}
 
 	private boolean _isObjectFieldName(
-		String actionId, long objectDefinitionId) {
+		String actionId, long companyId, long objectDefinitionId) {
+
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-17564")) {
+			return false;
+		}
 
 		for (ObjectField objectField :
 				_objectFieldLocalService.getObjectFieldsByBusinessType(

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/servlet/filter/AttachmentObjectFieldDownloadFilter.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/servlet/filter/AttachmentObjectFieldDownloadFilter.java
@@ -12,6 +12,7 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.login.AuthLoginGroupSettingsUtil;
@@ -49,6 +50,15 @@ import org.osgi.service.component.annotations.Reference;
 	service = Filter.class
 )
 public class AttachmentObjectFieldDownloadFilter extends BaseFilter {
+
+	@Override
+	public boolean isFilterEnabled(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		return FeatureFlagManagerUtil.isEnabled(
+			PortalUtil.getCompanyId(httpServletRequest), "LPD-17564");
+	}
 
 	@Override
 	protected Log getLog() {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/servlet/filter/AttachmentObjectFieldDownloadFilter.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/servlet/filter/AttachmentObjectFieldDownloadFilter.java
@@ -1,0 +1,185 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.servlet.filter;
+
+import com.liferay.object.constants.ObjectDefinitionConstants;
+import com.liferay.object.exception.NoSuchObjectEntryException;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.login.AuthLoginGroupSettingsUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermissionRegistryUtil;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.servlet.BaseFilter;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Manuele Castro
+ */
+@Component(
+	property = {
+		"servlet-context-name=",
+		"servlet-filter-name=Attachment ObjectField Download Filter",
+		"url-pattern=/documents/*", "url-pattern=/image/*"
+	},
+	service = Filter.class
+)
+public class AttachmentObjectFieldDownloadFilter extends BaseFilter {
+
+	@Override
+	protected Log getLog() {
+		return _log;
+	}
+
+	@Override
+	protected void processFilter(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, FilterChain filterChain)
+		throws Exception {
+
+		if (Validator.isNotNull(
+				ParamUtil.getString(
+					httpServletRequest, "objectFieldActionId"))) {
+
+			_checkObjectEntryModelResourcePermission(
+				httpServletRequest, httpServletResponse);
+		}
+
+		filterChain.doFilter(httpServletRequest, httpServletResponse);
+	}
+
+	private void _checkObjectEntryModelResourcePermission(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception {
+
+		long companyId = PortalUtil.getCompanyId(httpServletRequest);
+
+		ObjectDefinition objectDefinition =
+			_objectDefinitionLocalService.
+				fetchObjectDefinitionByExternalReferenceCode(
+					ParamUtil.getString(
+						httpServletRequest,
+						"objectDefinitionExternalReferenceCode"),
+					companyId);
+
+		if (objectDefinition == null) {
+			return;
+		}
+
+		long groupId = ObjectDefinitionConstants.GROUP_ID_DEFAULT;
+
+		Group group = _groupLocalService.fetchGroupByExternalReferenceCode(
+			ParamUtil.getString(
+				httpServletRequest, "groupExternalReferenceCode"),
+			companyId);
+
+		if (group != null) {
+			groupId = group.getGroupId();
+		}
+
+		ObjectEntry objectEntry = _objectEntryLocalService.fetchObjectEntry(
+			ParamUtil.getString(
+				httpServletRequest, "objectEntryExternalReferenceCode"),
+			groupId, objectDefinition.getObjectDefinitionId());
+
+		if (objectEntry == null) {
+			return;
+		}
+
+		ModelResourcePermission<?> objectEntryModelResourcePermission =
+			ModelResourcePermissionRegistryUtil.getModelResourcePermission(
+				objectDefinition.getClassName());
+
+		PermissionChecker permissionChecker = _getPermissionChecker(
+			httpServletRequest);
+
+		try {
+			objectEntryModelResourcePermission.check(
+				permissionChecker, objectEntry.getObjectEntryId(),
+				ActionKeys.VIEW);
+
+			String objectFieldActionId = ParamUtil.getString(
+				httpServletRequest, "objectFieldActionId");
+
+			if (ParamUtil.getBoolean(httpServletRequest, "download") &&
+				Validator.isNotNull(objectFieldActionId)) {
+
+				objectEntryModelResourcePermission.check(
+					permissionChecker, objectEntry.getObjectEntryId(),
+					objectFieldActionId);
+			}
+		}
+		catch (PortalException portalException) {
+			User user = permissionChecker.getUser();
+
+			if (user.isGuestUser() &&
+				!AuthLoginGroupSettingsUtil.isPromptEnabled(
+					objectEntry.getGroupId())) {
+
+				PortalUtil.sendError(
+					HttpServletResponse.SC_NOT_FOUND,
+					new NoSuchObjectEntryException(portalException),
+					httpServletRequest, httpServletResponse);
+			}
+
+			PortalUtil.sendError(
+				portalException, httpServletRequest, httpServletResponse);
+		}
+	}
+
+	private PermissionChecker _getPermissionChecker(
+			HttpServletRequest httpServletRequest)
+		throws Exception {
+
+		User user = PortalUtil.getUser(httpServletRequest);
+
+		if (user == null) {
+			user = _userLocalService.getGuestUser(
+				PortalUtil.getCompanyId(httpServletRequest));
+		}
+
+		return PermissionThreadLocal.getPermissionChecker(
+			user, !user.isGuestUser());
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AttachmentObjectFieldDownloadFilter.class);
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	@Reference
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectActionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectActionLocalServiceImpl.java
@@ -170,8 +170,8 @@ public class ObjectActionLocalServiceImpl
 
 			try {
 				ObjectDefinitionResourcePermissionUtil.populateResourceActions(
-					null, objectActionLocalService, objectDefinition, null,
-					_portletLocalService, _resourceActions, null);
+					null, null, objectActionLocalService, objectDefinition,
+					null, null, _portletLocalService, _resourceActions, null);
 			}
 			catch (Exception exception) {
 				ReflectionUtil.throwException(exception);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectActionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectActionLocalServiceImpl.java
@@ -170,7 +170,7 @@ public class ObjectActionLocalServiceImpl
 
 			try {
 				ObjectDefinitionResourcePermissionUtil.populateResourceActions(
-					objectActionLocalService, objectDefinition,
+					null, objectActionLocalService, objectDefinition, null,
 					_portletLocalService, _resourceActions, null);
 			}
 			catch (Exception exception) {

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -695,7 +695,7 @@ public class ObjectDefinitionLocalServiceImpl
 
 				ObjectDefinitionResourcePermissionUtil.removeResourceActions(
 					_objectActionLocalService, objectDefinition,
-					_resourceActions);
+					_objectFieldLocalService, _resourceActions);
 			}
 			catch (Exception exception) {
 				throw new PortalException(exception);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectDefinitionLocalServiceImpl.java
@@ -1057,7 +1057,7 @@ public class ObjectDefinitionLocalServiceImpl
 				_accountEntryOrganizationRelLocalService,
 				_assetEntryLocalService, _bundleContext,
 				_dynamicQueryBatchIndexingActionableFactory, _groupLocalService,
-				_kaleoDefinitionLocalService, _listTypeLocalService,
+				_kaleoDefinitionLocalService, _language, _listTypeLocalService,
 				_objectActionLocalService, objectDefinitionLocalService,
 				_objectDefinitionSettingLocalService,
 				_objectEntryFolderLocalService, _objectEntryLocalService,

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -13,6 +13,7 @@ import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldSettingConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.constants.ObjectValidationRuleSettingConstants;
+import com.liferay.object.definition.security.permission.resource.util.ObjectDefinitionResourcePermissionUtil;
 import com.liferay.object.definition.util.ObjectDefinitionUtil;
 import com.liferay.object.exception.DuplicateObjectFieldExternalReferenceCodeException;
 import com.liferay.object.exception.ObjectDefinitionEnableLocalizationException;
@@ -83,6 +84,8 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
+import com.liferay.portal.kernel.security.permission.ResourceActions;
+import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.Base64;
@@ -910,6 +913,21 @@ public class ObjectFieldLocalServiceImpl
 			objectField, objectDefinition, objectFieldBusinessType,
 			objectFieldSettings, null);
 
+		if (objectDefinition.isApproved() &&
+			Objects.equals(
+				objectField.getBusinessType(),
+				ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+
+			try {
+				ObjectDefinitionResourcePermissionUtil.populateResourceActions(
+					null, null, objectDefinition, objectFieldLocalService,
+					_portletLocalService, _resourceActions, null);
+			}
+			catch (Exception exception) {
+				ReflectionUtil.throwException(exception);
+			}
+		}
+
 		if (!objectDefinition.isApproved() ||
 			ObjectFieldUtil.isMetadata(name) ||
 			(system && objectDefinition.isUnmodifiableSystemObject())) {
@@ -1146,6 +1164,11 @@ public class ObjectFieldLocalServiceImpl
 		if (Objects.equals(
 				objectField.getBusinessType(),
 				ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+
+			if (objectDefinition.isApproved()) {
+				_resourceActions.removeModelResource(
+					objectDefinition.getClassName(), objectField.getName());
+			}
 
 			ObjectFieldSetting objectFieldSetting =
 				_objectFieldSettingPersistence.fetchByOFI_N(
@@ -1981,6 +2004,9 @@ public class ObjectFieldLocalServiceImpl
 	@Reference
 	private ObjectViewLocalService _objectViewLocalService;
 
+	@Reference
+	private PortletLocalService _portletLocalService;
+
 	private final Set<String> _readOnlyObjectFieldNames = SetUtil.fromArray(
 		"createDate", "creator", "id", "modifiedDate", "status");
 	private final Set<String> _reservedNames = SetUtil.fromArray(
@@ -1990,6 +2016,9 @@ public class ObjectFieldLocalServiceImpl
 		"modifieddate", "reviewdate", "status", "statusbyuserid",
 		"statusbyusername", "statusdate", "taxonomycategoryids", "userid",
 		"username");
+
+	@Reference
+	private ResourceActions _resourceActions;
 
 	@Reference
 	private SystemObjectDefinitionManagerRegistry

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -80,13 +80,19 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.search.Indexable;
 import com.liferay.portal.kernel.search.IndexableType;
 import com.liferay.portal.kernel.security.permission.ResourceActions;
 import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.Base64;
@@ -937,6 +943,8 @@ public class ObjectFieldLocalServiceImpl
 					null, _language, null, objectDefinition,
 					objectFieldLocalService, _ploEntryLocalService,
 					_portletLocalService, _resourceActions, null);
+
+				_updateResourcePermissions(objectDefinition, objectField);
 			}
 			catch (Exception exception) {
 				ReflectionUtil.throwException(exception);
@@ -1594,6 +1602,34 @@ public class ObjectFieldLocalServiceImpl
 		return newObjectField;
 	}
 
+	private void _updateResourcePermissions(
+			ObjectDefinition objectDefinition, ObjectField objectField)
+		throws PortalException {
+
+		Role role = _roleLocalService.getRole(
+			objectDefinition.getCompanyId(), RoleConstants.OWNER);
+
+		List<ResourcePermission> resourcePermissions =
+			_resourcePermissionLocalService.getResourcePermissions(
+				objectDefinition.getCompanyId(),
+				objectDefinition.getClassName(),
+				ResourceConstants.SCOPE_INDIVIDUAL, role.getRoleId(), true);
+
+		for (ResourcePermission resourcePermission : resourcePermissions) {
+			String objectFieldActionId =
+				ObjectFieldConstants.
+					ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX +
+						objectField.getName();
+
+			if (!resourcePermission.hasActionId(objectFieldActionId)) {
+				resourcePermission.addResourceAction(objectFieldActionId);
+
+				_resourcePermissionLocalService.updateResourcePermission(
+					resourcePermission);
+			}
+		}
+	}
+
 	private void _validateBusinessType(
 			ObjectDefinition objectDefinition, String businessType)
 		throws PortalException {
@@ -2074,6 +2110,12 @@ public class ObjectFieldLocalServiceImpl
 
 	@Reference
 	private ResourceActions _resourceActions;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
 
 	@Reference
 	private SystemObjectDefinitionManagerRegistry

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -1003,7 +1003,12 @@ public class ObjectFieldLocalServiceImpl
 
 			_ploEntryLocalService.addOrUpdatePLOEntry(
 				objectField.getCompanyId(), objectField.getUserId(),
-				"action.objectField." + objectField.getName(), languageId,
+				StringBundler.concat(
+					"action.",
+					ObjectFieldConstants.
+						ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX,
+					objectField.getName()),
+				languageId,
 				LanguageUtil.format(
 					locale, "download-x", objectField.getLabel(locale)));
 		}
@@ -1190,7 +1195,11 @@ public class ObjectFieldLocalServiceImpl
 
 				_ploEntryLocalService.deletePLOEntries(
 					objectField.getCompanyId(),
-					"action.objectField." + objectField.getName());
+					StringBundler.concat(
+						"action.",
+						ObjectFieldConstants.
+							ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX,
+						objectField.getName()));
 			}
 
 			ObjectFieldSetting objectFieldSetting =

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -339,7 +339,9 @@ public class ObjectFieldLocalServiceImpl
 					ObjectFieldUtil.getCounterName(objectField));
 			}
 
-			if (objectField.compareBusinessType(
+			if (FeatureFlagManagerUtil.isEnabled(
+					objectField.getCompanyId(), "LPD-17564") &&
+				objectField.compareBusinessType(
 					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
 
 				_ploEntryLocalService.deletePLOEntries(
@@ -933,7 +935,9 @@ public class ObjectFieldLocalServiceImpl
 			objectField, objectDefinition, objectFieldBusinessType,
 			objectFieldSettings, null);
 
-		if (objectDefinition.isApproved() &&
+		if (FeatureFlagManagerUtil.isEnabled(
+				objectField.getCompanyId(), "LPD-17564") &&
+			objectDefinition.isApproved() &&
 			Objects.equals(
 				objectField.getBusinessType(),
 				ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
@@ -1208,7 +1212,10 @@ public class ObjectFieldLocalServiceImpl
 				objectField.getBusinessType(),
 				ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
 
-			if (objectDefinition.isApproved()) {
+			if (FeatureFlagManagerUtil.isEnabled(
+					objectField.getCompanyId(), "LPD-17564") &&
+				objectDefinition.isApproved()) {
+
 				_resourceActions.removeModelResource(
 					objectDefinition.getClassName(),
 					ObjectFieldConstants.
@@ -1566,7 +1573,9 @@ public class ObjectFieldLocalServiceImpl
 				newObjectField, objectDefinition, objectFieldBusinessType,
 				objectFieldSettings, oldObjectField);
 
-			if (businessType.equals(
+			if (FeatureFlagManagerUtil.isEnabled(
+					newObjectField.getCompanyId(), "LPD-17564") &&
+				businessType.equals(
 					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
 
 				_addOrUpdateObjectFieldResourceActionPLOEntries(newObjectField);

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -77,6 +77,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.SystemEventConstants;
@@ -98,6 +99,7 @@ import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.language.override.service.PLOEntryLocalService;
 
 import java.io.Serializable;
 
@@ -922,6 +924,8 @@ public class ObjectFieldLocalServiceImpl
 				ObjectDefinitionResourcePermissionUtil.populateResourceActions(
 					null, null, objectDefinition, objectFieldLocalService,
 					_portletLocalService, _resourceActions, null);
+
+				_addOrUpdateObjectFieldResourceActionPLOEntries(objectField);
 			}
 			catch (Exception exception) {
 				ReflectionUtil.throwException(exception);
@@ -987,6 +991,21 @@ public class ObjectFieldLocalServiceImpl
 					dbTableName, objectField.getBusinessType(),
 					objectField.getSortableDBColumnName(),
 					ObjectFieldConstants.DB_TYPE_LONG));
+		}
+	}
+
+	private void _addOrUpdateObjectFieldResourceActionPLOEntries(
+			ObjectField objectField)
+		throws PortalException {
+
+		for (Locale locale : _language.getAvailableLocales()) {
+			String languageId = LocaleUtil.toLanguageId(locale);
+
+			_ploEntryLocalService.addOrUpdatePLOEntry(
+				objectField.getCompanyId(), objectField.getUserId(),
+				"action.objectField." + objectField.getName(), languageId,
+				LanguageUtil.format(
+					locale, "download-x", objectField.getLabel(locale)));
 		}
 	}
 
@@ -1168,6 +1187,10 @@ public class ObjectFieldLocalServiceImpl
 			if (objectDefinition.isApproved()) {
 				_resourceActions.removeModelResource(
 					objectDefinition.getClassName(), objectField.getName());
+
+				_ploEntryLocalService.deletePLOEntries(
+					objectField.getCompanyId(),
+					"action.objectField." + objectField.getName());
 			}
 
 			ObjectFieldSetting objectFieldSetting =
@@ -1511,6 +1534,12 @@ public class ObjectFieldLocalServiceImpl
 			_addOrUpdateObjectFieldSettings(
 				newObjectField, objectDefinition, objectFieldBusinessType,
 				objectFieldSettings, oldObjectField);
+
+			if (businessType.equals(
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+
+				_addOrUpdateObjectFieldResourceActionPLOEntries(newObjectField);
+			}
 
 			return newObjectField;
 		}
@@ -2003,6 +2032,9 @@ public class ObjectFieldLocalServiceImpl
 
 	@Reference
 	private ObjectViewLocalService _objectViewLocalService;
+
+	@Reference
+	private PLOEntryLocalService _ploEntryLocalService;
 
 	@Reference
 	private PortletLocalService _portletLocalService;

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectFieldLocalServiceImpl.java
@@ -333,6 +333,18 @@ public class ObjectFieldLocalServiceImpl
 					ObjectFieldUtil.getCounterName(objectField));
 			}
 
+			if (objectField.compareBusinessType(
+					ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT)) {
+
+				_ploEntryLocalService.deletePLOEntries(
+					objectField.getCompanyId(),
+					StringBundler.concat(
+						"action.",
+						ObjectFieldConstants.
+							ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX,
+						objectField.getName()));
+			}
+
 			_objectFieldSettingLocalService.deleteObjectFieldObjectFieldSetting(
 				objectField);
 		}
@@ -922,10 +934,9 @@ public class ObjectFieldLocalServiceImpl
 
 			try {
 				ObjectDefinitionResourcePermissionUtil.populateResourceActions(
-					null, null, objectDefinition, objectFieldLocalService,
+					null, _language, null, objectDefinition,
+					objectFieldLocalService, _ploEntryLocalService,
 					_portletLocalService, _resourceActions, null);
-
-				_addOrUpdateObjectFieldResourceActionPLOEntries(objectField);
 			}
 			catch (Exception exception) {
 				ReflectionUtil.throwException(exception);
@@ -1191,7 +1202,10 @@ public class ObjectFieldLocalServiceImpl
 
 			if (objectDefinition.isApproved()) {
 				_resourceActions.removeModelResource(
-					objectDefinition.getClassName(), objectField.getName());
+					objectDefinition.getClassName(),
+					ObjectFieldConstants.
+						ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX +
+							objectField.getName());
 
 				_ploEntryLocalService.deletePLOEntries(
 					objectField.getCompanyId(),

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/feature/flag/test/ObjectFieldFeatureFlagListenerTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/feature/flag/test/ObjectFieldFeatureFlagListenerTest.java
@@ -1,0 +1,230 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.feature.flag.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFieldSettingConstants;
+import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.NoSuchResourceActionException;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.FeatureFlagTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.TempFileEntryUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Manuele Castro
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class ObjectFieldFeatureFlagListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testOnValue() throws Exception {
+		ObjectField objectField = ObjectFieldUtil.createObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
+			ObjectFieldConstants.DB_TYPE_LONG, true, false, null,
+			RandomTestUtil.randomString(), "attachment",
+			Arrays.asList(
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_ACCEPTED_FILE_EXTENSIONS
+				).value(
+					"jpg, jpeg, png, svg, txt"
+				).build(),
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_FILE_SOURCE
+				).value(
+					ObjectFieldSettingConstants.VALUE_USER_COMPUTER
+				).build(),
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_MAX_FILE_SIZE
+				).value(
+					"100"
+				).build()),
+			false);
+
+		ObjectDefinition objectDefinition =
+			ObjectDefinitionTestUtil.publishObjectDefinition(
+				Collections.singletonList(objectField));
+
+		long companyId = objectDefinition.getCompanyId();
+
+		String name = objectDefinition.getClassName();
+
+		Role powerUserRole = _roleLocalService.getRole(
+			companyId, RoleConstants.POWER_USER);
+
+		ObjectEntry objectEntry =
+			_objectEntryLocalService.addOrUpdateObjectEntry(
+				RandomTestUtil.randomString(), 0, TestPropsValues.getUserId(),
+				objectDefinition.getObjectDefinitionId(),
+				ObjectEntryFolderConstants.
+					PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+				HashMapBuilder.<String, Serializable>put(
+					"attachment",
+					() -> {
+						DLFileEntry dlFileEntry = _addDLFileEntry();
+
+						return String.valueOf(dlFileEntry.getFileEntryId());
+					}
+				).build(),
+				ServiceContextTestUtil.getServiceContext());
+
+		String primKey = String.valueOf(objectEntry.getObjectEntryId());
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+			powerUserRole.getRoleId(), new String[] {ActionKeys.VIEW});
+
+		FeatureFlagTestUtil.invokeFeatureFlagListeners(
+			companyId, false, "LPD-17564");
+
+		String actionId =
+			ObjectFieldConstants.ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX +
+				objectField.getName();
+
+		Assert.assertNull(
+			_resourceActionLocalService.fetchResourceAction(name, actionId));
+
+		Role ownerRole = _roleLocalService.getRole(
+			companyId, RoleConstants.OWNER);
+
+		try {
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+				ownerRole.getRoleId(), actionId);
+		}
+		catch (Exception exception) {
+			Assert.assertTrue(
+				exception instanceof NoSuchResourceActionException);
+		}
+
+		try {
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+				powerUserRole.getRoleId(), actionId);
+		}
+		catch (Exception exception) {
+			Assert.assertTrue(
+				exception instanceof NoSuchResourceActionException);
+		}
+
+		FeatureFlagTestUtil.invokeFeatureFlagListeners(
+			companyId, true, "LPD-17564");
+
+		Assert.assertNotNull(
+			_resourceActionLocalService.fetchResourceAction(name, actionId));
+
+		Role guestRole = _roleLocalService.getRole(
+			companyId, RoleConstants.GUEST);
+
+		Assert.assertFalse(
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+				guestRole.getRoleId(), actionId));
+
+		Role userRole = _roleLocalService.getRole(
+			companyId, RoleConstants.USER);
+
+		Assert.assertFalse(
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+				userRole.getRoleId(), actionId));
+
+		Assert.assertTrue(
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+				ownerRole.getRoleId(), actionId));
+
+		Assert.assertTrue(
+			_resourcePermissionLocalService.hasResourcePermission(
+				companyId, name, ResourceConstants.SCOPE_INDIVIDUAL, primKey,
+				powerUserRole.getRoleId(), actionId));
+
+		FeatureFlagTestUtil.invokeFeatureFlagListeners(
+			companyId, false, "LPD-17564");
+	}
+
+	private DLFileEntry _addDLFileEntry() throws Exception {
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), TestPropsValues.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			TempFileEntryUtil.getTempFileName("image.jpg"),
+			ContentTypes.APPLICATION_TEXT, RandomTestUtil.randomString(),
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+			new ByteArrayInputStream(RandomTestUtil.randomBytes()), 67, null,
+			null, null, ServiceContextTestUtil.getServiceContext());
+
+		return _dlFileEntryLocalService.getFileEntry(
+			fileEntry.getFileEntryId());
+	}
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	@Inject
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/servlet/filter/test/AttachmentObjectFieldDownloadFilterTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/internal/servlet/filter/test/AttachmentObjectFieldDownloadFilterTest.java
@@ -1,0 +1,296 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.object.internal.servlet.filter.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
+import com.liferay.document.library.util.DLURLHelper;
+import com.liferay.object.constants.ObjectEntryFolderConstants;
+import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.constants.ObjectFieldSettingConstants;
+import com.liferay.object.field.setting.builder.ObjectFieldSettingBuilder;
+import com.liferay.object.field.util.ObjectFieldUtil;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.model.ObjectField;
+import com.liferay.object.service.ObjectDefinitionLocalService;
+import com.liferay.object.service.ObjectEntryLocalService;
+import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.TempFileEntryUtil;
+import com.liferay.portal.security.permission.PermissionCacheUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Manuele Castro
+ */
+@FeatureFlag("LPD-17564")
+@RunWith(Arquillian.class)
+public class AttachmentObjectFieldDownloadFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_objectField = ObjectFieldUtil.createObjectField(
+			ObjectFieldConstants.BUSINESS_TYPE_ATTACHMENT,
+			ObjectFieldConstants.DB_TYPE_LONG, true, false, null,
+			RandomTestUtil.randomString(), "attachment",
+			Arrays.asList(
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_ACCEPTED_FILE_EXTENSIONS
+				).value(
+					"jpg, jpeg, png, svg, txt"
+				).build(),
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_FILE_SOURCE
+				).value(
+					ObjectFieldSettingConstants.VALUE_USER_COMPUTER
+				).build(),
+				new ObjectFieldSettingBuilder(
+				).name(
+					ObjectFieldSettingConstants.NAME_MAX_FILE_SIZE
+				).value(
+					"100"
+				).build()),
+			false);
+
+		_objectDefinition = ObjectDefinitionTestUtil.publishObjectDefinition(
+			Collections.singletonList(_objectField));
+
+		_company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		_objectEntry = _objectEntryLocalService.addOrUpdateObjectEntry(
+			RandomTestUtil.randomString(), 0, TestPropsValues.getUserId(),
+			_objectDefinition.getObjectDefinitionId(),
+			ObjectEntryFolderConstants.PARENT_OBJECT_ENTRY_FOLDER_ID_DEFAULT,
+			HashMapBuilder.<String, Serializable>put(
+				"attachment",
+				() -> {
+					DLFileEntry dlFileEntry = _addDLFileEntry();
+
+					return String.valueOf(dlFileEntry.getFileEntryId());
+				}
+			).build(),
+			ServiceContextTestUtil.getServiceContext());
+
+		Map<String, Serializable> objectEntryValues = _objectEntry.getValues();
+
+		_fileEntry = _dlAppLocalService.getFileEntry(
+			(long)objectEntryValues.get("attachment"));
+
+		_role = _roleLocalService.getRole(
+			_company.getCompanyId(), RoleConstants.GUEST);
+
+		_themeDisplay.setCompany(_company);
+
+		_user = UserLocalServiceUtil.getGuestUser(_company.getCompanyId());
+
+		_permissionChecker = PermissionCheckerFactoryUtil.create(_user);
+	}
+
+	@After
+	public void tearDown() throws PortalException {
+		_objectDefinitionLocalService.deleteObjectDefinition(_objectDefinition);
+	}
+
+	@Test
+	public void testProcessFilter() throws Exception {
+		String objectFieldActionId =
+			ObjectFieldConstants.ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX +
+				_objectField.getName();
+
+		Assert.assertFalse(
+			_permissionChecker.hasPermission(
+				_user.getGroupId(), _objectDefinition.getClassName(),
+				_objectEntry.getObjectEntryId(), objectFieldActionId));
+
+		_testHttpURLConnection(HttpServletResponse.SC_NOT_FOUND);
+
+		_testProcessFilter(
+			HttpServletResponse.SC_NOT_FOUND, new String[] {ActionKeys.VIEW});
+		_testProcessFilter(
+			HttpServletResponse.SC_NOT_FOUND,
+			new String[] {objectFieldActionId});
+		_testProcessFilter(
+			HttpServletResponse.SC_OK,
+			new String[] {ActionKeys.VIEW, objectFieldActionId});
+
+		_resourcePermissionLocalService.setResourcePermissions(
+			_company.getCompanyId(), DLFileEntry.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(_fileEntry.getFileEntryId()), _role.getRoleId(),
+			new String[0]);
+
+		_testHttpURLConnection(HttpServletResponse.SC_NOT_FOUND);
+	}
+
+	private DLFileEntry _addDLFileEntry() throws Exception {
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _company.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			TempFileEntryUtil.getTempFileName("image.jpg"),
+			ContentTypes.APPLICATION_TEXT, RandomTestUtil.randomString(),
+			StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
+			new ByteArrayInputStream(RandomTestUtil.randomBytes()), 67, null,
+			null, null, ServiceContextTestUtil.getServiceContext());
+
+		return _dlFileEntryLocalService.getFileEntry(
+			fileEntry.getFileEntryId());
+	}
+
+	private HttpURLConnection _openHttpURLConnection(String urlString)
+		throws Exception {
+
+		URL url = new URL(urlString);
+
+		HttpURLConnection httpURLConnection =
+			(HttpURLConnection)url.openConnection();
+
+		httpURLConnection.setRequestMethod("GET");
+
+		return httpURLConnection;
+	}
+
+	private void _testHttpURLConnection(int expectedStatusCode)
+		throws Exception {
+
+		HttpURLConnection httpURLConnection = _openHttpURLConnection(
+			StringBundler.concat(
+				"http://", _company.getVirtualHostname(), ":8080",
+				ObjectFieldUtil.getAttachmentDownloadURL(
+					_dlURLHelper, _fileEntry, 0,
+					_objectDefinition.getExternalReferenceCode(),
+					_objectEntry.getExternalReferenceCode(), _themeDisplay,
+					_objectField.getName())));
+
+		httpURLConnection.connect();
+
+		Assert.assertEquals(
+			expectedStatusCode, httpURLConnection.getResponseCode());
+
+		httpURLConnection.disconnect();
+	}
+
+	private void _testPermissions(String[] permissions) throws Exception {
+		_resourcePermissionLocalService.setResourcePermissions(
+			_company.getCompanyId(), _objectDefinition.getClassName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(_objectEntry.getObjectEntryId()), _role.getRoleId(),
+			permissions);
+
+		PermissionCacheUtil.clearCache(_user.getUserId());
+
+		for (String permission : permissions) {
+			Assert.assertTrue(
+				_permissionChecker.hasPermission(
+					_user.getGroupId(), _objectDefinition.getClassName(),
+					_objectEntry.getObjectEntryId(), permission));
+		}
+	}
+
+	private void _testProcessFilter(
+			int expectedStatusCode, String[] permissions)
+		throws Exception {
+
+		_testPermissions(permissions);
+
+		_testHttpURLConnection(expectedStatusCode);
+	}
+
+	private Company _company;
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private DLAppLocalService _dlAppLocalService;
+
+	@Inject
+	private DLFileEntryLocalService _dlFileEntryLocalService;
+
+	@Inject
+	private DLURLHelper _dlURLHelper;
+
+	private FileEntry _fileEntry;
+	private ObjectDefinition _objectDefinition;
+
+	@Inject
+	private ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	private ObjectEntry _objectEntry;
+
+	@Inject
+	private ObjectEntryLocalService _objectEntryLocalService;
+
+	private ObjectField _objectField;
+	private PermissionChecker _permissionChecker;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	private Role _role;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	private final ThemeDisplay _themeDisplay = new ThemeDisplay();
+	private User _user;
+
+}

--- a/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
+++ b/modules/apps/object/object-test/src/testIntegration/java/com/liferay/object/service/test/ObjectFieldLocalServiceTest.java
@@ -76,6 +76,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.test.AssertUtils;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -91,6 +92,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.TextFormatter;
+import com.liferay.portal.language.override.service.PLOEntryLocalService;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
@@ -1395,6 +1397,7 @@ public class ObjectFieldLocalServiceTest {
 			modifiableSystemObjectDefinition);
 	}
 
+	@FeatureFlag("LPD-17564")
 	@Test
 	public void testDeleteObjectField() throws Exception {
 
@@ -1402,7 +1405,7 @@ public class ObjectFieldLocalServiceTest {
 
 		ObjectDefinition customObjectDefinition =
 			ObjectDefinitionTestUtil.addCustomObjectDefinition(
-				false,
+				true,
 				Collections.singletonList(
 					ObjectFieldUtil.createObjectField(
 						ObjectFieldConstants.BUSINESS_TYPE_TEXT,
@@ -1514,6 +1517,21 @@ public class ObjectFieldLocalServiceTest {
 					).build())
 			).build());
 
+		String actionId =
+			ObjectFieldConstants.ATTACHMENT_FIELD_DOWNLOAD_ACTION_ID_PREFIX +
+				attachmentObjectField.getName();
+
+		ObjectDefinition objectDefinition =
+			attachmentObjectField.getObjectDefinition();
+
+		Assert.assertNotNull(
+			_resourceActionLocalService.fetchResourceAction(
+				objectDefinition.getClassName(), actionId));
+		Assert.assertNotNull(
+			_ploEntryLocalService.fetchPLOEntry(
+				objectDefinition.getCompanyId(), "action." + actionId,
+				attachmentObjectField.getDefaultLanguageId()));
+
 		ObjectEntry objectEntry = _objectEntryLocalService.addObjectEntry(
 			0, TestPropsValues.getUserId(),
 			customObjectDefinition.getObjectDefinitionId(),
@@ -1550,6 +1568,13 @@ public class ObjectFieldLocalServiceTest {
 				"No FileEntry exists with the key {fileEntryId=",
 				persistedFileEntryId, "}"),
 			() -> _dlAppLocalService.getFileEntry(persistedFileEntryId));
+		Assert.assertNull(
+			_resourceActionLocalService.fetchResourceAction(
+				objectDefinition.getClassName(), actionId));
+		Assert.assertNull(
+			_ploEntryLocalService.fetchPLOEntry(
+				objectDefinition.getCompanyId(), "action." + actionId,
+				attachmentObjectField.getDefaultLanguageId()));
 
 		// Delete object field business type auto increment
 
@@ -1637,7 +1662,7 @@ public class ObjectFieldLocalServiceTest {
 
 		ObjectDefinition modifiableSystemObjectDefinition =
 			ObjectDefinitionTestUtil.addModifiableSystemObjectDefinition(
-				TestPropsValues.getUserId(), null, false,
+				TestPropsValues.getUserId(), null, true,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
 				"Test" + RandomTestUtil.randomString(), null, null,
 				LocalizedMapUtil.getLocalizedMap(RandomTestUtil.randomString()),
@@ -2949,6 +2974,9 @@ public class ObjectFieldLocalServiceTest {
 	@Inject
 	private ObjectRelationshipLocalService _objectRelationshipLocalService;
 
+	@Inject
+	private PLOEntryLocalService _ploEntryLocalService;
+
 	private final Map<String, String> _readOnlyObjectFieldDBTypes =
 		HashMapBuilder.put(
 			"createDate", ObjectFieldConstants.DB_TYPE_DATE
@@ -2961,5 +2989,8 @@ public class ObjectFieldLocalServiceTest {
 		).put(
 			"status", ObjectFieldConstants.DB_TYPE_INTEGER
 		).build();
+
+	@Inject
+	private ResourceActionLocalService _resourceActionLocalService;
 
 }

--- a/modules/test/playwright/pages/object-web/object-entries/ViewObjectEntriesPage.ts
+++ b/modules/test/playwright/pages/object-web/object-entries/ViewObjectEntriesPage.ts
@@ -19,6 +19,7 @@ export class ViewObjectEntriesPage {
 	readonly dateTimeInput: Locator;
 	readonly deletionConfirmationModal: Locator;
 	readonly deleteFileButton: Locator;
+	readonly downloadFileButton: Locator;
 	readonly duplicateEntryErrorMessage: Locator;
 	readonly editObjectEntryForm: Locator;
 	readonly expirationDateInput: Locator;
@@ -26,6 +27,7 @@ export class ViewObjectEntriesPage {
 	readonly frontendDatasetActions: Locator;
 	readonly frontendDatasetDeleteAction: Locator;
 	readonly frontendDatasetItems: Locator;
+	readonly frontendDatasetPermissionsAction: Locator;
 	readonly frontendDatasetViewAction: Locator;
 	readonly neverExpire: Locator;
 	readonly neverReview: Locator;
@@ -64,6 +66,7 @@ export class ViewObjectEntriesPage {
 		this.deletionConfirmationModal = page
 			.getByRole('dialog')
 			.and(page.getByLabel('Delete Entry'));
+		this.downloadFileButton = page.getByRole('button', {name: 'Download'});
 		this.duplicateEntryErrorMessage = page.getByText(
 			'Error:The field values are already in use. Please choose unique values.'
 		);
@@ -84,6 +87,9 @@ export class ViewObjectEntriesPage {
 			name: 'Delete',
 		});
 		this.frontendDatasetItems = page.getByRole('cell').getByRole('link');
+		this.frontendDatasetPermissionsAction = page.getByRole('menuitem', {
+			name: 'Permissions',
+		});
 		this.frontendDatasetViewAction = page.getByRole('menuitem', {
 			name: 'View',
 		});

--- a/modules/test/playwright/tests/object-web/main/objectEntries.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectEntries.spec.ts
@@ -84,7 +84,7 @@ const assigneeTest = mergeTests(
 	})
 );
 
-const scheduleTest = mergeTests(
+const cmsTest = mergeTests(
 	test,
 	featureFlagsTest({
 		'LPD-17564': {enabled: true},
@@ -1431,7 +1431,7 @@ test.describe('Manage object entries through View Object Entries', () => {
 
 		await page.getByRole('button', {name: ATTACHMENT_FILE_NAME}).hover();
 
-		await page.locator('.lexicon-icon-download').click();
+		await viewObjectEntriesPage.downloadFileButton.click();
 
 		expect((await downloadPromise).suggestedFilename()).toStrictEqual(
 			`${ATTACHMENT_FILE_NAME}`
@@ -3134,16 +3134,175 @@ test.describe('Manage object entries through Workflow', () => {
 	);
 });
 
-scheduleTest.describe('Manage object entries schedule properties', () => {
+cmsTest.describe('Manage attachment ObjectField download permission', () => {
+	cmsTest(
+		'Verify file download restrictions',
+		async ({apiHelpers, page, viewObjectEntriesPage}) => {
+			const ATTACHMENT_FILE_NAME = 'astronaut.png';
+
+			const objectFields = generateObjectFields({
+				objectFieldBusinessTypes: ['Attachment'],
+			});
+
+			const objectDefinition =
+				await apiHelpers.objectAdmin.postRandomObjectDefinition({
+					objectFields,
+					status: {code: 0},
+				});
+
+			apiHelpers.data.push({
+				id: objectDefinition.id,
+				type: 'objectDefinition',
+			});
+
+			const company =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					'liferay.com'
+				);
+
+			const user = await createUserWithPermissions({
+				apiHelpers,
+				rolePermissions: [
+					{
+						actionIds: ['VIEW_CONTROL_PANEL'],
+						primaryKey: company.companyId,
+						resourceName: '90',
+						scope: 1,
+					},
+					{
+						actionIds: ['ACCESS_IN_CONTROL_PANEL'],
+						primaryKey: company.companyId,
+						resourceName:
+							'com_liferay_users_admin_web_portlet_UsersAdminPortlet',
+						scope: 1,
+					},
+					{
+						actionIds: ['ACCESS_IN_CONTROL_PANEL'],
+						primaryKey: company.companyId,
+						resourceName: `com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet_${objectDefinition.className.split('#')[1]}`,
+						scope: 1,
+					},
+					{
+						actionIds: ['VIEW'],
+						primaryKey: company.companyId,
+						resourceName: `${objectDefinition.className}`,
+						scope: 1,
+					},
+				],
+			});
+
+			let entryUrl: string;
+
+			await test.step('go to entry page, upload a file, save the entry and check download button is present', async () => {
+				await viewObjectEntriesPage.goto(objectDefinition.className);
+
+				await viewObjectEntriesPage.clickAddObjectEntry(
+					objectDefinition.label['en_US']
+				);
+
+				await viewObjectEntriesPage.selectFileButton.click();
+
+				await viewObjectEntriesPage.selectFileFromDocumentsAndMedia(
+					ATTACHMENT_FILE_NAME
+				);
+
+				await viewObjectEntriesPage.saveObjectEntryButton.click();
+
+				await expect(
+					viewObjectEntriesPage.successMessage
+				).toBeVisible();
+
+				entryUrl = page.url();
+
+				await expect(
+					viewObjectEntriesPage.downloadFileButton
+				).toBeVisible();
+			});
+
+			await test.step('login user with only view permission, then check the user is unable to perform the file download', async () => {
+				await performUserSwitch(page, user.alternateName);
+
+				await viewObjectEntriesPage.goto(objectDefinition.className);
+
+				await page
+					.getByRole('link', {name: ATTACHMENT_FILE_NAME})
+					.click();
+
+				try {
+					await page.waitForEvent('download', {timeout: 1000});
+				}
+				catch (error) {
+					expect(error.message.includes('Timeout')).toBeTruthy();
+				}
+
+				await page.goto(entryUrl);
+
+				await expect(
+					viewObjectEntriesPage.downloadFileButton
+				).not.toBeVisible();
+			});
+
+			await test.step('add download permission to the user then check the user is able to perform the file download', async () => {
+				await performUserSwitch(page, 'test');
+
+				await viewObjectEntriesPage.goto(objectDefinition.className);
+
+				await viewObjectEntriesPage.frontendDatasetActions.click();
+
+				await viewObjectEntriesPage.frontendDatasetPermissionsAction.click();
+
+				const iframeLocator = page.frameLocator(
+					'iframe[title="Permissions"]'
+				);
+
+				const objectField = objectFields[0];
+
+				const objectFieldActionCheckbox = iframeLocator.locator(
+					'#guest_ACTION_download_' + objectField.name
+				);
+
+				await objectFieldActionCheckbox.click();
+
+				await expect(objectFieldActionCheckbox).toBeChecked();
+
+				await iframeLocator.getByRole('button', {name: 'Save'}).click();
+
+				await expect(
+					iframeLocator.getByText('Success:Your request')
+				).toBeVisible();
+
+				await performUserSwitch(page, user.alternateName);
+
+				await viewObjectEntriesPage.goto(objectDefinition.className);
+
+				const downloadPromise = page.waitForEvent('download');
+
+				await page.getByRole('link', {name: 'astronaut.png'}).click();
+
+				expect(
+					(await downloadPromise).suggestedFilename()
+				).toStrictEqual(`${ATTACHMENT_FILE_NAME}`);
+
+				await page.goto(entryUrl);
+
+				await expect(
+					viewObjectEntriesPage.downloadFileButton
+				).toBeVisible();
+			});
+		}
+	);
+});
+
+cmsTest.describe('Manage object entries schedule properties', () => {
 	let _objectDefinition: ObjectDefinition;
 
-	scheduleTest.afterEach(async ({accountSettingsPage}) => {
+	cmsTest.afterEach(async ({accountSettingsPage}) => {
 		await accountSettingsPage.goToDisplaySettings();
 
 		await accountSettingsPage.setTimeZone('UTC');
 	});
 
-	scheduleTest.beforeEach(async ({accountSettingsPage, apiHelpers, page}) => {
+	cmsTest.beforeEach(async ({accountSettingsPage, apiHelpers, page}) => {
 		const objectDefinition =
 			await apiHelpers.objectAdmin.postRandomObjectDefinition({
 				status: {code: 0},
@@ -3154,7 +3313,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		const objectDefinitionAPIClient =
 			await apiHelpers.buildRestClient(ObjectDefinitionAPI);
 
-		const shouldEnableConfiguration = !scheduleTest
+		const shouldEnableConfiguration = !cmsTest
 			.info()
 			.tags.includes('@enableObjectEntryScheduleFalse');
 
@@ -3188,7 +3347,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		await accountSettingsPage.setTimeZone(timeZoneValue);
 	});
 
-	scheduleTest(
+	cmsTest(
 		'can create, read, update, and delete a displayDate of an object entry',
 		async ({page, viewObjectEntriesPage}) => {
 			await viewObjectEntriesPage.goto(_objectDefinition.className);
@@ -3249,7 +3408,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		}
 	);
 
-	scheduleTest(
+	cmsTest(
 		'can create, read, update, and delete a expirationDate of an object entry',
 		async ({page, viewObjectEntriesPage}) => {
 			await viewObjectEntriesPage.goto(_objectDefinition.className);
@@ -3306,7 +3465,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		}
 	);
 
-	scheduleTest(
+	cmsTest(
 		'can create, read, update, and delete a reviewDate of an object entry',
 		async ({page, viewObjectEntriesPage}) => {
 			await viewObjectEntriesPage.goto(_objectDefinition.className);
@@ -3357,7 +3516,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		}
 	);
 
-	scheduleTest(
+	cmsTest(
 		'can see approved and scheduled labels for entry with a display date versioning enabled and at least one version approved',
 		async ({apiHelpers, page, viewObjectEntriesPage}) => {
 			const objectDefinitionAPIClient =
@@ -3420,7 +3579,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		}
 	);
 
-	scheduleTest(
+	cmsTest(
 		'cannot submit an empty displayDate',
 		async ({page, viewObjectEntriesPage}) => {
 			await viewObjectEntriesPage.goto(_objectDefinition.className);
@@ -3455,7 +3614,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		}
 	);
 
-	scheduleTest(
+	cmsTest(
 		'cannot submit an empty expirationDate and reviewDate when it is enabled',
 		async ({page, viewObjectEntriesPage}) => {
 			await viewObjectEntriesPage.goto(_objectDefinition.className);
@@ -3500,7 +3659,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		}
 	);
 
-	scheduleTest(
+	cmsTest(
 		'cannot submit a past expirationDate',
 		async ({page, viewObjectEntriesPage}) => {
 			await viewObjectEntriesPage.goto(_objectDefinition.className);
@@ -3537,7 +3696,7 @@ scheduleTest.describe('Manage object entries schedule properties', () => {
 		}
 	);
 
-	scheduleTest(
+	cmsTest(
 		'schedule container is not visible when enableObjectEntrySchedule is disabled',
 		{tag: '@enableObjectEntryScheduleFalse'},
 		async ({viewObjectEntriesPage}) => {

--- a/modules/test/playwright/tests/object-web/main/objectEntries.spec.ts
+++ b/modules/test/playwright/tests/object-web/main/objectEntries.spec.ts
@@ -222,6 +222,593 @@ assigneeTest(
 	}
 );
 
+cmsTest.describe('Manage attachment ObjectField download permission', () => {
+	cmsTest(
+		'verify file download restrictions',
+		async ({apiHelpers, page, viewObjectEntriesPage}) => {
+			const ATTACHMENT_FILE_NAME = 'astronaut.png';
+
+			const objectFields = generateObjectFields({
+				objectFieldBusinessTypes: ['Attachment'],
+			});
+
+			const objectDefinition =
+				await apiHelpers.objectAdmin.postRandomObjectDefinition({
+					objectFields,
+					status: {code: 0},
+				});
+
+			apiHelpers.data.push({
+				id: objectDefinition.id,
+				type: 'objectDefinition',
+			});
+
+			const company =
+				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+					'liferay.com'
+				);
+
+			const user = await createUserWithPermissions({
+				apiHelpers,
+				rolePermissions: [
+					{
+						actionIds: ['VIEW_CONTROL_PANEL'],
+						primaryKey: company.companyId,
+						resourceName: '90',
+						scope: 1,
+					},
+					{
+						actionIds: ['ACCESS_IN_CONTROL_PANEL'],
+						primaryKey: company.companyId,
+						resourceName:
+							'com_liferay_users_admin_web_portlet_UsersAdminPortlet',
+						scope: 1,
+					},
+					{
+						actionIds: ['ACCESS_IN_CONTROL_PANEL'],
+						primaryKey: company.companyId,
+						resourceName: `com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet_${objectDefinition.className.split('#')[1]}`,
+						scope: 1,
+					},
+					{
+						actionIds: ['VIEW'],
+						primaryKey: company.companyId,
+						resourceName: `${objectDefinition.className}`,
+						scope: 1,
+					},
+				],
+			});
+
+			let entryUrl: string;
+
+			await test.step('go to entry page, upload a file, save the entry and check download button is present', async () => {
+				await viewObjectEntriesPage.goto(objectDefinition.className);
+
+				await viewObjectEntriesPage.clickAddObjectEntry(
+					objectDefinition.label['en_US']
+				);
+
+				await viewObjectEntriesPage.selectFileButton.click();
+
+				await viewObjectEntriesPage.selectFileFromDocumentsAndMedia(
+					ATTACHMENT_FILE_NAME
+				);
+
+				await viewObjectEntriesPage.saveObjectEntryButton.click();
+
+				await expect(
+					viewObjectEntriesPage.successMessage
+				).toBeVisible();
+
+				entryUrl = page.url();
+
+				await expect(
+					viewObjectEntriesPage.downloadFileButton
+				).toBeVisible();
+			});
+
+			await test.step('login user with only view permission, then check the user is unable to perform the file download', async () => {
+				await performUserSwitch(page, user.alternateName);
+
+				await viewObjectEntriesPage.goto(objectDefinition.className);
+
+				await page
+					.getByRole('link', {name: ATTACHMENT_FILE_NAME})
+					.click();
+
+				try {
+					await page.waitForEvent('download', {timeout: 1000});
+				}
+				catch (error) {
+					expect(error.message.includes('Timeout')).toBeTruthy();
+				}
+
+				await page.goto(entryUrl);
+
+				await expect(
+					viewObjectEntriesPage.downloadFileButton
+				).not.toBeVisible();
+			});
+
+			await test.step('add download permission to the user then check the user is able to perform the file download', async () => {
+				await performUserSwitch(page, 'test');
+
+				await viewObjectEntriesPage.goto(objectDefinition.className);
+
+				await viewObjectEntriesPage.frontendDatasetActions.click();
+
+				await viewObjectEntriesPage.frontendDatasetPermissionsAction.click();
+
+				const iframeLocator = page.frameLocator(
+					'iframe[title="Permissions"]'
+				);
+
+				const objectField = objectFields[0];
+
+				const objectFieldActionCheckbox = iframeLocator.locator(
+					'#guest_ACTION_download_' + objectField.name
+				);
+
+				await objectFieldActionCheckbox.click();
+
+				await expect(objectFieldActionCheckbox).toBeChecked();
+
+				await iframeLocator.getByRole('button', {name: 'Save'}).click();
+
+				await expect(
+					iframeLocator.getByText('Success:Your request')
+				).toBeVisible();
+
+				await performUserSwitch(page, user.alternateName);
+
+				await viewObjectEntriesPage.goto(objectDefinition.className);
+
+				const downloadPromise = page.waitForEvent('download');
+
+				await page.getByRole('link', {name: 'astronaut.png'}).click();
+
+				expect(
+					(await downloadPromise).suggestedFilename()
+				).toStrictEqual(`${ATTACHMENT_FILE_NAME}`);
+
+				await page.goto(entryUrl);
+
+				await expect(
+					viewObjectEntriesPage.downloadFileButton
+				).toBeVisible();
+			});
+		}
+	);
+});
+
+cmsTest.describe('Manage object entries schedule properties', () => {
+	let _objectDefinition: ObjectDefinition;
+
+	cmsTest.afterEach(async ({accountSettingsPage}) => {
+		await accountSettingsPage.goToDisplaySettings();
+
+		await accountSettingsPage.setTimeZone('UTC');
+	});
+
+	cmsTest.beforeEach(async ({accountSettingsPage, apiHelpers, page}) => {
+		const objectDefinition =
+			await apiHelpers.objectAdmin.postRandomObjectDefinition({
+				status: {code: 0},
+			});
+
+		_objectDefinition = objectDefinition;
+
+		const objectDefinitionAPIClient =
+			await apiHelpers.buildRestClient(ObjectDefinitionAPI);
+
+		const shouldEnableConfiguration = !cmsTest
+			.info()
+			.tags.includes('@enableObjectEntryScheduleFalse');
+
+		if (shouldEnableConfiguration) {
+			await objectDefinitionAPIClient.patchObjectDefinition(
+				_objectDefinition.id,
+				{
+					enableObjectEntrySchedule: true,
+				}
+			);
+		}
+
+		apiHelpers.data.push({
+			id: objectDefinition.id,
+			type: 'objectDefinition',
+		});
+
+		const utcOffsetFormatted = getUTCOffsetFormatted(new Date());
+
+		await accountSettingsPage.goToDisplaySettings();
+
+		if (utcOffsetFormatted === 'UTC') {
+			return await accountSettingsPage.setTimeZone('UTC');
+		}
+
+		const timeZoneValue = await page
+			.locator('select option', {hasText: utcOffsetFormatted})
+			.first()
+			.getAttribute('value');
+
+		await accountSettingsPage.setTimeZone(timeZoneValue);
+	});
+
+	cmsTest(
+		'can create, read, update, and delete a displayDate of an object entry',
+		async ({page, viewObjectEntriesPage}) => {
+			await viewObjectEntriesPage.goto(_objectDefinition.className);
+
+			await viewObjectEntriesPage.clickAddObjectEntry(
+				_objectDefinition.label['en_US']
+			);
+
+			await viewObjectEntriesPage.choosePublicationOption('schedule');
+
+			await viewObjectEntriesPage.scheduleForCurrentDate('Publish');
+
+			await page.keyboard.press('Escape');
+
+			await viewObjectEntriesPage.schedulePublicationButton.click();
+
+			await waitForAlert(page);
+
+			const date = new Date();
+
+			const today = getObjectEntryUIDateTimeFormat(date);
+
+			await viewObjectEntriesPage.choosePublicationOption('schedule');
+
+			await expect(viewObjectEntriesPage.publishDateInput).toHaveValue(
+				today
+			);
+
+			date.setDate(date.getDate() + 1);
+
+			const tomorrow = getObjectEntryUIDateTimeFormat(date);
+
+			await viewObjectEntriesPage.publishDateInput.fill(tomorrow);
+
+			await viewObjectEntriesPage.schedulePublicationButton.click();
+
+			await waitForAlert(page);
+
+			await viewObjectEntriesPage.choosePublicationOption('schedule');
+
+			await expect(viewObjectEntriesPage.publishDateInput).toHaveValue(
+				tomorrow
+			);
+
+			await page.getByRole('button', {name: 'Close'}).click();
+
+			await viewObjectEntriesPage.choosePublicationOption('publish');
+
+			await waitForAlert(page);
+
+			await viewObjectEntriesPage.choosePublicationOption('schedule');
+
+			await expect(viewObjectEntriesPage.publishDateInput).toHaveValue(
+				''
+			);
+
+			await page.getByRole('button', {name: 'Close'}).click();
+		}
+	);
+
+	cmsTest(
+		'can create, read, update, and delete a expirationDate of an object entry',
+		async ({page, viewObjectEntriesPage}) => {
+			await viewObjectEntriesPage.goto(_objectDefinition.className);
+
+			await viewObjectEntriesPage.clickAddObjectEntry(
+				_objectDefinition.label['en_US']
+			);
+
+			await viewObjectEntriesPage.neverExpire.uncheck();
+
+			const date = new Date();
+
+			// Add a few minutes since expiration cant be scheduled for current dateTime
+
+			date.setMinutes(date.getMinutes() + 2);
+
+			const today = getObjectEntryUIDateTimeFormat(date);
+
+			await viewObjectEntriesPage.expirationDateInput.fill(today);
+
+			await page.keyboard.press('Escape');
+
+			await viewObjectEntriesPage.choosePublicationOption('publish');
+
+			await waitForAlert(page);
+
+			await expect(viewObjectEntriesPage.expirationDateInput).toHaveValue(
+				today
+			);
+
+			date.setDate(date.getDate() + 1);
+
+			const tomorrow = getObjectEntryUIDateTimeFormat(date);
+
+			await viewObjectEntriesPage.expirationDateInput.fill(tomorrow);
+
+			await viewObjectEntriesPage.choosePublicationOption('publish');
+
+			await waitForAlert(page);
+
+			await expect(viewObjectEntriesPage.expirationDateInput).toHaveValue(
+				tomorrow
+			);
+
+			await viewObjectEntriesPage.neverExpire.check();
+
+			await viewObjectEntriesPage.choosePublicationOption('publish');
+
+			await waitForAlert(page);
+
+			await expect(viewObjectEntriesPage.expirationDateInput).toHaveValue(
+				''
+			);
+		}
+	);
+
+	cmsTest(
+		'can create, read, update, and delete a reviewDate of an object entry',
+		async ({page, viewObjectEntriesPage}) => {
+			await viewObjectEntriesPage.goto(_objectDefinition.className);
+
+			await viewObjectEntriesPage.clickAddObjectEntry(
+				_objectDefinition.label['en_US']
+			);
+
+			await viewObjectEntriesPage.neverReview.uncheck();
+
+			await viewObjectEntriesPage.scheduleForCurrentDate('Review');
+
+			await page.keyboard.press('Escape');
+
+			await viewObjectEntriesPage.choosePublicationOption('publish');
+
+			await waitForAlert(page);
+
+			const date = new Date();
+
+			const today = getObjectEntryUIDateTimeFormat(date);
+
+			await expect(viewObjectEntriesPage.reviewDateInput).toHaveValue(
+				today
+			);
+
+			date.setDate(date.getDate() + 1);
+
+			const tomorrow = getObjectEntryUIDateTimeFormat(date);
+
+			await viewObjectEntriesPage.reviewDateInput.fill(tomorrow);
+
+			await viewObjectEntriesPage.choosePublicationOption('publish');
+
+			await waitForAlert(page);
+
+			await expect(viewObjectEntriesPage.reviewDateInput).toHaveValue(
+				tomorrow
+			);
+
+			await viewObjectEntriesPage.neverReview.check();
+
+			await viewObjectEntriesPage.choosePublicationOption('publish');
+
+			await waitForAlert(page);
+
+			await expect(viewObjectEntriesPage.reviewDateInput).toHaveValue('');
+		}
+	);
+
+	cmsTest(
+		'can see approved and scheduled labels for entry with a display date versioning enabled and at least one version approved',
+		async ({apiHelpers, page, viewObjectEntriesPage}) => {
+			const objectDefinitionAPIClient =
+				await apiHelpers.buildRestClient(ObjectDefinitionAPI);
+
+			await objectDefinitionAPIClient.patchObjectDefinition(
+				_objectDefinition.id,
+				{
+					enableObjectEntryVersioning: true,
+				}
+			);
+
+			await viewObjectEntriesPage.goto(_objectDefinition.className);
+
+			await viewObjectEntriesPage.clickAddObjectEntry(
+				_objectDefinition.label['en_US']
+			);
+
+			await viewObjectEntriesPage.choosePublicationOption('publish');
+
+			await waitForAlert(page);
+
+			await viewObjectEntriesPage.backButton.click();
+
+			await expect(page.getByText('Approved')).toBeVisible();
+
+			await expect(page.getByText('Scheduled')).not.toBeVisible();
+
+			const applicationName =
+				'c/' + _objectDefinition.name.toLowerCase() + 's';
+
+			const {items} =
+				await apiHelpers.objectEntry.getObjectDefinitionObjectEntries(
+					applicationName
+				);
+
+			const objectEntryId = items[0].id;
+
+			await page.getByRole('link', {name: objectEntryId}).click();
+
+			const date = new Date();
+
+			date.setDate(date.getDate() + 1);
+
+			const tomorrow = getObjectEntryUIDateTimeFormat(date);
+
+			await viewObjectEntriesPage.choosePublicationOption('schedule');
+
+			await viewObjectEntriesPage.publishDateInput.fill(tomorrow);
+
+			await viewObjectEntriesPage.schedulePublicationButton.click();
+
+			await waitForAlert(page);
+
+			await viewObjectEntriesPage.backButton.click();
+
+			await expect(page.getByText('Approved')).toBeVisible();
+
+			await expect(page.getByText('Scheduled')).toBeVisible();
+		}
+	);
+
+	cmsTest(
+		'cannot submit an empty displayDate',
+		async ({page, viewObjectEntriesPage}) => {
+			await viewObjectEntriesPage.goto(_objectDefinition.className);
+
+			await viewObjectEntriesPage.clickAddObjectEntry(
+				_objectDefinition.label['en_US']
+			);
+
+			await viewObjectEntriesPage.choosePublicationOption('schedule');
+
+			let requestWasMade = false;
+
+			page.on('request', (request) => {
+				if (request.url().includes(_objectDefinition.restContextPath)) {
+					requestWasMade = true;
+				}
+			});
+
+			await viewObjectEntriesPage.schedulePublicationButton.click();
+
+			// Wait a second before doing the assertion to simulate the time needed for the request to happen
+
+			await page.waitForTimeout(1000);
+
+			expect(requestWasMade).toBe(false);
+
+			await expect(
+				page.getByText('This field is required')
+			).toBeVisible();
+
+			await viewObjectEntriesPage.schedulePublicationCloseButton.click();
+		}
+	);
+
+	cmsTest(
+		'cannot submit an empty expirationDate and reviewDate when it is enabled',
+		async ({page, viewObjectEntriesPage}) => {
+			await viewObjectEntriesPage.goto(_objectDefinition.className);
+
+			await viewObjectEntriesPage.clickAddObjectEntry(
+				_objectDefinition.label['en_US']
+			);
+
+			for (const scheduleProperty of ['Expire', 'Review']) {
+				await viewObjectEntriesPage.page
+					.getByLabel(`Never ${scheduleProperty}`, {exact: true})
+					.uncheck();
+
+				let requestWasMade = false;
+
+				page.on('request', (request) => {
+					if (
+						request
+							.url()
+							.includes(_objectDefinition.restContextPath)
+					) {
+						requestWasMade = true;
+					}
+				});
+
+				await viewObjectEntriesPage.choosePublicationOption('publish');
+
+				// Wait a second before doing the assertion to simulate the time needed for the request to happen
+
+				await page.waitForTimeout(1000);
+
+				expect(requestWasMade).toBe(false);
+
+				await expect(
+					page.getByText('This field is required')
+				).toBeVisible();
+
+				await viewObjectEntriesPage.page
+					.getByLabel(`Never ${scheduleProperty}`, {exact: true})
+					.check();
+			}
+		}
+	);
+
+	cmsTest(
+		'cannot submit a past expirationDate',
+		async ({page, viewObjectEntriesPage}) => {
+			await viewObjectEntriesPage.goto(_objectDefinition.className);
+
+			await viewObjectEntriesPage.clickAddObjectEntry(
+				_objectDefinition.label['en_US']
+			);
+
+			await viewObjectEntriesPage.neverExpire.uncheck();
+
+			await viewObjectEntriesPage.scheduleForCurrentDate('Expiration');
+
+			await viewObjectEntriesPage.page.keyboard.press('Escape');
+
+			let requestWasMade = false;
+
+			page.on('request', (request) => {
+				if (request.url().includes(_objectDefinition.restContextPath)) {
+					requestWasMade = true;
+				}
+			});
+
+			await viewObjectEntriesPage.choosePublicationOption('publish');
+
+			// Wait a second before doing the assertion to simulate the time needed for the request to happen
+
+			await page.waitForTimeout(1000);
+
+			expect(requestWasMade).toBe(false);
+
+			await expect(
+				page.getByText('The date entered is in the past')
+			).toBeVisible();
+		}
+	);
+
+	cmsTest(
+		'schedule container is not visible when enableObjectEntrySchedule is disabled',
+		{tag: '@enableObjectEntryScheduleFalse'},
+		async ({viewObjectEntriesPage}) => {
+			await viewObjectEntriesPage.goto(_objectDefinition.className);
+
+			await viewObjectEntriesPage.clickAddObjectEntry(
+				_objectDefinition.label['en_US']
+			);
+
+			await expect(
+				viewObjectEntriesPage.schedulePanelButton
+			).not.toBeVisible();
+
+			await expect(
+				viewObjectEntriesPage.expirationDateInput
+			).not.toBeVisible();
+
+			await expect(
+				viewObjectEntriesPage.reviewDateInput
+			).not.toBeVisible();
+		}
+	);
+});
+
 test.describe('Manage object entries through Friendly URL', () => {
 	let _objectDefinition: ObjectDefinition;
 	let _objectEntryFriendlyURLPath: string;
@@ -3130,593 +3717,6 @@ test.describe('Manage object entries through Workflow', () => {
 					'input[placeholder="__/__/____ __:__ _"][value="10/05/2025 09:00 AM"]'
 				)
 			).toHaveValue('10/05/2025 09:00 AM');
-		}
-	);
-});
-
-cmsTest.describe('Manage attachment ObjectField download permission', () => {
-	cmsTest(
-		'Verify file download restrictions',
-		async ({apiHelpers, page, viewObjectEntriesPage}) => {
-			const ATTACHMENT_FILE_NAME = 'astronaut.png';
-
-			const objectFields = generateObjectFields({
-				objectFieldBusinessTypes: ['Attachment'],
-			});
-
-			const objectDefinition =
-				await apiHelpers.objectAdmin.postRandomObjectDefinition({
-					objectFields,
-					status: {code: 0},
-				});
-
-			apiHelpers.data.push({
-				id: objectDefinition.id,
-				type: 'objectDefinition',
-			});
-
-			const company =
-				await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
-					'liferay.com'
-				);
-
-			const user = await createUserWithPermissions({
-				apiHelpers,
-				rolePermissions: [
-					{
-						actionIds: ['VIEW_CONTROL_PANEL'],
-						primaryKey: company.companyId,
-						resourceName: '90',
-						scope: 1,
-					},
-					{
-						actionIds: ['ACCESS_IN_CONTROL_PANEL'],
-						primaryKey: company.companyId,
-						resourceName:
-							'com_liferay_users_admin_web_portlet_UsersAdminPortlet',
-						scope: 1,
-					},
-					{
-						actionIds: ['ACCESS_IN_CONTROL_PANEL'],
-						primaryKey: company.companyId,
-						resourceName: `com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet_${objectDefinition.className.split('#')[1]}`,
-						scope: 1,
-					},
-					{
-						actionIds: ['VIEW'],
-						primaryKey: company.companyId,
-						resourceName: `${objectDefinition.className}`,
-						scope: 1,
-					},
-				],
-			});
-
-			let entryUrl: string;
-
-			await test.step('go to entry page, upload a file, save the entry and check download button is present', async () => {
-				await viewObjectEntriesPage.goto(objectDefinition.className);
-
-				await viewObjectEntriesPage.clickAddObjectEntry(
-					objectDefinition.label['en_US']
-				);
-
-				await viewObjectEntriesPage.selectFileButton.click();
-
-				await viewObjectEntriesPage.selectFileFromDocumentsAndMedia(
-					ATTACHMENT_FILE_NAME
-				);
-
-				await viewObjectEntriesPage.saveObjectEntryButton.click();
-
-				await expect(
-					viewObjectEntriesPage.successMessage
-				).toBeVisible();
-
-				entryUrl = page.url();
-
-				await expect(
-					viewObjectEntriesPage.downloadFileButton
-				).toBeVisible();
-			});
-
-			await test.step('login user with only view permission, then check the user is unable to perform the file download', async () => {
-				await performUserSwitch(page, user.alternateName);
-
-				await viewObjectEntriesPage.goto(objectDefinition.className);
-
-				await page
-					.getByRole('link', {name: ATTACHMENT_FILE_NAME})
-					.click();
-
-				try {
-					await page.waitForEvent('download', {timeout: 1000});
-				}
-				catch (error) {
-					expect(error.message.includes('Timeout')).toBeTruthy();
-				}
-
-				await page.goto(entryUrl);
-
-				await expect(
-					viewObjectEntriesPage.downloadFileButton
-				).not.toBeVisible();
-			});
-
-			await test.step('add download permission to the user then check the user is able to perform the file download', async () => {
-				await performUserSwitch(page, 'test');
-
-				await viewObjectEntriesPage.goto(objectDefinition.className);
-
-				await viewObjectEntriesPage.frontendDatasetActions.click();
-
-				await viewObjectEntriesPage.frontendDatasetPermissionsAction.click();
-
-				const iframeLocator = page.frameLocator(
-					'iframe[title="Permissions"]'
-				);
-
-				const objectField = objectFields[0];
-
-				const objectFieldActionCheckbox = iframeLocator.locator(
-					'#guest_ACTION_download_' + objectField.name
-				);
-
-				await objectFieldActionCheckbox.click();
-
-				await expect(objectFieldActionCheckbox).toBeChecked();
-
-				await iframeLocator.getByRole('button', {name: 'Save'}).click();
-
-				await expect(
-					iframeLocator.getByText('Success:Your request')
-				).toBeVisible();
-
-				await performUserSwitch(page, user.alternateName);
-
-				await viewObjectEntriesPage.goto(objectDefinition.className);
-
-				const downloadPromise = page.waitForEvent('download');
-
-				await page.getByRole('link', {name: 'astronaut.png'}).click();
-
-				expect(
-					(await downloadPromise).suggestedFilename()
-				).toStrictEqual(`${ATTACHMENT_FILE_NAME}`);
-
-				await page.goto(entryUrl);
-
-				await expect(
-					viewObjectEntriesPage.downloadFileButton
-				).toBeVisible();
-			});
-		}
-	);
-});
-
-cmsTest.describe('Manage object entries schedule properties', () => {
-	let _objectDefinition: ObjectDefinition;
-
-	cmsTest.afterEach(async ({accountSettingsPage}) => {
-		await accountSettingsPage.goToDisplaySettings();
-
-		await accountSettingsPage.setTimeZone('UTC');
-	});
-
-	cmsTest.beforeEach(async ({accountSettingsPage, apiHelpers, page}) => {
-		const objectDefinition =
-			await apiHelpers.objectAdmin.postRandomObjectDefinition({
-				status: {code: 0},
-			});
-
-		_objectDefinition = objectDefinition;
-
-		const objectDefinitionAPIClient =
-			await apiHelpers.buildRestClient(ObjectDefinitionAPI);
-
-		const shouldEnableConfiguration = !cmsTest
-			.info()
-			.tags.includes('@enableObjectEntryScheduleFalse');
-
-		if (shouldEnableConfiguration) {
-			await objectDefinitionAPIClient.patchObjectDefinition(
-				_objectDefinition.id,
-				{
-					enableObjectEntrySchedule: true,
-				}
-			);
-		}
-
-		apiHelpers.data.push({
-			id: objectDefinition.id,
-			type: 'objectDefinition',
-		});
-
-		const utcOffsetFormatted = getUTCOffsetFormatted(new Date());
-
-		await accountSettingsPage.goToDisplaySettings();
-
-		if (utcOffsetFormatted === 'UTC') {
-			return await accountSettingsPage.setTimeZone('UTC');
-		}
-
-		const timeZoneValue = await page
-			.locator('select option', {hasText: utcOffsetFormatted})
-			.first()
-			.getAttribute('value');
-
-		await accountSettingsPage.setTimeZone(timeZoneValue);
-	});
-
-	cmsTest(
-		'can create, read, update, and delete a displayDate of an object entry',
-		async ({page, viewObjectEntriesPage}) => {
-			await viewObjectEntriesPage.goto(_objectDefinition.className);
-
-			await viewObjectEntriesPage.clickAddObjectEntry(
-				_objectDefinition.label['en_US']
-			);
-
-			await viewObjectEntriesPage.choosePublicationOption('schedule');
-
-			await viewObjectEntriesPage.scheduleForCurrentDate('Publish');
-
-			await page.keyboard.press('Escape');
-
-			await viewObjectEntriesPage.schedulePublicationButton.click();
-
-			await waitForAlert(page);
-
-			const date = new Date();
-
-			const today = getObjectEntryUIDateTimeFormat(date);
-
-			await viewObjectEntriesPage.choosePublicationOption('schedule');
-
-			await expect(viewObjectEntriesPage.publishDateInput).toHaveValue(
-				today
-			);
-
-			date.setDate(date.getDate() + 1);
-
-			const tomorrow = getObjectEntryUIDateTimeFormat(date);
-
-			await viewObjectEntriesPage.publishDateInput.fill(tomorrow);
-
-			await viewObjectEntriesPage.schedulePublicationButton.click();
-
-			await waitForAlert(page);
-
-			await viewObjectEntriesPage.choosePublicationOption('schedule');
-
-			await expect(viewObjectEntriesPage.publishDateInput).toHaveValue(
-				tomorrow
-			);
-
-			await page.getByRole('button', {name: 'Close'}).click();
-
-			await viewObjectEntriesPage.choosePublicationOption('publish');
-
-			await waitForAlert(page);
-
-			await viewObjectEntriesPage.choosePublicationOption('schedule');
-
-			await expect(viewObjectEntriesPage.publishDateInput).toHaveValue(
-				''
-			);
-
-			await page.getByRole('button', {name: 'Close'}).click();
-		}
-	);
-
-	cmsTest(
-		'can create, read, update, and delete a expirationDate of an object entry',
-		async ({page, viewObjectEntriesPage}) => {
-			await viewObjectEntriesPage.goto(_objectDefinition.className);
-
-			await viewObjectEntriesPage.clickAddObjectEntry(
-				_objectDefinition.label['en_US']
-			);
-
-			await viewObjectEntriesPage.neverExpire.uncheck();
-
-			const date = new Date();
-
-			// Add a few minutes since expiration cant be scheduled for current dateTime
-
-			date.setMinutes(date.getMinutes() + 2);
-
-			const today = getObjectEntryUIDateTimeFormat(date);
-
-			await viewObjectEntriesPage.expirationDateInput.fill(today);
-
-			await page.keyboard.press('Escape');
-
-			await viewObjectEntriesPage.choosePublicationOption('publish');
-
-			await waitForAlert(page);
-
-			await expect(viewObjectEntriesPage.expirationDateInput).toHaveValue(
-				today
-			);
-
-			date.setDate(date.getDate() + 1);
-
-			const tomorrow = getObjectEntryUIDateTimeFormat(date);
-
-			await viewObjectEntriesPage.expirationDateInput.fill(tomorrow);
-
-			await viewObjectEntriesPage.choosePublicationOption('publish');
-
-			await waitForAlert(page);
-
-			await expect(viewObjectEntriesPage.expirationDateInput).toHaveValue(
-				tomorrow
-			);
-
-			await viewObjectEntriesPage.neverExpire.check();
-
-			await viewObjectEntriesPage.choosePublicationOption('publish');
-
-			await waitForAlert(page);
-
-			await expect(viewObjectEntriesPage.expirationDateInput).toHaveValue(
-				''
-			);
-		}
-	);
-
-	cmsTest(
-		'can create, read, update, and delete a reviewDate of an object entry',
-		async ({page, viewObjectEntriesPage}) => {
-			await viewObjectEntriesPage.goto(_objectDefinition.className);
-
-			await viewObjectEntriesPage.clickAddObjectEntry(
-				_objectDefinition.label['en_US']
-			);
-
-			await viewObjectEntriesPage.neverReview.uncheck();
-
-			await viewObjectEntriesPage.scheduleForCurrentDate('Review');
-
-			await page.keyboard.press('Escape');
-
-			await viewObjectEntriesPage.choosePublicationOption('publish');
-
-			await waitForAlert(page);
-
-			const date = new Date();
-
-			const today = getObjectEntryUIDateTimeFormat(date);
-
-			await expect(viewObjectEntriesPage.reviewDateInput).toHaveValue(
-				today
-			);
-
-			date.setDate(date.getDate() + 1);
-
-			const tomorrow = getObjectEntryUIDateTimeFormat(date);
-
-			await viewObjectEntriesPage.reviewDateInput.fill(tomorrow);
-
-			await viewObjectEntriesPage.choosePublicationOption('publish');
-
-			await waitForAlert(page);
-
-			await expect(viewObjectEntriesPage.reviewDateInput).toHaveValue(
-				tomorrow
-			);
-
-			await viewObjectEntriesPage.neverReview.check();
-
-			await viewObjectEntriesPage.choosePublicationOption('publish');
-
-			await waitForAlert(page);
-
-			await expect(viewObjectEntriesPage.reviewDateInput).toHaveValue('');
-		}
-	);
-
-	cmsTest(
-		'can see approved and scheduled labels for entry with a display date versioning enabled and at least one version approved',
-		async ({apiHelpers, page, viewObjectEntriesPage}) => {
-			const objectDefinitionAPIClient =
-				await apiHelpers.buildRestClient(ObjectDefinitionAPI);
-
-			await objectDefinitionAPIClient.patchObjectDefinition(
-				_objectDefinition.id,
-				{
-					enableObjectEntryVersioning: true,
-				}
-			);
-
-			await viewObjectEntriesPage.goto(_objectDefinition.className);
-
-			await viewObjectEntriesPage.clickAddObjectEntry(
-				_objectDefinition.label['en_US']
-			);
-
-			await viewObjectEntriesPage.choosePublicationOption('publish');
-
-			await waitForAlert(page);
-
-			await viewObjectEntriesPage.backButton.click();
-
-			await expect(page.getByText('Approved')).toBeVisible();
-
-			await expect(page.getByText('Scheduled')).not.toBeVisible();
-
-			const applicationName =
-				'c/' + _objectDefinition.name.toLowerCase() + 's';
-
-			const {items} =
-				await apiHelpers.objectEntry.getObjectDefinitionObjectEntries(
-					applicationName
-				);
-
-			const objectEntryId = items[0].id;
-
-			await page.getByRole('link', {name: objectEntryId}).click();
-
-			const date = new Date();
-
-			date.setDate(date.getDate() + 1);
-
-			const tomorrow = getObjectEntryUIDateTimeFormat(date);
-
-			await viewObjectEntriesPage.choosePublicationOption('schedule');
-
-			await viewObjectEntriesPage.publishDateInput.fill(tomorrow);
-
-			await viewObjectEntriesPage.schedulePublicationButton.click();
-
-			await waitForAlert(page);
-
-			await viewObjectEntriesPage.backButton.click();
-
-			await expect(page.getByText('Approved')).toBeVisible();
-
-			await expect(page.getByText('Scheduled')).toBeVisible();
-		}
-	);
-
-	cmsTest(
-		'cannot submit an empty displayDate',
-		async ({page, viewObjectEntriesPage}) => {
-			await viewObjectEntriesPage.goto(_objectDefinition.className);
-
-			await viewObjectEntriesPage.clickAddObjectEntry(
-				_objectDefinition.label['en_US']
-			);
-
-			await viewObjectEntriesPage.choosePublicationOption('schedule');
-
-			let requestWasMade = false;
-
-			page.on('request', (request) => {
-				if (request.url().includes(_objectDefinition.restContextPath)) {
-					requestWasMade = true;
-				}
-			});
-
-			await viewObjectEntriesPage.schedulePublicationButton.click();
-
-			// Wait a second before doing the assertion to simulate the time needed for the request to happen
-
-			await page.waitForTimeout(1000);
-
-			expect(requestWasMade).toBe(false);
-
-			await expect(
-				page.getByText('This field is required')
-			).toBeVisible();
-
-			await viewObjectEntriesPage.schedulePublicationCloseButton.click();
-		}
-	);
-
-	cmsTest(
-		'cannot submit an empty expirationDate and reviewDate when it is enabled',
-		async ({page, viewObjectEntriesPage}) => {
-			await viewObjectEntriesPage.goto(_objectDefinition.className);
-
-			await viewObjectEntriesPage.clickAddObjectEntry(
-				_objectDefinition.label['en_US']
-			);
-
-			for (const scheduleProperty of ['Expire', 'Review']) {
-				await viewObjectEntriesPage.page
-					.getByLabel(`Never ${scheduleProperty}`, {exact: true})
-					.uncheck();
-
-				let requestWasMade = false;
-
-				page.on('request', (request) => {
-					if (
-						request
-							.url()
-							.includes(_objectDefinition.restContextPath)
-					) {
-						requestWasMade = true;
-					}
-				});
-
-				await viewObjectEntriesPage.choosePublicationOption('publish');
-
-				// Wait a second before doing the assertion to simulate the time needed for the request to happen
-
-				await page.waitForTimeout(1000);
-
-				expect(requestWasMade).toBe(false);
-
-				await expect(
-					page.getByText('This field is required')
-				).toBeVisible();
-
-				await viewObjectEntriesPage.page
-					.getByLabel(`Never ${scheduleProperty}`, {exact: true})
-					.check();
-			}
-		}
-	);
-
-	cmsTest(
-		'cannot submit a past expirationDate',
-		async ({page, viewObjectEntriesPage}) => {
-			await viewObjectEntriesPage.goto(_objectDefinition.className);
-
-			await viewObjectEntriesPage.clickAddObjectEntry(
-				_objectDefinition.label['en_US']
-			);
-
-			await viewObjectEntriesPage.neverExpire.uncheck();
-
-			await viewObjectEntriesPage.scheduleForCurrentDate('Expiration');
-
-			await viewObjectEntriesPage.page.keyboard.press('Escape');
-
-			let requestWasMade = false;
-
-			page.on('request', (request) => {
-				if (request.url().includes(_objectDefinition.restContextPath)) {
-					requestWasMade = true;
-				}
-			});
-
-			await viewObjectEntriesPage.choosePublicationOption('publish');
-
-			// Wait a second before doing the assertion to simulate the time needed for the request to happen
-
-			await page.waitForTimeout(1000);
-
-			expect(requestWasMade).toBe(false);
-
-			await expect(
-				page.getByText('The date entered is in the past')
-			).toBeVisible();
-		}
-	);
-
-	cmsTest(
-		'schedule container is not visible when enableObjectEntrySchedule is disabled',
-		{tag: '@enableObjectEntryScheduleFalse'},
-		async ({viewObjectEntriesPage}) => {
-			await viewObjectEntriesPage.goto(_objectDefinition.className);
-
-			await viewObjectEntriesPage.clickAddObjectEntry(
-				_objectDefinition.label['en_US']
-			);
-
-			await expect(
-				viewObjectEntriesPage.schedulePanelButton
-			).not.toBeVisible();
-
-			await expect(
-				viewObjectEntriesPage.expirationDateInput
-			).not.toBeVisible();
-
-			await expect(
-				viewObjectEntriesPage.reviewDateInput
-			).not.toBeVisible();
 		}
 	);
 });


### PR DESCRIPTION
### Related stories: [LPD-61657](https://liferay.atlassian.net/browse/LPD-61657) | [LPD-61658](https://liferay.atlassian.net/browse/LPD-61658)

## Context:
Object Definitions can have Object Fields of type _Attachment_  and those attachments can be downloaded. ObjectField Attachments entries are stored as DLFileEntry, that have their own ResourcePermission which includes a _download_ ResourceAction. Currently, this action can only be configured on the _Documents and Media_ side.

## Issue:
**Attachment Object Fields have 2 types of storage:** 

1. Upload Directly from the User's Computer
2. Upload or Select from Documents and Media Item Selector

When using the first option, the creator can choose to _Show Files in Documents and Media_. If choose not to show, the file will be hidden and no download permission change will be possible on the documents and media side(the default is to allow all users to download).

Currently, for this usecase, the DLFileEntry DOWNLOAD permission is linked with its related ObjectEntry VIEW permission(if an user has view permission, they can download the attachment). While this allows admins to give some restriction, if they want users to see an ObjectEntry but don't want them to download a specific attachment from it, they cannot perform this action.

## Solution:
On this PR we're creating a new download ResourceAction for Attachment Object Fields, that will be under the ObjectEntryModel ResourcePermission. This will enable the view and download permissions to work independently, giving the admins more flexibility and power for giving resource restrictions.

How it works:

1. When adding a new attachment ObjectField to a published ObjectDefinition, it will call `ObjectDefinitionResourcePermissionUtil#populateResourceActions()`, which will be responsible for adding the new ObjectField download `ResourceAction` to the ObjectDefinition's `ObjectEntryModelResourcePermission`. After this, the admin can check the new permission was added on the permission framework for the definition entries.
2. Once the new ResourceAction is added, it will be responsible for restricting roles download access to the related attachment. If a role doesn't have the permission, the restrictions are reflected on the UI by:
    1. The _view object entries table_ no longer exposes the attachment download link. This is done by `LinkUtil#toLink()`;
    2. The download button on the ObjectEntry view is no longer available. This is done by `AttachmentDDMFormFieldTemplateContextContributor#_getFileEntryProperties()` and `FileContainer.tsx`;
    3. If somehow the user get access to the link, it will be filtered by `AttachmentObjectFieldDownloadFilter` which checks the permission for both VIEW and DOWNLOAD permissions, and redirects the user to either 401 or 404(if guest) pages if unauthorized.

**Additional info:** regarding the permission on the Documents and Media side, the new ObjectField download permission **will NOT** bypass that permission, there will only be a **new layer** of permission checking for the respective attachment. So, if an user has permission to download on the Object side but doesn't on the DM side, the user will still be unable to perform download. For the download action to be enabled, an user needs to have DOWNLOAD permission on **both** Object and DM side, they also need VIEW permission on the Object side as well.

## Preview:

### Download permission is available for Attachment object fields:
<img width="1914" height="808" alt="image" src="https://github.com/user-attachments/assets/21586448-62a4-4ad9-89b6-a26903be28b2" />
<img width="3819" height="2026" alt="image" src="https://github.com/user-attachments/assets/9c2f8d0d-6d42-46bd-961e-e4bdb8eae77d" />

### ObjectEntry view: download button is unavailable when permission is not granted:
<img width="1438" height="644" alt="image" src="https://github.com/user-attachments/assets/48171305-69a2-4c07-ac17-305c25972219" />

### Unauthorized user tries to access the download link:
<img width="1909" height="991" alt="image" src="https://github.com/user-attachments/assets/8ff61fac-9da0-4f23-a4ef-cb26550fca8f" />
<img width="1893" height="1723" alt="image" src="https://github.com/user-attachments/assets/4f34cb0d-02e9-486d-a163-8f3dec0255e7" />
