### PR TITLE
[AI-Hub] LPD-86151

### DIFF
--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/mcp/tool/provider/MCPToolProviderUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/mcp/tool/provider/MCPToolProviderUtil.java
@@ -20,7 +20,10 @@ import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserServiceUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
+import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
@@ -35,6 +38,8 @@ import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
+
+import java.net.UnknownHostException;
 
 import java.util.Base64;
 import java.util.List;
@@ -112,14 +117,25 @@ public class MCPToolProviderUtil {
 	}
 
 	private static McpTransport _createMcpTransport(
-		Map<String, Object> properties) {
+			Map<String, Object> properties)
+		throws UnknownHostException {
+
+		String url = GetterUtil.getString(properties.get("url"));
+
+		if (!PortalRunMode.isTestMode() &&
+			InetAddressUtil.isLocalInetAddress(
+				InetAddressUtil.getInetAddressByName(
+					HttpComponentsUtil.getDomain(url)))) {
+
+			throw new SecurityException("Local links are not allowed: " + url);
+		}
 
 		return new StreamableHttpMcpTransport.Builder(
 		).customHeaders(
 			_createCustomHeaders(
 				GetterUtil.getString(properties.get("authArguments")))
 		).url(
-			GetterUtil.getString(properties.get("url"))
+			url
 		).build();
 	}
 

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/mcp/tool/provider/MCPToolProviderUtil.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/mcp/tool/provider/MCPToolProviderUtil.java
@@ -8,6 +8,7 @@ package com.liferay.ai.hub.internal.mcp.tool.provider;
 import com.liferay.object.rest.dto.v1_0.ObjectEntry;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.service.ObjectDefinitionLocalServiceUtil;
+import com.liferay.object.service.ObjectEntryLocalServiceUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -38,6 +39,8 @@ import dev.langchain4j.mcp.client.transport.http.StreamableHttpMcpTransport;
 import dev.langchain4j.model.chat.request.json.JsonAnyOfSchema;
 import dev.langchain4j.model.chat.request.json.JsonObjectSchema;
 import dev.langchain4j.model.chat.request.json.JsonSchemaElement;
+
+import java.io.Serializable;
 
 import java.net.UnknownHostException;
 
