### PR TITLE
LPD 80665 Validate JCE Provider Order (FIPS properties) 

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7496,6 +7496,67 @@
     feature.flag.LRAC-14771.system=true
 
 ##
+## FIPS
+##
+
+    #
+    # Set this to true to enable FIPS compliant mode. When enabled, the portal
+    # validates its JCE provider set, runs Known-Answer Tests, verifies the
+    # software integrity manifest, and routes key generation through the
+    # configured FIPS provider at startup. Any violation aborts startup.
+    #
+    # Env: LIFERAY_FIPS_PERIOD_ENABLED
+    #
+    fips.enabled=false
+
+    #
+    # Set the name of the JCE provider expected to serve FIPS-approved
+    # cryptographic operations.
+    #
+    # Use BouncyCastle FIPS when you control the JDK and infrastructure
+    # (on-premises or any cloud environment). It works with any JDK.
+    #
+    #     fips.provider=BCFIPS
+    #
+    # Env: LIFERAY_FIPS_PERIOD_PROVIDER
+    #
+    #fips.provider=BCFIPS
+
+    #
+    # Set this to true to require that only approved providers are registered
+    # when FIPS mode is enabled. When false, unapproved providers emit a warn
+    # logs but don't abort startup.
+    #
+    # Env: LIFERAY_FIPS_PERIOD_STRICT_PERIOD_MODE_PERIOD_ENABLED
+    #
+    #fips.strict.mode.enabled=
+
+    #
+    # Set the comma-separated list of JCE provider names that are allowed when
+    # FIPS mode is enabled. The provider named by fips.provider must be first.
+    #
+    # BouncyCastle FIPS:
+    #     fips.strict.mode.approved.providers=\
+    #         BCFIPS,\
+    #         BCJSSE,\
+    #         SUN,\
+    #         XMLDSig,\
+    #         SunJGSS,\
+    #         SunSASL,\
+    #         JdkSASL
+    #
+    # Env: LIFERAY_FIPS_PERIOD_STRICT_PERIOD_MODE_PERIOD_APPROVED_PERIOD_PROVIDERS
+    #
+    #fips.strict.mode.approved.providers=\
+    #         BCFIPS,\
+    #         BCJSSE,\
+    #         SUN,\
+    #         XMLDSig,\
+    #         SunJGSS,\
+    #         SunSASL,\
+    #         JdkSASL
+
+##
 ## HTTP
 ##
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1072,6 +1072,16 @@ public interface PropsKeys {
 		FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS =
 			"field.enable.com.liferay.portal.kernel.model.Organization.status";
 
+	public static final String FIPS_ENABLED = "fips.enabled";
+
+	public static final String FIPS_PROVIDER = "fips.provider";
+
+	public static final String FIPS_STRICT_MODE_APPROVED_PROVIDERS =
+		"fips.strict.mode.approved.providers";
+
+	public static final String FIPS_STRICT_MODE_ENABLED =
+		"fips.strict.mode.enabled";
+
 	public static final String FULL_PAGE_DISPLAYABLE = "full.page.displayable";
 
 	public static final String GLOBAL_SHUTDOWN_EVENTS =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -876,6 +876,19 @@ public class PropsValues {
 					PropsKeys.
 						FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS));
 
+	public static final boolean FIPS_ENABLED = GetterUtil.getBoolean(
+		PropsUtil.get(PropsKeys.FIPS_ENABLED));
+
+	public static final String FIPS_PROVIDER = PropsUtil.get(
+		PropsKeys.FIPS_PROVIDER);
+
+	public static final String[] FIPS_STRICT_MODE_APPROVED_PROVIDERS =
+		PropsUtil.getArray(PropsKeys.FIPS_STRICT_MODE_APPROVED_PROVIDERS);
+
+	public static final boolean FIPS_STRICT_MODE_ENABLED =
+		GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.FIPS_STRICT_MODE_ENABLED));
+
 	public static final String[] GLOBAL_SHUTDOWN_EVENTS = PropsUtil.getArray(
 		PropsKeys.GLOBAL_SHUTDOWN_EVENTS);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 97.1.0
+version 97.2.0


### PR DESCRIPTION
[LPD-80665](https://liferay.atlassian.net/browse/LPD-80665)

After analyzing the portal.properties, I realized that the `portal.*` prefix is often related to Portal Context configuration. Also, there's a pattern between section titles and property keyword suffix. So, it does not make sense to use this key prefix for any FIPS configuration. Given this and the nature of the FIPS context, it seems like creating `fips.*` is supposed to be the correct way.

About the correct position, I've tried to identify the right place for the FIPS section and it seems like there's an alpha sorted region at the end of the file where generic and broad configurations are placed. Adding the FIPS section there looks like the correct place.

Were my previous assumptions about portal.properties correct? What still needs adjustment?