### PR TITLE
LPD-88105 - Can not add method name right away when adding service policy.

### DIFF
--- a/modules/apps/portal-security/portal-security-service-access-policy-web/src/main/java/com/liferay/portal/security/service/access/policy/web/internal/portlet/SAPPortlet.java
+++ b/modules/apps/portal-security/portal-security-service-access-policy-web/src/main/java/com/liferay/portal/security/service/access/policy/web/internal/portlet/SAPPortlet.java
@@ -102,19 +102,21 @@ public class SAPPortlet extends MVCPortlet {
 		Set<JSONWebServiceActionMapping> jsonWebServiceActionMappingsSet =
 			jsonWebServiceActionMappingsMap.get(serviceClassName);
 
-		for (JSONWebServiceActionMapping jsonWebServiceActionMapping :
-				jsonWebServiceActionMappingsSet) {
+		if (jsonWebServiceActionMappingsSet != null) {
+			for (JSONWebServiceActionMapping jsonWebServiceActionMapping :
+					jsonWebServiceActionMappingsSet) {
 
-			JSONObject jsonObject = JSONUtil.put(
-				"actionMethodName",
-				() -> {
-					Method method =
-						jsonWebServiceActionMapping.getActionMethod();
+				JSONObject jsonObject = JSONUtil.put(
+					"actionMethodName",
+					() -> {
+						Method method =
+							jsonWebServiceActionMapping.getActionMethod();
 
-					return method.getName();
-				});
+						return method.getName();
+					});
 
-			jsonArray.put(jsonObject);
+				jsonArray.put(jsonObject);
+			}
 		}
 
 		printWriter.write(jsonArray.toString());

--- a/modules/apps/portal-security/portal-security-service-access-policy-web/src/main/resources/META-INF/resources/edit_entry.jsp
+++ b/modules/apps/portal-security/portal-security-service-access-policy-web/src/main/resources/META-INF/resources/edit_entry.jsp
@@ -192,7 +192,7 @@ renderResponse.setTitle((sapEntry == null) ? LanguageUtil.get(request, "new-serv
 					})
 					.then((data) => {
 						methodObj.actionMethodNames = data;
-						callback(actionMethodNames);
+						callback(data);
 					});
 			}
 			else {
@@ -220,6 +220,16 @@ renderResponse.setTitle((sapEntry == null) ? LanguageUtil.get(request, "new-serv
 		var actionMethodNameInput = rowNode.one('.action-method-name');
 		var serviceClassNameInput = rowNode.one('.service-class-name');
 
+		var syncActionMethodNameDisabled = function () {
+			var hasServiceClassName = serviceClassNameInput.val().trim().length > 0;
+
+			actionMethodNameInput.attr('disabled', !hasServiceClassName);
+		};
+
+		syncActionMethodNameDisabled();
+
+		serviceClassNameInput.on('input', syncActionMethodNameDisabled);
+
 		new A.AutoComplete({
 			inputNode: serviceClassNameInput,
 			on: {
@@ -235,7 +245,7 @@ renderResponse.setTitle((sapEntry == null) ? LanguageUtil.get(request, "new-serv
 						result.contextName
 					);
 
-					actionMethodNameInput.attr('disabled', false);
+					syncActionMethodNameDisabled();
 				},
 			},
 			resultFilters: 'phraseMatch',
@@ -334,10 +344,7 @@ renderResponse.setTitle((sapEntry == null) ? LanguageUtil.get(request, "new-serv
 			clone: function (event) {
 				var rowNode = event.row;
 
-				var actionMethodNameInput = rowNode.one('.action-method-name');
 				var serviceClassNameInput = rowNode.one('.service-class-name');
-
-				actionMethodNameInput.attr('disabled', true);
 
 				serviceClassNameInput.attr({
 					'data-context-name': '',

--- a/modules/test/playwright/pages/portal-security-service-access-policy-service/EditServiceAccessPolicyPage.ts
+++ b/modules/test/playwright/pages/portal-security-service-access-policy-service/EditServiceAccessPolicyPage.ts
@@ -6,27 +6,41 @@
 import {Locator, Page} from '@playwright/test';
 
 export class EditServiceAccessPolicyPage {
-	readonly enabledButton: Locator;
+	readonly addRowButton: Locator;
 	readonly defaultButton: Locator;
-	readonly methodNameField: Locator;
+	readonly enabledButton: Locator;
 	readonly nameField: Locator;
-	readonly saveButton: Locator;
-	readonly serviceClassField: Locator;
-	readonly successMessage: Locator;
 	readonly page: Page;
+	readonly saveButton: Locator;
+	readonly successMessage: Locator;
+	readonly titleField: Locator;
 
 	constructor(page: Page) {
-		this.enabledButton = page.getByLabel('Enabled');
+		this.addRowButton = page.locator('button.add-row').first();
 		this.defaultButton = page.getByLabel('Default');
-		this.methodNameField = page.getByLabel('Default');
-		this.nameField = page.getByLabel('Name');
+		this.enabledButton = page.getByLabel('Enabled');
+		this.nameField = page.getByRole('textbox', {name: 'Name Required'});
+		this.page = page;
 		this.saveButton = page.getByRole('button').filter({
 			hasText: 'Save',
 		});
-		this.serviceClassField = page.getByLabel('Default');
 		this.successMessage = page.getByText(
 			'Your request completed successfully'
 		);
-		this.page = page;
+		this.titleField = page.getByRole('textbox', {name: 'Title Required'});
+	}
+
+	methodNameField(rowIndex = 0): Locator {
+		return this.page
+			.locator('.lfr-form-row')
+			.nth(rowIndex)
+			.locator('.action-method-name');
+	}
+
+	serviceClassField(rowIndex = 0): Locator {
+		return this.page
+			.locator('.lfr-form-row')
+			.nth(rowIndex)
+			.locator('.service-class-name');
 	}
 }

--- a/modules/test/playwright/pages/portal-security-service-access-policy-service/ServiceAccessPolicyPage.ts
+++ b/modules/test/playwright/pages/portal-security-service-access-policy-service/ServiceAccessPolicyPage.ts
@@ -13,9 +13,7 @@ export class ServiceAccessPolicyPage {
 	readonly page: Page;
 
 	constructor(page: Page) {
-		this.newButton = page.getByRole('button').filter({
-			hasText: 'New',
-		});
+		this.newButton = page.getByRole('link', {exact: true, name: 'New'});
 		this.successMessage = page.getByText(
 			'Your request completed successfully'
 		);

--- a/modules/test/playwright/tests/portal-security-service-access-policy-service/main/addServiceClassRowMethodName.spec.ts
+++ b/modules/test/playwright/tests/portal-security-service-access-policy-service/main/addServiceClassRowMethodName.spec.ts
@@ -11,70 +11,74 @@ import getRandomString from '../../../utils/getRandomString';
 
 export const test = mergeTests(loginTest(), serviceAccessPolicyPageTest);
 
-test('LPP-63887 Method Name accepts input after typing a Service Class in a newly added row', async ({
-	editServiceAccessPolicyPage,
-	page,
-	serviceAccessPolicyPage,
-}) => {
-	const policyName = getRandomString();
-	const serviceClassName = `com.example.${getRandomString()}`;
-	const methodName = getRandomString();
+test(
+	'Method Name accepts input after typing a Service Class in a newly added row',
+	{tag: '@LPD-88105'},
+	async ({editServiceAccessPolicyPage, page, serviceAccessPolicyPage}) => {
+		const policyName = getRandomString();
+		const serviceClassName = `com.example.${getRandomString()}`;
+		const methodName = getRandomString();
 
-	await serviceAccessPolicyPage.goto();
-
-	await serviceAccessPolicyPage.newConfiguration();
-
-	await editServiceAccessPolicyPage.nameField.fill(policyName);
-	await editServiceAccessPolicyPage.titleField.fill(policyName);
-	await editServiceAccessPolicyPage
-		.serviceClassField(0)
-		.fill('com.example.InitialService');
-
-	await editServiceAccessPolicyPage.saveButton.click();
-
-	await expect(editServiceAccessPolicyPage.successMessage).toBeVisible();
-
-	try {
 		await serviceAccessPolicyPage.goto();
 
-		await page.getByRole('link', {name: policyName}).click();
+		await serviceAccessPolicyPage.newConfiguration();
 
-		await editServiceAccessPolicyPage.addRowButton.click();
-
-		await expect(
-			editServiceAccessPolicyPage.methodNameField(1)
-		).toBeDisabled();
-
+		await editServiceAccessPolicyPage.nameField.fill(policyName);
+		await editServiceAccessPolicyPage.titleField.fill(policyName);
 		await editServiceAccessPolicyPage
-			.serviceClassField(1)
-			.fill(serviceClassName);
-
-		await expect(
-			editServiceAccessPolicyPage.methodNameField(1)
-		).toBeEnabled();
-
-		await editServiceAccessPolicyPage.methodNameField(1).fill(methodName);
+			.serviceClassField(0)
+			.fill('com.example.InitialService');
 
 		await editServiceAccessPolicyPage.saveButton.click();
 
 		await expect(editServiceAccessPolicyPage.successMessage).toBeVisible();
-	}
-	finally {
-		await serviceAccessPolicyPage.goto();
 
-		const link = page.getByRole('link', {name: policyName});
+		try {
+			await serviceAccessPolicyPage.goto();
 
-		if ((await link.count()) > 0) {
-			await link
-				.locator('xpath=ancestor::tr[1]')
-				.locator('.component-action.dropdown-toggle')
-				.click();
+			await page.getByRole('link', {name: policyName}).click();
 
-			page.once('dialog', (dialog) => {
-				dialog.accept();
-			});
+			await editServiceAccessPolicyPage.addRowButton.click();
 
-			await page.getByRole('link', {name: 'Delete'}).click();
+			await expect(
+				editServiceAccessPolicyPage.methodNameField(1)
+			).toBeDisabled();
+
+			await editServiceAccessPolicyPage
+				.serviceClassField(1)
+				.fill(serviceClassName);
+
+			await expect(
+				editServiceAccessPolicyPage.methodNameField(1)
+			).toBeEnabled();
+
+			await editServiceAccessPolicyPage
+				.methodNameField(1)
+				.fill(methodName);
+
+			await editServiceAccessPolicyPage.saveButton.click();
+
+			await expect(
+				editServiceAccessPolicyPage.successMessage
+			).toBeVisible();
+		}
+		finally {
+			await serviceAccessPolicyPage.goto();
+
+			const link = page.getByRole('link', {name: policyName});
+
+			if ((await link.count()) > 0) {
+				await link
+					.locator('xpath=ancestor::tr[1]')
+					.locator('.component-action.dropdown-toggle')
+					.click();
+
+				page.once('dialog', (dialog) => {
+					dialog.accept();
+				});
+
+				await page.getByRole('link', {name: 'Delete'}).click();
+			}
 		}
 	}
-});
+);

--- a/modules/test/playwright/tests/portal-security-service-access-policy-service/main/addServiceClassRowMethodName.spec.ts
+++ b/modules/test/playwright/tests/portal-security-service-access-policy-service/main/addServiceClassRowMethodName.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {loginTest} from '../../../fixtures/loginTest';
+import {serviceAccessPolicyPageTest} from '../../../fixtures/serviceAccessPolicyPageTest';
+import getRandomString from '../../../utils/getRandomString';
+
+export const test = mergeTests(loginTest(), serviceAccessPolicyPageTest);
+
+test('LPP-63887 Method Name accepts input after typing a Service Class in a newly added row', async ({
+	editServiceAccessPolicyPage,
+	page,
+	serviceAccessPolicyPage,
+}) => {
+	const policyName = getRandomString();
+	const serviceClassName = `com.example.${getRandomString()}`;
+	const methodName = getRandomString();
+
+	await serviceAccessPolicyPage.goto();
+
+	await serviceAccessPolicyPage.newConfiguration();
+
+	await editServiceAccessPolicyPage.nameField.fill(policyName);
+	await editServiceAccessPolicyPage.titleField.fill(policyName);
+	await editServiceAccessPolicyPage
+		.serviceClassField(0)
+		.fill('com.example.InitialService');
+
+	await editServiceAccessPolicyPage.saveButton.click();
+
+	await expect(editServiceAccessPolicyPage.successMessage).toBeVisible();
+
+	try {
+		await serviceAccessPolicyPage.goto();
+
+		await page.getByRole('link', {name: policyName}).click();
+
+		await editServiceAccessPolicyPage.addRowButton.click();
+
+		await expect(
+			editServiceAccessPolicyPage.methodNameField(1)
+		).toBeDisabled();
+
+		await editServiceAccessPolicyPage
+			.serviceClassField(1)
+			.fill(serviceClassName);
+
+		await expect(
+			editServiceAccessPolicyPage.methodNameField(1)
+		).toBeEnabled();
+
+		await editServiceAccessPolicyPage.methodNameField(1).fill(methodName);
+
+		await editServiceAccessPolicyPage.saveButton.click();
+
+		await expect(editServiceAccessPolicyPage.successMessage).toBeVisible();
+	}
+	finally {
+		await serviceAccessPolicyPage.goto();
+
+		const link = page.getByRole('link', {name: policyName});
+
+		if ((await link.count()) > 0) {
+			await link
+				.locator('xpath=ancestor::tr[1]')
+				.locator('.component-action.dropdown-toggle')
+				.click();
+
+			page.once('dialog', (dialog) => {
+				dialog.accept();
+			});
+
+			await page.getByRole('link', {name: 'Delete'}).click();
+		}
+	}
+});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88105

# Problem
When editing a SAP the method field is disabled. 

# Solution
The problem is because the event to enable depend of the search of the service, not if the customer set the class.

# Test
e2e test addServiceClassRowMethodName.spec.ts 

