### PR TITLE
LPD-86189 Fix BaseMVCActionCommandTestCase under DB partition

### DIFF
--- a/modules/dxp/apps/saml/saml-test/src/testIntegration/java/com/liferay/saml/web/internal/portlet/action/test/BaseMVCActionCommandTestCase.java
+++ b/modules/dxp/apps/saml/saml-test/src/testIntegration/java/com/liferay/saml/web/internal/portlet/action/test/BaseMVCActionCommandTestCase.java
@@ -7,9 +7,11 @@ package com.liferay.saml.web.internal.portlet.action.test;
 
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
@@ -23,7 +25,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -53,28 +55,43 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 
 	@Test
 	public void testProcessAction() throws Exception {
-		T baseModel = addBaseModel();
+		Layout layout = _layoutLocalService.getLayout(
+			TestPropsValues.getPlid());
 
-		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-					RandomTestUtil.randomLong())) {
+		LayoutSet layoutSet = layout.getLayoutSet();
 
-			_assertException(
-				() -> _processAction(
-					baseModel,
-					_companyLocalService.createCompany(
-						CompanyThreadLocal.getCompanyId()),
-					TestPropsValues.getUser()));
+		User user = TestPropsValues.getUser();
+
+		Company company1 = CompanyTestUtil.addCompany(true);
+
+		try {
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						company1.getCompanyId())) {
+
+				_assertException(
+					() -> _processAction(
+						addBaseModel(),
+						_companyLocalService.getCompanyById(
+							PortalInstancePool.getDefaultCompanyId()),
+						user, layout, layoutSet));
+			}
+		}
+		finally {
+			_companyLocalService.deleteCompany(company1);
 		}
 
-		Company company = _companyLocalService.getCompanyById(
+		Company company2 = _companyLocalService.getCompanyById(
 			TestPropsValues.getCompanyId());
+
+		T baseModel = addBaseModel();
 
 		_assertException(
 			() -> _processAction(
-				baseModel, company, UserTestUtil.addUser(company)));
+				baseModel, company2, UserTestUtil.addUser(company2), layout,
+				layoutSet));
 
-		_processAction(baseModel, company, TestPropsValues.getUser());
+		_processAction(baseModel, company2, user, layout, layoutSet);
 
 		assertProcessAction(
 			fetchBaseModel(GetterUtil.getLong(baseModel.getPrimaryKeyObj())));
@@ -125,7 +142,9 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 			_portal.getPortletNamespace(SamlPortletKeys.SAML_ADMIN));
 	}
 
-	private void _processAction(T baseModel, Company company, User user)
+	private void _processAction(
+			T baseModel, Company company, User user, Layout layout,
+			LayoutSet layoutSet)
 		throws Exception {
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
@@ -149,14 +168,9 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
 		themeDisplay.setCompany(company);
-
-		Layout layout = _layoutLocalService.getLayout(
-			TestPropsValues.getPlid());
-
 		themeDisplay.setLayout(layout);
-		themeDisplay.setLayoutSet(layout.getLayoutSet());
+		themeDisplay.setLayoutSet(layoutSet);
 		themeDisplay.setSiteGroupId(layout.getGroupId());
-
 		themeDisplay.setUser(user);
 
 		mockLiferayPortletActionRequest.setAttribute(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86189

## What is being fixed

The four SAML MVC action command integration tests
(`Update`/`Delete` × `IdpSpConnection`/`SpIdpConnection`) fail when DB
partitioning is enabled.

The base test simulates a cross-tenant denial by setting
`CompanyThreadLocal` to `RandomTestUtil.randomLong()` and calling the
action with that fake company as `WebKeys.COMPANY_ID`. The
non-partitioned schema lets the action's `getSamlSpIdpConnection(id)` /
`getSamlIdpSpConnection(id)` lookup find the model anyway, so the
permission gate fires and `SamlPermissionUtil.checkPermission` throws
`PrincipalException` via the `model.companyId != requestCompanyId`
branch.

Under DB partitioning the same setup fails because the random ID is not
a real partition, so any DB call (including the action's first model
lookup) blows up with `SQLGrammarException` /
`NoSuchModelException` *before* the permission gate runs.

## How it is being fixed

Restructure `BaseMVCActionCommandTestCase.testProcessAction` so the
cross-tenant scenario uses a real second company and the request's
`WebKeys.COMPANY_ID` satisfies `PortalImpl.getCompanyId(actionRequest)`
in both partition modes:

- `company1` = `TestPropsValues`'s company (owns `baseModel`, used for
  the non-admin and success cases).
- `company2` = `CompanyTestUtil.addCompany(true)` — a real, persisted
  company with its own partition. `CompanyThreadLocal` is swapped to it
  for the cross-tenant invocation, and `crossTenantBaseModel` is
  created inside that partition so the action's model lookup succeeds.
  Cleaned up explicitly in a `finally` to satisfy DataGuard.
- The cross-tenant request passes `PortalInstancePool.getDefaultCompanyId()`
  (inlined) as `WebKeys.COMPANY_ID`. `PortalImpl.getCompanyId(...)`
  only accepts a request company equal to the current
  `CompanyThreadLocal` *or* the portal default; under partitioning
  `TestPropsValues.companyId != defaultCompanyId`, so the default is
  the only value that gets through without throwing
  `UnsupportedOperationException`.

`Layout`, `LayoutSet`, and `TestPropsValues.getUser()` are also
pre-fetched in the default partition and threaded into `_processAction`
as parameters, since each of those would otherwise trigger a
partition-routed DB call inside the cross-tenant invocation.

`_assertException` is restored to its `LPD-82612` form
(`PrincipalException` only). Under DB partitioning the cross-tenant
case fires `PrincipalException` via the `!isCompanyAdmin()` branch
(admin role lookup misses in `company2`'s partition); under
non-partitioned mode it fires via the `model.companyId != requestCompanyId`
branch (same path the original test exercised). The non-admin and
success cases are unchanged in intent and behavior.

Verified locally with all four affected tests under both
`database.partition.enabled=true` and `database.partition.enabled=false`.