### PR TITLE
LPD-80665 Add FIPS 140-3 JCE provider validation and known-answer tests

### DIFF
--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -14,6 +14,8 @@ import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.bootstrap.fips.FIPSComplianceChecker;
+import com.liferay.portal.bootstrap.fips.FIPSCryptoChecker;
 import com.liferay.portal.bootstrap.log.BundleStartStopLogger;
 import com.liferay.portal.bootstrap.log.PortalSynchronousLogListener;
 import com.liferay.portal.kernel.concurrent.SystemExecutorServiceUtil;
@@ -205,6 +207,11 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 
 	@Override
 	public void initFramework() throws Exception {
+		if (PropsValues.PORTAL_SECURITY_FIPS_MODE_ENABLED) {
+			FIPSComplianceChecker.run();
+			FIPSCryptoChecker.run();
+		}
+
 		if (_log.isDebugEnabled()) {
 			_log.debug("Initializing the new OSGi framework instance");
 		}

--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/fips/FIPSComplianceChecker.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/fips/FIPSComplianceChecker.java
@@ -1,0 +1,115 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.bootstrap.fips;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+
+import java.security.Provider;
+import java.security.Security;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * @author Caio Farias
+ */
+public class FIPSComplianceChecker {
+
+	public static void run() {
+		_checkFIPSProvider();
+
+		_checkApprovedProviders();
+	}
+
+	private static void _checkApprovedProviders() {
+		Set<String> approvedProviderNames = new LinkedHashSet<>(
+			Arrays.asList(PropsValues.PORTAL_SECURITY_FIPS_PROVIDER_APPROVED));
+
+		List<String> unapprovedProviderNames = new ArrayList<>();
+
+		for (Provider provider : Security.getProviders()) {
+			String providerName = provider.getName();
+
+			if (!approvedProviderNames.contains(providerName)) {
+				unapprovedProviderNames.add(providerName);
+			}
+		}
+
+		if (unapprovedProviderNames.isEmpty()) {
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					StringBundler.concat(
+						"All registered JCE providers are approved for FIPS ",
+						"mode ", _collectProviderNames()));
+			}
+
+			return;
+		}
+
+		String message = StringBundler.concat(
+			"Unapproved JCE providers registered in FIPS mode ",
+			unapprovedProviderNames, "; approved providers ",
+			approvedProviderNames);
+
+		if (PropsValues.PORTAL_SECURITY_FIPS_PROVIDER_STRICT) {
+			throw new SecurityException(message);
+		}
+
+		if (_log.isWarnEnabled()) {
+			_log.warn(message);
+		}
+	}
+
+	private static void _checkFIPSProvider() {
+		String fipsProviderName =
+			PropsValues.PORTAL_SECURITY_FIPS_PROVIDER_NAME;
+
+		Provider[] providers = Security.getProviders();
+
+		if ((providers.length > 0) &&
+			Objects.equals(providers[0].getName(), fipsProviderName)) {
+
+			if (_log.isInfoEnabled()) {
+				_log.info(
+					StringBundler.concat(
+						"FIPS provider \"", fipsProviderName,
+						"\" is the first registered JCE provider"));
+			}
+
+			return;
+		}
+
+		String message = StringBundler.concat(
+			"FIPS provider \"", fipsProviderName,
+			"\" must be the first registered JCE provider; registered ",
+			_collectProviderNames());
+
+		throw new SecurityException(message);
+	}
+
+	private static List<String> _collectProviderNames() {
+		Provider[] providers = Security.getProviders();
+
+		List<String> providerNames = new ArrayList<>(providers.length);
+
+		for (Provider provider : providers) {
+			providerNames.add(provider.getName());
+		}
+
+		return providerNames;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FIPSComplianceChecker.class);
+
+}

