### PR TITLE
LPD-89572 add readonly for ERC in oauth2 client administrator

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
@@ -14,6 +14,7 @@ OAuth2Application oAuth2Application = oAuth2AdminPortletDisplayContext.getOAuth2
 
 String clientId = (oAuth2Application == null) ? "" : oAuth2Application.getClientId();
 String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getClientSecret();
+String externalReferenceCode = (oAuth2Application == null) ? "" : oAuth2Application.getExternalReferenceCode();
 %>
 
 <portlet:actionURL name="/oauth2_provider/update_oauth2_application" var="updateOAuth2ApplicationURL">
@@ -97,6 +98,8 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 										"clientId", clientId
 									).put(
 										"clientSecret", clientSecret
+									).put(
+										"externalReferenceCode", externalReferenceCode
 									).build()
 								%>'
 							/>

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/EditClientDetails.tsx
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/EditClientDetails.tsx
@@ -11,6 +11,7 @@ interface IEditClientDetailsProps extends React.HTMLAttributes<HTMLElement> {
 	baseResourceURL: string;
 	clientId: string;
 	clientSecret: string;
+	externalReferenceCode: string;
 	portletNamespace: string;
 }
 
@@ -40,6 +41,17 @@ const EditClientDetails: React.FC<IEditClientDetailsProps> = (props) => {
 				title={Liferay.Language.get('edit-client-secret')}
 				tooltip={Liferay.Language.get('client-secret-help[oauth2]')}
 				type="password"
+			/>
+
+			<ReadOnlyInput
+				editable={false}
+				id={`${props.portletNamespace}externalReferenceCode`}
+				initialValue={props.externalReferenceCode}
+				label={Liferay.Language.get('external-reference-code')}
+				title={Liferay.Language.get('edit-external-reference-code')}
+				tooltip={Liferay.Language.get(
+					'external-reference-code-help[oauth2]'
+				)}
 			/>
 		</>
 	);

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/ReadOnlyInput.tsx
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/ReadOnlyInput.tsx
@@ -11,8 +11,9 @@ import React, {useState} from 'react';
 import {EditClientOAuth2ModalContent} from './modals/EditClientOAuth2ModalContent';
 
 interface IReadOnlyInputProps extends React.HTMLAttributes<HTMLElement> {
-	alertText: string;
+	alertText?: string;
 	baseResourceURL?: string;
+	editable?: boolean;
 	id: string;
 	initialValue: string;
 	isSecret?: boolean;
@@ -24,8 +25,9 @@ interface IReadOnlyInputProps extends React.HTMLAttributes<HTMLElement> {
 
 const ReadOnlyInput: React.FC<IReadOnlyInputProps> = (props) => {
 	const {
-		alertText,
+		alertText = '',
 		baseResourceURL = '',
+		editable = true,
 		id,
 		initialValue,
 		isSecret = false,
@@ -55,38 +57,40 @@ const ReadOnlyInput: React.FC<IReadOnlyInputProps> = (props) => {
 						/>
 					</ClayInput.GroupItem>
 
-					<ClayInput.GroupItem append shrink>
-						<ClayButton
-							displayType="secondary"
-							onClick={() =>
-								openModal({
-									center: true,
-									contentComponent: ({
-										closeModal,
-									}: {
-										closeModal: () => void;
-									}) =>
-										EditClientOAuth2ModalContent({
-											alertText,
-											baseResourceURL,
+					{editable && (
+						<ClayInput.GroupItem append shrink>
+							<ClayButton
+								displayType="secondary"
+								onClick={() =>
+									openModal({
+										center: true,
+										contentComponent: ({
 											closeModal,
-											handleSetInputValue,
-											id,
-											initialValue,
-											isSecret,
-											label,
-											title,
-											tooltip,
-										}),
-									id: 'editClientOAuth2Modal',
-									size: 'md',
-									status: 'warning',
-								})
-							}
-						>
-							{Liferay.Language.get('edit')}
-						</ClayButton>
-					</ClayInput.GroupItem>
+										}: {
+											closeModal: () => void;
+										}) =>
+											EditClientOAuth2ModalContent({
+												alertText,
+												baseResourceURL,
+												closeModal,
+												handleSetInputValue,
+												id,
+												initialValue,
+												isSecret,
+												label,
+												title,
+												tooltip,
+											}),
+										id: 'editClientOAuth2Modal',
+										size: 'md',
+										status: 'warning',
+									})
+								}
+							>
+								{Liferay.Language.get('edit')}
+							</ClayButton>
+						</ClayInput.GroupItem>
+					)}
 				</ClayInput.Group>
 			</FieldBase>
 		</>


### PR DESCRIPTION
## Summary

Display the External Reference Code (ERC) of an OAuth2 client as a read-only field on the OAuth2 application credentials administration page, alongside the existing Client ID and Client Secret.

The `ReadOnlyInput` React component is extended with an `editable` prop (default `true`); when set to `false`, the Edit button and modal trigger are hidden.

## Ticket

[LPD-89572](https://liferay.atlassian.net/browse/LPD-89572)

<img width="3450" height="1920" alt="image" src="https://github.com/user-attachments/assets/e9fb6967-d095-4c4b-b37d-bf47eb46887f" />