### PR TITLE
LPD-89572 add readonly for ERC in oauth2 client administrator

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
@@ -14,6 +14,7 @@ OAuth2Application oAuth2Application = oAuth2AdminPortletDisplayContext.getOAuth2
 
 String clientId = (oAuth2Application == null) ? "" : oAuth2Application.getClientId();
 String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getClientSecret();
+String externalReferenceCode = (oAuth2Application == null) ? "" : oAuth2Application.getExternalReferenceCode();
 %>
 
 <portlet:actionURL name="/oauth2_provider/update_oauth2_application" var="updateOAuth2ApplicationURL">
@@ -97,6 +98,8 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 										"clientId", clientId
 									).put(
 										"clientSecret", clientSecret
+									).put(
+										"externalReferenceCode", externalReferenceCode
 									).build()
 								%>'
 							/>

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/EditClientDetails.tsx
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/EditClientDetails.tsx
@@ -47,7 +47,9 @@ const EditClientDetails: React.FC<IEditClientDetailsProps> = (props) => {
 				editable={false}
 				id={`${props.portletNamespace}externalReferenceCode`}
 				initialValue={props.externalReferenceCode}
-				label={Liferay.Language.get('oauth2-application-external-reference-code')}
+				label={Liferay.Language.get(
+					'oauth2-application-external-reference-code'
+				)}
 			/>
 		</>
 	);

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/EditClientDetails.tsx
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/EditClientDetails.tsx
@@ -47,11 +47,7 @@ const EditClientDetails: React.FC<IEditClientDetailsProps> = (props) => {
 				editable={false}
 				id={`${props.portletNamespace}externalReferenceCode`}
 				initialValue={props.externalReferenceCode}
-				label={Liferay.Language.get('external-reference-code')}
-				title={Liferay.Language.get('edit-external-reference-code')}
-				tooltip={Liferay.Language.get(
-					'external-reference-code-help[oauth2]'
-				)}
+				label={Liferay.Language.get('oauth2-application-external-reference-code')}
 			/>
 		</>
 	);

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/EditClientDetails.tsx
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/EditClientDetails.tsx
@@ -11,6 +11,7 @@ interface IEditClientDetailsProps extends React.HTMLAttributes<HTMLElement> {
 	baseResourceURL: string;
 	clientId: string;
 	clientSecret: string;
+	externalReferenceCode: string;
 	portletNamespace: string;
 }
 
@@ -40,6 +41,17 @@ const EditClientDetails: React.FC<IEditClientDetailsProps> = (props) => {
 				title={Liferay.Language.get('edit-client-secret')}
 				tooltip={Liferay.Language.get('client-secret-help[oauth2]')}
 				type="password"
+			/>
+
+			<ReadOnlyInput
+				editable={false}
+				id={`${props.portletNamespace}externalReferenceCode`}
+				initialValue={props.externalReferenceCode}
+				label={Liferay.Language.get('external-reference-code')}
+				title={Liferay.Language.get('edit-external-reference-code')}
+				tooltip={Liferay.Language.get(
+					'external-reference-code-help[oauth2]'
+				)}
 			/>
 		</>
 	);

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/ReadOnlyInput.tsx
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/ReadOnlyInput.tsx
@@ -18,8 +18,8 @@ interface IReadOnlyInputProps extends React.HTMLAttributes<HTMLElement> {
 	initialValue: string;
 	isSecret?: boolean;
 	label: string;
-	title: string;
-	tooltip: string;
+	title?: string;
+	tooltip?: string;
 	type?: string;
 }
 
