### PR TITLE
LPD-86057 Setting a default landing page will not take effect if there's a login utility page is being used

### DIFF
--- a/modules/apps/login/login-test/src/testIntegration/java/com/liferay/login/internal/portlet/action/test/LoginActionTest.java
+++ b/modules/apps/login/login-test/src/testIntegration/java/com/liferay/login/internal/portlet/action/test/LoginActionTest.java
@@ -49,8 +49,6 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.site.initializer.SiteInitializer;
 import com.liferay.site.initializer.SiteInitializerRegistry;
 
-import java.io.IOException;
-
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -92,7 +90,13 @@ public class LoginActionTest {
 
 	@Test
 	public void testExecuteHasExclusiveState() throws Exception {
-		String query = _checkConnectionAndGetURLQuery(_getHttpURLConnection());
+		HttpURLConnection httpURLConnection = _getHttpURLConnection();
+
+		Assert.assertEquals(200, httpURLConnection.getResponseCode());
+
+		URL url = httpURLConnection.getURL();
+
+		String query = url.getQuery();
 
 		Assert.assertTrue(query.contains("p_p_state=exclusive"));
 	}
@@ -133,8 +137,13 @@ public class LoginActionTest {
 					PropsKeys.DEFAULT_LANDING_PAGE_PATH,
 					RandomTestUtil.randomString())) {
 
-			String query = _checkConnectionAndGetURLQuery(
-				_getHttpURLConnection());
+			HttpURLConnection httpURLConnection = _getHttpURLConnection();
+
+			Assert.assertEquals(200, httpURLConnection.getResponseCode());
+
+			URL url = httpURLConnection.getURL();
+
+			String query = url.getQuery();
 
 			Assert.assertFalse(
 				query.contains(
@@ -150,8 +159,13 @@ public class LoginActionTest {
 					PropsKeys.VIRTUAL_HOSTS_DEFAULT_SITE_NAME,
 					StringPool.BLANK)) {
 
-			String query = _checkConnectionAndGetURLQuery(
-				_getHttpURLConnection());
+			HttpURLConnection httpURLConnection = _getHttpURLConnection();
+
+			Assert.assertEquals(200, httpURLConnection.getResponseCode());
+
+			URL url = httpURLConnection.getURL();
+
+			String query = url.getQuery();
 
 			Assert.assertTrue(
 				query.contains(
@@ -226,21 +240,14 @@ public class LoginActionTest {
 
 			httpURLConnection.setRequestMethod("GET");
 
-			String query = _checkConnectionAndGetURLQuery(httpURLConnection);
+			Assert.assertEquals(200, httpURLConnection.getResponseCode());
+
+			url = httpURLConnection.getURL();
+
+			String query = url.getQuery();
 
 			Assert.assertTrue(query.contains("p_p_state=normal"));
 		}
-	}
-
-	private String _checkConnectionAndGetURLQuery(
-			HttpURLConnection httpURLConnection)
-		throws IOException {
-
-		Assert.assertEquals(200, httpURLConnection.getResponseCode());
-
-		URL url = httpURLConnection.getURL();
-
-		return url.getQuery();
 	}
 
 	private HttpURLConnection _getHttpURLConnection() throws Exception {

--- a/modules/apps/login/login-test/src/testIntegration/java/com/liferay/login/internal/portlet/action/test/LoginActionTest.java
+++ b/modules/apps/login/login-test/src/testIntegration/java/com/liferay/login/internal/portlet/action/test/LoginActionTest.java
@@ -49,6 +49,8 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.site.initializer.SiteInitializer;
 import com.liferay.site.initializer.SiteInitializerRegistry;
 
+import java.io.IOException;
+
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -90,13 +92,7 @@ public class LoginActionTest {
 
 	@Test
 	public void testExecuteHasExclusiveState() throws Exception {
-		HttpURLConnection httpURLConnection = _getHttpURLConnection();
-
-		Assert.assertEquals(200, httpURLConnection.getResponseCode());
-
-		URL url = httpURLConnection.getURL();
-
-		String query = url.getQuery();
+		String query = _checkConnectionAndGetURLQuery(_getHttpURLConnection());
 
 		Assert.assertTrue(query.contains("p_p_state=exclusive"));
 	}
@@ -137,13 +133,8 @@ public class LoginActionTest {
 					PropsKeys.DEFAULT_LANDING_PAGE_PATH,
 					RandomTestUtil.randomString())) {
 
-			HttpURLConnection httpURLConnection = _getHttpURLConnection();
-
-			Assert.assertEquals(200, httpURLConnection.getResponseCode());
-
-			URL url = httpURLConnection.getURL();
-
-			String query = url.getQuery();
+			String query = _checkConnectionAndGetURLQuery(
+				_getHttpURLConnection());
 
 			Assert.assertFalse(
 				query.contains(
@@ -159,13 +150,8 @@ public class LoginActionTest {
 					PropsKeys.VIRTUAL_HOSTS_DEFAULT_SITE_NAME,
 					StringPool.BLANK)) {
 
-			HttpURLConnection httpURLConnection = _getHttpURLConnection();
-
-			Assert.assertEquals(200, httpURLConnection.getResponseCode());
-
-			URL url = httpURLConnection.getURL();
-
-			String query = url.getQuery();
+			String query = _checkConnectionAndGetURLQuery(
+				_getHttpURLConnection());
 
 			Assert.assertTrue(
 				query.contains(
@@ -240,14 +226,21 @@ public class LoginActionTest {
 
 			httpURLConnection.setRequestMethod("GET");
 
-			Assert.assertEquals(200, httpURLConnection.getResponseCode());
-
-			url = httpURLConnection.getURL();
-
-			String query = url.getQuery();
+			String query = _checkConnectionAndGetURLQuery(httpURLConnection);
 
 			Assert.assertTrue(query.contains("p_p_state=normal"));
 		}
+	}
+
+	private String _checkConnectionAndGetURLQuery(
+			HttpURLConnection httpURLConnection)
+		throws IOException {
+
+		Assert.assertEquals(200, httpURLConnection.getResponseCode());
+
+		URL url = httpURLConnection.getURL();
+
+		return url.getQuery();
 	}
 
 	private HttpURLConnection _getHttpURLConnection() throws Exception {

--- a/modules/apps/login/login-test/src/testIntegration/java/com/liferay/login/internal/portlet/action/test/LoginActionTest.java
+++ b/modules/apps/login/login-test/src/testIntegration/java/com/liferay/login/internal/portlet/action/test/LoginActionTest.java
@@ -128,6 +128,30 @@ public class LoginActionTest {
 	}
 
 	@Test
+	public void testExecuteWithDefaultLandingPagePathSkipsRedirectInjection()
+		throws Exception {
+
+		try (SafeCloseable safeCloseable =
+				PrefsPropsTestUtil.swapWithSafeCloseable(
+					TestPropsValues.getCompanyId(),
+					PropsKeys.DEFAULT_LANDING_PAGE_PATH,
+					RandomTestUtil.randomString())) {
+
+			HttpURLConnection httpURLConnection = _getHttpURLConnection();
+
+			Assert.assertEquals(200, httpURLConnection.getResponseCode());
+
+			URL url = httpURLConnection.getURL();
+
+			String query = url.getQuery();
+
+			Assert.assertFalse(
+				query.contains(
+					"_com_liferay_login_web_portlet_LoginPortlet_redirect="));
+		}
+	}
+
+	@Test
 	public void testExecuteWithNoDefaultSiteName() throws Exception {
 		try (SafeCloseable safeCloseable =
 				PrefsPropsTestUtil.swapWithSafeCloseable(

--- a/portal-impl/src/com/liferay/portal/action/LoginAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LoginAction.java
@@ -19,6 +19,8 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PrefsPropsUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -140,7 +142,12 @@ public class LoginAction implements Action {
 			}
 		}
 		else {
-			if (Validator.isNull(loginRedirect)) {
+			if (Validator.isNull(loginRedirect) &&
+				Validator.isNull(
+					PrefsPropsUtil.getString(
+						themeDisplay.getCompanyId(),
+						PropsKeys.DEFAULT_LANDING_PAGE_PATH))) {
+
 				loginRedirect = GetterUtil.getString(
 					PortalUtil.getLayoutFullURL(
 						themeDisplay.getLayout(), themeDisplay));


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86057

# Problem
When a TYPE_LOGIN Utility Page is configured for the site, after a successful login the user is redirected to the page from which they initiated the sign-in (usually the home page) rather than being redirected to the Default Landing
Page configured at company level. The bug occurs with both username/password login and OpenID Connect, because both flows originate from the same LoginAction and reuse the same redirect parameter.

Root cause: Commit 1a1ee1cdd0700 (ticket LPD-22656, May 2024) introduced a branch in portal-impl/.../LoginAction.java which, when a login utility page exists, forces loginRedirect to the user’s current layout if no explicit redirect had been
specified. This loginRedirect is injected as the redirect parameter into the utility page’s URL, propagates to the login form, and takes precedence over the LAST_PATH mechanism that DefaultLandingPageAction uses to
send the user to the Default Landing Page.

The intention of the commit was to preserve the context of the page from which the login was initiated (previously this was done via a pop-up; following LPD-22656, sign-in is full-page and the context was lost). However, this ‘preservation’ silently overrides the Default Landing Page.

# Solution
Change in LoginAction.java: only set loginRedirect to the current layout when no Default Landing Page is configured for the company. If one is configured, leave loginRedirect as null, allowing the standard mechanism
(DefaultLandingPageAction → LAST_PATH → PortalRequestProcessor) to direct the user to the correct page.
With this:
- Default Landing Page configured → the Default Landing Page takes precedence (bug fixed; applies to both basic login and OIDC).
- No Default Landing Page → the behaviour of LPD-22656 is preserved (returns to the originating page).
- Explicit redirect in the request → this is still respected (the corresponding branch is not altered).

# Test
Integration test:
- Configure `PropsKeys.DEFAULT_LANDING_PAGE_PATH` for the company using the existing pattern (already uses `PrefsPropsTestUtil`).
- Create a `LayoutUtilityPageEntry` of type `TYPE_LOGIN`.
- Call `LoginAction` and verify that the resulting URL does not contain the `__redirect` parameter pointing to the active layout.
