### PR TITLE
LPD-84985 Fix the date parse locale when checking the OSGi config while importing LDAP users

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -698,10 +698,6 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 		return user;
 	}
 
-	protected String escapeLDAPName(String ldapName) {
-		return StringUtil.replace(ldapName, '\\', "\\\\");
-	}
-
 	protected User getUser(long companyId, LDAPUser ldapUser) throws Exception {
 		LDAPImportConfiguration ldapImportConfiguration =
 			_ldapImportConfigurationProvider.getConfiguration(companyId);

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -54,6 +54,7 @@ import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -1822,14 +1823,12 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 			passwordReset = user.isPasswordReset();
 		}
 
-		ServiceContext serviceContext = ldapUser.getServiceContext();
 		boolean updatedCustomMappings = false;
 
 		if (Validator.isNotNull(ldapServerConfiguration.modifiedDate())) {
 			Date serverConfigurationModifiedDate = DateUtil.parseDate(
 				"EEE MMM d HH:mm:ss zzz yyyy",
-				ldapServerConfiguration.modifiedDate(),
-				serviceContext.getLocale());
+				ldapServerConfiguration.modifiedDate(), LocaleUtil.US);
 
 			updatedCustomMappings = serverConfigurationModifiedDate.after(
 				new Date(_lastImportTime));
@@ -1932,6 +1931,8 @@ public class LDAPUserImporterImpl implements LDAPUserImporter {
 		int birthdayMonth = birthdayCal.get(Calendar.MONTH);
 		int birthdayDay = birthdayCal.get(Calendar.DAY_OF_MONTH);
 		int birthdayYear = birthdayCal.get(Calendar.YEAR);
+
+		ServiceContext serviceContext = ldapUser.getServiceContext();
 
 		if (modifiedDate != null) {
 			serviceContext.setModifiedDate(modifiedDate);

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImplTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImplTest.java
@@ -5,7 +5,20 @@
 
 package com.liferay.portal.security.ldap.internal.exportimport;
 
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.ldap.LDAPSettings;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.security.ldap.configuration.ConfigurationProvider;
+import com.liferay.portal.security.ldap.configuration.LDAPServerConfiguration;
+import com.liferay.portal.security.ldap.exportimport.LDAPUser;
+import com.liferay.portal.security.ldap.exportimport.configuration.LDAPImportConfiguration;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Date;
 
 import javax.naming.InvalidNameException;
 
@@ -13,6 +26,9 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * @author Jorge Díaz
@@ -34,6 +50,104 @@ public class LDAPUserImporterImplTest {
 			"cn=User\\\\2cwith\\\\2ccommas,ou=users,dc=example,dc=com",
 			escapeLDAPName(
 				"cn=User\\2cwith\\2ccommas,ou=users,dc=example,dc=com"));
+	}
+
+	@Test
+	public void testUpdateUser() throws Exception {
+		ConfigurationProvider<LDAPImportConfiguration>
+			ldapImportConfigurationProvider = Mockito.mock(
+				ConfigurationProvider.class);
+
+		Mockito.when(
+			ldapImportConfigurationProvider.getConfiguration(Mockito.anyLong())
+		).thenReturn(
+			Mockito.mock(LDAPImportConfiguration.class)
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_ldapUserImporterImpl, "_ldapImportConfigurationProvider",
+			ldapImportConfigurationProvider);
+
+		ConfigurationProvider<LDAPServerConfiguration>
+			ldapServerConfigurationProvider = Mockito.mock(
+				ConfigurationProvider.class);
+
+		LDAPServerConfiguration ldapServerConfiguration = Mockito.mock(
+			LDAPServerConfiguration.class);
+
+		String modifiedDate = "Thu Apr 2 19:18:33 GMT 2026";
+
+		Mockito.when(
+			ldapServerConfiguration.modifiedDate()
+		).thenReturn(
+			modifiedDate
+		);
+
+		Mockito.when(
+			ldapServerConfigurationProvider.getConfiguration(
+				Mockito.anyLong(), Mockito.anyLong())
+		).thenReturn(
+			ldapServerConfiguration
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_ldapUserImporterImpl, "_ldapServerConfigurationProvider",
+			ldapServerConfigurationProvider);
+
+		ReflectionTestUtil.setFieldValue(
+			_ldapUserImporterImpl, "_ldapSettings",
+			Mockito.mock(LDAPSettings.class));
+
+		LDAPImportContext ldapImportContext = Mockito.mock(
+			LDAPImportContext.class);
+
+		Mockito.when(
+			ldapImportContext.getCompanyId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			ldapImportContext.getLdapServerId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		LDAPUser ldapUser = new LDAPUser();
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setLanguageId(LocaleUtil.BRAZIL.toLanguageTag());
+
+		ldapUser.setServiceContext(serviceContext);
+
+		User user = Mockito.mock(User.class);
+
+		Mockito.when(
+			user.getModifiedDate()
+		).thenReturn(
+			new Date()
+		);
+
+		try (MockedStatic<DateUtil> dateUtilMockedStatic = Mockito.mockStatic(
+				DateUtil.class, Mockito.CALLS_REAL_METHODS)) {
+
+			ReflectionTestUtil.invoke(
+				_ldapUserImporterImpl, "_updateUser",
+				new Class<?>[] {
+					LDAPImportContext.class, LDAPUser.class, User.class,
+					String.class, String.class, boolean.class
+				},
+				ldapImportContext, ldapUser, user,
+				RandomTestUtil.randomString(),
+				String.valueOf(RandomTestUtil.randomLong()), false);
+
+			dateUtilMockedStatic.verify(
+				() -> DateUtil.parseDate(
+					Mockito.eq("EEE MMM d HH:mm:ss zzz yyyy"),
+					Mockito.eq(modifiedDate), Mockito.eq(LocaleUtil.US)),
+				Mockito.times(1));
+		}
 	}
 
 	protected String escapeLDAPName(String query) {

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImplTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImplTest.java
@@ -20,9 +20,6 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Date;
 
-import javax.naming.InvalidNameException;
-
-import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -32,6 +29,7 @@ import org.mockito.Mockito;
 
 /**
  * @author Jorge Díaz
+ * @author Manuele Castro
  */
 public class LDAPUserImporterImplTest {
 
@@ -39,18 +37,6 @@ public class LDAPUserImporterImplTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
-
-	@Test
-	public void testBindingInNamespaceEscape() throws InvalidNameException {
-		Assert.assertEquals(
-			"cn=User\\\\,with\\\\,commas,ou=users,dc=example,dc=com",
-			escapeLDAPName(
-				"cn=User\\,with\\,commas,ou=users,dc=example,dc=com"));
-		Assert.assertEquals(
-			"cn=User\\\\2cwith\\\\2ccommas,ou=users,dc=example,dc=com",
-			escapeLDAPName(
-				"cn=User\\2cwith\\2ccommas,ou=users,dc=example,dc=com"));
-	}
 
 	@Test
 	public void testUpdateUser() throws Exception {
@@ -148,10 +134,6 @@ public class LDAPUserImporterImplTest {
 					Mockito.eq(modifiedDate), Mockito.eq(LocaleUtil.US)),
 				Mockito.times(1));
 		}
-	}
-
-	protected String escapeLDAPName(String query) {
-		return _ldapUserImporterImpl.escapeLDAPName(query);
 	}
 
 	private static final LDAPUserImporterImpl _ldapUserImporterImpl =


### PR DESCRIPTION
Related issue: [LPD-84985](https://liferay.atlassian.net/browse/LPD-84985)

Fixing the date locale to US since OSGi configs use it for adding the modified date value