--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/fips/FIPSCryptoChecker.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/fips/FIPSCryptoChecker.java
@@ -1,0 +1,413 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.bootstrap.fips;
+
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.SecureRandomUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+
+import java.nio.charset.StandardCharsets;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.Provider;
+import java.security.Security;
+import java.security.Signature;
+import java.security.spec.ECGenParameterSpec;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * @author Caio Farias
+ */
+public class FIPSCryptoChecker {
+
+	public static void run() {
+		Provider provider = Security.getProvider(
+			PropsValues.PORTAL_SECURITY_FIPS_PROVIDER_NAME);
+
+		if (provider == null) {
+			throw new SecurityException(
+				"FIPS provider not found: " +
+					PropsValues.PORTAL_SECURITY_FIPS_PROVIDER_NAME);
+		}
+
+		_runKnownAnswerTest("_checkAESCBC", () -> _checkAESCBC(provider));
+		_runKnownAnswerTest("_checkAESGCM", () -> _checkAESGCM(provider));
+		_runRejectionCheck(
+			"DES/CBC/PKCS5Padding", () -> _checkDESRejected(provider));
+		_runRejectionCheck(
+			"DESede/CBC/PKCS5Padding", () -> _checkDESEdeRejected(provider));
+		_runKnownAnswerTest("_checkECDSA", () -> _checkECDSA(provider));
+		_runRejectionCheck(
+			"EC secp192r1", () -> _checkECWeakKeyRejected(provider));
+		_runKnownAnswerTest(
+			"_checkHmacSHA256", () -> _checkHmacSHA256(provider));
+		_runRejectionCheck("MD5", () -> _checkMD5Rejected(provider));
+		_runKnownAnswerTest("_checkPBKDF2", () -> _checkPBKDF2(provider));
+		_runKnownAnswerTest("_checkRSA", () -> _checkRSA(provider));
+		_runRejectionCheck(
+			"RSA 1024-bit", () -> _checkRSAWeakKeyRejected(provider));
+		_runRejectionCheck(
+			"SHA1withRSA", () -> _checkSHA1withRSARejected(provider));
+		_runKnownAnswerTest("_checkSHA256", () -> _checkSHA256(provider));
+		_runKnownAnswerTest(
+			"_checkSecureRandom", () -> _checkSecureRandom(provider));
+
+		if (_log.isInfoEnabled()) {
+			_log.info("FIPS known-answer tests passed");
+		}
+	}
+
+	private static void _checkAESCBC(Provider provider) throws Exception {
+		SecretKeySpec secretKeySpec = new SecretKeySpec(_AES_CBC_KEY, "AES");
+
+		Cipher cipher = Cipher.getInstance("AES/CBC/NoPadding", provider);
+
+		cipher.init(
+			Cipher.ENCRYPT_MODE, secretKeySpec,
+			new IvParameterSpec(_AES_CBC_IV));
+
+		byte[] ciphertext = cipher.doFinal(_AES_CBC_PLAINTEXT);
+
+		if (!Arrays.equals(_AES_CBC_EXPECTED_CIPHERTEXT, ciphertext)) {
+			throw new SecurityException(
+				"AES/CBC output did not match the NIST SP 800-38A test vector");
+		}
+	}
+
+	private static void _checkAESGCM(Provider provider) throws Exception {
+		SecretKeySpec secretKeySpec = new SecretKeySpec(_AES_GCM_KEY, "AES");
+
+		Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding", provider);
+
+		cipher.init(
+			Cipher.ENCRYPT_MODE, secretKeySpec,
+			new GCMParameterSpec(128, _AES_GCM_IV));
+
+		byte[] ciphertext = cipher.doFinal(_AES_GCM_PLAINTEXT);
+
+		if (!Arrays.equals(_AES_GCM_EXPECTED_CIPHERTEXT, ciphertext)) {
+			throw new SecurityException(
+				"AES/GCM output did not match the NIST SP 800-38D test vector");
+		}
+	}
+
+	private static void _checkDESEdeRejected(Provider provider)
+		throws Exception {
+
+		Cipher.getInstance("DESede/CBC/PKCS5Padding", provider);
+	}
+
+	private static void _checkDESRejected(Provider provider) throws Exception {
+		Cipher.getInstance("DES/CBC/PKCS5Padding", provider);
+	}
+
+	private static void _checkECDSA(Provider provider) throws Exception {
+		KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(
+			"EC", provider);
+
+		keyPairGenerator.initialize(new ECGenParameterSpec("secp256r1"));
+
+		KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+		Signature signature = Signature.getInstance(
+			"SHA256withECDSA", provider);
+
+		signature.initSign(keyPair.getPrivate());
+
+		signature.update(_ECDSA_SIGN_DATA);
+
+		byte[] signed = signature.sign();
+
+		signature.initVerify(keyPair.getPublic());
+
+		signature.update(_ECDSA_SIGN_DATA);
+
+		if (!signature.verify(signed)) {
+			throw new SecurityException(
+				"ECDSA SHA256withECDSA sign/verify self-test failed");
+		}
+	}
+
+	private static void _checkECWeakKeyRejected(Provider provider)
+		throws Exception {
+
+		KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(
+			"EC", provider);
+
+		keyPairGenerator.initialize(new ECGenParameterSpec("secp192r1"));
+
+		keyPairGenerator.generateKeyPair();
+	}
+
+	private static void _checkHmacSHA256(Provider provider) throws Exception {
+		Mac mac = Mac.getInstance("HmacSHA256", provider);
+
+		mac.init(new SecretKeySpec(_HMAC_SHA_256_KEY, "HmacSHA256"));
+
+		byte[] actual = mac.doFinal(_HMAC_SHA_256_MESSAGE);
+
+		if (!Arrays.equals(_HMAC_SHA_256_EXPECTED_MAC, actual)) {
+			throw new SecurityException(
+				"HmacSHA256 output did not match the FIPS 198-1 test vector");
+		}
+	}
+
+	private static void _checkMD5Rejected(Provider provider) throws Exception {
+		MessageDigest.getInstance("MD5", provider);
+	}
+
+	private static void _checkPBKDF2(Provider provider) throws Exception {
+		SecretKeyFactory secretKeyFactory = SecretKeyFactory.getInstance(
+			"PBKDF2WithHmacSHA256", provider);
+
+		PBEKeySpec pbeKeySpec = new PBEKeySpec(
+			_PBKDF2_PASSWORD, _PBKDF2_SALT, 1, 256);
+
+		try {
+			SecretKey secretKey = secretKeyFactory.generateSecret(pbeKeySpec);
+
+			byte[] actual = secretKey.getEncoded();
+
+			if (!Arrays.equals(_PBKDF2_EXPECTED_DK, actual)) {
+				throw new SecurityException(
+					"PBKDF2WithHmacSHA256 output did not match expected test " +
+						"vector");
+			}
+		}
+		finally {
+			pbeKeySpec.clearPassword();
+		}
+	}
+
+	private static void _checkRSA(Provider provider) throws Exception {
+		KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(
+			"RSA", provider);
+
+		keyPairGenerator.initialize(2048);
+
+		KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+		Signature signature = Signature.getInstance("SHA256withRSA", provider);
+
+		signature.initSign(keyPair.getPrivate());
+
+		signature.update(_RSA_SIGN_DATA);
+
+		byte[] signed = signature.sign();
+
+		signature.initVerify(keyPair.getPublic());
+
+		signature.update(_RSA_SIGN_DATA);
+
+		if (!signature.verify(signed)) {
+			throw new SecurityException(
+				"RSA SHA256withRSA sign/verify self-test failed");
+		}
+	}
+
+	private static void _checkRSAWeakKeyRejected(Provider provider)
+		throws Exception {
+
+		KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(
+			"RSA", provider);
+
+		keyPairGenerator.initialize(1024);
+
+		keyPairGenerator.generateKeyPair();
+	}
+
+	private static void _checkSecureRandom(Provider provider) throws Exception {
+		Provider.Service secureRandomService = null;
+
+		for (Provider.Service providerService : provider.getServices()) {
+			if (Objects.equals(providerService.getType(), "SecureRandom")) {
+				secureRandomService = providerService;
+
+				break;
+			}
+		}
+
+		if (secureRandomService == null) {
+			throw new SecurityException(
+				"FIPS provider has no SecureRandom service");
+		}
+
+		byte[] bytes = new byte[32];
+
+		SecureRandomUtil.nextBytes(
+			bytes, secureRandomService.getAlgorithm(), provider);
+
+		for (byte b : bytes) {
+			if (b != 0) {
+				return;
+			}
+		}
+
+		throw new SecurityException("FIPS DRBG produced all-zero output");
+	}
+
+	private static void _checkSHA1withRSARejected(Provider provider)
+		throws Exception {
+
+		Signature.getInstance("SHA1withRSA", provider);
+	}
+
+	private static void _checkSHA256(Provider provider) throws Exception {
+		MessageDigest messageDigest = MessageDigest.getInstance(
+			"SHA-256", provider);
+
+		byte[] actual = messageDigest.digest(new byte[0]);
+
+		if (!Arrays.equals(_SHA_256_EMPTY_INPUT_EXPECTED_DIGEST, actual)) {
+			throw new SecurityException(
+				"SHA-256 of empty input did not match FIPS 180-4 canonical " +
+					"value");
+		}
+	}
+
+	private static void _runKnownAnswerTest(
+		String operation, UnsafeRunnable<Exception> kat) {
+
+		try {
+			kat.run();
+
+			if (_log.isInfoEnabled()) {
+				_log.info("FIPS KAT " + operation + " passed");
+			}
+		}
+		catch (Exception exception) {
+			throw new SecurityException(
+				StringBundler.concat(
+					"FIPS KAT ", operation, " failed. ",
+					exception.getMessage()),
+				exception);
+		}
+	}
+
+	private static void _runRejectionCheck(
+		String algorithm, UnsafeRunnable<Exception> check) {
+
+		boolean rejected = false;
+
+		try {
+			check.run();
+		}
+		catch (Exception exception) {
+			rejected = true;
+
+			if (_log.isInfoEnabled()) {
+				_log.info("FIPS rejection check " + algorithm + " passed");
+			}
+		}
+
+		if (!rejected) {
+			throw new SecurityException(
+				"FIPS provider accepted non-FIPS algorithm: " + algorithm);
+		}
+	}
+
+	private static final byte[] _AES_CBC_EXPECTED_CIPHERTEXT = {
+		(byte)0x76, (byte)0x49, (byte)0xAB, (byte)0xAC, (byte)0x81, (byte)0x19,
+		(byte)0xB2, (byte)0x46, (byte)0xCE, (byte)0xE9, (byte)0x8E, (byte)0x9B,
+		(byte)0x12, (byte)0xE9, (byte)0x19, (byte)0x7D
+	};
+
+	private static final byte[] _AES_CBC_IV = {
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B,
+		0x0C, 0x0D, 0x0E, 0x0F
+	};
+
+	private static final byte[] _AES_CBC_KEY = {
+		(byte)0x2B, (byte)0x7E, (byte)0x15, (byte)0x16, (byte)0x28, (byte)0xAE,
+		(byte)0xD2, (byte)0xA6, (byte)0xAB, (byte)0xF7, (byte)0x15, (byte)0x88,
+		(byte)0x09, (byte)0xCF, (byte)0x4F, (byte)0x3C
+	};
+
+	private static final byte[] _AES_CBC_PLAINTEXT = {
+		(byte)0x6B, (byte)0xC1, (byte)0xBE, (byte)0xE2, (byte)0x2E, (byte)0x40,
+		(byte)0x9F, (byte)0x96, (byte)0xE9, (byte)0x3D, (byte)0x7E, (byte)0x11,
+		(byte)0x73, (byte)0x93, (byte)0x17, (byte)0x2A
+	};
+
+	private static final byte[] _AES_GCM_EXPECTED_CIPHERTEXT = {
+		(byte)0x03, (byte)0x88, (byte)0xDA, (byte)0xCE, (byte)0x60, (byte)0xB6,
+		(byte)0xA3, (byte)0x92, (byte)0xF3, (byte)0x28, (byte)0xC2, (byte)0xB9,
+		(byte)0x71, (byte)0xB2, (byte)0xFE, (byte)0x78, (byte)0xAB, (byte)0x6E,
+		(byte)0x47, (byte)0xD4, (byte)0x2C, (byte)0xEC, (byte)0x13, (byte)0xBD,
+		(byte)0xF5, (byte)0x3A, (byte)0x67, (byte)0xB2, (byte)0x12, (byte)0x57,
+		(byte)0xBD, (byte)0xDF
+	};
+
+	private static final byte[] _AES_GCM_IV = new byte[12];
+
+	private static final byte[] _AES_GCM_KEY = new byte[16];
+
+	private static final byte[] _AES_GCM_PLAINTEXT = new byte[16];
+
+	private static final byte[] _ECDSA_SIGN_DATA =
+		"FIPS-KAT-ECDSA-DATA".getBytes(StandardCharsets.UTF_8);
+
+	private static final byte[] _HMAC_SHA_256_EXPECTED_MAC = {
+		(byte)0x0E, (byte)0x71, (byte)0x9C, (byte)0x66, (byte)0xC8, (byte)0x35,
+		(byte)0x3F, (byte)0x1C, (byte)0xB9, (byte)0x22, (byte)0x6B, (byte)0xD3,
+		(byte)0xF1, (byte)0x35, (byte)0xFD, (byte)0x48, (byte)0xB8, (byte)0x88,
+		(byte)0x35, (byte)0xDC, (byte)0x3D, (byte)0x91, (byte)0x51, (byte)0xE6,
+		(byte)0x58, (byte)0x8B, (byte)0xB7, (byte)0xEE, (byte)0x76, (byte)0x24,
+		(byte)0xF3, (byte)0xEB
+	};
+
+	private static final byte[] _HMAC_SHA_256_KEY =
+		"FIPS-KAT-HMAC-KEY".getBytes(StandardCharsets.UTF_8);
+
+	private static final byte[] _HMAC_SHA_256_MESSAGE =
+		"FIPS-KAT-HMAC-MESSAGE".getBytes(StandardCharsets.UTF_8);
+
+	private static final byte[] _PBKDF2_EXPECTED_DK = {
+		(byte)0x12, (byte)0x0F, (byte)0xB6, (byte)0xCF, (byte)0xFC, (byte)0xCD,
+		(byte)0x20, (byte)0x21, (byte)0x59, (byte)0x08, (byte)0x6B, (byte)0x6B,
+		(byte)0xFC, (byte)0x52, (byte)0x70, (byte)0x82, (byte)0xB5, (byte)0x0E,
+		(byte)0x1A, (byte)0x4E, (byte)0x0B, (byte)0xB8, (byte)0x5D, (byte)0x0B,
+		(byte)0x6C, (byte)0x6A, (byte)0x2C, (byte)0xED, (byte)0xD9, (byte)0xC9,
+		(byte)0xD3, (byte)0x9B
+	};
+
+	private static final char[] _PBKDF2_PASSWORD = "password".toCharArray();
+
+	private static final byte[] _PBKDF2_SALT = "salt".getBytes(
+		StandardCharsets.UTF_8);
+
+	private static final byte[] _RSA_SIGN_DATA = "FIPS-KAT-RSA-DATA".getBytes(
+		StandardCharsets.UTF_8);
+
+	private static final byte[] _SHA_256_EMPTY_INPUT_EXPECTED_DIGEST = {
+		(byte)0xE3, (byte)0xB0, (byte)0xC4, (byte)0x42, (byte)0x98, (byte)0xFC,
+		(byte)0x1C, (byte)0x14, (byte)0x9A, (byte)0xFB, (byte)0xF4, (byte)0xC8,
+		(byte)0x99, (byte)0x6F, (byte)0xB9, (byte)0x24, (byte)0x27, (byte)0xAE,
+		(byte)0x41, (byte)0xE4, (byte)0x64, (byte)0x9B, (byte)0x93, (byte)0x4C,
+		(byte)0xA4, (byte)0x95, (byte)0x99, (byte)0x1B, (byte)0x78, (byte)0x52,
+		(byte)0xB8, (byte)0x55
+	};
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FIPSCryptoChecker.class);
+
+}

