### PR TITLE
LPD-86315 Detect GPC Signal via Server

### DIFF
--- a/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/configuration/GlobalPrivacyControlProvider.java
+++ b/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/configuration/GlobalPrivacyControlProvider.java
@@ -1,0 +1,22 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.cookies.configuration;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * @author Christian Moura
+ */
+@ProviderType
+public interface GlobalPrivacyControlProvider {
+
+	public boolean isEnabled(HttpServletRequest httpServletRequest);
+
+	public boolean isSignalActive(HttpServletRequest httpServletRequest);
+
+}

--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/configuration/provider/GlobalPrivacyControlProviderImpl.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/configuration/provider/GlobalPrivacyControlProviderImpl.java
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.cookies.internal.configuration.provider;
+
+import com.liferay.cookies.configuration.CookiesConfigurationProvider;
+import com.liferay.cookies.configuration.GlobalPrivacyControlProvider;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.Portal;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.util.Enumeration;
+import java.util.Objects;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Christian Moura
+ */
+@Component(service = GlobalPrivacyControlProvider.class)
+public class GlobalPrivacyControlProviderImpl
+	implements GlobalPrivacyControlProvider {
+
+	@Override
+	public boolean isEnabled(HttpServletRequest httpServletRequest) {
+		long companyId = _portal.getCompanyId(httpServletRequest);
+
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-75064")) {
+			return false;
+		}
+
+		ExtendedObjectClassDefinition.Scope scope =
+			ExtendedObjectClassDefinition.Scope.COMPANY;
+		long scopePK = companyId;
+
+		try {
+			long groupId = _portal.getScopeGroupId(httpServletRequest);
+
+			if (groupId > 0) {
+				scope = ExtendedObjectClassDefinition.Scope.GROUP;
+				scopePK = groupId;
+			}
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		if (_cookiesConfigurationProvider.isCookiesPreferenceHandlingEnabled(
+				scope, scopePK) &&
+			_cookiesConfigurationProvider.
+				isCookiesPreferenceHandlingGlobalPrivacyControlEnabled(
+					scope, scopePK)) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
+	public boolean isSignalActive(HttpServletRequest httpServletRequest) {
+		if (!isEnabled(httpServletRequest)) {
+			return false;
+		}
+
+		Enumeration<String> secGPCHeaderEnumeration =
+			httpServletRequest.getHeaders("Sec-GPC");
+
+		while (secGPCHeaderEnumeration.hasMoreElements()) {
+			String headerValue = secGPCHeaderEnumeration.nextElement();
+
+			if ((headerValue != null) &&
+				Objects.equals(headerValue.trim(), "1")) {
+
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GlobalPrivacyControlProviderImpl.class);
+
+	@Reference
+	private CookiesConfigurationProvider _cookiesConfigurationProvider;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/cookies/cookies-test/build.gradle
+++ b/modules/apps/cookies/cookies-test/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	testImplementation project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	testImplementation project(":apps:static:portal:portal-upgrade-api")
 	testImplementation project(":core:petra:petra-string")
+	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:static:portal-configuration:portal-configuration-metatype-api")

--- a/modules/apps/cookies/cookies-test/src/testIntegration/java/com/liferay/cookies/internal/configuration/provider/test/GlobalPrivacyControlProviderImplTest.java
+++ b/modules/apps/cookies/cookies-test/src/testIntegration/java/com/liferay/cookies/internal/configuration/provider/test/GlobalPrivacyControlProviderImplTest.java
@@ -1,0 +1,371 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.cookies.internal.configuration.provider.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.cookies.configuration.CookiesPreferenceHandlingConfiguration;
+import com.liferay.cookies.configuration.GlobalPrivacyControlProvider;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Christian Moura
+ */
+@FeatureFlag("LPD-75064")
+@RunWith(Arquillian.class)
+public class GlobalPrivacyControlProviderImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_companyId = TestPropsValues.getCompanyId();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (_companyConfigurationPid != null) {
+			ConfigurationTestUtil.deleteFactoryConfiguration(
+				_companyConfigurationPid, _SCOPED_FACTORY_PID);
+
+			_companyConfigurationPid = null;
+		}
+
+		if (_groupConfigurationPid != null) {
+			ConfigurationTestUtil.deleteFactoryConfiguration(
+				_groupConfigurationPid, _SCOPED_FACTORY_PID);
+
+			_groupConfigurationPid = null;
+		}
+
+		if (_systemConfigurationSaved) {
+			ConfigurationTestUtil.deleteConfiguration(_SYSTEM_PID);
+
+			_systemConfigurationSaved = false;
+		}
+
+		if (_group != null) {
+			GroupTestUtil.deleteGroup(_group);
+
+			_group = null;
+			_layout = null;
+		}
+	}
+
+	@Test
+	public void testConsentManagerDisabled() throws Exception {
+		_saveCompanyConfiguration(false, true);
+
+		Assert.assertFalse(
+			_globalPrivacyControlProvider.isSignalActive(_createRequest("1")));
+	}
+
+	@Test
+	public void testDefaultsToInactive() throws Exception {
+		Assert.assertFalse(
+			_globalPrivacyControlProvider.isSignalActive(_createRequest("1")));
+	}
+
+	@FeatureFlag(enable = false, value = "LPD-75064")
+	@Test
+	public void testFeatureFlagDisabled() throws Exception {
+		_saveCompanyConfiguration(true, true);
+
+		Assert.assertFalse(
+			_globalPrivacyControlProvider.isSignalActive(_createRequest("1")));
+	}
+
+	@Test
+	public void testGlobalPrivacyControlDisabled() throws Exception {
+		_saveCompanyConfiguration(true, false);
+
+		Assert.assertFalse(
+			_globalPrivacyControlProvider.isSignalActive(_createRequest("1")));
+	}
+
+	@Test
+	public void testHeaderAbsent() throws Exception {
+		_saveCompanyConfiguration(true, true);
+
+		Assert.assertFalse(
+			_globalPrivacyControlProvider.isSignalActive(_createRequest(null)));
+	}
+
+	@Test
+	public void testHeaderCommaSeparatedIsIgnored() throws Exception {
+		_saveCompanyConfiguration(true, true);
+
+		Assert.assertFalse(
+			_globalPrivacyControlProvider.isSignalActive(
+				_createRequest("0, 1")));
+		Assert.assertFalse(
+			_globalPrivacyControlProvider.isSignalActive(
+				_createRequest("1, 0")));
+	}
+
+	@Test
+	public void testHeaderUnrecognizedValue() throws Exception {
+		_saveCompanyConfiguration(true, true);
+
+		Assert.assertFalse(
+			_globalPrivacyControlProvider.isSignalActive(
+				_createRequest("true")));
+	}
+
+	@Test
+	public void testHeaderWithWhitespace() throws Exception {
+		_saveCompanyConfiguration(true, true);
+
+		Assert.assertTrue(
+			_globalPrivacyControlProvider.isSignalActive(
+				_createRequest(" 1 ")));
+	}
+
+	@Test
+	public void testHeaderZero() throws Exception {
+		_saveCompanyConfiguration(true, true);
+
+		Assert.assertFalse(
+			_globalPrivacyControlProvider.isSignalActive(_createRequest("0")));
+	}
+
+	@Test
+	public void testIsEnabled() throws Exception {
+		_saveCompanyConfiguration(true, true);
+
+		Assert.assertTrue(
+			_globalPrivacyControlProvider.isEnabled(_createRequest(null)));
+	}
+
+	@Test
+	public void testIsEnabledConsentManagerDisabled() throws Exception {
+		_saveCompanyConfiguration(false, true);
+
+		Assert.assertFalse(
+			_globalPrivacyControlProvider.isEnabled(_createRequest(null)));
+	}
+
+	@Test
+	public void testIsEnabledDefaultsToDisabled() throws Exception {
+		Assert.assertFalse(
+			_globalPrivacyControlProvider.isEnabled(_createRequest(null)));
+	}
+
+	@FeatureFlag(enable = false, value = "LPD-75064")
+	@Test
+	public void testIsEnabledFeatureFlagDisabled() throws Exception {
+		_saveCompanyConfiguration(true, true);
+
+		Assert.assertFalse(
+			_globalPrivacyControlProvider.isEnabled(_createRequest(null)));
+	}
+
+	@Test
+	public void testIsEnabledGlobalPrivacyControlDisabled() throws Exception {
+		_saveCompanyConfiguration(true, false);
+
+		Assert.assertFalse(
+			_globalPrivacyControlProvider.isEnabled(_createRequest(null)));
+	}
+
+	@Test
+	public void testIsEnabledIndependentOfHeader() throws Exception {
+		_saveCompanyConfiguration(true, true);
+
+		Assert.assertTrue(
+			_globalPrivacyControlProvider.isEnabled(_createRequest("0")));
+		Assert.assertTrue(
+			_globalPrivacyControlProvider.isEnabled(_createRequest("invalid")));
+	}
+
+	@Test
+	public void testMultipleHeadersAtLeastOneActive() throws Exception {
+		_saveCompanyConfiguration(true, true);
+
+		MockHttpServletRequest mockHttpServletRequest = _createRequest("0");
+
+		mockHttpServletRequest.addHeader("Sec-GPC", "1");
+
+		Assert.assertTrue(
+			_globalPrivacyControlProvider.isSignalActive(
+				mockHttpServletRequest));
+	}
+
+	@Test
+	public void testSignalActive() throws Exception {
+		_saveCompanyConfiguration(true, true);
+
+		Assert.assertTrue(
+			_globalPrivacyControlProvider.isSignalActive(_createRequest("1")));
+	}
+
+	@Test
+	public void testSiteLevelEnablesOverCompanyDisabled() throws Exception {
+		_saveCompanyConfiguration(true, false);
+
+		MockHttpServletRequest mockHttpServletRequest = _createLayoutRequest(
+			"1");
+
+		_saveGroupConfiguration(_group.getGroupId(), true, true);
+
+		Assert.assertTrue(
+			_globalPrivacyControlProvider.isSignalActive(
+				mockHttpServletRequest));
+	}
+
+	@Test
+	public void testSiteLevelOverridesCompany() throws Exception {
+		_saveCompanyConfiguration(true, true);
+
+		MockHttpServletRequest mockHttpServletRequest = _createLayoutRequest(
+			"1");
+
+		_saveGroupConfiguration(_group.getGroupId(), true, false);
+
+		Assert.assertFalse(
+			_globalPrivacyControlProvider.isSignalActive(
+				mockHttpServletRequest));
+	}
+
+	@Test
+	public void testSiteScopeFallsBackToCompany() throws Exception {
+		_saveCompanyConfiguration(true, true);
+
+		Assert.assertTrue(
+			_globalPrivacyControlProvider.isSignalActive(
+				_createLayoutRequest("1")));
+	}
+
+	@Test
+	public void testSystemScopeFallback() throws Exception {
+		_saveSystemConfiguration(true, true);
+
+		Assert.assertTrue(
+			_globalPrivacyControlProvider.isSignalActive(_createRequest("1")));
+	}
+
+	private MockHttpServletRequest _createLayoutRequest(String secGpcHeader)
+		throws Exception {
+
+		if (_group == null) {
+			_group = GroupTestUtil.addGroup();
+
+			_layout = LayoutTestUtil.addTypePortletLayout(_group);
+		}
+
+		MockHttpServletRequest mockHttpServletRequest = _createRequest(
+			secGpcHeader);
+
+		mockHttpServletRequest.setAttribute(WebKeys.LAYOUT, _layout);
+
+		return mockHttpServletRequest;
+	}
+
+	private MockHttpServletRequest _createRequest(String secGpcHeader) {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(WebKeys.COMPANY_ID, _companyId);
+
+		if (secGpcHeader != null) {
+			mockHttpServletRequest.addHeader("Sec-GPC", secGpcHeader);
+		}
+
+		return mockHttpServletRequest;
+	}
+
+	private void _saveCompanyConfiguration(
+			boolean cookiesPreferenceHandlingEnabled,
+			boolean globalPrivacyControlEnabled)
+		throws Exception {
+
+		_companyConfigurationPid =
+			ConfigurationTestUtil.createFactoryConfiguration(
+				_SCOPED_FACTORY_PID,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"companyId", _companyId
+				).put(
+					"enabled", cookiesPreferenceHandlingEnabled
+				).put(
+					"globalPrivacyControlEnabled", globalPrivacyControlEnabled
+				).build());
+	}
+
+	private void _saveGroupConfiguration(
+			long groupId, boolean cookiesPreferenceHandlingEnabled,
+			boolean globalPrivacyControlEnabled)
+		throws Exception {
+
+		_groupConfigurationPid =
+			ConfigurationTestUtil.createFactoryConfiguration(
+				_SCOPED_FACTORY_PID,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"companyId", _companyId
+				).put(
+					"enabled", cookiesPreferenceHandlingEnabled
+				).put(
+					"globalPrivacyControlEnabled", globalPrivacyControlEnabled
+				).put(
+					"groupId", groupId
+				).build());
+	}
+
+	private void _saveSystemConfiguration(
+			boolean cookiesPreferenceHandlingEnabled,
+			boolean globalPrivacyControlEnabled)
+		throws Exception {
+
+		ConfigurationTestUtil.saveConfiguration(
+			_SYSTEM_PID,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"enabled", cookiesPreferenceHandlingEnabled
+			).put(
+				"globalPrivacyControlEnabled", globalPrivacyControlEnabled
+			).build());
+
+		_systemConfigurationSaved = true;
+	}
+
+	private static final String _SCOPED_FACTORY_PID =
+		CookiesPreferenceHandlingConfiguration.class.getName() + ".scoped";
+
+	private static final String _SYSTEM_PID =
+		CookiesPreferenceHandlingConfiguration.class.getName();
+
+	private String _companyConfigurationPid;
+	private long _companyId;
+
+	@Inject
+	private GlobalPrivacyControlProvider _globalPrivacyControlProvider;
+
+	private Group _group;
+	private String _groupConfigurationPid;
+	private Layout _layout;
+	private boolean _systemConfigurationSaved;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86315

**What is being fixed:** Liferay had no server-side way to detect the Global Privacy Control (GPC) `Sec-GPC` HTTP header. Without server-side detection, backend components cannot honor a visitor's opt-out signal before a page response is generated.

**How it is being fixed:** Introduces a new `GlobalPrivacyControlProvider` OSGi service exposed from the cookies module. The implementation gates on the `LPD-75064` feature flag, resolves the active scope (group when a layout is on the request, otherwise company), and consults `CookiesConfigurationProvider` to verify that cookies preference handling and Global Privacy Control are both enabled for that scope. Only then does it inspect the `Sec-GPC` request headers and return `true` when any header value equals `1` after trimming optional whitespace. An integration test covers the feature-flag gate, each configuration toggle, site-over-company override and fallback, system-PID fallback, and the header parsing edge cases (absent, zero, unrecognized token, comma-separated, whitespace, multiple header instances).