@@ -32,8 +32,8 @@ const ReadOnlyInput: React.FC<IReadOnlyInputProps> = (props) => {
 		initialValue,
 		isSecret = false,
 		label,
-		title,
-		tooltip,
+		title = '',
+		tooltip = '',
 		type = 'text',
 	} = props;
 

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/ReadOnlyInput.tsx
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/js/components/ReadOnlyInput.tsx
@@ -11,8 +11,9 @@ import React, {useState} from 'react';
 import {EditClientOAuth2ModalContent} from './modals/EditClientOAuth2ModalContent';
 
 interface IReadOnlyInputProps extends React.HTMLAttributes<HTMLElement> {
-	alertText: string;
+	alertText?: string;
 	baseResourceURL?: string;
+	editable?: boolean;
 	id: string;
 	initialValue: string;
 	isSecret?: boolean;
@@ -24,8 +25,9 @@ interface IReadOnlyInputProps extends React.HTMLAttributes<HTMLElement> {
 
 const ReadOnlyInput: React.FC<IReadOnlyInputProps> = (props) => {
 	const {
-		alertText,
+		alertText = '',
 		baseResourceURL = '',
+		editable = true,
 		id,
 		initialValue,
 		isSecret = false,
@@ -55,38 +57,40 @@ const ReadOnlyInput: React.FC<IReadOnlyInputProps> = (props) => {
 						/>
 					</ClayInput.GroupItem>
 
-					<ClayInput.GroupItem append shrink>
-						<ClayButton
-							displayType="secondary"
-							onClick={() =>
-								openModal({
-									center: true,
-									contentComponent: ({
-										closeModal,
-									}: {
-										closeModal: () => void;
-									}) =>
-										EditClientOAuth2ModalContent({
-											alertText,
-											baseResourceURL,
+					{editable && (
+						<ClayInput.GroupItem append shrink>
+							<ClayButton
+								displayType="secondary"
+								onClick={() =>
+									openModal({
+										center: true,
+										contentComponent: ({
 											closeModal,
-											handleSetInputValue,
-											id,
-											initialValue,
-											isSecret,
-											label,
-											title,
-											tooltip,
-										}),
-									id: 'editClientOAuth2Modal',
-									size: 'md',
-									status: 'warning',
-								})
-							}
-						>
-							{Liferay.Language.get('edit')}
-						</ClayButton>
-					</ClayInput.GroupItem>
+										}: {
+											closeModal: () => void;
+										}) =>
+											EditClientOAuth2ModalContent({
+												alertText,
+												baseResourceURL,
+												closeModal,
+												handleSetInputValue,
+												id,
+												initialValue,
+												isSecret,
+												label,
+												title,
+												tooltip,
+											}),
+										id: 'editClientOAuth2Modal',
+										size: 'md',
+										status: 'warning',
+									})
+								}
+							>
+								{Liferay.Language.get('edit')}
+							</ClayButton>
+						</ClayInput.GroupItem>
+					)}
 				</ClayInput.Group>
 			</FieldBase>
 		</>

--- a/modules/apps/oauth2-provider/oauth2-provider-web/test.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/test.properties
@@ -1,0 +1,11 @@
+modified.files.includes[relevant][oauth2-provider-web-playwright-rule]=**
+
+playwright.projects.includes[playwright-js-tomcat101-postgresql163][relevant][oauth2-provider-web-playwright-rule]=\
+    oauth2-provider-web.main
+
+relevant.rule.names=oauth2-provider-web-playwright-rule
+
+test.batch.names[relevant][oauth2-provider-web-playwright-rule]=\
+    playwright-js-tomcat101-postgresql163
+
+testray.main.component.name=OAuth 2

--- a/modules/test/playwright/fixtures/oauth2ApplicationPagesTest.ts
+++ b/modules/test/playwright/fixtures/oauth2ApplicationPagesTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {OAuth2ApplicationPage} from '../pages/oauth2-provider-web/OAuth2ApplicationPage';
+
+const oauth2ApplicationPagesTest = test.extend<{
+	oauth2ApplicationPage: OAuth2ApplicationPage;
+}>({
+	oauth2ApplicationPage: async ({page}, use) => {
+		await use(new OAuth2ApplicationPage(page));
+	},
+});
+
+export {oauth2ApplicationPagesTest};

--- a/modules/test/playwright/pages/oauth2-provider-web/OAuth2ApplicationPage.ts
+++ b/modules/test/playwright/pages/oauth2-provider-web/OAuth2ApplicationPage.ts
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Locator, Page, expect} from '@playwright/test';
+
+import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
+import {GlobalMenuPage} from '../product-navigation-applications-menu/GlobalMenuPage';
+
+export class OAuth2ApplicationPage {
+	readonly addButton: Locator;
+	readonly ercInput: Locator;
+	readonly globalMenuPage: GlobalMenuPage;
+	readonly nameInput: Locator;
+	readonly page: Page;
+	readonly redirectURIsInput: Locator;
+	readonly saveButton: Locator;
+
+	constructor(page: Page) {
+		this.addButton = page.getByRole('link', {
+			name: 'Add OAuth 2 Application',
+		});
+		this.ercInput = page.getByRole('textbox', {
+			name: 'OAuth 2 Application External',
+		});
+		this.globalMenuPage = new GlobalMenuPage(page);
+		this.nameInput = page.getByRole('textbox', {
+			name: 'Name Required Provide a name',
+		});
+		this.page = page;
+		this.redirectURIsInput = page.getByRole('textbox', {
+			name: 'Characters Maximum:',
+		});
+		this.saveButton = page.getByRole('button', {name: 'Save'});
+	}
+
+	async createApplication(name: string, redirectURI: string) {
+		await this.addButton.click();
+
+		await expect(this.nameInput).toBeVisible();
+
+		await this.nameInput.fill(name);
+		await this.redirectURIsInput.fill(redirectURI);
+		await this.saveButton.click();
+
+		await expect(
+			this.page.getByText('Your request completed successfully')
+		).toBeVisible();
+	}
+
+	async deleteApplication(name: string) {
+		await this.goTo();
+
+		const row = this.page.locator('tr').filter({hasText: name});
+
+		this.page.once('dialog', (dialog) => dialog.accept());
+
+		await clickAndExpectToBeVisible({
+			autoClick: true,
+			target: this.page.getByRole('link', {name: 'Delete'}),
+			trigger: row.locator('.dropdown-toggle'),
+		});
+
+		await expect(
+			this.page.getByText('Your request completed successfully')
+		).toBeVisible();
+	}
+
+	async goTo() {
+		await this.globalMenuPage.goToControlPanel('OAuth 2 Administration');
+
+		await expect(this.addButton).toBeVisible();
+	}
+
+	async goToApplication(name: string) {
+		await this.page.getByRole('link', {exact: true, name}).click();
+
+		await expect(this.nameInput).toBeVisible();
+	}
+}

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -119,6 +119,7 @@ import {config as nestedPortletsWebConfig} from './tests/nested-portlets-web/mai
 import {config as notificationWebConfig} from './tests/notification-web/main/config';
 import {config as notificationsWebConfig} from './tests/notifications-web/main/config';
 import {config as oauthClientAdministrationConfig} from './tests/oauth-client-administration/main/config';
+import {config as oauth2ProviderWebConfig} from './tests/oauth2-provider-web/main/config';
 import {config as objectActionWebConfig} from './tests/object-web/action/config';
 import {config as objectClientExtensionWebConfig} from './tests/object-web/client-extension/config';
 import {config as objectContentPageIntegrationWebConfig} from './tests/object-web/content-page-integration/config';
@@ -344,6 +345,7 @@ export default defineConfig({
 		notificationWebConfig,
 		notificationsWebConfig,
 		oauthClientAdministrationConfig,
+		oauth2ProviderWebConfig,
 		listTypeDefinitionsWebConfig,
 		objectActionWebConfig,
 		objectClientExtensionWebConfig,

--- a/modules/test/playwright/tests/oauth2-provider-web/main/config.ts
+++ b/modules/test/playwright/tests/oauth2-provider-web/main/config.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'oauth2-provider-web.main',
+	testDir: 'tests/oauth2-provider-web/main',
+	use: {
+		testIdAttribute: 'data-qa-id',
+	},
+};

--- a/modules/test/playwright/tests/oauth2-provider-web/main/oauth2Application.spec.ts
+++ b/modules/test/playwright/tests/oauth2-provider-web/main/oauth2Application.spec.ts
@@ -1,0 +1,31 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {loginTest} from '../../../fixtures/loginTest';
+import {oauth2ApplicationPagesTest} from '../../../fixtures/oauth2ApplicationPagesTest';
+
+const test = mergeTests(oauth2ApplicationPagesTest, loginTest());
+
+test.describe('OAuth2 Application ERC field', () => {
+	test(
+		'ERC field is readonly on the credentials tab',
+		{tag: '@LPD-89572'},
+		async ({oauth2ApplicationPage}) => {
+			await oauth2ApplicationPage.goTo();
+
+			await oauth2ApplicationPage.goToApplication('Analytics Cloud');
+
+			await expect(oauth2ApplicationPage.ercInput).toBeVisible();
+
+			await expect(oauth2ApplicationPage.ercInput).not.toBeEditable();
+
+			await expect(
+				oauth2ApplicationPage.page.getByRole('button', {name: 'Edit'})
+			).toHaveCount(2);
+		}
+	);
+});

--- a/modules/test/playwright/tests/oauth2-provider-web/main/test.properties
+++ b/modules/test/playwright/tests/oauth2-provider-web/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=OAuth 2

--- a/test.properties
+++ b/test.properties
@@ -6662,6 +6662,7 @@
         login-web.setup-admin,\
         multi-factor-authentication-timebased-otp-web.main,\
         oauth-client-administration.main,\
+        oauth2-provider-web.main,\
         openid-link.main,\
         password-policies-admin-web.first-login,\
         password-policies-admin-web.main,\


### PR DESCRIPTION
Resent from: https://github.com/liferay-appsec/liferay-portal/pull/2842

---

## Summary

Display the External Reference Code (ERC) of an OAuth2 client as a read-only field on the OAuth2 application credentials administration page, alongside the existing Client ID and Client Secret.

The `ReadOnlyInput` React component is extended with an `editable` prop (default `true`); when set to `false`, the Edit button and modal trigger are hidden.

## Ticket

[LPD-89572](https://liferay.atlassian.net/browse/LPD-89572)

<img width="3108" height="1021" alt="image" src="https://github.com/user-attachments/assets/57613984-29db-4677-ac7c-fd8eb9f71f69" />

cc: @kevenleone