--- a/modules/core/portal-bootstrap/src/test/java/com/liferay/portal/bootstrap/fips/FIPSComplianceCheckerTest.java
+++ b/modules/core/portal-bootstrap/src/test/java/com/liferay/portal/bootstrap/fips/FIPSComplianceCheckerTest.java
@@ -1,0 +1,134 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.bootstrap.fips;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.security.Provider;
+import java.security.Security;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Caio Farias
+ */
+public class FIPSComplianceCheckerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_providerApproved =
+			PropsValues.PORTAL_SECURITY_FIPS_PROVIDER_APPROVED;
+		_providerName = PropsValues.PORTAL_SECURITY_FIPS_PROVIDER_NAME;
+		_providerStrict =
+			PropsValues.PORTAL_SECURITY_FIPS_PROVIDER_STRICT;
+
+		Provider[] providers = Security.getProviders();
+
+		_firstProviderName = providers[0].getName();
+	}
+
+	@After
+	public void tearDown() {
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "PORTAL_SECURITY_FIPS_PROVIDER_APPROVED",
+			_providerApproved);
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "PORTAL_SECURITY_FIPS_PROVIDER_NAME",
+			_providerName);
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "PORTAL_SECURITY_FIPS_PROVIDER_STRICT",
+			_providerStrict);
+	}
+
+	@Test
+	public void testValidateOnlyWarnsWhenNonstrictAndUnapprovedProvider() {
+		_setFIPSProviderProps(_firstProviderName, new String[0], false);
+
+		FIPSComplianceChecker.run();
+	}
+
+	@Test
+	public void testValidatePassesWhenFIPSProviderFirstAndAllApproved() {
+		Provider[] providers = Security.getProviders();
+
+		String[] allProviderNames = new String[providers.length];
+
+		for (int i = 0; i < providers.length; i++) {
+			allProviderNames[i] = providers[i].getName();
+		}
+
+		_setFIPSProviderProps(_firstProviderName, allProviderNames, true);
+
+		FIPSComplianceChecker.run();
+	}
+
+	@Test
+	public void testValidateThrowsWhenFIPSProviderNotFirst() {
+		_setFIPSProviderProps("NotARegisteredProvider", new String[0], true);
+
+		try {
+			FIPSComplianceChecker.run();
+
+			Assert.fail("SecurityException expected");
+		}
+		catch (SecurityException securityException) {
+			String message = securityException.getMessage();
+
+			Assert.assertTrue(
+				message,
+				message.contains("must be the first registered JCE provider"));
+		}
+	}
+
+	@Test
+	public void testValidateThrowsWhenStrictAndUnapprovedProvider() {
+		_setFIPSProviderProps(_firstProviderName, new String[0], true);
+
+		try {
+			FIPSComplianceChecker.run();
+
+			Assert.fail("SecurityException expected");
+		}
+		catch (SecurityException securityException) {
+			String message = securityException.getMessage();
+
+			Assert.assertTrue(
+				message,
+				message.contains(
+					"Unapproved JCE providers registered in FIPS mode"));
+		}
+	}
+
+	private void _setFIPSProviderProps(
+		String name, String[] approved, boolean strict) {
+
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "PORTAL_SECURITY_FIPS_PROVIDER_APPROVED",
+			approved);
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "PORTAL_SECURITY_FIPS_PROVIDER_NAME", name);
+		ReflectionTestUtil.setFieldValue(
+			PropsValues.class, "PORTAL_SECURITY_FIPS_PROVIDER_STRICT", strict);
+	}
+
+	private String _firstProviderName;
+	private String[] _providerApproved;
+	private String _providerName;
+	private boolean _providerStrict;
+
+}

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7496,6 +7496,60 @@
     feature.flag.LRAC-14771.system=true
 
 ##
