### PR TITLE
[AI HUB] LPD-81715 Cache access token using WebCachePoolUtil

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/main/java/com/liferay/ai/hub/cell/rest/internal/resource/v1_0/AuthorizationTokenResourceImpl.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/main/java/com/liferay/ai/hub/cell/rest/internal/resource/v1_0/AuthorizationTokenResourceImpl.java
@@ -7,13 +7,12 @@ package com.liferay.ai.hub.cell.rest.internal.resource.v1_0;
 
 import com.liferay.ai.hub.cell.configuration.AIHubCellConfiguration;
 import com.liferay.ai.hub.cell.rest.dto.v1_0.AuthorizationToken;
+import com.liferay.ai.hub.cell.rest.internal.web.cache.AIHubCellAccessTokenWebCacheItem;
 import com.liferay.ai.hub.cell.rest.resource.v1_0.AuthorizationTokenResource;
 import com.liferay.ai.hub.cell.security.JWTTokenUtil;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
-import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.util.Http;
 
 import java.util.concurrent.TimeUnit;
 
@@ -39,22 +38,12 @@ public class AuthorizationTokenResourceImpl
 			throw new UnsupportedOperationException();
 		}
 
-		Http.Options options = new Http.Options();
-
 		AIHubCellConfiguration aiHubCellConfiguration =
 			_configurationProvider.getCompanyConfiguration(
 				AIHubCellConfiguration.class, contextCompany.getCompanyId());
 
-		options.addPart("client_id", aiHubCellConfiguration.clientId());
-		options.addPart("client_secret", aiHubCellConfiguration.clientSecret());
-
-		options.addPart("grant_type", "client_credentials");
-		options.setLocation(
-			aiHubCellConfiguration.serviceURL() + "/o/oauth2/token");
-		options.setMethod(Http.Method.POST);
-
-		JSONObject jsonObject = _jsonFactory.createJSONObject(
-			_http.URLtoString(options));
+		JSONObject jsonObject = AIHubCellAccessTokenWebCacheItem.get(
+			aiHubCellConfiguration, contextCompany.getCompanyId());
 
 		return new AuthorizationToken() {
 			{
@@ -72,11 +61,5 @@ public class AuthorizationTokenResourceImpl
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;
-
-	@Reference
-	private Http _http;
-
-	@Reference
-	private JSONFactory _jsonFactory;
 
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/main/java/com/liferay/ai/hub/cell/rest/internal/web/cache/AIHubCellAccessTokenWebCacheItem.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-rest-impl/src/main/java/com/liferay/ai/hub/cell/rest/internal/web/cache/AIHubCellAccessTokenWebCacheItem.java
@@ -1,0 +1,102 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.cell.rest.internal.web.cache;
+
+import com.liferay.ai.hub.cell.configuration.AIHubCellConfiguration;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.webcache.WebCacheItem;
+import com.liferay.portal.kernel.webcache.WebCachePoolUtil;
+
+import java.net.HttpURLConnection;
+
+/**
+ * @author Manuele Castro
+ */
+public class AIHubCellAccessTokenWebCacheItem implements WebCacheItem {
+
+	public static JSONObject get(
+		AIHubCellConfiguration aiHubCellConfiguration, long companyId) {
+
+		return (JSONObject)WebCachePoolUtil.get(
+			StringBundler.concat(
+				AIHubCellAccessTokenWebCacheItem.class.getName(),
+				StringPool.POUND, companyId, StringPool.POUND,
+				aiHubCellConfiguration.clientId(), StringPool.POUND,
+				aiHubCellConfiguration.serviceURL()),
+			new AIHubCellAccessTokenWebCacheItem(aiHubCellConfiguration));
+	}
+
+	public AIHubCellAccessTokenWebCacheItem(
+		AIHubCellConfiguration aiHubCellConfiguration) {
+
+		_aiHubCellConfiguration = aiHubCellConfiguration;
+	}
+
+	@Override
+	public Object convert(String key) {
+		try {
+			Http.Options options = new Http.Options();
+
+			options.addPart("client_id", _aiHubCellConfiguration.clientId());
+			options.addPart(
+				"client_secret", _aiHubCellConfiguration.clientSecret());
+			options.addPart("grant_type", "client_credentials");
+			options.setLocation(
+				_aiHubCellConfiguration.serviceURL() + "/o/oauth2/token");
+			options.setPost(true);
+
+			String responseJSON = HttpUtil.URLtoString(options);
+
+			Http.Response response = options.getResponse();
+
+			if (response.getResponseCode() != HttpURLConnection.HTTP_OK) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						StringBundler.concat(
+							"Response code ", response.getResponseCode(), ": ",
+							responseJSON));
+				}
+
+				return null;
+			}
+
+			JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+				responseJSON);
+
+			_refreshTime =
+				(long)(jsonObject.getLong("expires_in") * 0.8 * Time.SECOND);
+
+			return jsonObject;
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return null;
+		}
+	}
+
+	@Override
+	public long getRefreshTime() {
+		return _refreshTime;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AIHubCellAccessTokenWebCacheItem.class);
+
+	private final AIHubCellConfiguration _aiHubCellConfiguration;
+	private long _refreshTime;
+
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-rest-test/src/testIntegration/java/com/liferay/ai/hub/cell/rest/resource/v1_0/test/AuthorizationTokenResourceTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-rest-test/src/testIntegration/java/com/liferay/ai/hub/cell/rest/resource/v1_0/test/AuthorizationTokenResourceTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.webcache.WebCachePoolUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 
@@ -44,6 +45,8 @@ public class AuthorizationTokenResourceTest
 		try {
 			ConfigurationTestUtil.deleteConfiguration(
 				AIHubCellConfiguration.class.getName());
+
+			WebCachePoolUtil.clear();
 		}
 		catch (Exception exception) {
 			throw new RuntimeException(exception);
@@ -78,12 +81,19 @@ public class AuthorizationTokenResourceTest
 				"serviceURL", "http://localhost:8080"
 			).build());
 
