### PR TITLE
LPD-86897 Fix NPE when extending OIDC session from background threads

### DIFF
--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/session/manager/OfflineOpenIdConnectSessionManager.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/session/manager/OfflineOpenIdConnectSessionManager.java
@@ -25,7 +25,6 @@ import com.liferay.portal.kernel.messaging.MessageListener;
 import com.liferay.portal.kernel.scheduler.SchedulerJobConfiguration;
 import com.liferay.portal.kernel.scheduler.TimeUnit;
 import com.liferay.portal.kernel.scheduler.TriggerConfiguration;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.MethodHandler;
@@ -255,7 +254,7 @@ public class OfflineOpenIdConnectSessionManager {
 					getOpenIdConnectProviderConfigurationProperties(
 						oAuthClientEntry.getAuthServerWellKnownURI(),
 						oAuthClientEntry.getClientId(),
-						CompanyThreadLocal.getCompanyId(), _configurationAdmin,
+						oAuthClientEntry.getCompanyId(), _configurationAdmin,
 						String.valueOf(oidcProviderMetadata.getIssuer()),
 						String.valueOf(
 							oidcProviderMetadata.getTokenEndpointURI()));

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/session/manager/OfflineOpenIdConnectSessionManagerTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/session/manager/OfflineOpenIdConnectSessionManagerTest.java
@@ -5,23 +5,39 @@
 
 package com.liferay.portal.security.sso.openid.connect.internal.session.manager;
 
+import com.liferay.oauth.client.persistence.model.OAuthClientEntry;
+import com.liferay.oauth.client.persistence.service.OAuthClientEntryLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.security.sso.openid.connect.internal.AuthorizationServerMetadataResolver;
 import com.liferay.portal.security.sso.openid.connect.persistence.model.OpenIdConnectSession;
 import com.liferay.portal.security.sso.openid.connect.persistence.service.OpenIdConnectSessionLocalService;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import com.nimbusds.oauth2.sdk.Scope;
+import com.nimbusds.oauth2.sdk.id.Issuer;
 import com.nimbusds.oauth2.sdk.token.AccessToken;
 import com.nimbusds.oauth2.sdk.token.AccessTokenType;
 import com.nimbusds.oauth2.sdk.token.RefreshToken;
+import com.nimbusds.openid.connect.sdk.SubjectType;
+import com.nimbusds.openid.connect.sdk.op.OIDCProviderMetadata;
 import com.nimbusds.openid.connect.sdk.token.OIDCTokens;
 
+import java.net.URI;
+
+import java.util.List;
+
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+
+import org.osgi.service.cm.ConfigurationAdmin;
 
 /**
  * @author Manuele Castro
@@ -32,6 +48,171 @@ public class OfflineOpenIdConnectSessionManagerTest {
 	@Rule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testExtendOpenIdConnectSessionUsesOAuthClientEntryCompanyId()
+		throws Exception {
+
+		long oAuthClientEntryCompanyId = 1234L;
+		String authServerWellKnownURI =
+			"https://idp.example.com/.well-known/openid-configuration";
+		String clientId = "my-client-id";
+
+		Assert.assertEquals(
+			"Precondition: test thread must have the default (system) " +
+				"companyId to simulate a background thread",
+			0L,
+			CompanyThreadLocal.getCompanyId(
+			).longValue());
+
+		OpenIdConnectSession openIdConnectSession = Mockito.mock(
+			OpenIdConnectSession.class);
+
+		Mockito.when(
+			openIdConnectSession.getRefreshToken()
+		).thenReturn(
+			"some-refresh-token"
+		);
+
+		Mockito.when(
+			openIdConnectSession.getCompanyId()
+		).thenReturn(
+			oAuthClientEntryCompanyId
+		);
+
+		Mockito.when(
+			openIdConnectSession.getAuthServerWellKnownURI()
+		).thenReturn(
+			authServerWellKnownURI
+		);
+
+		Mockito.when(
+			openIdConnectSession.getClientId()
+		).thenReturn(
+			clientId
+		);
+
+		OAuthClientEntry oAuthClientEntry = Mockito.mock(
+			OAuthClientEntry.class);
+
+		Mockito.when(
+			oAuthClientEntry.getCompanyId()
+		).thenReturn(
+			oAuthClientEntryCompanyId
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getAuthServerWellKnownURI()
+		).thenReturn(
+			authServerWellKnownURI
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getClientId()
+		).thenReturn(
+			clientId
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getMetadataCacheInSeconds()
+		).thenReturn(
+			3600
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getOAuthClientEntryId()
+		).thenReturn(
+			99L
+		);
+
+		OAuthClientEntryLocalService oAuthClientEntryLocalService =
+			Mockito.mock(OAuthClientEntryLocalService.class);
+
+		Mockito.when(
+			oAuthClientEntryLocalService.fetchOAuthClientEntry(
+				oAuthClientEntryCompanyId, authServerWellKnownURI, clientId)
+		).thenReturn(
+			oAuthClientEntry
+		);
+
+		OIDCProviderMetadata oidcProviderMetadata = new OIDCProviderMetadata(
+			new Issuer("https://idp.example.com"), List.of(SubjectType.PUBLIC),
+			new URI("https://idp.example.com/jwks"));
+
+		oidcProviderMetadata.setTokenEndpointURI(
+			new URI("https://idp.example.com/token"));
+
+		AuthorizationServerMetadataResolver
+			authorizationServerMetadataResolver = Mockito.mock(
+				AuthorizationServerMetadataResolver.class);
+
+		Mockito.when(
+			authorizationServerMetadataResolver.resolveOIDCProviderMetadata(
+				Mockito.anyString(), Mockito.anyLong(), Mockito.anyInt(),
+				Mockito.anyLong())
+		).thenReturn(
+			oidcProviderMetadata
+		);
+
+		ConfigurationAdmin configurationAdmin = Mockito.mock(
+			ConfigurationAdmin.class);
+
+		Mockito.when(
+			configurationAdmin.listConfigurations(Mockito.anyString())
+		).thenReturn(
+			null
+		);
+
+		OpenIdConnectSessionLocalService openIdConnectSessionLocalService =
+			Mockito.mock(OpenIdConnectSessionLocalService.class);
+
+		OfflineOpenIdConnectSessionManager offlineOpenIdConnectSessionManager =
+			new OfflineOpenIdConnectSessionManager();
+
+		ReflectionTestUtil.setFieldValue(
+			offlineOpenIdConnectSessionManager,
+			"_authorizationServerMetadataResolver",
+			authorizationServerMetadataResolver);
+		ReflectionTestUtil.setFieldValue(
+			offlineOpenIdConnectSessionManager, "_configurationAdmin",
+			configurationAdmin);
+		ReflectionTestUtil.setFieldValue(
+			offlineOpenIdConnectSessionManager, "_oAuthClientEntryLocalService",
+			oAuthClientEntryLocalService);
+		ReflectionTestUtil.setFieldValue(
+			offlineOpenIdConnectSessionManager,
+			"_openIdConnectSessionLocalService",
+			openIdConnectSessionLocalService);
+
+		ReflectionTestUtil.invoke(
+			offlineOpenIdConnectSessionManager, "_extendOpenIdConnectSession",
+			new Class<?>[] {OpenIdConnectSession.class}, openIdConnectSession);
+
+		ArgumentCaptor<String> filterArgumentCaptor = ArgumentCaptor.forClass(
+			String.class);
+
+		Mockito.verify(
+			configurationAdmin
+		).listConfigurations(
+			filterArgumentCaptor.capture()
+		);
+
+		String filter = filterArgumentCaptor.getValue();
+
+		Assert.assertTrue(
+			StringBundler.concat(
+				"Configuration lookup filter must use the OAuthClientEntry's ",
+				"companyId (", oAuthClientEntryCompanyId, "). Filter was: ",
+				filter),
+			filter.contains("(companyId=" + oAuthClientEntryCompanyId + ")"));
+		Assert.assertFalse(
+			StringBundler.concat(
+				"Configuration lookup filter must not fall back to ",
+				"CompanyThreadLocal's default (0) when ",
+				"_extendOpenIdConnectSession runs in a background thread. ",
+				"Filter was: ", filter),
+			filter.contains("(companyId=0)"));
+	}
 
 	@Test
 	public void testStartOpenIdConnectSession() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86897

**What is being fixed:** `OfflineOpenIdConnectSessionManager._extendOpenIdConnectSession` is invoked from background entry points — the `TokenRefreshMessageListener` (message-bus thread) and the `TokensRefreshSchedulerJobConfiguration` (scheduler thread). Neither propagates `CompanyThreadLocal`, so `CompanyThreadLocal.getCompanyId()` returns `CompanyConstants.SYSTEM` (`0`) on those threads. The filter built for `ConfigurationAdmin.listConfigurations` then scopes to `companyId=0` and matches no real OIDC client configuration, so the util returns `null` and the subsequent `properties.get("tokenConnectionTimeout")` throws a `NullPointerException`. The broad `catch (Exception)` block logs only at `debug` level and then deletes the `OpenIdConnectSession`, silently logging the user out on every scheduled refresh tick.

**How it is being fixed:** The call site uses `oAuthClientEntry.getCompanyId()` — already in scope — instead of `CompanyThreadLocal.getCompanyId()` when building the configuration lookup filter. This matches the interactive path in `OpenIdConnectAuthenticationHandlerImpl`, which already uses the request-scoped company ID. A unit test captures the filter argument passed to `ConfigurationAdmin.listConfigurations` and asserts it contains the `OAuthClientEntry` companyId rather than `0`; the test fails with the bug reintroduced.