+## FIPS
+##
+
+    #
+    # Set this to true to enable FIPS compliant mode. When enabled, the portal
+    # validates its JCE provider set, runs Known-Answer Tests, verifies the
+    # software integrity manifest, and routes key generation through the
+    # configured FIPS provider at startup. Any violation aborts startup.
+    #
+    # Env: LIFERAY_FIPS_PERIOD_ENABLED
+    #
+    fips.enabled=false
+
+    #
+    # Set the name of the JCE provider expected to serve FIPS-approved
+    # cryptographic operations.
+    #
+    # Use BouncyCastle FIPS when you control the JDK and infrastructure
+    # (on-premises or any cloud environment). It works with any JDK.
+    #
+    #     fips.provider.name=BCFIPS
+    #
+    # Env: LIFERAY_FIPS_PERIOD_PROVIDER
+    #
+    #fips.provider=
+
+    #
+    # Set this to true to require that only approved providers are registered
+    # when FIPS mode is enabled. When false, unapproved providers emit a warn
+    # logs but don't abort startup
+    #
+    # Env: LIFERAY_FIPS_PERIOD_STRICT_PERIOD_MODE_PERIOD_ENABLED
+    #
+    #fips.strict.mode.enabled=
+
+    #
+    # Set the comma-separated list of JCE provider names that are allowed when
+    # FIPS mode is enabled. The provider named by fips.provider must be first.
+    #
+    # BouncyCastle FIPS:
+    #     fips.strict.mode.approved.providers=\
+    #         BCFIPS,\
+    #         BCJSSE,\
+    #         SUN,\
+    #         XMLDSig,\
+    #         SunJGSS,\
+    #         SunSASL,\
+    #         JdkSASL
+    #
+    # Env: LIFERAY_FIPS_PERIOD_STRICT_PERIOD_MODE_PERIOD_APPROVED_PERIOD_PROVIDERS
+    #
+    #fips.strict.mode.approved.providers=
+
+##
 ## HTTP
 ##
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/SecureRandomUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/SecureRandomUtil.java
@@ -9,6 +9,8 @@ import com.liferay.petra.io.BigEndianCodec;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.SystemProperties;
 
