### PR TITLE
LPD-42545 WIP

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-rest-test/src/testIntegration/java/com/liferay/ai/hub/cell/rest/resource/v1_0/test/AuthorizationTokenResourceTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-rest-test/src/testIntegration/java/com/liferay/ai/hub/cell/rest/resource/v1_0/test/AuthorizationTokenResourceTest.java
@@ -9,6 +9,7 @@ import com.liferay.ai.hub.cell.configuration.AIHubCellConfiguration;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
@@ -58,8 +59,9 @@ public class AuthorizationTokenResourceTest
 		OAuth2Application oAuth2Application =
 			_oAuth2ApplicationLocalService.addOAuth2Application(
 				user.getCompanyId(), user.getUserId(), user.getFullName(),
-				List.of(GrantType.CLIENT_CREDENTIALS), "client_secret_post",
-				user.getUserId(),
+				List.of(GrantType.CLIENT_CREDENTIALS),
+				OAuth2ApplicationConstants.APPLICATION_TYPE_USER,
+				"client_secret_post", user.getUserId(),
 				OAuth2SecureRandomGenerator.generateClientId(),
 				ClientProfile.WEB_APPLICATION.id(),
 				OAuth2SecureRandomGenerator.generateClientSecret(), "",

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/client/AnalyticsCloudClient.java
@@ -20,6 +20,7 @@ import com.liferay.analytics.settings.rest.internal.client.pagination.Page;
 import com.liferay.analytics.settings.rest.internal.client.pagination.Pagination;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
@@ -147,6 +148,7 @@ public class AnalyticsCloudClient {
 							add(GrantType.JWT_BEARER);
 						}
 					},
+					OAuth2ApplicationConstants.APPLICATION_TYPE_SYSTEM,
 					"client_secret_post", user.getUserId(),
 					OAuth2SecureRandomGenerator.generateClientId(),
 					ClientProfile.HEADLESS_SERVER.id(),

--- a/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/configuration/persistence/listener/CTSettingsConfigurationModelListener.java
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/java/com/liferay/change/tracking/web/internal/configuration/persistence/listener/CTSettingsConfigurationModelListener.java
@@ -15,6 +15,7 @@ import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTPreferencesLocalService;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
@@ -282,6 +283,7 @@ public class CTSettingsConfigurationModelListener
 					add(GrantType.JWT_BEARER);
 				}
 			},
