### PR TITLE
[AI HUB] LPD-87413 Validate JWT issuer claim during token verification

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/bnd.bnd
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay AI Hub Cell API
 Bundle-SymbolicName: com.liferay.ai.hub.cell.api
-Bundle-Version: 1.1.0
+Bundle-Version: 2.0.0
 Export-Package:\
 	com.liferay.ai.hub.cell.configuration,\
 	com.liferay.ai.hub.cell.security

--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/src/main/java/com/liferay/ai/hub/cell/security/JWTTokenUtil.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/src/main/java/com/liferay/ai/hub/cell/security/JWTTokenUtil.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.SecureRandomUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
@@ -56,7 +57,7 @@ public class JWTTokenUtil {
 		return signedJWT.serialize();
 	}
 
-	public static long getUserId(String token) {
+	public static long getUserId(String issuer, String token) {
 		JWTClaimsSet jwtClaimsSet = null;
 
 		try {
@@ -76,6 +77,16 @@ public class JWTTokenUtil {
 			if (_log.isDebugEnabled()) {
 				_log.debug(
 					"Unable to parse and verify the JWT token", exception);
+			}
+
+			return 0;
+		}
+
+		if (Validator.isNull(issuer) ||
+			!issuer.equals(jwtClaimsSet.getIssuer())) {
+
+			if (_log.isDebugEnabled()) {
+				_log.debug("Invalid JWT issuer");
 			}
 
 			return 0;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/src/main/resources/com/liferay/ai/hub/cell/configuration/packageinfo
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/src/main/resources/com/liferay/ai/hub/cell/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.0.1

--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/src/main/resources/com/liferay/ai/hub/cell/security/packageinfo
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/src/main/resources/com/liferay/ai/hub/cell/security/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
@@ -54,7 +54,7 @@ public class JWTTokenUtilTest {
 		String token = JWTTokenUtil.generateToken(
 			TimeUnit.MINUTES.toMillis(1), _ISSUER, _USER_ID);
 
-		Assert.assertEquals(_USER_ID, JWTTokenUtil.getUserId(token));
+		Assert.assertEquals(_USER_ID, JWTTokenUtil.getUserId(_ISSUER, token));
 
 		byte[] secret = new byte[64];
 
@@ -66,26 +66,32 @@ public class JWTTokenUtilTest {
 				ReflectionTestUtil.setFieldValueWithAutoCloseable(
 					JWTTokenUtil.class, "_SECRET", secret)) {
 
-			_testGetUserId("Invalid JWT signature", token);
+			_testGetUserId("Invalid JWT signature", _ISSUER, token);
 		}
 
 		_testGetUserId(
-			"Invalid JWT signature",
+			"Invalid JWT signature", _ISSUER,
 			token.substring(0, token.length() - 5) + "abcde");
 		_testGetUserId(
-			"The JWT token is expired",
+			"Invalid JWT issuer", RandomTestUtil.randomString(),
+			JWTTokenUtil.generateToken(
+				TimeUnit.MINUTES.toMillis(1), _ISSUER, _USER_ID));
+		_testGetUserId(
+			"The JWT token is expired", _ISSUER,
 			JWTTokenUtil.generateToken(0, _ISSUER, _USER_ID));
 		_testGetUserId(
-			"Unable to parse and verify the JWT token",
+			"Unable to parse and verify the JWT token", _ISSUER,
 			RandomTestUtil.randomString());
 	}
 
-	private void _testGetUserId(String expectedLogMessage, String token) {
+	private void _testGetUserId(
+		String expectedLogMessage, String issuer, String token) {
+
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				"com.liferay.ai.hub.cell.security.JWTTokenUtil",
 				LoggerTestUtil.DEBUG)) {
 
-			JWTTokenUtil.getUserId(token);
+			JWTTokenUtil.getUserId(issuer, token);
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
 

--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/build.gradle
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"

--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/security/auth/verifier/AIHubCellRequestAuthVerifier.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/security/auth/verifier/AIHubCellRequestAuthVerifier.java
@@ -8,11 +8,14 @@ package com.liferay.ai.hub.cell.internal.security.auth.verifier;
 import com.liferay.ai.hub.cell.security.JWTTokenUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.security.auth.AccessControlContext;
 import com.liferay.portal.kernel.security.auth.AuthException;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifier;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierResult;
 import com.liferay.portal.kernel.security.service.access.policy.ServiceAccessPolicy;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -23,6 +26,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Rafael Praxedes
@@ -56,7 +60,11 @@ public class AIHubCellRequestAuthVerifier implements AuthVerifier {
 				return new AuthVerifierResult();
 			}
 
-			long userId = JWTTokenUtil.getUserId(token);
+			Company company = _companyLocalService.getCompany(
+				_portal.getCompanyId(httpServletRequest));
+
+			long userId = JWTTokenUtil.getUserId(
+				company.getVirtualHostname(), token);
 
 			if (userId == 0) {
 				AuthVerifierResult authVerifierResult =
@@ -95,5 +103,11 @@ public class AIHubCellRequestAuthVerifier implements AuthVerifier {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AIHubCellRequestAuthVerifier.class);
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private Portal _portal;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-87413

**What is being fixed:** `JWTTokenUtil.getUserId` accepted any token whose
signature and expiration were valid, without ever checking the issuer claim.
Since tokens are generated with the company virtual hostname as the issuer,
a token with a forged or mismatched issuer could still pass verification —
violating the principle that every JWT claim that is set should also be
validated.

**How it is being fixed:** `getUserId` now requires the caller to supply the
expected issuer and rejects any token whose issuer claim does not match.
`AIHubCellRequestAuthVerifier` is updated to look up the current portal
company via `CompanyLocalService` and `Portal`, passing
`company.getVirtualHostname()` as the expected issuer. The test class is
extended with an explicit case that asserts the new check fires correctly.