### PR TITLE
LPD-86767

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/LiferayAccessTokenService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/LiferayAccessTokenService.java
@@ -10,7 +10,6 @@ import com.liferay.oauth2.provider.rest.internal.endpoint.liferay.LiferayOAuthDa
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.InetAddressUtil;
-import com.liferay.portal.remote.cors.annotation.CORS;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -39,7 +38,6 @@ import org.apache.cxf.rs.security.oauth2.services.AccessTokenService;
 public class LiferayAccessTokenService extends AccessTokenService {
 
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-	@CORS(allowMethods = "POST")
 	@Override
 	@POST
 	@Produces(MediaType.APPLICATION_JSON)

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
@@ -12,7 +12,6 @@ import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.remote.cors.annotation.CORS;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
@@ -80,7 +79,6 @@ public class LiferayDynamicRegistrationService
 	}
 
 	@Consumes(MediaType.APPLICATION_JSON)
-	@CORS(allowMethods = "POST")
 	@POST
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response register(

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/introspect/LiferayTokenIntrospectionService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/introspect/LiferayTokenIntrospectionService.java
@@ -11,7 +11,6 @@ import com.liferay.oauth2.provider.rest.internal.endpoint.liferay.LiferayOAuthDa
 import com.liferay.oauth2.provider.rest.spi.bearer.token.provider.BearerTokenProvider;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.remote.cors.annotation.CORS;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.Encoded;
@@ -52,7 +51,6 @@ public class LiferayTokenIntrospectionService extends AbstractTokenService {
 	}
 
 	@Consumes(MediaType.APPLICATION_FORM_URLENCODED)
-	@CORS(allowMethods = "POST")
 	@POST
 	@Produces(MediaType.APPLICATION_JSON)
 	public Response getTokenIntrospection(

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseClientTestCase.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseClientTestCase.java
@@ -690,6 +690,8 @@ public abstract class BaseClientTestCase {
 			oAuth2Authorization);
 	}
 
+	protected static final String TEST_CORS_URI = "http://test-cors.com";
+
 	private static Set<String> _originalRestrictedHeaderSet;
 	private static final Pattern _pAuthTokenPattern = Pattern.compile(
 		"authToken:\\s*(['\"])(((?!\\1).)*)\\1,");

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/CORSApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/CORSApplicationClientTest.java
@@ -59,7 +59,7 @@ public class CORSApplicationClientTest extends BaseClientTestCase {
 		formData.add("password", PropsValues.DEFAULT_ADMIN_PASSWORD);
 		formData.add("username", _user.getEmailAddress());
 
-		tokenInvocationBuilder.header("Origin", _TEST_CORS_URI);
+		tokenInvocationBuilder.header("Origin", TEST_CORS_URI);
 
 		Response response = tokenInvocationBuilder.post(Entity.form(formData));
 
@@ -80,7 +80,7 @@ public class CORSApplicationClientTest extends BaseClientTestCase {
 		Invocation.Builder invocationBuilder = authorize(
 			webTarget.request(), tokenString);
 
-		invocationBuilder.header("Origin", _TEST_CORS_URI);
+		invocationBuilder.header("Origin", TEST_CORS_URI);
 
 		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
 				new ConfigurationTemporarySwapper(
@@ -97,7 +97,7 @@ public class CORSApplicationClientTest extends BaseClientTestCase {
 			Response response = invocationBuilder.get();
 
 			Assert.assertEquals(
-				_TEST_CORS_URI,
+				TEST_CORS_URI,
 				response.getHeaderString("Access-Control-Allow-Origin"));
 		}
 	}
@@ -111,7 +111,7 @@ public class CORSApplicationClientTest extends BaseClientTestCase {
 		Invocation.Builder invocationBuilder = authorize(
 			webTarget.request(), tokenString);
 
-		invocationBuilder.header("Origin", _TEST_CORS_URI);
+		invocationBuilder.header("Origin", TEST_CORS_URI);
 
 		Response response = invocationBuilder.get();
 
@@ -136,7 +136,7 @@ public class CORSApplicationClientTest extends BaseClientTestCase {
 
 		invocationBuilder.header(
 			"Access-Control-Request-Method", HttpMethod.OPTIONS);
-		invocationBuilder.header("Origin", _TEST_CORS_URI);
+		invocationBuilder.header("Origin", TEST_CORS_URI);
 
 		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
 				new ConfigurationTemporarySwapper(
@@ -153,7 +153,7 @@ public class CORSApplicationClientTest extends BaseClientTestCase {
 			Response response = invocationBuilder.options();
 
 			Assert.assertEquals(
-				_TEST_CORS_URI,
+				TEST_CORS_URI,
 				response.getHeaderString("Access-Control-Allow-Origin"));
 		}
 	}
@@ -162,8 +162,6 @@ public class CORSApplicationClientTest extends BaseClientTestCase {
 	protected BundleActivator getBundleActivator() {
 		return new CORSApplicationTestPreparatorBundleActivator();
 	}
-
-	private static final String _TEST_CORS_URI = "http://test-cors.com";
 
 	private User _user;
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/CORSApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/CORSApplicationClientTest.java
@@ -63,8 +63,7 @@ public class CORSApplicationClientTest extends BaseClientTestCase {
 
 		Response response = tokenInvocationBuilder.post(Entity.form(formData));
 
-		Assert.assertEquals(
-			_TEST_CORS_URI,
+		Assert.assertNull(
 			response.getHeaderString("Access-Control-Allow-Origin"));
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenIntrospectionTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenIntrospectionTest.java
@@ -65,6 +65,8 @@ public class TokenIntrospectionTest extends BaseClientTestCase {
 		formData.add("client_secret", "oauthTestApplicationSecret");
 		formData.add("token", token);
 
+		invocationBuilder.header("Origin", _TEST_CORS_URI);
+
 		Response response = invocationBuilder.post(Entity.form(formData));
 
 		Assert.assertEquals(
@@ -72,6 +74,9 @@ public class TokenIntrospectionTest extends BaseClientTestCase {
 
 		Assert.assertEquals(
 			applicationClientId, parseJsonField(response, "client_id"));
+
+		Assert.assertNull(
+			response.getHeaderString("Access-Control-Allow-Origin"));
 	}
 
 	@Test
@@ -120,6 +125,8 @@ public class TokenIntrospectionTest extends BaseClientTestCase {
 
 		return webTarget;
 	}
+
+	private static final String _TEST_CORS_URI = "http://test-cors.com";
 
 	private User _user;
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenIntrospectionTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenIntrospectionTest.java
@@ -65,7 +65,7 @@ public class TokenIntrospectionTest extends BaseClientTestCase {
 		formData.add("client_secret", "oauthTestApplicationSecret");
 		formData.add("token", token);
 
-		invocationBuilder.header("Origin", _TEST_CORS_URI);
+		invocationBuilder.header("Origin", TEST_CORS_URI);
 
 		Response response = invocationBuilder.post(Entity.form(formData));
 
@@ -125,8 +125,6 @@ public class TokenIntrospectionTest extends BaseClientTestCase {
 
 		return webTarget;
 	}
-
-	private static final String _TEST_CORS_URI = "http://test-cors.com";
 
 	private User _user;
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
@@ -170,7 +170,7 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 		invocationBuilder = authorize(
 			registerWebTarget.request(), _getToken(oAuth2Application));
 
-		invocationBuilder.header("Origin", _TEST_CORS_URI);
+		invocationBuilder.header("Origin", TEST_CORS_URI);
 
 		response = invocationBuilder.get();
 
@@ -289,8 +289,6 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 
 		return tokenString;
 	}
-
-	private static final String _TEST_CORS_URI = "http://test-cors.com";
 
 	@Inject
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
@@ -170,6 +170,8 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 		invocationBuilder = authorize(
 			registerWebTarget.request(), _getToken(oAuth2Application));
 
+		invocationBuilder.header("Origin", _TEST_CORS_URI);
+
 		response = invocationBuilder.get();
 
 		Assert.assertEquals(200, response.getStatus());
@@ -178,6 +180,9 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 
 		Assert.assertEquals(
 			clientName, responseJSONObject.getString("client_name"));
+
+		Assert.assertNull(
+			response.getHeaderString("Access-Control-Allow-Origin"));
 	}
 
 	@FeatureFlag("LPD-63416")
@@ -284,6 +289,8 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 
 		return tokenString;
 	}
+
+	private static final String _TEST_CORS_URI = "http://test-cors.com";
 
 	@Inject
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;


### PR DESCRIPTION
In some oauth2 endpoints we use the CORS annotation. in that cases we don't get the settings configuration in the portal and we accept all the origins. 

# Problem
The root cause is the use of the static `@CORS `annotation at the method level, which bypasses the dynamic PortalCORSServletFilter and explicitly reflects arbitrary Origins. 

# Solution
Removing the `@CORS` annotation the following service classes:

- `LiferayAccessTokenService.java`
- `LiferayTokenIntrospectionService.java`
- `LiferayDynamicRegistrationService.java`

# Tests

Updated the integration tests related:

- `CORSApplicationClientTest.java`
- `TokenIntrospectionTest.java`
- `DynamicRegistrationServiceTest.java`

En [example of manual test](https://liferay.atlassian.net/browse/LPD-86767?focusedCommentId=5036970) and how the configuration is used with this change. 