@@ -87,7 +90,7 @@ public class MCPToolProviderUtil {
 				mcpServerExternalReferenceCodes, objectEntryManager, userId),
 			objectEntry -> {
 				McpTransport mcpTransport = _createMcpTransport(
-					objectEntry.getProperties());
+					ObjectEntryLocalServiceUtil.getValues(objectEntry.getId()));
 
 				return new DefaultMcpClient.Builder(
 				).transport(
@@ -117,10 +120,10 @@ public class MCPToolProviderUtil {
 	}
 
 	private static McpTransport _createMcpTransport(
-			Map<String, Object> properties)
+			Map<String, Serializable> values)
 		throws UnknownHostException {
 
-		String url = GetterUtil.getString(properties.get("url"));
+		String url = GetterUtil.getString(values.get("url"));
 
 		if (!PortalRunMode.isTestMode() &&
 			InetAddressUtil.isLocalInetAddress(
@@ -133,7 +136,7 @@ public class MCPToolProviderUtil {
 		return new StreamableHttpMcpTransport.Builder(
 		).customHeaders(
 			_createCustomHeaders(
-				GetterUtil.getString(properties.get("authArguments")))
+				GetterUtil.getString(values.get("authArguments")))
 		).url(
 			url
 		).build();

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/web/search/LiferayWebSearchEngine.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/main/java/com/liferay/ai/hub/internal/web/search/LiferayWebSearchEngine.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
+import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.rest.dto.v1_0.SearchResult;
 
@@ -29,6 +30,7 @@ import dev.langchain4j.web.search.WebSearchRequest;
 import dev.langchain4j.web.search.WebSearchResults;
 
 import java.net.URI;
+import java.net.URL;
 import java.net.URLEncoder;
 
 import java.util.ArrayList;
@@ -71,9 +73,6 @@ public class LiferayWebSearchEngine implements WebSearchEngine {
 			throw new IllegalArgumentException();
 		}
 
-		List<WebSearchOrganicResult> webSearchOrganicResults =
-			new ArrayList<>();
-
 		Http.Options options = new Http.Options();
 
 		options.addHeader(
@@ -89,8 +88,20 @@ public class LiferayWebSearchEngine implements WebSearchEngine {
 			OAuth2ApplicationLocalServiceUtil.getOAuth2Application(
 				oAuth2Authorization.getOAuth2ApplicationId());
 
-		String location =
-			oAuth2Application.getHomePageURL() + "/o/search/v1.0/search";
+		String homePageURL = oAuth2Application.getHomePageURL();
+
+		URL url = new URL(homePageURL);
+
+		if (InetAddressUtil.isLocalInetAddress(
+				InetAddressUtil.getInetAddressByName(url.getHost()))) {
+
+			throw new SecurityException("Local links are not allowed: " + url);
+		}
+
+		List<WebSearchOrganicResult> webSearchOrganicResults =
+			new ArrayList<>();
+
+		String location = homePageURL + "/o/search/v1.0/search";
 
 		if (!Validator.isBlank(_blueprintExternalReferenceCode)) {
 			location = HttpComponentsUtil.addParameter(
@@ -124,16 +135,16 @@ public class LiferayWebSearchEngine implements WebSearchEngine {
 				continue;
 			}
 
-			String url = oAuth2Application.getHomePageURL();
+			String itemURL = homePageURL;
 
 			if (searchResult.getItemURL() != null) {
-				url = searchResult.getItemURL();
+				itemURL = searchResult.getItemURL();
 			}
 
 			webSearchOrganicResults.add(
 				WebSearchOrganicResult.from(
 					searchResult.getTitle(),
-					URI.create(URLEncoder.encode(url, "UTF-8")), null,
+					URI.create(URLEncoder.encode(itemURL, "UTF-8")), null,
 					searchResult.getDescription(),
 					Map.of("score", String.valueOf(score))));
 		}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/mcp/tool/provider/MCPToolProviderUtilTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/mcp/tool/provider/MCPToolProviderUtilTest.java
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.mcp.tool.provider;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class MCPToolProviderUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testCreateMcpTransport() {
+		_testCreateMcpTransport("http://127.0.0.1/mcp");
+		_testCreateMcpTransport("http://169.254.169.254/mcp");
+		_testCreateMcpTransport("http://192.168.1.1/mcp");
+	}
+
+	private void _testCreateMcpTransport(String url) {
+		SecurityException securityException = Assert.assertThrows(
+			SecurityException.class,
+			() -> ReflectionTestUtil.invoke(
+				MCPToolProviderUtil.class, "_createMcpTransport",
+				new Class<?>[] {Map.class},
+				Map.of("url", url, "authArguments", "")));
+
+		String message = securityException.getMessage();
+
+		Assert.assertTrue(message, message.contains(url));
+	}
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/web/search/LiferayWebSearchEngineTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-impl/src/test/java/com/liferay/ai/hub/internal/web/search/LiferayWebSearchEngineTest.java
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.ai.hub.internal.web.search;
+
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.model.OAuth2Authorization;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalServiceUtil;
+import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalServiceUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import dev.langchain4j.web.search.WebSearchRequest;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Lucas Miranda
+ */
+public class LiferayWebSearchEngineTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testSearch() {
+		_search("http://127.0.0.1:8080");
+		_search("http://192.168.1.1");
+	}
+
+	private void _search(String homePageURL) {
+		try (MockedStatic<OAuth2ApplicationLocalServiceUtil>
+				oAuth2ApplicationLocalServiceUtilMockedStatic =
+					Mockito.mockStatic(OAuth2ApplicationLocalServiceUtil.class);
+			MockedStatic<OAuth2AuthorizationLocalServiceUtil>
+				oAuth2AuthorizationLocalServiceUtilMockedStatic =
+					Mockito.mockStatic(
+						OAuth2AuthorizationLocalServiceUtil.class)) {
+
+			oAuth2AuthorizationLocalServiceUtilMockedStatic.when(
+				() ->
+					OAuth2AuthorizationLocalServiceUtil.
+						getOAuth2AuthorizationByAccessTokenContent(
+							Mockito.any())
+			).thenReturn(
+				Mockito.mock(OAuth2Authorization.class)
+			);
+
+			OAuth2Application oAuth2Application = Mockito.mock(
+				OAuth2Application.class);
+
+			Mockito.when(
+				oAuth2Application.getHomePageURL()
+			).thenReturn(
+				homePageURL
+			);
+
+			oAuth2ApplicationLocalServiceUtilMockedStatic.when(
+				() -> OAuth2ApplicationLocalServiceUtil.getOAuth2Application(
+					Mockito.anyLong())
+			).thenReturn(
+				oAuth2Application
+			);
+
+			LiferayWebSearchEngine liferayWebSearchEngine =
+				new LiferayWebSearchEngine("Bearer testtoken", null, 0, null);
+
+			Assert.assertThrows(
+				SecurityException.class,
+				() -> liferayWebSearchEngine.search(
+					Mockito.mock(WebSearchRequest.class)));
+		}
+	}
+
+}

--- a/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
+++ b/modules/dxp/apps/ai-hub/ai-hub-rest-test/src/testIntegration/java/com/liferay/ai/hub/rest/resource/v1_0/test/AgentInstanceResourceTest.java
@@ -23,6 +23,7 @@ import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.test.util.ObjectDefinitionTestUtil;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
@@ -45,11 +46,13 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -85,6 +88,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -144,11 +150,38 @@ public class AgentInstanceResourceTest
 				"serviceURL", "http://localhost:8080"
 			).build());
 
+		_mcpServerConfigurationPid =
+			ConfigurationTestUtil.createFactoryConfiguration(
+				"com.liferay.mcp.server.internal.configuration." +
+					"MCPServerConfiguration.scoped",
+				HashMapDictionaryBuilder.<String, Object>put(
+					"companyId", TestPropsValues.getCompanyId()
+				).put(
+					"enabled", true
+				).build());
+
 		PrincipalThreadLocal.setName(TestPropsValues.getUserId());
 
 		ServiceContextThreadLocal.pushServiceContext(
 			ServiceContextTestUtil.getServiceContext(
 				TestPropsValues.getGroupId(), TestPropsValues.getUserId()));
+
+		_objectEncryptionAlgorithmSafeCloseable =
+			PropsValuesTestUtil.swapWithSafeCloseable(
+				"OBJECT_ENCRYPTION_ALGORITHM", "AES");
+		_objectEncryptionEnabledSafeCloseable =
+			PropsValuesTestUtil.swapWithSafeCloseable(
+				"OBJECT_ENCRYPTION_ENABLED", true);
+
+		KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
+
+		keyGenerator.init(128);
+
+		SecretKey secretKey = keyGenerator.generateKey();
+
+		_objectEncryptionKeySafeCloseable =
+			PropsValuesTestUtil.swapWithSafeCloseable(
+				"OBJECT_ENCRYPTION_KEY", Base64.encode(secretKey.getEncoded()));
 
 		SiteInitializer siteInitializer =
 			_siteInitializerRegistry.getSiteInitializer(
@@ -248,12 +281,17 @@ public class AgentInstanceResourceTest
 
 	@AfterClass
 	public static void tearDownClass() throws Exception {
+		ConfigurationTestUtil.deleteConfiguration(_mcpServerConfigurationPid);
+
 		PermissionThreadLocal.setPermissionChecker(_originalPermissionChecker);
 
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			_mcpServerObjectDefinition.getObjectDefinitionId());
 		_objectDefinitionLocalService.deleteObjectDefinition(
 			_objectDefinition.getObjectDefinitionId());
+		_objectEncryptionAlgorithmSafeCloseable.close();
+		_objectEncryptionEnabledSafeCloseable.close();
+		_objectEncryptionKeySafeCloseable.close();
 
 		PrincipalThreadLocal.setName(_originalName);
 	}
@@ -1059,11 +1097,16 @@ public class AgentInstanceResourceTest
 
 	private static ObjectDefinition _contentRetrieverObjectDefinition;
 	private static ObjectDefinition _instructionObjectDefinition;
+	private static String _mcpServerConfigurationPid;
 	private static ObjectDefinition _mcpServerObjectDefinition;
 	private static ObjectDefinition _objectDefinition;
 
 	@Inject
 	private static ObjectDefinitionLocalService _objectDefinitionLocalService;
+
+	private static SafeCloseable _objectEncryptionAlgorithmSafeCloseable;
+	private static SafeCloseable _objectEncryptionEnabledSafeCloseable;
+	private static SafeCloseable _objectEncryptionKeySafeCloseable;
 
 	@Inject
 	private static ObjectEntryLocalService _objectEntryLocalService;

--- a/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-definitions/mcp-server-object-definition.json
+++ b/modules/dxp/apps/ai-hub/ai-hub-site-initializer/src/main/resources/site-initializer/object-definitions/mcp-server-object-definition.json
@@ -19,24 +19,15 @@
 	"objectFields": [
 		{
 			"DBType": "Clob",
-			"businessType": "LongText",
-			"defaultValue": "null",
+			"businessType": "Encrypted",
 			"externalReferenceCode": "AUTHENTICATION_ARGUMENTS",
-			"indexed": true,
-			"indexedAsKeyword": false,
-			"indexedLanguageId": "en_US",
+			"indexed": false,
 			"label": {
 				"en_US": "Authentication Arguments"
 			},
 			"listTypeDefinitionId": 0,
 			"localized": false,
 			"name": "authArguments",
-			"objectFieldSettings": [
-				{
-					"name": "showCounter",
-					"value": false
-				}
-			],
 			"readOnly": "false",
 			"readOnlyConditionExpression": "",
 			"required": false,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86151

  ## What is being fixed                                                                                                                                          
                                                                                                                                                             
  Fixes CWE-256 (Plaintext Storage of a Password): MCP server credentials (authArguments) were stored as unencrypted text in the database and returned in    
  plaintext via the Object REST API to anyone with object read permission.                                                                                   
                                                                                                                                                             
  ## How is being fixed                                                                                                                                     
                                                                                                                                                             
  ### At-rest encryption                                                                                                                                     
  authArguments field in mcp-server-object-definition.json changed from LongText to Encrypted business type — credentials are now stored using AES encryption
   in the database.                                                                                                                                          
                                                                                                                                                           
  ### Correct decryption for internal use                                                                                                                    
  MCPToolProviderUtil switched from reading authArguments via the REST DTO (objectEntry.getProperties(), which returns the raw/masked value) to            
  ObjectEntryLocalServiceUtil.getValues(), which goes through the service layer and returns the properly decrypted value needed to build the Basic Auth      
  header.                                                                                                
                                                                                                                                                             
  ### REST API masking                                                                                   
  AIHubEncryptedObjectFieldBusinessType registers as a higher-ranked (service.ranking=100) replacement for the platform's Encrypted business type. It
  overrides getDTOValue() to return an empty string for L_AI_HUB_MCP_SERVER entries, preventing decrypted credentials from being exposed in REST responses.  
   
  ### Test coverage                                                                                                                                          
  AgentInstanceResourceTest adds testGetMCPServerObjectEntryDoesNotExposeAuthArguments, which:           
  - Calls the Object REST API GET for the MCP server entry and asserts that authArguments is null/empty in the response (verifying the masking).             
  - Reads the same entry via ObjectEntryLocalService.getValues() and asserts the decrypted credentials are still accessible internally (verifying            
  MCPToolProviderUtil can still build the Authorization header at runtime).                                                                                  
  AES encryption props (OBJECT_ENCRYPTION_ALGORITHM, OBJECT_ENCRYPTION_ENABLED, OBJECT_ENCRYPTION_KEY) are swapped in setUpClass and restored in             
  tearDownClass so the Encrypted field behaves correctly during the test run.