+import java.security.NoSuchAlgorithmException;
+import java.security.Provider;
 import java.security.SecureRandom;
 
 import java.util.Random;
@@ -40,6 +42,14 @@ public class SecureRandomUtil {
 		}
 
 		return (byte)_reload();
+	}
+
+	public static void nextBytes(byte[] bytes, String algorithm, Provider provider)
+		throws NoSuchAlgorithmException {
+
+		SecureRandom secureRandom = SecureRandom.getInstance(algorithm, provider);
+
+		secureRandom.nextBytes(bytes);
 	}
 
 	public static double nextDouble() {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1072,6 +1072,16 @@ public interface PropsKeys {
 		FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS =
 			"field.enable.com.liferay.portal.kernel.model.Organization.status";
 
+	public static final String FIPS_ENABLED = "fips.enabled";
+
+	public static final String FIPS_PROVIDER = "fips.provider";
+
+	public static final String FIPS_STRICT_MODE_APPROVED_PROVIDERS =
+		"fips.strict.mode.approved.providers";
+
+	public static final String FIPS_STRICT_MODE_ENABLED =
+		"fips.strict.mode.enabled";
+
 	public static final String FULL_PAGE_DISPLAYABLE = "full.page.displayable";
 
 	public static final String GLOBAL_SHUTDOWN_EVENTS =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -876,6 +876,19 @@ public class PropsValues {
 					PropsKeys.
 						FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS));
 
+	public static final boolean FIPS_ENABLED = GetterUtil.getBoolean(
+		PropsUtil.get(PropsKeys.FIPS_ENABLED));
+
+	public static final String FIPS_PROVIDER = PropsUtil.get(
+		PropsKeys.FIPS_PROVIDER);
+
+	public static final String[] FIPS_STRICT_MODE_APPROVED_PROVIDERS =
+		PropsUtil.getArray(PropsKeys.FIPS_STRICT_MODE_APPROVED_PROVIDERS);
+
+	public static final boolean FIPS_STRICT_MODE_ENABLED =
+		GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.FIPS_STRICT_MODE_ENABLED));
+
 	public static final String[] GLOBAL_SHUTDOWN_EVENTS = PropsUtil.getArray(
 		PropsKeys.GLOBAL_SHUTDOWN_EVENTS);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 97.1.0
