### PR TITLE
LPD-81719 Ephemeral JWT Secret Key - Non-Persistent and Lacks Cluster Support

### DIFF
--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/build.gradle
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.nimbusds", name: "nimbus-jose-jwt", version: "10.4"
+	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-string")

--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/src/main/java/com/liferay/ai/hub/cell/configuration/AIHubCellConfiguration.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/src/main/java/com/liferay/ai/hub/cell/configuration/AIHubCellConfiguration.java
@@ -7,6 +7,7 @@ package com.liferay.ai.hub.cell.configuration;
 
 import aQute.bnd.annotation.metatype.Meta;
 
+import com.liferay.portal.configuration.metatype.annotations.ExtendedAttributeDefinition;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 
 /**
@@ -28,6 +29,14 @@ public interface AIHubCellConfiguration {
 
 	@Meta.AD(name = "client-secret", type = Meta.Type.Password)
 	public String clientSecret();
+
+	@ExtendedAttributeDefinition(
+		visibilityControllerKey = "com.liferay.ai.hub.cell.internal.configuration.admin.display.AIHubCellSecretVisibilityController"
+	)
+	@Meta.AD(
+		deflt = "", name = "secret", required = false, type = Meta.Type.Password
+	)
+	public String secret();
 
 	@Meta.AD(name = "service-url")
 	public String serviceURL();

--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/src/main/java/com/liferay/ai/hub/cell/security/JWTTokenUtil.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/src/main/java/com/liferay/ai/hub/cell/security/JWTTokenUtil.java
@@ -5,9 +5,12 @@
 
 package com.liferay.ai.hub.cell.security;
 
+import com.liferay.ai.hub.cell.configuration.AIHubCellConfiguration;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.security.SecureRandomUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import com.nimbusds.jose.JWSAlgorithm;
@@ -43,7 +46,7 @@ public class JWTTokenUtil {
 			).build());
 
 		try {
-			signedJWT.sign(new MACSigner(_SECRET));
+			signedJWT.sign(new MACSigner(_getSecret()));
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
@@ -62,7 +65,7 @@ public class JWTTokenUtil {
 		try {
 			SignedJWT signedJWT = SignedJWT.parse(token);
 
-			if (!signedJWT.verify(new MACVerifier(_SECRET))) {
+			if (!signedJWT.verify(new MACVerifier(_getSecret()))) {
 				if (_log.isDebugEnabled()) {
 					_log.debug("Invalid JWT signature");
 				}
@@ -94,20 +97,15 @@ public class JWTTokenUtil {
 		return GetterUtil.getLong(jwtClaimsSet.getSubject());
 	}
 
-	private static final byte[] _SECRET;
+	private static byte[] _getSecret() throws Exception {
+		AIHubCellConfiguration aiHubCellConfiguration =
+			ConfigurationProviderUtil.getCompanyConfiguration(
+				AIHubCellConfiguration.class,
+				CompanyThreadLocal.getCompanyId());
+
+		return Base64.decode(aiHubCellConfiguration.secret());
+	}
 
 	private static final Log _log = LogFactoryUtil.getLog(JWTTokenUtil.class);
-
-	static {
-		int sha256BlockSize = 64;
-
-		byte[] secret = new byte[sha256BlockSize];
-
-		for (int i = 0; i < secret.length; i++) {
-			secret[i] = SecureRandomUtil.nextByte();
-		}
-
-		_SECRET = secret;
-	}
 
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
@@ -46,12 +46,11 @@ public class JWTTokenUtilTest {
 			String token = JWTTokenUtil.generateToken(
 				TimeUnit.MINUTES.toMillis(1), _ISSUER, _USER_ID);
 
-			Assert.assertNotNull(token);
 			Assert.assertFalse(token.isEmpty());
 
-			SignedJWT signedJWT = SignedJWT.parse(token);
-
-			JWTClaimsSet jwtClaimsSet = signedJWT.getJWTClaimsSet();
+			JWTClaimsSet jwtClaimsSet = SignedJWT.parse(
+				token
+			).getJWTClaimsSet();
 
 			Assert.assertEquals(_ISSUER, jwtClaimsSet.getIssuer());
 			Assert.assertEquals(
@@ -93,9 +92,6 @@ public class JWTTokenUtilTest {
 	}
 
 	private AIHubCellConfiguration _mockAIHubCellConfiguration() {
-		AIHubCellConfiguration aiHubCellConfiguration = Mockito.mock(
-			AIHubCellConfiguration.class);
-
 		int sha256BlockSize = 64;
 
 		byte[] secretBytes = new byte[sha256BlockSize];
@@ -103,6 +99,9 @@ public class JWTTokenUtilTest {
 		for (int i = 0; i < secretBytes.length; i++) {
 			secretBytes[i] = SecureRandomUtil.nextByte();
 		}
+
+		AIHubCellConfiguration aiHubCellConfiguration = Mockito.mock(
+			AIHubCellConfiguration.class);
 
 		Mockito.when(
 			aiHubCellConfiguration.secret()
@@ -120,11 +119,14 @@ public class JWTTokenUtilTest {
 			configurationProviderUtilMockedStatic = Mockito.mockStatic(
 				ConfigurationProviderUtil.class);
 
+		AIHubCellConfiguration aiHubCellConfiguration =
+			_mockAIHubCellConfiguration();
+
 		configurationProviderUtilMockedStatic.when(
 			() -> ConfigurationProviderUtil.getCompanyConfiguration(
 				Mockito.eq(AIHubCellConfiguration.class), Mockito.anyLong())
-		).thenAnswer(
-			invocation -> _mockAIHubCellConfiguration()
+		).thenReturn(
+			aiHubCellConfiguration
 		);
 
 		return configurationProviderUtilMockedStatic;

--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
@@ -5,9 +5,11 @@
 
 package com.liferay.ai.hub.cell.security;
 
+import com.liferay.ai.hub.cell.configuration.AIHubCellConfiguration;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.security.SecureRandomUtil;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -19,9 +21,14 @@ import com.nimbusds.jwt.SignedJWT;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * @author Rafael Praxedes
@@ -31,6 +38,17 @@ public class JWTTokenUtilTest {
 	@ClassRule
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_aiHubCellConfiguration = _mockAIHubCellConfiguration();
+		_setUpConfigurationProviderUtil();
+	}
+
+	@After
+	public void tearDown() {
+		_configurationProviderUtilMockedStatic.close();
+	}
 
 	@Test
 	public void testGenerateToken() throws Exception {
@@ -56,28 +74,50 @@ public class JWTTokenUtilTest {
 
 		Assert.assertEquals(_USER_ID, JWTTokenUtil.getUserId(token));
 
-		byte[] secret = new byte[64];
-
-		for (int i = 0; i < secret.length; i++) {
-			secret[i] = SecureRandomUtil.nextByte();
-		}
-
-		try (AutoCloseable autoCloseable =
-				ReflectionTestUtil.setFieldValueWithAutoCloseable(
-					JWTTokenUtil.class, "_SECRET", secret)) {
-
-			_testGetUserId("Invalid JWT signature", token);
-		}
-
 		_testGetUserId(
 			"Invalid JWT signature",
 			token.substring(0, token.length() - 5) + "abcde");
+
 		_testGetUserId(
 			"The JWT token is expired",
 			JWTTokenUtil.generateToken(0, _ISSUER, _USER_ID));
 		_testGetUserId(
 			"Unable to parse and verify the JWT token",
 			RandomTestUtil.randomString());
+
+		_aiHubCellConfiguration = _mockAIHubCellConfiguration();
+
+		_testGetUserId("Invalid JWT signature", token);
+	}
+
+	private AIHubCellConfiguration _mockAIHubCellConfiguration() {
+		AIHubCellConfiguration aiHubCellConfiguration = Mockito.mock(
+			AIHubCellConfiguration.class);
+
+		int sha256BlockSize = 64;
+
+		byte[] secretBytes = new byte[sha256BlockSize];
+
+		for (int i = 0; i < secretBytes.length; i++) {
+			secretBytes[i] = SecureRandomUtil.nextByte();
+		}
+
+		Mockito.when(
+			aiHubCellConfiguration.secret()
+		).thenReturn(
+			Base64.encode(secretBytes)
+		);
+
+		return aiHubCellConfiguration;
+	}
+
+	private void _setUpConfigurationProviderUtil() {
+		_configurationProviderUtilMockedStatic.when(
+			() -> ConfigurationProviderUtil.getCompanyConfiguration(
+				Mockito.eq(AIHubCellConfiguration.class), Mockito.anyLong())
+		).thenAnswer(
+			invocation -> _aiHubCellConfiguration
+		);
 	}
 
 	private void _testGetUserId(String expectedLogMessage, String token) {
@@ -102,5 +142,10 @@ public class JWTTokenUtilTest {
 	private static final String _ISSUER = RandomTestUtil.randomString();
 
 	private static final long _USER_ID = RandomTestUtil.randomLong();
+
+	private AIHubCellConfiguration _aiHubCellConfiguration;
+	private final MockedStatic<ConfigurationProviderUtil>
+		_configurationProviderUtilMockedStatic = Mockito.mockStatic(
+			ConfigurationProviderUtil.class);
 
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-api/src/test/java/com/liferay/ai/hub/cell/security/JWTTokenUtilTest.java
@@ -21,9 +21,7 @@ import com.nimbusds.jwt.SignedJWT;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -39,55 +37,59 @@ public class JWTTokenUtilTest {
 	public static final LiferayUnitTestRule liferayUnitTestRule =
 		LiferayUnitTestRule.INSTANCE;
 
-	@Before
-	public void setUp() {
-		_aiHubCellConfiguration = _mockAIHubCellConfiguration();
-		_setUpConfigurationProviderUtil();
-	}
-
-	@After
-	public void tearDown() {
-		_configurationProviderUtilMockedStatic.close();
-	}
-
 	@Test
 	public void testGenerateToken() throws Exception {
-		String token = JWTTokenUtil.generateToken(
-			TimeUnit.MINUTES.toMillis(1), _ISSUER, _USER_ID);
+		try (MockedStatic<ConfigurationProviderUtil>
+				configurationProviderUtilMockedStatic =
+					_mockConfigurationProviderUtil()) {
 
-		Assert.assertNotNull(token);
-		Assert.assertFalse(token.isEmpty());
+			String token = JWTTokenUtil.generateToken(
+				TimeUnit.MINUTES.toMillis(1), _ISSUER, _USER_ID);
 
-		SignedJWT signedJWT = SignedJWT.parse(token);
+			Assert.assertNotNull(token);
+			Assert.assertFalse(token.isEmpty());
 
-		JWTClaimsSet jwtClaimsSet = signedJWT.getJWTClaimsSet();
+			SignedJWT signedJWT = SignedJWT.parse(token);
 
-		Assert.assertEquals(_ISSUER, jwtClaimsSet.getIssuer());
-		Assert.assertEquals(
-			String.valueOf(_USER_ID), jwtClaimsSet.getSubject());
+			JWTClaimsSet jwtClaimsSet = signedJWT.getJWTClaimsSet();
+
+			Assert.assertEquals(_ISSUER, jwtClaimsSet.getIssuer());
+			Assert.assertEquals(
+				String.valueOf(_USER_ID), jwtClaimsSet.getSubject());
+		}
 	}
 
 	@Test
 	public void testGetUserId() throws Exception {
-		String token = JWTTokenUtil.generateToken(
-			TimeUnit.MINUTES.toMillis(1), _ISSUER, _USER_ID);
+		String token = null;
 
-		Assert.assertEquals(_USER_ID, JWTTokenUtil.getUserId(token));
+		try (MockedStatic<ConfigurationProviderUtil>
+				configurationProviderUtilMockedStatic =
+					_mockConfigurationProviderUtil()) {
 
-		_testGetUserId(
-			"Invalid JWT signature",
-			token.substring(0, token.length() - 5) + "abcde");
+			token = JWTTokenUtil.generateToken(
+				TimeUnit.MINUTES.toMillis(1), _ISSUER, _USER_ID);
 
-		_testGetUserId(
-			"The JWT token is expired",
-			JWTTokenUtil.generateToken(0, _ISSUER, _USER_ID));
-		_testGetUserId(
-			"Unable to parse and verify the JWT token",
-			RandomTestUtil.randomString());
+			Assert.assertEquals(_USER_ID, JWTTokenUtil.getUserId(token));
 
-		_aiHubCellConfiguration = _mockAIHubCellConfiguration();
+			_testGetUserId(
+				"Invalid JWT signature",
+				token.substring(0, token.length() - 5) + "abcde");
 
-		_testGetUserId("Invalid JWT signature", token);
+			_testGetUserId(
+				"The JWT token is expired",
+				JWTTokenUtil.generateToken(0, _ISSUER, _USER_ID));
+			_testGetUserId(
+				"Unable to parse and verify the JWT token",
+				RandomTestUtil.randomString());
+		}
+
+		try (MockedStatic<ConfigurationProviderUtil>
+				configurationProviderUtilMockedStatic =
+					_mockConfigurationProviderUtil()) {
+
+			_testGetUserId("Invalid JWT signature", token);
+		}
 	}
 
 	private AIHubCellConfiguration _mockAIHubCellConfiguration() {
@@ -111,13 +113,21 @@ public class JWTTokenUtilTest {
 		return aiHubCellConfiguration;
 	}
 
-	private void _setUpConfigurationProviderUtil() {
-		_configurationProviderUtilMockedStatic.when(
+	private MockedStatic<ConfigurationProviderUtil>
+		_mockConfigurationProviderUtil() {
+
+		MockedStatic<ConfigurationProviderUtil>
+			configurationProviderUtilMockedStatic = Mockito.mockStatic(
+				ConfigurationProviderUtil.class);
+
+		configurationProviderUtilMockedStatic.when(
 			() -> ConfigurationProviderUtil.getCompanyConfiguration(
 				Mockito.eq(AIHubCellConfiguration.class), Mockito.anyLong())
 		).thenAnswer(
-			invocation -> _aiHubCellConfiguration
+			invocation -> _mockAIHubCellConfiguration()
 		);
+
+		return configurationProviderUtilMockedStatic;
 	}
 
 	private void _testGetUserId(String expectedLogMessage, String token) {
@@ -142,10 +152,5 @@ public class JWTTokenUtilTest {
 	private static final String _ISSUER = RandomTestUtil.randomString();
 
 	private static final long _USER_ID = RandomTestUtil.randomLong();
-
-	private AIHubCellConfiguration _aiHubCellConfiguration;
-	private final MockedStatic<ConfigurationProviderUtil>
-		_configurationProviderUtilMockedStatic = Mockito.mockStatic(
-			ConfigurationProviderUtil.class);
 
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/build.gradle
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/build.gradle
@@ -6,5 +6,7 @@ dependencies {
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:portal-security:portal-security-service-access-policy-api")
 	compileOnly project(":apps:portal:portal-instance-lifecycle-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/admin/display/AIHubCellSecretVisibilityController.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/admin/display/AIHubCellSecretVisibilityController.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.cell.internal.configuration.admin.display;
+
+import com.liferay.configuration.admin.display.ConfigurationVisibilityController;
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+import java.io.Serializable;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Pedro Victor Silvestre
+ */
+@Component(service = ConfigurationVisibilityController.class)
+public class AIHubCellSecretVisibilityController
+	implements ConfigurationVisibilityController {
+
+	@Override
+	public boolean isVisible(
+		ExtendedObjectClassDefinition.Scope scope, Serializable scopePK) {
+
+		return false;
+	}
+
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListener.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/main/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListener.java
@@ -1,0 +1,41 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.cell.internal.configuration.persistence.listener;
+
+import com.liferay.portal.configuration.persistence.listener.ConfigurationModelListener;
+import com.liferay.portal.kernel.security.SecureRandomUtil;
+import com.liferay.portal.kernel.util.Base64;
+
+import java.util.Dictionary;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Pedro Victor Silvestre
+ */
+@Component(
+	property = "model.class.name=com.liferay.ai.hub.cell.configuration.AIHubCellConfiguration",
+	service = ConfigurationModelListener.class
+)
+public class AIHubCellConfigurationModelListener
+	implements ConfigurationModelListener {
+
+	@Override
+	public void onBeforeSave(
+		String pid, Dictionary<String, Object> properties) {
+
+		int sha256BlockSize = 64;
+
+		byte[] secretBytes = new byte[sha256BlockSize];
+
+		for (int i = 0; i < secretBytes.length; i++) {
+			secretBytes[i] = SecureRandomUtil.nextByte();
+		}
+
+		properties.put("secret", Base64.encode(secretBytes));
+	}
+
+}

--- a/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/test/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListenerTest.java
+++ b/modules/apps/ai-hub-cell/ai-hub-cell-impl/src/test/java/com/liferay/ai/hub/cell/internal/configuration/persistence/listener/AIHubCellConfigurationModelListenerTest.java
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.cell.internal.configuration.persistence.listener;
+
+import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Dictionary;
+import java.util.Hashtable;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/**
+ * @author Pedro Victor Silvestre
+ */
+public class AIHubCellConfigurationModelListenerTest {
+
+	@ClassRule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void test() {
+		Dictionary<String, Object> properties = new Hashtable<>();
+
+		_aiHubCellConfigurationModelListener.onBeforeSave("pid", properties);
+
+		String secret = GetterUtil.getString(properties.get("secret"));
+
+		Assert.assertFalse(Validator.isBlank(secret));
+		Assert.assertEquals(64, Base64.decode(secret).length);
+	}
+
+	private final AIHubCellConfigurationModelListener
+		_aiHubCellConfigurationModelListener =
+			new AIHubCellConfigurationModelListener();
+
+}


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPD-81719

## Issue

`JWTTokenUtil._SECRET` was a `static final byte[]` generated at class-load time using `SecureRandomUtil`. While the randomness source is cryptographically secure, this design has two critical operational problems:

1. **Non-persistent** — every JVM restart generates a new signing key, immediately invalidating all outstanding JWT tokens.
2. **Cluster-incompatible** — in a clustered DXP deployment each node independently generates a different key, so a token signed by node A cannot be verified by node B, leading to authentication failures or exploitable inconsistencies.

## Fix

The signing key is now persisted as a hidden field in the existing company-scoped `AIHubCellConfiguration`.

- **`AIHubCellConfigurationModelListener.onBeforeSave`** — when the admin saves the AI Hub Cell configuration in Instance Settings and no key exists yet, the listener generates 64 cryptographically random bytes via `SecureRandomUtil`, Base64-encodes them, and injects them into the properties dictionary before persistence. The OSGi ConfigAdmin framework then stores the value in the configuration file. On subsequent saves the listener detects a non-blank value and leaves it unchanged.
- **`AIHubCellSecretVisibilityController`** — always returns `false`, hiding the field from the auto-generated admin UI so administrators cannot accidentally view or modify the key.
- **`JWTTokenUtil._getSecret()`** — replaced the static field reference with an on-demand read via `ConfigurationProviderUtil.getCompanyConfiguration(AIHubCellConfiguration.class, CompanyThreadLocal.getCompanyId())`, decoding the stored Base64 value into bytes for the HMAC signer/verifier.

The key now survives restarts (persisted in the OSGi `.config` file) and is identical on every cluster node (all nodes read from the same persisted configuration).