### PR TITLE
LPD-86043 Use ConfigurationTestUtil to avoid OSGi config race

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
@@ -16,8 +16,8 @@ import com.liferay.oauth2.provider.scope.spi.scope.mapper.ScopeMapper;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalServiceUtil;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTemporarySwapper;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -36,30 +36,20 @@ import com.liferay.portal.security.service.access.policy.service.SAPEntryLocalSe
 
 import jakarta.ws.rs.core.Application;
 
-import java.io.IOException;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Dictionary;
-import java.util.Enumeration;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Objects;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.cxf.rs.security.oauth2.utils.OAuthConstants;
 
 import org.osgi.framework.BundleActivator;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
-import org.osgi.service.cm.ManagedServiceFactory;
 
 /**
  * @author Carlos Sierra Andrés
@@ -182,98 +172,19 @@ public abstract class BaseTestPreparatorBundleActivator
 		return company;
 	}
 
-	protected Configuration createFactoryConfiguration(
-		BundleContext bundleContext, String factoryPid,
-		Dictionary<String, Object> properties) {
-
-		CountDownLatch countDownLatch = new CountDownLatch(1);
-
-		Dictionary<String, Object> registrationProperties =
-			HashMapDictionaryBuilder.<String, Object>put(
-				Constants.SERVICE_PID, factoryPid
-			).build();
-
-		ServiceRegistration<ManagedServiceFactory> serviceRegistration =
-			bundleContext.registerService(
-				ManagedServiceFactory.class,
-				new ManagedServiceFactory() {
-
-					@Override
-					public void deleted(String pid) {
-					}
-
-					@Override
-					public String getName() {
-						return "Test managed service factory for PID " +
-							factoryPid;
-					}
-
-					@Override
-					public void updated(
-						String pid, Dictionary<String, ?> updatedProperties) {
-
-						if (updatedProperties == null) {
-							return;
-						}
-
-						if (isIncluded(properties, updatedProperties)) {
-							countDownLatch.countDown();
-						}
-					}
-
-				},
-				registrationProperties);
-
-		try {
-			ServiceReference<ConfigurationAdmin> serviceReference =
-				bundleContext.getServiceReference(ConfigurationAdmin.class);
-
-			ConfigurationAdmin configurationAdmin = bundleContext.getService(
-				serviceReference);
-
-			Configuration configuration = null;
-
-			try {
-				configuration = configurationAdmin.createFactoryConfiguration(
-					factoryPid, StringPool.QUESTION);
-
-				configuration.update(properties);
-
-				countDownLatch.await(5, TimeUnit.MINUTES);
-
-				return configuration;
-			}
-			catch (IOException ioException) {
-				throw new RuntimeException(ioException);
-			}
-			catch (InterruptedException interruptedException) {
-				try {
-					configuration.delete();
-				}
-				catch (IOException ioException) {
-					throw new RuntimeException(ioException);
-				}
-
-				throw new RuntimeException(interruptedException);
-			}
-			finally {
-				bundleContext.ungetService(serviceReference);
-			}
-		}
-		finally {
-			serviceRegistration.unregister();
-		}
-	}
-
-	protected Configuration createFactoryConfiguration(
+	protected void createFactoryConfiguration(
 		String factoryPid, Dictionary<String, Object> properties) {
 
-		Configuration configuration = createFactoryConfiguration(
-			bundleContext, factoryPid, properties);
+		try {
+			String pid = ConfigurationTestUtil.createFactoryConfiguration(
+				factoryPid, properties);
 
-		autoCloseables.add(configuration::delete);
-
-		return configuration;
+			autoCloseables.add(
+				() -> ConfigurationTestUtil.deleteConfiguration(pid));
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
 	}
 
 	protected OAuth2Application createOAuth2Application(
@@ -472,28 +383,6 @@ public abstract class BaseTestPreparatorBundleActivator
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
 		}
-	}
-
-	protected boolean isIncluded(
-		Dictionary<String, ?> properties1, Dictionary<String, ?> properties2) {
-
-		if (properties1.size() > properties2.size()) {
-			return false;
-		}
-
-		Enumeration<String> enumeration = properties1.keys();
-
-		while (enumeration.hasMoreElements()) {
-			String key = enumeration.nextElement();
-
-			if (!Objects.deepEquals(
-					properties1.get(key), properties2.get(key))) {
-
-				return false;
-			}
-		}
-
-		return true;
 	}
 
 	protected abstract void prepareTest() throws Exception;

--- a/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/BaseCORSClientTestCase.java
+++ b/modules/apps/portal-remote/portal-remote-cors-test/src/testIntegration/java/com/liferay/portal/remote/cors/client/test/BaseCORSClientTestCase.java
@@ -15,15 +15,14 @@ import com.liferay.petra.process.ProcessExecutor;
 import com.liferay.petra.process.local.LocalProcessExecutor;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
-import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import jakarta.ws.rs.HttpMethod;
 import jakarta.ws.rs.core.Application;
 
 import java.io.File;
-import java.io.IOException;
 
 import java.net.URL;
 
@@ -33,13 +32,9 @@ import java.security.ProtectionDomain;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Dictionary;
-import java.util.Enumeration;
 import java.util.List;
-import java.util.Objects;
 import java.util.Queue;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Logger;
@@ -50,13 +45,8 @@ import org.junit.BeforeClass;
 
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
-import org.osgi.framework.Constants;
 import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceReference;
 import org.osgi.framework.ServiceRegistration;
-import org.osgi.service.cm.Configuration;
-import org.osgi.service.cm.ConfigurationAdmin;
-import org.osgi.service.cm.ManagedServiceFactory;
 
 /**
  * @author Marta Medio
@@ -167,95 +157,15 @@ public abstract class BaseCORSClientTestCase {
 	protected void createFactoryConfiguration(
 		String configurationClassName, Dictionary<String, Object> properties) {
 
-		CountDownLatch countDownLatch = new CountDownLatch(1);
-
-		Dictionary<String, Object> registrationProperties =
-			HashMapDictionaryBuilder.<String, Object>put(
-				Constants.SERVICE_PID, configurationClassName
-			).build();
-
-		ServiceRegistration<ManagedServiceFactory> serviceRegistration =
-			_bundleContext.registerService(
-				ManagedServiceFactory.class,
-				new ManagedServiceFactory() {
-
-					@Override
-					public void deleted(String pid) {
-					}
-
-					@Override
-					public String getName() {
-						return "Test managed service factory for PID " +
-							configurationClassName;
-					}
-
-					@Override
-					public void updated(
-						String pid, Dictionary<String, ?> updatedProperties) {
-
-						if ((updatedProperties == null) ||
-							(properties.size() > updatedProperties.size())) {
-
-							return;
-						}
-
-						Enumeration<String> enumeration = properties.keys();
-
-						while (enumeration.hasMoreElements()) {
-							String key = enumeration.nextElement();
-
-							if (!Objects.deepEquals(
-									properties.get(key),
-									updatedProperties.get(key))) {
-
-								return;
-							}
-						}
-
-						countDownLatch.countDown();
-					}
-
-				},
-				registrationProperties);
-
 		try {
-			ServiceReference<ConfigurationAdmin> serviceReference =
-				_bundleContext.getServiceReference(ConfigurationAdmin.class);
+			String pid = ConfigurationTestUtil.createFactoryConfiguration(
+				configurationClassName, properties);
 
-			ConfigurationAdmin configurationAdmin = _bundleContext.getService(
-				serviceReference);
-
-			Configuration configuration = null;
-
-			try {
-				configuration = configurationAdmin.createFactoryConfiguration(
-					configurationClassName, StringPool.QUESTION);
-
-				configuration.update(properties);
-
-				countDownLatch.await(5, TimeUnit.MINUTES);
-
-				_autoCloseables.add(configuration::delete);
-			}
-			catch (IOException ioException) {
-				throw new RuntimeException(ioException);
-			}
-			catch (InterruptedException interruptedException) {
-				try {
-					configuration.delete();
-				}
-				catch (IOException ioException) {
-					throw new RuntimeException(ioException);
-				}
-
-				throw new RuntimeException(interruptedException);
-			}
-			finally {
-				_bundleContext.ungetService(serviceReference);
-			}
+			_autoCloseables.add(
+				() -> ConfigurationTestUtil.deleteConfiguration(pid));
 		}
-		finally {
-			serviceRegistration.unregister();
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88479

## What is being fixed

Two integration tests fail intermittently on CI:

- `com.liferay.portal.remote.cors.configuration.test.ConfigurationCORSClientTest`
- `com.liferay.oauth2.provider.token.endpoint.test.JWTAssertAuthorizationGrantTest`

The failure surfaces as a worker-thread `AssertionError` with the message `Ignoring new configuration pid=...PortalCORSConfiguration.scoped~<uuid>`, promoted to a test failure by `LogAssertionTestRule`. The root cause is a race in the bespoke factory-configuration helpers in `BaseCORSClientTestCase` and `BaseTestPreparatorBundleActivator`: each registers a one-shot `ManagedServiceFactory` and counts down on its first `updated()`, but Felix's `ConfigurationManager` iterates **every** factory configuration during a delivery cycle. When a sibling `.scoped` factory (registered by `ScopedConfigurationManagedServiceFactory`) is still in `isNew()` state, the same delivery emits the `ERROR` log above.

## How it is being fixed

Both helpers now delegate to `com.liferay.portal.configuration.test.util.ConfigurationTestUtil`, which synchronizes on a `ConfigurationListener` plus a marker `ManagedService` to ensure the Configuration Admin delivery cycle has fully drained before returning. The bespoke `ManagedServiceFactory` + `CountDownLatch` + manual `ConfigurationAdmin` dance is removed from both base classes, along with the now-unused `isIncluded` helper in `BaseTestPreparatorBundleActivator`. Net `+17 / -218` lines.

## Why are there no tests?

The change is a refactor of two test base classes. The validation is the existing test suites that already exercise both helpers — they pass locally on the refactored code (4 CORS classes, 5 OAuth2 classes including the two originally-flaky ones), and a 10× rerun of each originally-flaky test is 10/10 green.