### PR TITLE
LPD-89372 Set filter order on GlobalPrivacyControlWellKnownFilter

### DIFF
--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/servlet/filter/GlobalPrivacyControlWellKnownFilter.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/servlet/filter/GlobalPrivacyControlWellKnownFilter.java
@@ -39,7 +39,8 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"dispatcher=REQUEST", "servlet-context-name=",
+		"before-filter=Virtual Host Filter", "dispatcher=REQUEST",
+		"servlet-context-name=",
 		"servlet-filter-name=Global Privacy Control Well-Known Filter",
 		"url-pattern=/.well-known/gpc.json"
 	},

--- a/modules/test/playwright/tests/cookies-banner-web/main/gpcWellKnownEndpoint.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/main/gpcWellKnownEndpoint.spec.ts
@@ -7,8 +7,11 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {apiHelpersTest} from '../../../fixtures/apiHelpersTest';
 import {consentManagerConfigurationPageTest} from '../../../fixtures/consentManagerConfigurationPageTest';
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {systemSettingsPageTest} from '../../../fixtures/systemSettingsPageTest';
+import {SiteSettingsPage} from '../../../pages/users-admin-web/site-admin-web/SiteSettingsPage';
+import getRandomString from '../../../utils/getRandomString';
 import {waitForAlert} from '../../../utils/waitForAlert';
 import {
 	resetAllConsentManagerConfigurations,
@@ -22,6 +25,7 @@ const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 export const test = mergeTests(
 	apiHelpersTest,
 	consentManagerConfigurationPageTest,
+	dataApiHelpersTest,
 	loginTest(),
 	systemSettingsPageTest
 );
@@ -36,6 +40,53 @@ test.beforeEach(async ({page}) => {
 		forceReload: true,
 	});
 });
+
+test(
+	'GPC well-known endpoint is reachable when request matches a site virtual host',
+	{tag: '@LPD-89372'},
+	async ({apiHelpers, browser, page}) => {
+		const site = await apiHelpers.headlessAdminSite.postSite({
+			name: getRandomString(),
+		});
+
+		const siteSettingsPage = new SiteSettingsPage(page);
+
+		await siteSettingsPage.goto(site.friendlyUrlPath);
+
+		await siteSettingsPage.siteConfigurationLink.click();
+		await siteSettingsPage.siteURLLink.click();
+
+		await page.getByRole('button', {name: 'Decline All'}).click();
+
+		const virtualHostName = 'www.easy.com';
+
+		await siteSettingsPage.virtualHostInput.fill(virtualHostName);
+		await siteSettingsPage.saveButton.click();
+
+		await waitForAlert(page);
+
+		const context = await browser.newContext({
+			baseURL: `http://${virtualHostName}:8080`,
+			storageState: undefined,
+		});
+
+		try {
+			const response = await context.request.get(GPC_ENDPOINT);
+
+			expect(response.status()).toBe(200);
+			expect(response.headers()['content-type']).toContain(
+				'application/json'
+			);
+
+			const body = await response.json();
+
+			expect(typeof body.gpc).toBe('boolean');
+		}
+		finally {
+			await context.close();
+		}
+	}
+);
 
 test(
 	'GPC well-known endpoint is reachable without authentication',


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-89372

## What is being fixed

The `GlobalPrivacyControlWellKnownFilter` (serving `/.well-known/gpc.json`) was registered without any `before-filter` or `after-filter` constraint. `InvokerFilterHelper._registerFilterMapping` appends order-less dynamic filters to the end of the chain, so the well-known filter ran after `Virtual Host Filter`. When a virtual host is attached to the request host, VHF dispatches the request as a friendly URL before our filter ever runs, so the endpoint returns HTML (or a 404) instead of the expected JSON.

## How it is being fixed

Adds `"before-filter=Virtual Host Filter"` to the `@Component` property array on `GlobalPrivacyControlWellKnownFilter`. This anchors the filter into the dynamic-position map so `InvokerFilterHelper._getFilterNames` inserts it immediately before VHF. A broader audit of `/*`-mapped filters confirmed VHF is the only one that could short-circuit the chain on `/.well-known/gpc.json` — no further anchors are needed.

A new Playwright test in `gpcWellKnownEndpoint.spec.ts` exercises the bug path end-to-end: it creates an ephemeral site via the headless-admin-site API, binds a virtual host to it through Site Settings, then opens a fresh browser context against `http://<virtual-host>:8080/.well-known/gpc.json` and asserts a 200 response with `application/json` content and a boolean `gpc` field. Without the production fix the request returns 404 because VHF rewrites the URL before the filter can match; with the fix it returns the expected JSON.