+			OAuth2ApplicationConstants.APPLICATION_TYPE_SYSTEM,
 			"client_secret_post", user.getUserId(), clientId,
 			ClientProfile.HEADLESS_SERVER.id(), clientSecret, null,
 			new ArrayList<String>() {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourcePerformanceTest.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-test/src/testIntegration/java/com/liferay/headless/admin/user/resource/v1_0/test/UserAccountResourcePerformanceTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.admin.user.client.http.HttpInvoker;
 import com.liferay.oauth.client.LocalOAuthClient;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.petra.string.StringBundler;
@@ -172,6 +173,7 @@ public class UserAccountResourcePerformanceTest {
 					GrantType.CLIENT_CREDENTIALS, GrantType.REFRESH_TOKEN,
 					GrantType.JWT_BEARER, GrantType.RESOURCE_OWNER_PASSWORD,
 					GrantType.AUTHORIZATION_CODE),
+				OAuth2ApplicationConstants.APPLICATION_TYPE_USER,
 				"client_secret_post", user.getUserId(),
 				RandomTestUtil.randomString(), 0, RandomTestUtil.randomString(),
 				"", Collections.emptyList(), "", 0, "", "rest_token", "",

--- a/modules/apps/oauth-client/oauth-client-test/src/testIntegration/java/com/liferay/oauth/client/test/LocalOAuthClientTest.java
+++ b/modules/apps/oauth-client/oauth-client-test/src/testIntegration/java/com/liferay/oauth/client/test/LocalOAuthClientTest.java
@@ -8,6 +8,7 @@ package com.liferay.oauth.client.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth.client.LocalOAuthClient;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -49,6 +50,7 @@ public class LocalOAuthClientTest {
 			_oAuth2ApplicationLocalService.addOAuth2Application(
 				user.getCompanyId(), user.getUserId(), user.getLogin(),
 				Arrays.asList(GrantType.RESOURCE_OWNER_PASSWORD),
+				OAuth2ApplicationConstants.APPLICATION_TYPE_USER,
 				"client_secret_post", user.getUserId(), "testClient", 0,
 				"testClientSecret", "test oauth client",
 				Collections.singletonList("token.introspection"),

--- a/modules/apps/oauth2-provider/oauth2-provider-api/bnd.bnd
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay OAuth2 Provider API
 Bundle-SymbolicName: com.liferay.oauth2.provider.api
-Bundle-Version: 19.0.1
+Bundle-Version: 20.0.0
 Export-Package:\
 	com.liferay.oauth2.provider.configuration,\
 	com.liferay.oauth2.provider.constants,\

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/constants/OAuth2ApplicationConstants.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/constants/OAuth2ApplicationConstants.java
@@ -10,6 +10,12 @@ package com.liferay.oauth2.provider.constants;
  */
 public class OAuth2ApplicationConstants {
 
+	public static final int APPLICATION_TYPE_CLIENT_EXTENSION = 2;
+
+	public static final int APPLICATION_TYPE_SYSTEM = 0;
+
+	public static final int APPLICATION_TYPE_USER = 1;
+
 	public static final String NAME_DYNAMIC_REGISTRATOR = "Dynamic Registrator";
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationModel.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationModel.java
@@ -490,6 +490,20 @@ public interface OAuth2ApplicationModel
 	 */
 	public void setTrustedApplication(boolean trustedApplication);
 
+	/**
+	 * Returns the application type of this o auth2 application.
+	 *
+	 * @return the application type of this o auth2 application
+	 */
+	public int getApplicationType();
+
+	/**
+	 * Sets the application type of this o auth2 application.
+	 *
+	 * @param applicationType the application type of this o auth2 application
+	 */
+	public void setApplicationType(int applicationType);
+
 	@Override
 	public OAuth2Application cloneWithOriginalValues();
 
@@ -498,4 +512,4 @@ public interface OAuth2ApplicationModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1896141665
+// LIFERAY-SERVICE-BUILDER-HASH:-1191866482

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationTable.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationTable.java
@@ -103,10 +103,14 @@ public class OAuth2ApplicationTable extends BaseTable<OAuth2ApplicationTable> {
 		createColumn(
 			"trustedApplication", Boolean.class, Types.BOOLEAN,
 			Column.FLAG_DEFAULT);
+	public final Column<OAuth2ApplicationTable, Integer> applicationType =
+		createColumn(
+			"applicationType", Integer.class, Types.INTEGER,
+			Column.FLAG_DEFAULT);
 
 	private OAuth2ApplicationTable() {
 		super("OAuth2Application", OAuth2ApplicationTable::new);
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1631243351
+// LIFERAY-SERVICE-BUILDER-HASH:-886840389

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationWrapper.java
@@ -46,6 +46,7 @@ public class OAuth2ApplicationWrapper
 			"oAuth2ApplicationScopeAliasesId",
 			getOAuth2ApplicationScopeAliasesId());
 		attributes.put("allowedGrantTypes", getAllowedGrantTypes());
+		attributes.put("applicationType", getApplicationType());
 		attributes.put(
 			"clientAuthenticationMethod", getClientAuthenticationMethod());
 		attributes.put("clientCredentialUserId", getClientCredentialUserId());
@@ -231,6 +232,12 @@ public class OAuth2ApplicationWrapper
 		if (trustedApplication != null) {
 			setTrustedApplication(trustedApplication);
 		}
+
+		Integer applicationType = (Integer)attributes.get("applicationType");
+
+		if (applicationType != null) {
+			setApplicationType(applicationType);
+		}
 	}
 
 	@Override
@@ -253,6 +260,16 @@ public class OAuth2ApplicationWrapper
 		getAllowedGrantTypesList() {
 
 		return model.getAllowedGrantTypesList();
+	}
+
+	/**
+	 * Returns the application type of this o auth2 application.
+	 *
+	 * @return the application type of this o auth2 application
+	 */
+	@Override
+	public int getApplicationType() {
+		return model.getApplicationType();
 	}
 
 	/**
@@ -589,6 +606,16 @@ public class OAuth2ApplicationWrapper
 	}
 
 	/**
+	 * Sets the application type of this o auth2 application.
+	 *
+	 * @param applicationType the application type of this o auth2 application
+	 */
+	@Override
+	public void setApplicationType(int applicationType) {
+		model.setApplicationType(applicationType);
+	}
+
+	/**
 	 * Sets the client authentication method of this o auth2 application.
 	 *
 	 * @param clientAuthenticationMethod the client authentication method of this o auth2 application
@@ -901,4 +928,4 @@ public class OAuth2ApplicationWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-237298256
+// LIFERAY-SERVICE-BUILDER-HASH:951410180

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
@@ -62,7 +62,7 @@ public interface OAuth2ApplicationLocalService
 	 */
 	public OAuth2Application addOAuth2Application(
 			long companyId, long userId, String userName,
-			List<GrantType> allowedGrantTypesList,
+			List<GrantType> allowedGrantTypesList, int applicationType,
 			String clientAuthenticationMethod, long clientCredentialUserId,
 			String clientId, int clientProfile, String clientSecret,
 			String description, List<String> featuresList, String homePageURL,
@@ -75,7 +75,7 @@ public interface OAuth2ApplicationLocalService
 
 	public OAuth2Application addOAuth2Application(
 			long companyId, long userId, String userName,
-			List<GrantType> allowedGrantTypesList,
+			List<GrantType> allowedGrantTypesList, int applicationType,
 			String clientAuthenticationMethod, long clientCredentialUserId,
 			String clientId, int clientProfile, String clientSecret,
 			String description, List<String> featuresList, String homePageURL,
@@ -101,7 +101,7 @@ public interface OAuth2ApplicationLocalService
 
 	public OAuth2Application addOrUpdateOAuth2Application(
 			String externalReferenceCode, long userId, String userName,
-			List<GrantType> allowedGrantTypesList,
+			List<GrantType> allowedGrantTypesList, int applicationType,
 			String clientAuthenticationMethod, long clientCredentialUserId,
 			String clientId, int clientProfile, String clientSecret,
 			String description, List<String> featuresList, String homePageURL,
@@ -114,7 +114,7 @@ public interface OAuth2ApplicationLocalService
 
 	public OAuth2Application addOrUpdateOAuth2Application(
 			String externalReferenceCode, long userId, String userName,
-			List<GrantType> allowedGrantTypesList,
+			List<GrantType> allowedGrantTypesList, int applicationType,
 			String clientAuthenticationMethod, long clientCredentialUserId,
 			String clientId, int clientProfile, String clientSecret,
 			String description, List<String> featuresList, String homePageURL,
@@ -406,4 +406,4 @@ public interface OAuth2ApplicationLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1041698936
+// LIFERAY-SERVICE-BUILDER-HASH:-957444928

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
@@ -41,10 +41,10 @@ public class OAuth2ApplicationLocalServiceUtil {
 			long companyId, long userId, String userName,
 			List<com.liferay.oauth2.provider.constants.GrantType>
 				allowedGrantTypesList,
-			String clientAuthenticationMethod, long clientCredentialUserId,
-			String clientId, int clientProfile, String clientSecret,
-			String description, List<String> featuresList, String homePageURL,
-			long iconFileEntryId, String jwks, String name,
+			int applicationType, String clientAuthenticationMethod,
+			long clientCredentialUserId, String clientId, int clientProfile,
+			String clientSecret, String description, List<String> featuresList,
+			String homePageURL, long iconFileEntryId, String jwks, String name,
 			String privacyPolicyURL, List<String> redirectURIsList,
 			boolean rememberDevice, boolean trustedApplication,
 			java.util.function.Consumer
@@ -54,7 +54,7 @@ public class OAuth2ApplicationLocalServiceUtil {
 		throws PortalException {
 
 		return getService().addOAuth2Application(
-			companyId, userId, userName, allowedGrantTypesList,
+			companyId, userId, userName, allowedGrantTypesList, applicationType,
 			clientAuthenticationMethod, clientCredentialUserId, clientId,
 			clientProfile, clientSecret, description, featuresList, homePageURL,
 			iconFileEntryId, jwks, name, privacyPolicyURL, redirectURIsList,
@@ -66,10 +66,10 @@ public class OAuth2ApplicationLocalServiceUtil {
 			long companyId, long userId, String userName,
 			List<com.liferay.oauth2.provider.constants.GrantType>
 				allowedGrantTypesList,
-			String clientAuthenticationMethod, long clientCredentialUserId,
-			String clientId, int clientProfile, String clientSecret,
-			String description, List<String> featuresList, String homePageURL,
-			long iconFileEntryId, String jwks, String name,
+			int applicationType, String clientAuthenticationMethod,
+			long clientCredentialUserId, String clientId, int clientProfile,
+			String clientSecret, String description, List<String> featuresList,
+			String homePageURL, long iconFileEntryId, String jwks, String name,
 			String privacyPolicyURL, List<String> redirectURIsList,
 			boolean rememberDevice, List<String> scopeAliasesList,
 			boolean trustedApplication,
@@ -77,7 +77,7 @@ public class OAuth2ApplicationLocalServiceUtil {
 		throws PortalException {
 
 		return getService().addOAuth2Application(
-			companyId, userId, userName, allowedGrantTypesList,
+			companyId, userId, userName, allowedGrantTypesList, applicationType,
 			clientAuthenticationMethod, clientCredentialUserId, clientId,
 			clientProfile, clientSecret, description, featuresList, homePageURL,
 			iconFileEntryId, jwks, name, privacyPolicyURL, redirectURIsList,
@@ -105,10 +105,10 @@ public class OAuth2ApplicationLocalServiceUtil {
 			String externalReferenceCode, long userId, String userName,
 			List<com.liferay.oauth2.provider.constants.GrantType>
 				allowedGrantTypesList,
-			String clientAuthenticationMethod, long clientCredentialUserId,
-			String clientId, int clientProfile, String clientSecret,
-			String description, List<String> featuresList, String homePageURL,
-			long iconFileEntryId, String jwks, String name,
+			int applicationType, String clientAuthenticationMethod,
+			long clientCredentialUserId, String clientId, int clientProfile,
+			String clientSecret, String description, List<String> featuresList,
+			String homePageURL, long iconFileEntryId, String jwks, String name,
 			String privacyPolicyURL, List<String> redirectURIsList,
 			boolean rememberDevice, boolean trustedApplication,
 			java.util.function.Consumer
@@ -119,21 +119,21 @@ public class OAuth2ApplicationLocalServiceUtil {
 
 		return getService().addOrUpdateOAuth2Application(
 			externalReferenceCode, userId, userName, allowedGrantTypesList,
-			clientAuthenticationMethod, clientCredentialUserId, clientId,
-			clientProfile, clientSecret, description, featuresList, homePageURL,
-			iconFileEntryId, jwks, name, privacyPolicyURL, redirectURIsList,
-			rememberDevice, trustedApplication, builderConsumer,
-			serviceContext);
+			applicationType, clientAuthenticationMethod, clientCredentialUserId,
+			clientId, clientProfile, clientSecret, description, featuresList,
+			homePageURL, iconFileEntryId, jwks, name, privacyPolicyURL,
+			redirectURIsList, rememberDevice, trustedApplication,
+			builderConsumer, serviceContext);
 	}
 
 	public static OAuth2Application addOrUpdateOAuth2Application(
 			String externalReferenceCode, long userId, String userName,
 			List<com.liferay.oauth2.provider.constants.GrantType>
 				allowedGrantTypesList,
-			String clientAuthenticationMethod, long clientCredentialUserId,
-			String clientId, int clientProfile, String clientSecret,
-			String description, List<String> featuresList, String homePageURL,
-			long iconFileEntryId, String jwks, String name,
+			int applicationType, String clientAuthenticationMethod,
+			long clientCredentialUserId, String clientId, int clientProfile,
+			String clientSecret, String description, List<String> featuresList,
+			String homePageURL, long iconFileEntryId, String jwks, String name,
 			String privacyPolicyURL, List<String> redirectURIsList,
 			boolean rememberDevice, List<String> scopeAliasesList,
 			boolean trustedApplication,
@@ -142,11 +142,11 @@ public class OAuth2ApplicationLocalServiceUtil {
 
 		return getService().addOrUpdateOAuth2Application(
 			externalReferenceCode, userId, userName, allowedGrantTypesList,
-			clientAuthenticationMethod, clientCredentialUserId, clientId,
-			clientProfile, clientSecret, description, featuresList, homePageURL,
-			iconFileEntryId, jwks, name, privacyPolicyURL, redirectURIsList,
-			rememberDevice, scopeAliasesList, trustedApplication,
-			serviceContext);
+			applicationType, clientAuthenticationMethod, clientCredentialUserId,
+			clientId, clientProfile, clientSecret, description, featuresList,
+			homePageURL, iconFileEntryId, jwks, name, privacyPolicyURL,
+			redirectURIsList, rememberDevice, scopeAliasesList,
+			trustedApplication, serviceContext);
 	}
 
 	/**
@@ -544,4 +544,4 @@ public class OAuth2ApplicationLocalServiceUtil {
 			OAuth2ApplicationLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1677176149
+// LIFERAY-SERVICE-BUILDER-HASH:-358677419

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
@@ -35,11 +35,12 @@ public class OAuth2ApplicationLocalServiceWrapper
 				long companyId, long userId, String userName,
 				java.util.List<com.liferay.oauth2.provider.constants.GrantType>
 					allowedGrantTypesList,
-				String clientAuthenticationMethod, long clientCredentialUserId,
-				String clientId, int clientProfile, String clientSecret,
-				String description, java.util.List<String> featuresList,
-				String homePageURL, long iconFileEntryId, String jwks,
-				String name, String privacyPolicyURL,
+				int applicationType, String clientAuthenticationMethod,
+				long clientCredentialUserId, String clientId, int clientProfile,
+				String clientSecret, String description,
+				java.util.List<String> featuresList, String homePageURL,
+				long iconFileEntryId, String jwks, String name,
+				String privacyPolicyURL,
 				java.util.List<String> redirectURIsList, boolean rememberDevice,
 				boolean trustedApplication,
 				java.util.function.Consumer
@@ -49,7 +50,7 @@ public class OAuth2ApplicationLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _oAuth2ApplicationLocalService.addOAuth2Application(
-			companyId, userId, userName, allowedGrantTypesList,
+			companyId, userId, userName, allowedGrantTypesList, applicationType,
 			clientAuthenticationMethod, clientCredentialUserId, clientId,
 			clientProfile, clientSecret, description, featuresList, homePageURL,
 			iconFileEntryId, jwks, name, privacyPolicyURL, redirectURIsList,
@@ -63,11 +64,12 @@ public class OAuth2ApplicationLocalServiceWrapper
 				long companyId, long userId, String userName,
 				java.util.List<com.liferay.oauth2.provider.constants.GrantType>
 					allowedGrantTypesList,
-				String clientAuthenticationMethod, long clientCredentialUserId,
-				String clientId, int clientProfile, String clientSecret,
-				String description, java.util.List<String> featuresList,
-				String homePageURL, long iconFileEntryId, String jwks,
-				String name, String privacyPolicyURL,
+				int applicationType, String clientAuthenticationMethod,
+				long clientCredentialUserId, String clientId, int clientProfile,
+				String clientSecret, String description,
+				java.util.List<String> featuresList, String homePageURL,
+				long iconFileEntryId, String jwks, String name,
+				String privacyPolicyURL,
 				java.util.List<String> redirectURIsList, boolean rememberDevice,
 				java.util.List<String> scopeAliasesList,
 				boolean trustedApplication,
@@ -75,7 +77,7 @@ public class OAuth2ApplicationLocalServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _oAuth2ApplicationLocalService.addOAuth2Application(
-			companyId, userId, userName, allowedGrantTypesList,
+			companyId, userId, userName, allowedGrantTypesList, applicationType,
 			clientAuthenticationMethod, clientCredentialUserId, clientId,
 			clientProfile, clientSecret, description, featuresList, homePageURL,
 			iconFileEntryId, jwks, name, privacyPolicyURL, redirectURIsList,
@@ -109,11 +111,12 @@ public class OAuth2ApplicationLocalServiceWrapper
 				String externalReferenceCode, long userId, String userName,
 				java.util.List<com.liferay.oauth2.provider.constants.GrantType>
 					allowedGrantTypesList,
-				String clientAuthenticationMethod, long clientCredentialUserId,
-				String clientId, int clientProfile, String clientSecret,
-				String description, java.util.List<String> featuresList,
-				String homePageURL, long iconFileEntryId, String jwks,
-				String name, String privacyPolicyURL,
+				int applicationType, String clientAuthenticationMethod,
+				long clientCredentialUserId, String clientId, int clientProfile,
+				String clientSecret, String description,
+				java.util.List<String> featuresList, String homePageURL,
+				long iconFileEntryId, String jwks, String name,
+				String privacyPolicyURL,
 				java.util.List<String> redirectURIsList, boolean rememberDevice,
 				boolean trustedApplication,
 				java.util.function.Consumer
@@ -124,11 +127,11 @@ public class OAuth2ApplicationLocalServiceWrapper
 
 		return _oAuth2ApplicationLocalService.addOrUpdateOAuth2Application(
 			externalReferenceCode, userId, userName, allowedGrantTypesList,
-			clientAuthenticationMethod, clientCredentialUserId, clientId,
-			clientProfile, clientSecret, description, featuresList, homePageURL,
-			iconFileEntryId, jwks, name, privacyPolicyURL, redirectURIsList,
-			rememberDevice, trustedApplication, builderConsumer,
-			serviceContext);
+			applicationType, clientAuthenticationMethod, clientCredentialUserId,
+			clientId, clientProfile, clientSecret, description, featuresList,
+			homePageURL, iconFileEntryId, jwks, name, privacyPolicyURL,
+			redirectURIsList, rememberDevice, trustedApplication,
+			builderConsumer, serviceContext);
 	}
 
 	@Override
@@ -137,11 +140,12 @@ public class OAuth2ApplicationLocalServiceWrapper
 				String externalReferenceCode, long userId, String userName,
 				java.util.List<com.liferay.oauth2.provider.constants.GrantType>
 					allowedGrantTypesList,
-				String clientAuthenticationMethod, long clientCredentialUserId,
-				String clientId, int clientProfile, String clientSecret,
-				String description, java.util.List<String> featuresList,
-				String homePageURL, long iconFileEntryId, String jwks,
-				String name, String privacyPolicyURL,
+				int applicationType, String clientAuthenticationMethod,
+				long clientCredentialUserId, String clientId, int clientProfile,
+				String clientSecret, String description,
+				java.util.List<String> featuresList, String homePageURL,
+				long iconFileEntryId, String jwks, String name,
+				String privacyPolicyURL,
 				java.util.List<String> redirectURIsList, boolean rememberDevice,
 				java.util.List<String> scopeAliasesList,
 				boolean trustedApplication,
@@ -150,11 +154,11 @@ public class OAuth2ApplicationLocalServiceWrapper
 
 		return _oAuth2ApplicationLocalService.addOrUpdateOAuth2Application(
 			externalReferenceCode, userId, userName, allowedGrantTypesList,
-			clientAuthenticationMethod, clientCredentialUserId, clientId,
-			clientProfile, clientSecret, description, featuresList, homePageURL,
-			iconFileEntryId, jwks, name, privacyPolicyURL, redirectURIsList,
-			rememberDevice, scopeAliasesList, trustedApplication,
-			serviceContext);
+			applicationType, clientAuthenticationMethod, clientCredentialUserId,
+			clientId, clientProfile, clientSecret, description, featuresList,
+			homePageURL, iconFileEntryId, jwks, name, privacyPolicyURL,
+			redirectURIsList, rememberDevice, scopeAliasesList,
+			trustedApplication, serviceContext);
 	}
 
 	/**
@@ -637,4 +641,4 @@ public class OAuth2ApplicationLocalServiceWrapper
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:682669637
+// LIFERAY-SERVICE-BUILDER-HASH:1372745597

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationService.java
@@ -48,7 +48,7 @@ public interface OAuth2ApplicationService extends BaseService {
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.oauth2.provider.service.impl.OAuth2ApplicationServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the o auth2 application remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link OAuth2ApplicationServiceUtil} if injection and service tracking are not available.
 	 */
 	public OAuth2Application addOAuth2Application(
-			List<GrantType> allowedGrantTypesList,
+			List<GrantType> allowedGrantTypesList, int applicationType,
 			String clientAuthenticationMethod, long clientCredentialUserId,
 			String clientId, int clientProfile, String clientSecret,
 			String description, List<String> featuresList, String homePageURL,
@@ -110,4 +110,4 @@ public interface OAuth2ApplicationService extends BaseService {
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:353725954
+// LIFERAY-SERVICE-BUILDER-HASH:1251719568

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationServiceUtil.java
@@ -36,10 +36,10 @@ public class OAuth2ApplicationServiceUtil {
 	public static OAuth2Application addOAuth2Application(
 			List<com.liferay.oauth2.provider.constants.GrantType>
 				allowedGrantTypesList,
-			String clientAuthenticationMethod, long clientCredentialUserId,
-			String clientId, int clientProfile, String clientSecret,
-			String description, List<String> featuresList, String homePageURL,
-			long iconFileEntryId, String jwks, String name,
+			int applicationType, String clientAuthenticationMethod,
+			long clientCredentialUserId, String clientId, int clientProfile,
+			String clientSecret, String description, List<String> featuresList,
+			String homePageURL, long iconFileEntryId, String jwks, String name,
 			String privacyPolicyURL, List<String> redirectURIsList,
 			boolean rememberDevice, List<String> scopeAliasesList,
 			boolean trustedApplication,
@@ -47,7 +47,7 @@ public class OAuth2ApplicationServiceUtil {
 		throws PortalException {
 
 		return getService().addOAuth2Application(
-			allowedGrantTypesList, clientAuthenticationMethod,
+			allowedGrantTypesList, applicationType, clientAuthenticationMethod,
 			clientCredentialUserId, clientId, clientProfile, clientSecret,
 			description, featuresList, homePageURL, iconFileEntryId, jwks, name,
 			privacyPolicyURL, redirectURIsList, rememberDevice,
@@ -148,4 +148,4 @@ public class OAuth2ApplicationServiceUtil {
 			OAuth2ApplicationServiceUtil.class, OAuth2ApplicationService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1874331327
+// LIFERAY-SERVICE-BUILDER-HASH:-276166062

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationServiceWrapper.java
@@ -33,11 +33,12 @@ public class OAuth2ApplicationServiceWrapper
 			addOAuth2Application(
 				java.util.List<com.liferay.oauth2.provider.constants.GrantType>
 					allowedGrantTypesList,
-				String clientAuthenticationMethod, long clientCredentialUserId,
-				String clientId, int clientProfile, String clientSecret,
-				String description, java.util.List<String> featuresList,
-				String homePageURL, long iconFileEntryId, String jwks,
-				String name, String privacyPolicyURL,
+				int applicationType, String clientAuthenticationMethod,
+				long clientCredentialUserId, String clientId, int clientProfile,
+				String clientSecret, String description,
+				java.util.List<String> featuresList, String homePageURL,
+				long iconFileEntryId, String jwks, String name,
+				String privacyPolicyURL,
 				java.util.List<String> redirectURIsList, boolean rememberDevice,
 				java.util.List<String> scopeAliasesList,
 				boolean trustedApplication,
@@ -45,7 +46,7 @@ public class OAuth2ApplicationServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _oAuth2ApplicationService.addOAuth2Application(
-			allowedGrantTypesList, clientAuthenticationMethod,
+			allowedGrantTypesList, applicationType, clientAuthenticationMethod,
 			clientCredentialUserId, clientId, clientProfile, clientSecret,
 			description, featuresList, homePageURL, iconFileEntryId, jwks, name,
 			privacyPolicyURL, redirectURIsList, rememberDevice,
@@ -174,4 +175,4 @@ public class OAuth2ApplicationServiceWrapper
 	private OAuth2ApplicationService _oAuth2ApplicationService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-893493330
+// LIFERAY-SERVICE-BUILDER-HASH:373709791

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/constants/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/model/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/model/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 4.3.0

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 6.0.0

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -869,6 +869,7 @@ public class LiferayOAuthDataProvider
 					externalReferenceCode, user.getUserId(),
 					user.getScreenName() + "_dynamic_registered",
 					_getAllowedGrantTypes(client),
+					OAuth2ApplicationConstants.APPLICATION_TYPE_USER,
 					client.getTokenEndpointAuthMethod(), user.getUserId(),
 					clientId, ClientProfile.WEB_APPLICATION.id(), clientSecret,
 					null, null, client.getApplicationWebUri(), 0, jwks,

--- a/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay OAuth2 Provider Service
 Bundle-SymbolicName: com.liferay.oauth2.provider.service
 Bundle-Version: 4.0.108
-Liferay-Require-SchemaVersion: 4.2.7
+Liferay-Require-SchemaVersion: 4.2.8
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/oauth2-provider/oauth2-provider-service/service.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/service.xml
@@ -37,6 +37,7 @@
 		<column name="redirectURIs" type="String" />
 		<column name="rememberDevice" type="boolean" />
 		<column name="trustedApplication" type="boolean" />
+		<column name="applicationType" type="int" />
 
 		<!-- Finder methods -->
 

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
@@ -8,6 +8,7 @@ package com.liferay.oauth2.provider.internal.configuration;
 import com.liferay.oauth2.provider.configuration.OAuth2ProviderApplicationHeadlessServerConfiguration;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
@@ -182,6 +183,7 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 				externalReferenceCode, user.getUserId(), user.getScreenName(),
 				ListUtil.fromArray(
 					GrantType.CLIENT_CREDENTIALS, GrantType.JWT_BEARER),
+				OAuth2ApplicationConstants.APPLICATION_TYPE_CLIENT_EXTENSION,
 				"client_secret_post", serviceUser.getUserId(), clientId,
 				ClientProfile.HEADLESS_SERVER.id(), clientSecret,
 				oAuth2ProviderApplicationHeadlessServerConfiguration.

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationUserAgentConfigurationFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationUserAgentConfigurationFactory.java
@@ -8,6 +8,7 @@ package com.liferay.oauth2.provider.internal.configuration;
 import com.liferay.oauth2.provider.configuration.OAuth2ProviderApplicationUserAgentConfiguration;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.redirect.OAuth2RedirectURIInterpolator;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
@@ -156,6 +157,7 @@ public class OAuth2ProviderApplicationUserAgentConfigurationFactory
 				externalReferenceCode, user.getUserId(), user.getScreenName(),
 				ListUtil.fromArray(
 					GrantType.AUTHORIZATION_CODE_PKCE, GrantType.JWT_BEARER),
+				OAuth2ApplicationConstants.APPLICATION_TYPE_CLIENT_EXTENSION,
 				"none", user.getUserId(), clientId,
 				ClientProfile.USER_AGENT_APPLICATION.id(), null,
 				oAuth2ProviderApplicationUserAgentConfiguration.description(),

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
@@ -144,6 +144,23 @@ public class OAuth2ServiceUpgradeStepRegistrator
 			UpgradeProcessFactory.alterColumnType(
 				"OAuth2Application", "externalReferenceCode",
 				"VARCHAR(1000) null"));
+
+		registry.register(
+			"4.2.7", "4.2.8",
+			UpgradeProcessFactory.addColumns(
+				"OAuth2Application", "applicationType INTEGER default 1"),
+			UpgradeProcessFactory.runSQL(
+				"update OAuth2Application set applicationType = 0 where " +
+					"externalReferenceCode = 'ANALYTICS-CLOUD'"),
+			UpgradeProcessFactory.runSQL(
+				"update OAuth2Application set applicationType = 0 where " +
+					"name = 'Dynamic Registrator'"),
+			UpgradeProcessFactory.runSQL(
+				"update OAuth2Application set applicationType = 0 where " +
+					"clientId = 'FragmentRenderer'"),
+			UpgradeProcessFactory.runSQL(
+				"update OAuth2Application set applicationType = 0 where " +
+					"name = 'Remote Publications Headless Server'"));
 	}
 
 	@Reference

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationCacheModel.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationCacheModel.java
@@ -55,7 +55,7 @@ public class OAuth2ApplicationCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(53);
+		StringBundler sb = new StringBundler(55);
 
 		sb.append("{uuid=");
 		sb.append(uuid);
@@ -109,6 +109,8 @@ public class OAuth2ApplicationCacheModel
 		sb.append(rememberDevice);
 		sb.append(", trustedApplication=");
 		sb.append(trustedApplication);
+		sb.append(", applicationType=");
+		sb.append(applicationType);
 		sb.append("}");
 
 		return sb.toString();
@@ -256,6 +258,7 @@ public class OAuth2ApplicationCacheModel
 
 		oAuth2ApplicationImpl.setRememberDevice(rememberDevice);
 		oAuth2ApplicationImpl.setTrustedApplication(trustedApplication);
+		oAuth2ApplicationImpl.setApplicationType(applicationType);
 
 		oAuth2ApplicationImpl.resetOriginalValues();
 
@@ -299,6 +302,8 @@ public class OAuth2ApplicationCacheModel
 		rememberDevice = objectInput.readBoolean();
 
 		trustedApplication = objectInput.readBoolean();
+
+		applicationType = objectInput.readInt();
 	}
 
 	@Override
@@ -428,6 +433,8 @@ public class OAuth2ApplicationCacheModel
 		objectOutput.writeBoolean(rememberDevice);
 
 		objectOutput.writeBoolean(trustedApplication);
+
+		objectOutput.writeInt(applicationType);
 	}
 
 	public String uuid;
@@ -456,6 +463,7 @@ public class OAuth2ApplicationCacheModel
 	public String redirectURIs;
 	public boolean rememberDevice;
 	public boolean trustedApplication;
+	public int applicationType;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1038855590
+// LIFERAY-SERVICE-BUILDER-HASH:585689954

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationModelImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationModelImpl.java
@@ -79,7 +79,8 @@ public class OAuth2ApplicationModelImpl
 		{"iconFileEntryId", Types.BIGINT}, {"jwks", Types.VARCHAR},
 		{"name", Types.VARCHAR}, {"privacyPolicyURL", Types.VARCHAR},
 		{"redirectURIs", Types.VARCHAR}, {"rememberDevice", Types.BOOLEAN},
-		{"trustedApplication", Types.BOOLEAN}
+		{"trustedApplication", Types.BOOLEAN},
+		{"applicationType", Types.INTEGER}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -112,10 +113,11 @@ public class OAuth2ApplicationModelImpl
 		TABLE_COLUMNS_MAP.put("redirectURIs", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("rememberDevice", Types.BOOLEAN);
 		TABLE_COLUMNS_MAP.put("trustedApplication", Types.BOOLEAN);
+		TABLE_COLUMNS_MAP.put("applicationType", Types.INTEGER);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table OAuth2Application (uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(1000) null,oAuth2ApplicationId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,oA2AScopeAliasesId LONG,allowedGrantTypes VARCHAR(128) null,clientAuthenticationMethod VARCHAR(75) null,clientCredentialUserId LONG,clientCredentialUserName VARCHAR(75) null,clientId VARCHAR(75) null,clientProfile INTEGER,clientSecret VARCHAR(75) null,description STRING null,features STRING null,homePageURL STRING null,iconFileEntryId LONG,jwks VARCHAR(3999) null,name VARCHAR(255) null,privacyPolicyURL STRING null,redirectURIs STRING null,rememberDevice BOOLEAN,trustedApplication BOOLEAN)";
+		"create table OAuth2Application (uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(1000) null,oAuth2ApplicationId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,oA2AScopeAliasesId LONG,allowedGrantTypes VARCHAR(128) null,clientAuthenticationMethod VARCHAR(75) null,clientCredentialUserId LONG,clientCredentialUserName VARCHAR(75) null,clientId VARCHAR(75) null,clientProfile INTEGER,clientSecret VARCHAR(75) null,description STRING null,features STRING null,homePageURL STRING null,iconFileEntryId LONG,jwks VARCHAR(3999) null,name VARCHAR(255) null,privacyPolicyURL STRING null,redirectURIs STRING null,rememberDevice BOOLEAN,trustedApplication BOOLEAN,applicationType INTEGER)";
 
 	public static final String TABLE_SQL_DROP = "drop table OAuth2Application";
 
@@ -336,6 +338,8 @@ public class OAuth2ApplicationModelImpl
 				"rememberDevice", OAuth2Application::getRememberDevice);
 			attributeGetterFunctions.put(
 				"trustedApplication", OAuth2Application::getTrustedApplication);
+			attributeGetterFunctions.put(
+				"applicationType", OAuth2Application::getApplicationType);
 
 			_attributeGetterFunctions = Collections.unmodifiableMap(
 				attributeGetterFunctions);
@@ -458,6 +462,10 @@ public class OAuth2ApplicationModelImpl
 				"trustedApplication",
 				(BiConsumer<OAuth2Application, Boolean>)
 					OAuth2Application::setTrustedApplication);
+			attributeSetterBiConsumers.put(
+				"applicationType",
+				(BiConsumer<OAuth2Application, Integer>)
+					OAuth2Application::setApplicationType);
 
 			_attributeSetterBiConsumers = Collections.unmodifiableMap(
 				(Map)attributeSetterBiConsumers);
@@ -1032,6 +1040,21 @@ public class OAuth2ApplicationModelImpl
 		_trustedApplication = trustedApplication;
 	}
 
+	@JSON
+	@Override
+	public int getApplicationType() {
+		return _applicationType;
+	}
+
+	@Override
+	public void setApplicationType(int applicationType) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_applicationType = applicationType;
+	}
+
 	@Override
 	public StagedModelType getStagedModelType() {
 		return new StagedModelType(
@@ -1126,6 +1149,7 @@ public class OAuth2ApplicationModelImpl
 		oAuth2ApplicationImpl.setRedirectURIs(getRedirectURIs());
 		oAuth2ApplicationImpl.setRememberDevice(isRememberDevice());
 		oAuth2ApplicationImpl.setTrustedApplication(isTrustedApplication());
+		oAuth2ApplicationImpl.setApplicationType(getApplicationType());
 
 		oAuth2ApplicationImpl.resetOriginalValues();
 
@@ -1189,6 +1213,8 @@ public class OAuth2ApplicationModelImpl
 			this.<Boolean>getColumnOriginalValue("rememberDevice"));
 		oAuth2ApplicationImpl.setTrustedApplication(
 			this.<Boolean>getColumnOriginalValue("trustedApplication"));
+		oAuth2ApplicationImpl.setApplicationType(
+			this.<Integer>getColumnOriginalValue("applicationType"));
 
 		return oAuth2ApplicationImpl;
 	}
@@ -1439,6 +1465,8 @@ public class OAuth2ApplicationModelImpl
 
 		oAuth2ApplicationCacheModel.trustedApplication = isTrustedApplication();
 
+		oAuth2ApplicationCacheModel.applicationType = getApplicationType();
+
 		return oAuth2ApplicationCacheModel;
 	}
 
@@ -1528,6 +1556,7 @@ public class OAuth2ApplicationModelImpl
 	private String _redirectURIs;
 	private boolean _rememberDevice;
 	private boolean _trustedApplication;
+	private int _applicationType;
 
 	public <T> T getColumnValue(String columnName) {
 		columnName = _attributeNames.getOrDefault(columnName, columnName);
@@ -1590,6 +1619,7 @@ public class OAuth2ApplicationModelImpl
 		_columnOriginalValues.put("redirectURIs", _redirectURIs);
 		_columnOriginalValues.put("rememberDevice", _rememberDevice);
 		_columnOriginalValues.put("trustedApplication", _trustedApplication);
+		_columnOriginalValues.put("applicationType", _applicationType);
 	}
 
 	private static final Map<String, String> _attributeNames;
@@ -1667,6 +1697,8 @@ public class OAuth2ApplicationModelImpl
 
 		columnBitmasks.put("trustedApplication", 33554432L);
 
+		columnBitmasks.put("applicationType", 67108864L);
+
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}
 
@@ -1674,4 +1706,4 @@ public class OAuth2ApplicationModelImpl
 	private OAuth2Application _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:376422472
+// LIFERAY-SERVICE-BUILDER-HASH:161909756

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/http/OAuth2ApplicationServiceHttp.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/http/OAuth2ApplicationServiceHttp.java
@@ -46,11 +46,12 @@ public class OAuth2ApplicationServiceHttp {
 				HttpPrincipal httpPrincipal,
 				java.util.List<com.liferay.oauth2.provider.constants.GrantType>
 					allowedGrantTypesList,
-				String clientAuthenticationMethod, long clientCredentialUserId,
-				String clientId, int clientProfile, String clientSecret,
-				String description, java.util.List<String> featuresList,
-				String homePageURL, long iconFileEntryId, String jwks,
-				String name, String privacyPolicyURL,
+				int applicationType, String clientAuthenticationMethod,
+				long clientCredentialUserId, String clientId, int clientProfile,
+				String clientSecret, String description,
+				java.util.List<String> featuresList, String homePageURL,
+				long iconFileEntryId, String jwks, String name,
+				String privacyPolicyURL,
 				java.util.List<String> redirectURIsList, boolean rememberDevice,
 				java.util.List<String> scopeAliasesList,
 				boolean trustedApplication,
@@ -63,11 +64,12 @@ public class OAuth2ApplicationServiceHttp {
 				_addOAuth2ApplicationParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, allowedGrantTypesList, clientAuthenticationMethod,
-				clientCredentialUserId, clientId, clientProfile, clientSecret,
-				description, featuresList, homePageURL, iconFileEntryId, jwks,
-				name, privacyPolicyURL, redirectURIsList, rememberDevice,
-				scopeAliasesList, trustedApplication, serviceContext);
+				methodKey, allowedGrantTypesList, applicationType,
+				clientAuthenticationMethod, clientCredentialUserId, clientId,
+				clientProfile, clientSecret, description, featuresList,
+				homePageURL, iconFileEntryId, jwks, name, privacyPolicyURL,
+				redirectURIsList, rememberDevice, scopeAliasesList,
+				trustedApplication, serviceContext);
 
 			Object returnObj = null;
 
@@ -485,11 +487,11 @@ public class OAuth2ApplicationServiceHttp {
 
 	private static final Class<?>[] _addOAuth2ApplicationParameterTypes0 =
 		new Class[] {
+			java.util.List.class, int.class, String.class, long.class,
+			String.class, int.class, String.class, String.class,
 			java.util.List.class, String.class, long.class, String.class,
-			int.class, String.class, String.class, java.util.List.class,
-			String.class, long.class, String.class, String.class, String.class,
-			java.util.List.class, boolean.class, java.util.List.class,
-			boolean.class,
+			String.class, String.class, java.util.List.class, boolean.class,
+			java.util.List.class, boolean.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _deleteOAuth2ApplicationParameterTypes1 =
@@ -522,4 +524,4 @@ public class OAuth2ApplicationServiceHttp {
 		new Class[] {long.class, java.util.List.class};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-471470981
+// LIFERAY-SERVICE-BUILDER-HASH:641396410

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -92,7 +92,7 @@ public class OAuth2ApplicationLocalServiceImpl
 	@Override
 	public OAuth2Application addOAuth2Application(
 			long companyId, long userId, String userName,
-			List<GrantType> allowedGrantTypesList,
+			List<GrantType> allowedGrantTypesList, int applicationType,
 			String clientAuthenticationMethod, long clientCredentialUserId,
 			String clientId, int clientProfile, String clientSecret,
 			String description, List<String> featuresList, String homePageURL,
@@ -163,6 +163,7 @@ public class OAuth2ApplicationLocalServiceImpl
 		oAuth2Application.setRedirectURIsList(redirectURIsList);
 		oAuth2Application.setRememberDevice(rememberDevice);
 		oAuth2Application.setTrustedApplication(trustedApplication);
+		oAuth2Application.setApplicationType(applicationType);
 
 		if (builderConsumer != null) {
 			OAuth2ApplicationScopeAliases oAuth2ApplicationScopeAliases =
@@ -187,7 +188,7 @@ public class OAuth2ApplicationLocalServiceImpl
 	@Override
 	public OAuth2Application addOAuth2Application(
 			long companyId, long userId, String userName,
-			List<GrantType> allowedGrantTypesList,
+			List<GrantType> allowedGrantTypesList, int applicationType,
 			String clientAuthenticationMethod, long clientCredentialUserId,
 			String clientId, int clientProfile, String clientSecret,
 			String description, List<String> featuresList, String homePageURL,
@@ -261,6 +262,7 @@ public class OAuth2ApplicationLocalServiceImpl
 		oAuth2Application.setRedirectURIsList(redirectURIsList);
 		oAuth2Application.setRememberDevice(rememberDevice);
 		oAuth2Application.setTrustedApplication(trustedApplication);
+		oAuth2Application.setApplicationType(applicationType);
 
 		if (ListUtil.isNotEmpty(scopeAliasesList)) {
 			OAuth2ApplicationScopeAliases oAuth2ApplicationScopeAliases =
@@ -285,7 +287,7 @@ public class OAuth2ApplicationLocalServiceImpl
 	@Override
 	public OAuth2Application addOrUpdateOAuth2Application(
 			String externalReferenceCode, long userId, String userName,
-			List<GrantType> allowedGrantTypesList,
+			List<GrantType> allowedGrantTypesList, int applicationType,
 			String clientAuthenticationMethod, long clientCredentialUserId,
 			String clientId, int clientProfile, String clientSecret,
 			String description, List<String> featuresList, String homePageURL,
@@ -330,11 +332,11 @@ public class OAuth2ApplicationLocalServiceImpl
 
 		oAuth2Application = addOAuth2Application(
 			user.getCompanyId(), userId, userName, allowedGrantTypesList,
-			clientAuthenticationMethod, clientCredentialUserId, clientId,
-			clientProfile, clientSecret, description, featuresList, homePageURL,
-			iconFileEntryId, jwks, name, privacyPolicyURL, redirectURIsList,
-			rememberDevice, trustedApplication, builderConsumer,
-			serviceContext);
+			applicationType, clientAuthenticationMethod, clientCredentialUserId,
+			clientId, clientProfile, clientSecret, description, featuresList,
+			homePageURL, iconFileEntryId, jwks, name, privacyPolicyURL,
+			redirectURIsList, rememberDevice, trustedApplication,
+			builderConsumer, serviceContext);
 
 		oAuth2Application.setExternalReferenceCode(externalReferenceCode);
 
@@ -344,7 +346,7 @@ public class OAuth2ApplicationLocalServiceImpl
 	@Override
 	public OAuth2Application addOrUpdateOAuth2Application(
 			String externalReferenceCode, long userId, String userName,
-			List<GrantType> allowedGrantTypesList,
+			List<GrantType> allowedGrantTypesList, int applicationType,
 			String clientAuthenticationMethod, long clientCredentialUserId,
 			String clientId, int clientProfile, String clientSecret,
 			String description, List<String> featuresList, String homePageURL,
@@ -383,11 +385,11 @@ public class OAuth2ApplicationLocalServiceImpl
 
 		oAuth2Application = addOAuth2Application(
 			user.getCompanyId(), userId, userName, allowedGrantTypesList,
-			clientAuthenticationMethod, clientCredentialUserId, clientId,
-			clientProfile, clientSecret, description, featuresList, homePageURL,
-			iconFileEntryId, jwks, name, privacyPolicyURL, redirectURIsList,
-			rememberDevice, scopeAliasesList, trustedApplication,
-			serviceContext);
+			applicationType, clientAuthenticationMethod, clientCredentialUserId,
+			clientId, clientProfile, clientSecret, description, featuresList,
+			homePageURL, iconFileEntryId, jwks, name, privacyPolicyURL,
+			redirectURIsList, rememberDevice, scopeAliasesList,
+			trustedApplication, serviceContext);
 
 		oAuth2Application.setExternalReferenceCode(externalReferenceCode);
 

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationServiceImpl.java
@@ -40,7 +40,7 @@ public class OAuth2ApplicationServiceImpl
 
 	@Override
 	public OAuth2Application addOAuth2Application(
-			List<GrantType> allowedGrantTypesList,
+			List<GrantType> allowedGrantTypesList, int applicationType,
 			String clientAuthenticationMethod, long clientCredentialUserId,
 			String clientId, int clientProfile, String clientSecret,
 			String description, List<String> featuresList, String homePageURL,
@@ -78,7 +78,7 @@ public class OAuth2ApplicationServiceImpl
 
 		return oAuth2ApplicationLocalService.addOAuth2Application(
 			user.getCompanyId(), user.getUserId(), user.getFullName(),
-			allowedGrantTypesList, clientAuthenticationMethod,
+			allowedGrantTypesList, applicationType, clientAuthenticationMethod,
 			clientCredentialUserId, clientId, clientProfile, clientSecret,
 			description, featuresList, homePageURL, iconFileEntryId, jwks, name,
 			privacyPolicyURL, redirectURIsList, rememberDevice,

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/module-hbm.xml
@@ -35,6 +35,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="redirectURIs" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="rememberDevice" type="com.liferay.portal.dao.orm.hibernate.BooleanType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="trustedApplication" type="com.liferay.portal.dao.orm.hibernate.BooleanType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="applicationType" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 	</class>
 	<class name="com.liferay.oauth2.provider.model.impl.OAuth2ApplicationScopeAliasesImpl" table="OAuth2ApplicationScopeAliases">
 		<id access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="oA2AScopeAliasesId" name="oAuth2ApplicationScopeAliasesId" type="long">

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -48,6 +48,7 @@
 		</field>
 		<field name="rememberDevice" type="boolean" />
 		<field name="trustedApplication" type="boolean" />
+		<field name="applicationType" type="int" />
 	</model>
 	<model name="com.liferay.oauth2.provider.model.OAuth2ApplicationScopeAliases">
 		<field name="oAuth2ApplicationScopeAliasesId" type="long" />

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/tables.sql
@@ -31,7 +31,8 @@ create table OAuth2Application (
 	privacyPolicyURL STRING null,
 	redirectURIs STRING null,
 	rememberDevice BOOLEAN,
-	trustedApplication BOOLEAN
+	trustedApplication BOOLEAN,
+	applicationType INTEGER
 );
 
 create table OAuth2ApplicationScopeAliases (

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/service.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.oauth2.provider.service
-    build.number=1
-    build.date=1511982781730
+    build.number=2
+    build.date=1776465626524

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/test/java/com/liferay/oauth2/provider/internal/configuration/ConfigurationFactoryTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/test/java/com/liferay/oauth2/provider/internal/configuration/ConfigurationFactoryTest.java
@@ -116,8 +116,8 @@ public class ConfigurationFactoryTest {
 		Mockito.when(
 			_oAuth2ApplicationLocalService.addOrUpdateOAuth2Application(
 				Mockito.anyString(), Mockito.anyLong(), Mockito.anyString(),
-				Mockito.anyList(), Mockito.anyString(), Mockito.anyLong(),
-				Mockito.anyString(), Mockito.anyInt(),
+				Mockito.anyList(), Mockito.anyInt(), Mockito.anyString(),
+				Mockito.anyLong(), Mockito.anyString(), Mockito.anyInt(),
 				AdditionalMatchers.or(Mockito.anyString(), Mockito.isNull()),
 				Mockito.anyString(), Mockito.anyList(), Mockito.anyString(),
 				Mockito.anyLong(),

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/AnalyticsCloudInitialRequestPortalInstanceLifecycleListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/AnalyticsCloudInitialRequestPortalInstanceLifecycleListener.java
@@ -7,6 +7,7 @@ package com.liferay.oauth2.provider.shortcut.internal.instance.lifecycle;
 
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.constants.OAuth2ProviderActionKeys;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.scope.spi.application.descriptor.ApplicationDescriptor;
@@ -161,6 +162,7 @@ public class AnalyticsCloudInitialRequestPortalInstanceLifecycleListener
 						add(GrantType.JWT_BEARER);
 					}
 				},
+				OAuth2ApplicationConstants.APPLICATION_TYPE_SYSTEM,
 				"client_secret_post", user.getUserId(),
 				OAuth2SecureRandomGenerator.generateClientId(),
 				ClientProfile.HEADLESS_SERVER.id(),

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/DynamicRegistrationPortalInstanceLifecycleListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/DynamicRegistrationPortalInstanceLifecycleListener.java
@@ -71,6 +71,7 @@ public class DynamicRegistrationPortalInstanceLifecycleListener
 			_oAuth2ApplicationLocalService.addOAuth2Application(
 				company.getCompanyId(), user.getUserId(), user.getScreenName(),
 				Collections.singletonList(GrantType.CLIENT_CREDENTIALS),
+				OAuth2ApplicationConstants.APPLICATION_TYPE_SYSTEM,
 				"client_secret_post", user.getUserId(),
 				OAuth2SecureRandomGenerator.generateClientId(),
 				ClientProfile.HEADLESS_SERVER.id(),

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/FragmentRendererPortalInstanceLifecycleListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/instance/lifecycle/FragmentRendererPortalInstanceLifecycleListener.java
@@ -7,6 +7,7 @@ package com.liferay.oauth2.provider.shortcut.internal.instance.lifecycle;
 
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.osgi.util.configuration.ConfigurationPersistenceUtil;
@@ -64,10 +65,10 @@ public class FragmentRendererPortalInstanceLifecycleListener
 					add(GrantType.RESOURCE_OWNER_PASSWORD);
 				}
 			},
-			"none", user.getUserId(), _clientId,
-			ClientProfile.NATIVE_APPLICATION.id(), StringPool.BLANK, null, null,
-			null, 0, null, _applicationName, null, Collections.emptyList(),
-			false, false,
+			OAuth2ApplicationConstants.APPLICATION_TYPE_SYSTEM, "none",
+			user.getUserId(), _clientId, ClientProfile.NATIVE_APPLICATION.id(),
+			StringPool.BLANK, null, null, null, 0, null, _applicationName, null,
+			Collections.emptyList(), false, false,
 			builder -> builder.forApplication(
 				"liferay-json-web-services",
 				"com.liferay.oauth2.provider.jsonws",

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/upgrade/v1_0_0/OAuth2ApplicationAnalyticsCloudUpgradeProcess.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/upgrade/v1_0_0/OAuth2ApplicationAnalyticsCloudUpgradeProcess.java
@@ -7,6 +7,7 @@ package com.liferay.oauth2.provider.shortcut.internal.upgrade.v1_0_0;
 
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.constants.OAuth2ProviderActionKeys;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
@@ -134,6 +135,7 @@ public class OAuth2ApplicationAnalyticsCloudUpgradeProcess
 						add(GrantType.JWT_BEARER);
 					}
 				},
+				OAuth2ApplicationConstants.APPLICATION_TYPE_SYSTEM,
 				"client_secret_post", user.getUserId(),
 				OAuth2SecureRandomGenerator.generateClientId(),
 				ClientProfile.HEADLESS_SERVER.id(),

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
@@ -7,6 +7,7 @@ package com.liferay.oauth2.provider.client.test;
 
 import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.scope.spi.prefix.handler.PrefixHandler;
@@ -371,9 +372,10 @@ public abstract class BaseTestPreparatorBundleActivator
 		OAuth2Application oAuth2Application =
 			oAuth2ApplicationLocalService.addOAuth2Application(
 				companyId, user.getUserId(), user.getFullName(),
-				allowedGrantTypesList, clientAuthenticationMethod,
-				user.getUserId(), clientId, 0, clientSecret,
-				"test oauth application",
+				allowedGrantTypesList,
+				OAuth2ApplicationConstants.APPLICATION_TYPE_USER,
+				clientAuthenticationMethod, user.getUserId(), clientId, 0,
+				clientSecret, "test oauth application",
 				Collections.singletonList("token.introspection"),
 				"http://localhost:8080", 0, jwks, "test application",
 				"http://localhost:8080", redirectURIsList, rememberDevice,

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/service/test/OAuth2ApplicationLocalServiceExternalReferenceCodeTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/service/test/OAuth2ApplicationLocalServiceExternalReferenceCodeTest.java
@@ -1,0 +1,193 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
+import com.liferay.oauth2.provider.exception.DuplicateOAuth2ApplicationExternalReferenceCodeException;
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Keven Leone
+ */
+@RunWith(Arquillian.class)
+public class OAuth2ApplicationLocalServiceExternalReferenceCodeTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_user = TestPropsValues.getUser();
+
+		_oAuth2Applications = new ArrayList<>();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		for (OAuth2Application oAuth2Application : _oAuth2Applications) {
+			_oAuth2ApplicationLocalService.deleteOAuth2Application(
+				oAuth2Application.getOAuth2ApplicationId());
+		}
+	}
+
+	@Test
+	public void testFetchOAuth2ApplicationByExternalReferenceCode()
+		throws Exception {
+
+		OAuth2Application oAuth2Application = _addOAuth2Application();
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		_oAuth2ApplicationLocalService.updateExternalReferenceCode(
+			oAuth2Application.getOAuth2ApplicationId(), externalReferenceCode);
+
+		OAuth2Application fetchedOAuth2Application =
+			_oAuth2ApplicationLocalService.
+				fetchOAuth2ApplicationByExternalReferenceCode(
+					externalReferenceCode, _user.getCompanyId());
+
+		Assert.assertNotNull(fetchedOAuth2Application);
+		Assert.assertEquals(
+			oAuth2Application.getOAuth2ApplicationId(),
+			fetchedOAuth2Application.getOAuth2ApplicationId());
+	}
+
+	@Test
+	public void testFetchOAuth2ApplicationByExternalReferenceCodeReturnsNullForNonexistent()
+		throws Exception {
+
+		OAuth2Application oAuth2Application =
+			_oAuth2ApplicationLocalService.
+				fetchOAuth2ApplicationByExternalReferenceCode(
+					"nonexistent-erc-" + RandomTestUtil.randomString(),
+					_user.getCompanyId());
+
+		Assert.assertNull(oAuth2Application);
+	}
+
+	@Test
+	public void testUpdateExternalReferenceCode() throws Exception {
+		OAuth2Application oAuth2Application = _addOAuth2Application();
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		Assert.assertNotEquals(
+			externalReferenceCode,
+			oAuth2Application.getExternalReferenceCode());
+
+		oAuth2Application =
+			_oAuth2ApplicationLocalService.updateExternalReferenceCode(
+				oAuth2Application.getOAuth2ApplicationId(),
+				externalReferenceCode);
+
+		Assert.assertEquals(
+			externalReferenceCode,
+			oAuth2Application.getExternalReferenceCode());
+	}
+
+	@Test(
+		expected = DuplicateOAuth2ApplicationExternalReferenceCodeException.class
+	)
+	public void testUpdateExternalReferenceCodeDuplicate() throws Exception {
+		OAuth2Application oAuth2Application1 = _addOAuth2Application();
+		OAuth2Application oAuth2Application2 = _addOAuth2Application();
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		_oAuth2ApplicationLocalService.updateExternalReferenceCode(
+			oAuth2Application1.getOAuth2ApplicationId(), externalReferenceCode);
+
+		_oAuth2ApplicationLocalService.updateExternalReferenceCode(
+			oAuth2Application2.getOAuth2ApplicationId(), externalReferenceCode);
+	}
+
+	@Test
+	public void testUpdateExternalReferenceCodeToBlank() throws Exception {
+		OAuth2Application oAuth2Application = _addOAuth2Application();
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		_oAuth2ApplicationLocalService.updateExternalReferenceCode(
+			oAuth2Application.getOAuth2ApplicationId(), externalReferenceCode);
+
+		oAuth2Application =
+			_oAuth2ApplicationLocalService.updateExternalReferenceCode(
+				oAuth2Application.getOAuth2ApplicationId(), "");
+
+		Assert.assertEquals("", oAuth2Application.getExternalReferenceCode());
+	}
+
+	@Test
+	public void testUpdateExternalReferenceCodeWithSameValue()
+		throws Exception {
+
+		OAuth2Application oAuth2Application = _addOAuth2Application();
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		oAuth2Application =
+			_oAuth2ApplicationLocalService.updateExternalReferenceCode(
+				oAuth2Application.getOAuth2ApplicationId(),
+				externalReferenceCode);
+
+		OAuth2Application updatedOAuth2Application =
+			_oAuth2ApplicationLocalService.updateExternalReferenceCode(
+				oAuth2Application.getOAuth2ApplicationId(),
+				externalReferenceCode);
+
+		Assert.assertEquals(
+			externalReferenceCode,
+			updatedOAuth2Application.getExternalReferenceCode());
+	}
+
+	private OAuth2Application _addOAuth2Application() throws Exception {
+		OAuth2Application oAuth2Application =
+			_oAuth2ApplicationLocalService.addOAuth2Application(
+				_user.getCompanyId(), _user.getUserId(), _user.getFullName(),
+				Arrays.asList(GrantType.CLIENT_CREDENTIALS),
+				OAuth2ApplicationConstants.APPLICATION_TYPE_USER,
+				"client_secret_post", _user.getUserId(),
+				RandomTestUtil.randomString(), 0, RandomTestUtil.randomString(),
+				"", Collections.emptyList(), "http://localhost:8080", 0, "",
+				RandomTestUtil.randomString(), "", Collections.emptyList(),
+				false, Collections.emptyList(), false, new ServiceContext());
+
+		_oAuth2Applications.add(oAuth2Application);
+
+		return oAuth2Application;
+	}
+
+	@Inject
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
+
+	private ArrayList<OAuth2Application> _oAuth2Applications;
+	private User _user;
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/portlet/action/UpdateOAuth2ApplicationMVCActionCommand.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/portlet/action/UpdateOAuth2ApplicationMVCActionCommand.java
@@ -10,7 +10,10 @@ import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
+import com.liferay.oauth2.provider.exception.DuplicateOAuth2ApplicationExternalReferenceCodeException;
 import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationScopeAliasesLocalService;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationService;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
@@ -165,12 +168,13 @@ public class UpdateOAuth2ApplicationMVCActionCommand
 
 				OAuth2Application oAuth2Application =
 					_oAuth2ApplicationService.addOAuth2Application(
-						allowedGrantTypesList, clientAuthenticationMethod,
-						clientCredentialUserId, clientId, clientProfile.id(),
-						clientSecret, description, featuresList, homePageURL, 0,
-						jwks, name, privacyPolicyURL, redirectURIsList,
-						rememberDevice, scopeAliasesList, trustedApplication,
-						serviceContext);
+						allowedGrantTypesList,
+						OAuth2ApplicationConstants.APPLICATION_TYPE_USER,
+						clientAuthenticationMethod, clientCredentialUserId,
+						clientId, clientProfile.id(), clientSecret, description,
+						featuresList, homePageURL, 0, jwks, name,
+						privacyPolicyURL, redirectURIsList, rememberDevice,
+						scopeAliasesList, trustedApplication, serviceContext);
 
 				response.setRenderParameter(
 					"oAuth2ApplicationId",
@@ -191,6 +195,12 @@ public class UpdateOAuth2ApplicationMVCActionCommand
 					privacyPolicyURL, redirectURIsList, rememberDevice,
 					trustedApplication);
 
+				String externalReferenceCode = ParamUtil.get(
+					request, "externalReferenceCode", StringPool.BLANK);
+
+				_oAuth2ApplicationLocalService.updateExternalReferenceCode(
+					oAuth2ApplicationId, externalReferenceCode);
+
 				long fileEntryId = ParamUtil.getLong(request, "fileEntryId");
 
 				if (ParamUtil.getBoolean(request, "deleteLogo")) {
@@ -209,6 +219,20 @@ public class UpdateOAuth2ApplicationMVCActionCommand
 					_dlAppService.deleteFileEntry(fileEntryId);
 				}
 			}
+		}
+		catch (DuplicateOAuth2ApplicationExternalReferenceCodeException
+					duplicateOAuth2ApplicationExternalReferenceCodeException) {
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					duplicateOAuth2ApplicationExternalReferenceCodeException);
+			}
+
+			SessionErrors.add(
+				request,
+				DuplicateOAuth2ApplicationExternalReferenceCodeException.class.
+					getName(),
+				duplicateOAuth2ApplicationExternalReferenceCodeException);
 		}
 		catch (PortalException portalException) {
 			if (_log.isDebugEnabled()) {
@@ -252,6 +276,9 @@ public class UpdateOAuth2ApplicationMVCActionCommand
 
 	@Reference
 	private DLURLHelper _dlurlHelper;
+
+	@Reference
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 	@Reference
 	private OAuth2ApplicationScopeAliasesLocalService

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
@@ -12,8 +12,10 @@ String redirect = ParamUtil.getString(request, "redirect");
 
 OAuth2Application oAuth2Application = oAuth2AdminPortletDisplayContext.getOAuth2Application();
 
+int applicationType = (oAuth2Application == null) ? 1 : oAuth2Application.getApplicationType();
 String clientId = (oAuth2Application == null) ? "" : oAuth2Application.getClientId();
 String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getClientSecret();
+String externalReferenceCode = (oAuth2Application == null) ? "" : oAuth2Application.getExternalReferenceCode();
 %>
 
 <portlet:actionURL name="/oauth2_provider/update_oauth2_application" var="updateOAuth2ApplicationURL">
@@ -32,6 +34,8 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 					lg="12"
 				>
 					<liferay-ui:error exception="<%= DuplicateOAuth2ApplicationClientIdException.class %>" focusField="clientId" message="client-id-already-exists" />
+
+					<liferay-ui:error exception="<%= DuplicateOAuth2ApplicationExternalReferenceCodeException.class %>" focusField="externalReferenceCode" message="please-enter-a-unique-external-reference-code" />
 
 					<liferay-ui:error exception="<%= OAuth2ApplicationClientGrantTypeException.class %>">
 						<liferay-ui:message arguments="<%= HtmlUtil.escape(((OAuth2ApplicationClientGrantTypeException)errorException).getMessage()) %>" key="grant-type-x-is-unsupported-for-this-client-type" />
@@ -92,11 +96,15 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 								module="{EditClientDetails} from oauth2-provider-web"
 								props='<%=
 									HashMapBuilder.<String, Object>put(
+										"applicationType", applicationType
+									).put(
 										"baseResourceURL", String.valueOf(baseResourceURL)
 									).put(
 										"clientId", clientId
 									).put(
 										"clientSecret", clientSecret
+									).put(
+										"externalReferenceCode", externalReferenceCode
 									).build()
 								%>'
 							/>

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/init.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/init.jsp
@@ -15,6 +15,7 @@ page import="com.liferay.item.selector.criteria.UUIDItemSelectorReturnType" %><%
 page import="com.liferay.oauth2.provider.constants.ClientProfile" %><%@
 page import="com.liferay.oauth2.provider.constants.GrantType" %><%@
 page import="com.liferay.oauth2.provider.exception.DuplicateOAuth2ApplicationClientIdException" %><%@
+page import="com.liferay.oauth2.provider.exception.DuplicateOAuth2ApplicationExternalReferenceCodeException" %><%@
 page import="com.liferay.oauth2.provider.exception.OAuth2ApplicationClientCredentialUserIdException" %><%@
 page import="com.liferay.oauth2.provider.exception.OAuth2ApplicationClientGrantTypeException" %><%@
 page import="com.liferay.oauth2.provider.exception.OAuth2ApplicationHomePageURLException" %><%@

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/EditClientDetails.tsx
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/EditClientDetails.tsx
@@ -8,9 +8,11 @@ import React from 'react';
 import ReadOnlyInput from './ReadOnlyInput';
 
 interface IEditClientDetailsProps extends React.HTMLAttributes<HTMLElement> {
+	applicationType: number;
 	baseResourceURL: string;
 	clientId: string;
 	clientSecret: string;
+	externalReferenceCode: string;
 	portletNamespace: string;
 }
 
@@ -40,6 +42,21 @@ const EditClientDetails: React.FC<IEditClientDetailsProps> = (props) => {
 				title={Liferay.Language.get('edit-client-secret')}
 				tooltip={Liferay.Language.get('client-secret-help[oauth2]')}
 				type="password"
+			/>
+
+			<ReadOnlyInput
+				alertText={Liferay.Language.get(
+					'if-changed-the-external-reference-code-must-be-unique-across-all-oauth2-applications-in-this-instance'
+				)}
+				editable={props.applicationType === 1}
+				id={`${props.portletNamespace}externalReferenceCode`}
+				initialValue={props.externalReferenceCode}
+				label={Liferay.Language.get('external-reference-code')}
+				required={false}
+				title={Liferay.Language.get('edit-external-reference-code')}
+				tooltip={Liferay.Language.get(
+					'external-reference-code-help[oauth2]'
+				)}
 			/>
 		</>
 	);

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/ReadOnlyInput.tsx
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/ReadOnlyInput.tsx
@@ -13,10 +13,12 @@ import {EditClientOAuth2ModalContent} from './modals/EditClientOAuth2ModalConten
 interface IReadOnlyInputProps extends React.HTMLAttributes<HTMLElement> {
 	alertText: string;
 	baseResourceURL?: string;
+	editable?: boolean;
 	id: string;
 	initialValue: string;
 	isSecret?: boolean;
 	label: string;
+	required?: boolean;
 	title: string;
 	tooltip: string;
 	type?: string;
@@ -26,10 +28,12 @@ const ReadOnlyInput: React.FC<IReadOnlyInputProps> = (props) => {
 	const {
 		alertText,
 		baseResourceURL = '',
+		editable = true,
 		id,
 		initialValue,
 		isSecret = false,
 		label,
+		required = true,
 		title,
 		tooltip,
 		type = 'text',
@@ -43,7 +47,7 @@ const ReadOnlyInput: React.FC<IReadOnlyInputProps> = (props) => {
 
 	return (
 		<>
-			<FieldBase id={id} label={label} required={true} tooltip={tooltip}>
+			<FieldBase id={id} label={label} required={required} tooltip={tooltip}>
 				<ClayInput.Group>
 					<ClayInput.GroupItem prepend>
 						<ClayInput
@@ -55,38 +59,40 @@ const ReadOnlyInput: React.FC<IReadOnlyInputProps> = (props) => {
 						/>
 					</ClayInput.GroupItem>
 
-					<ClayInput.GroupItem append shrink>
-						<ClayButton
-							displayType="secondary"
-							onClick={() =>
-								openModal({
-									center: true,
-									contentComponent: ({
-										closeModal,
-									}: {
-										closeModal: () => void;
-									}) =>
-										EditClientOAuth2ModalContent({
-											alertText,
-											baseResourceURL,
+					{editable && (
+						<ClayInput.GroupItem append shrink>
+							<ClayButton
+								displayType="secondary"
+								onClick={() =>
+									openModal({
+										center: true,
+										contentComponent: ({
 											closeModal,
-											handleSetInputValue,
-											id,
-											initialValue,
-											isSecret,
-											label,
-											title,
-											tooltip,
-										}),
-									id: 'editClientOAuth2Modal',
-									size: 'md',
-									status: 'warning',
-								})
-							}
-						>
-							{Liferay.Language.get('edit')}
-						</ClayButton>
-					</ClayInput.GroupItem>
+										}: {
+											closeModal: () => void;
+										}) =>
+											EditClientOAuth2ModalContent({
+												alertText,
+												baseResourceURL,
+												closeModal,
+												handleSetInputValue,
+												id,
+												initialValue,
+												isSecret,
+												label,
+												title,
+												tooltip,
+											}),
+										id: 'editClientOAuth2Modal',
+										size: 'md',
+										status: 'warning',
+									})
+								}
+							>
+								{Liferay.Language.get('edit')}
+							</ClayButton>
+						</ClayInput.GroupItem>
+					)}
 				</ClayInput.Group>
 			</FieldBase>
 		</>

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/util/TokenTestUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/util/TokenTestUtil.java
@@ -8,6 +8,7 @@ package com.liferay.ai.hub.rest.resource.v1_0.test.util;
 import com.liferay.ai.hub.cell.configuration.AIHubCellConfiguration;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalServiceUtil;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
@@ -34,8 +35,9 @@ public class TokenTestUtil {
 		OAuth2Application oAuth2Application =
 			OAuth2ApplicationLocalServiceUtil.addOAuth2Application(
 				user.getCompanyId(), user.getUserId(), user.getFullName(),
-				List.of(GrantType.CLIENT_CREDENTIALS), "client_secret_post",
-				user.getUserId(),
+				List.of(GrantType.CLIENT_CREDENTIALS),
+				OAuth2ApplicationConstants.APPLICATION_TYPE_USER,
+				"client_secret_post", user.getUserId(),
 				OAuth2SecureRandomGenerator.generateClientId(),
 				ClientProfile.WEB_APPLICATION.id(),
 				OAuth2SecureRandomGenerator.generateClientSecret(), "",

--- a/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2Controller.java
+++ b/modules/dxp/apps/osb/osb-faro/osb-faro-web/src/main/java/com/liferay/osb/faro/web/internal/controller/main/OAuth2Controller.java
@@ -8,6 +8,7 @@ package com.liferay.osb.faro.web.internal.controller.main;
 import com.liferay.expando.kernel.model.ExpandoBridge;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
@@ -302,7 +303,8 @@ public class OAuth2Controller extends BaseFaroController {
 
 		return _oAuth2ApplicationLocalService.addOAuth2Application(
 			user.getCompanyId(), user.getUserId(), user.getFullName(),
-			Arrays.asList(GrantType.CLIENT_CREDENTIALS), StringPool.BLANK,
+			Arrays.asList(GrantType.CLIENT_CREDENTIALS),
+			OAuth2ApplicationConstants.APPLICATION_TYPE_USER, StringPool.BLANK,
 			user.getUserId(), clientId, clientProfile.id(),
 			_generateClientSecret(), StringPool.BLANK, Collections.emptyList(),
 			StringPool.BLANK, 0, StringPool.BLANK, _generateApplicationName(),

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/configuration/ScimClientOAuth2ApplicationConfigurationFactory.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/configuration/ScimClientOAuth2ApplicationConfigurationFactory.java
@@ -7,6 +7,7 @@ package com.liferay.scim.rest.internal.configuration;
 
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.rest.spi.bearer.token.provider.BearerTokenProvider;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
@@ -128,6 +129,7 @@ public class ScimClientOAuth2ApplicationConfigurationFactory {
 				_oAuth2ApplicationLocalService.addOAuth2Application(
 					companyId, user.getUserId(), user.getScreenName(),
 					ListUtil.fromArray(GrantType.CLIENT_CREDENTIALS),
+					OAuth2ApplicationConstants.APPLICATION_TYPE_SYSTEM,
 					"client_secret_post", user.getUserId(), clientId,
 					ClientProfile.HEADLESS_SERVER.id(),
 					OAuth2SecureRandomGenerator.generateClientSecret(), null,

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/internal/provider/test/ScimClientBearerTokenProviderTest.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/internal/provider/test/ScimClientBearerTokenProviderTest.java
@@ -7,6 +7,7 @@ package com.liferay.scim.rest.internal.provider.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.petra.string.StringBundler;
@@ -57,6 +58,7 @@ public class ScimClientBearerTokenProviderTest {
 				TestPropsValues.getCompanyId(), user.getUserId(),
 				user.getFullName(),
 				Collections.singletonList(GrantType.CLIENT_CREDENTIALS),
+				OAuth2ApplicationConstants.APPLICATION_TYPE_USER,
 				"client_secret_post", user.getUserId(),
 				RandomTestUtil.randomString(), 0, RandomTestUtil.randomString(),
 				null, null, null, 0, null, RandomTestUtil.randomString(), null,


### PR DESCRIPTION
## What

Adds an `applicationType` field to `OAuth2Application` to distinguish between system-managed, user-created, and client-extension OAuth2 applications. Also exposes the `externalReferenceCode` field in the admin UI for user-type applications.

> **Work in progress** — upgrade SQL and full test coverage still pending.

## Why

Without an explicit type, there is no programmatic way to differentiate system-internal OAuth2 apps (Analytics Cloud, Dynamic Registrator, FragmentRenderer, etc.) from user-created ones. This distinction is needed to:
- Gate ERC editing in the UI to user-owned apps only.
- Safely apply data migrations without touching system apps.

## Changes

### Model / Service
- Added `applicationType INTEGER` column to `OAuth2Application` (default `1` = user).
- New constants in `OAuth2ApplicationConstants`:
  - `APPLICATION_TYPE_SYSTEM = 0`
  - `APPLICATION_TYPE_USER = 1`
  - `APPLICATION_TYPE_CLIENT_EXTENSION = 2`
- Updated `addOAuth2Application` and `addOrUpdateOAuth2Application` signatures to accept `applicationType`.
- Applications created via the admin UI are tagged as `APPLICATION_TYPE_USER`.

### Database Upgrade (4.2.7 → 4.2.8)
- Adds the `applicationType` column with `default 1`.
- Backfills known system apps (`ANALYTICS-CLOUD`, `Dynamic Registrator`, `FragmentRenderer`, `Remote Publications Headless Server`) to type `0`.

### Admin UI
- `externalReferenceCode` is now displayed and editable on the credentials screen, but only for `APPLICATION_TYPE_USER` apps.
- `DuplicateOAuth2ApplicationExternalReferenceCodeException` is handled and surfaced as a user-facing error.

### Tests
- Added `OAuth2ApplicationLocalServiceExternalReferenceCodeTest` — integration tests covering fetch by ERC, update ERC, and duplicate ERC enforcement.
- Refactored upgrade test field injections to `static` where appropriate.