-		JSONObject jsonObject = HTTPTestUtil.invokeToJSONObject(
+		JSONObject jsonObject1 = HTTPTestUtil.invokeToJSONObject(
 			null, "ai-hub-cell/v1.0/authorization-tokens", Http.Method.POST);
 
-		Assert.assertTrue(jsonObject.has("accessToken"));
-		Assert.assertTrue(jsonObject.has("scope"));
-		Assert.assertTrue(jsonObject.has("userToken"));
+		Assert.assertTrue(jsonObject1.has("accessToken"));
+		Assert.assertTrue(jsonObject1.has("scope"));
+		Assert.assertTrue(jsonObject1.has("userToken"));
+
+		JSONObject jsonObject2 = HTTPTestUtil.invokeToJSONObject(
+			null, "ai-hub-cell/v1.0/authorization-tokens", Http.Method.POST);
+
+		Assert.assertEquals(
+			jsonObject1.getString("accessToken"),
+			jsonObject2.getString("accessToken"));
 	}
 
 	@Inject


### PR DESCRIPTION
[LPD-81715](https://liferay.atlassian.net/browse/LPD-81715
)
**What is being fixed:** The OAuth2 access token was being fetched from the /oauth2/token endpoint on every call to postAuthorizationToken, even though the token remains valid for the duration of its expires_in TTL.

**How it is being fixed:** A new AIHubCellAccessTokenWebCacheItem is introduced to cache the token via WebCachePoolUtil keyed by companyId, clientId, and serviceURL. The cache TTL is derived from the token's expires_in value. AuthorizationTokenResourceImpl now delegates to this cache item instead of performing the HTTP call directly. The integration test verifies the caching behavior by deleting the OAuth2 application after the first call and asserting the second call still returns the same access token.