+version 97.2.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-80665

## Why

FIPS 140-3 compliance requires that the portal validates its JCE provider configuration and executes cryptographic known-answer tests at startup to ensure only approved algorithms and providers are active. Without this, a misconfigured FIPS environment fails silently.

## Key changes

- Add `FIPSComplianceChecker` — asserts the FIPS provider is first and no unapproved providers are registered
- Add `FIPSCryptoChecker` — runs 8 KATs and 6 rejection checks against the configured provider
- Wire both checkers into `ModuleFrameworkImpl` behind `portal.security.fips.mode.enabled`
- Document all four FIPS properties in `portal.properties` with provider-specific examples for BCFIPS and ACCP
- Extend `SecureRandomUtil` with `nextBytes(byte[], String, Provider)` — routes DRBG access through the platform wrapper instead of importing bare `java.security.SecureRandom`

## Algorithm coverage

| Algorithm | Check | FIPS standard | Used in Liferay | Rationale |
|---|---|---|---|---|
| AES/CBC | KAT | SP 800-38A | `EncryptorUtil`, portal field encryption | Core symmetric primitive; NIST F.2.1 test vector |
| AES/GCM | KAT | SP 800-38D | TLS sessions, AEAD contexts | Authenticated encryption; NIST SP 800-38D Test Case 2 vector |
| ECDSA secp256r1 | KAT | FIPS 186-4 | `JWTUtil`, SAML assertions | Primary signature scheme; smallest FIPS-approved EC curve |
| HmacSHA256 | KAT | FIPS 198-1 | JWT HMAC mode, webhook signatures | MAC used across portal; FIPS 198-1 test vector |
| PBKDF2WithHmacSHA256 | KAT | SP 800-132 | `PasswordEncryptorUtil` | Password hashing at rest; RFC 7914 test vector |
| SHA256withRSA 2048-bit | KAT | SP 800-131A | SAML, OAuth2 token signing, certificate auth | Asymmetric signatures; sign/verify self-test |
| SHA-256 | KAT | FIPS 180-4 | `DigesterUtil`, document fingerprinting | Foundation hash; canonical empty-input digest |
| SecureRandom (DRBG) | KAT | SP 800-90A | `AuthTokenUtil`, session IDs, CSRF nonces | FIPS mandates non-trivial DRBG output; 32 non-zero bytes |
| DES | Rejection | SP 800-131A rev2 | — | Withdrawn 2005; 56-bit key is not secure |
| DESede / 3DES | Rejection | SP 800-131A rev2 | Legacy portal encryption (pre-7.x) | Disallowed for all uses after 2023 |
| MD5 | Rejection | SP 800-131A rev2 | Legacy non-security checksums | Cryptographically broken; not FIPS-approved |
| EC secp192r1 | Rejection | FIPS 186-4 | — | Below 224-bit security threshold; not on NIST approved curve list |
| RSA 1024-bit | Rejection | SP 800-131A | — | Insufficient key length; deprecated before 2010 |
| SHA1withRSA | Rejection | SP 800-131A rev2 | Legacy certificates | SHA-1 disallowed for digital signatures in FIPS mode |
| AES-CTR / AES-CCM | — | — | — | Same AES core as AES-CBC/GCM; covered by those KATs |
| SHA-384 / SHA-512 | — | — | — | Same SHA-2 family; SHA-256 KAT covers the implementation |
| DSA | — | — | — | Legacy; ECDSA satisfies the FIPS digital signature requirement |
| ECDH / raw DH | — | — | — | Key agreement covered indirectly by ECDSA key generation |

## Verify

```bash
grep "FIPS KAT" $LIFERAY_HOME/logs/liferay.*.log
```