### PR TITLE
LPD-90466 Null-guard tokenConnectionTimeout lookup in OIDC scheduler

### DIFF
--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/session/manager/OfflineOpenIdConnectSessionManager.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/session/manager/OfflineOpenIdConnectSessionManager.java
@@ -259,11 +259,17 @@ public class OfflineOpenIdConnectSessionManager {
 						String.valueOf(
 							oidcProviderMetadata.getTokenEndpointURI()));
 
+			int tokenConnectionTimeout = 0;
+
+			if (properties != null) {
+				tokenConnectionTimeout = GetterUtil.getInteger(
+					properties.get("tokenConnectionTimeout"));
+			}
+
 			OIDCTokens oidcTokens = OpenIdConnectTokenRequestUtil.request(
 				OIDCClientInformation.parse(
 					JSONObjectUtils.parse(oAuthClientEntry.getInfoJSON())),
-				oidcProviderMetadata, refreshToken,
-				GetterUtil.getInteger(properties.get("tokenConnectionTimeout")),
+				oidcProviderMetadata, refreshToken, tokenConnectionTimeout,
 				oAuthClientEntry.getTokenRequestParametersJSON());
 
 			_updateOpenIdConnectSessionIdToken(

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/session/manager/OfflineOpenIdConnectSessionManagerTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/session/manager/OfflineOpenIdConnectSessionManagerTest.java
@@ -64,31 +64,6 @@ public class OfflineOpenIdConnectSessionManagerTest {
 		String authServerWellKnownURI = RandomTestUtil.randomString();
 		String clientId = RandomTestUtil.randomString();
 
-		OAuthClientEntry oAuthClientEntry = _createOAuthClientEntry(
-			authServerWellKnownURI, clientId, oAuthClientEntryCompanyId);
-
-		OAuthClientEntryLocalService oAuthClientEntryLocalService =
-			Mockito.mock(OAuthClientEntryLocalService.class);
-
-		Mockito.when(
-			oAuthClientEntryLocalService.fetchOAuthClientEntry(
-				oAuthClientEntryCompanyId, authServerWellKnownURI, clientId)
-		).thenReturn(
-			oAuthClientEntry
-		);
-
-		AuthorizationServerMetadataResolver
-			authorizationServerMetadataResolver = Mockito.mock(
-				AuthorizationServerMetadataResolver.class);
-
-		Mockito.when(
-			authorizationServerMetadataResolver.resolveOIDCProviderMetadata(
-				Mockito.anyString(), Mockito.anyLong(), Mockito.anyInt(),
-				Mockito.anyLong())
-		).thenReturn(
-			_createOIDCProviderMetadata()
-		);
-
 		ConfigurationAdmin configurationAdmin = Mockito.mock(
 			ConfigurationAdmin.class);
 
@@ -102,25 +77,9 @@ public class OfflineOpenIdConnectSessionManagerTest {
 			Mockito.mock(OpenIdConnectSessionLocalService.class);
 
 		OfflineOpenIdConnectSessionManager offlineOpenIdConnectSessionManager =
-			new OfflineOpenIdConnectSessionManager();
-
-		ReflectionTestUtil.setFieldValue(
-			offlineOpenIdConnectSessionManager,
-			"_authorizationServerMetadataResolver",
-			authorizationServerMetadataResolver);
-		ReflectionTestUtil.setFieldValue(
-			offlineOpenIdConnectSessionManager, "_configurationAdmin",
-			configurationAdmin);
-		ReflectionTestUtil.setFieldValue(
-			offlineOpenIdConnectSessionManager, "_oAuthClientEntryLocalService",
-			oAuthClientEntryLocalService);
-		ReflectionTestUtil.setFieldValue(
-			offlineOpenIdConnectSessionManager,
-			"_openIdConnectSessionLocalService",
-			openIdConnectSessionLocalService);
-
-		OIDCTokens oidcTokens = new OIDCTokens(
-			RandomTestUtil.randomString(), _createAccessToken(), null);
+			_createOfflineOpenIdConnectSessionManager(
+				authServerWellKnownURI, clientId, oAuthClientEntryCompanyId,
+				configurationAdmin, openIdConnectSessionLocalService);
 
 		OpenIdConnectSession openIdConnectSession = _createOpenIdConnectSession(
 			authServerWellKnownURI, clientId, oAuthClientEntryCompanyId,
@@ -137,7 +96,8 @@ public class OfflineOpenIdConnectSessionManagerTest {
 					Mockito.any(RefreshToken.class), Mockito.anyInt(),
 					Mockito.anyString())
 			).thenReturn(
-				oidcTokens
+				new OIDCTokens(
+					RandomTestUtil.randomString(), _createAccessToken(), null)
 			);
 
 			ReflectionTestUtil.invoke(
@@ -178,51 +138,14 @@ public class OfflineOpenIdConnectSessionManagerTest {
 		String authServerWellKnownURI = RandomTestUtil.randomString();
 		String clientId = RandomTestUtil.randomString();
 
-		OAuthClientEntry oAuthClientEntry = _createOAuthClientEntry(
-			authServerWellKnownURI, clientId, companyId);
-
-		OAuthClientEntryLocalService oAuthClientEntryLocalService =
-			Mockito.mock(OAuthClientEntryLocalService.class);
-
-		Mockito.when(
-			oAuthClientEntryLocalService.fetchOAuthClientEntry(
-				companyId, authServerWellKnownURI, clientId)
-		).thenReturn(
-			oAuthClientEntry
-		);
-
-		AuthorizationServerMetadataResolver
-			authorizationServerMetadataResolver = Mockito.mock(
-				AuthorizationServerMetadataResolver.class);
-
-		Mockito.when(
-			authorizationServerMetadataResolver.resolveOIDCProviderMetadata(
-				Mockito.anyString(), Mockito.anyLong(), Mockito.anyInt(),
-				Mockito.anyLong())
-		).thenReturn(
-			_createOIDCProviderMetadata()
-		);
-
 		OpenIdConnectSessionLocalService openIdConnectSessionLocalService =
 			Mockito.mock(OpenIdConnectSessionLocalService.class);
 
 		OfflineOpenIdConnectSessionManager offlineOpenIdConnectSessionManager =
-			new OfflineOpenIdConnectSessionManager();
-
-		ReflectionTestUtil.setFieldValue(
-			offlineOpenIdConnectSessionManager,
-			"_authorizationServerMetadataResolver",
-			authorizationServerMetadataResolver);
-		ReflectionTestUtil.setFieldValue(
-			offlineOpenIdConnectSessionManager, "_configurationAdmin",
-			Mockito.mock(ConfigurationAdmin.class));
-		ReflectionTestUtil.setFieldValue(
-			offlineOpenIdConnectSessionManager, "_oAuthClientEntryLocalService",
-			oAuthClientEntryLocalService);
-		ReflectionTestUtil.setFieldValue(
-			offlineOpenIdConnectSessionManager,
-			"_openIdConnectSessionLocalService",
-			openIdConnectSessionLocalService);
+			_createOfflineOpenIdConnectSessionManager(
+				authServerWellKnownURI, clientId, companyId,
+				Mockito.mock(ConfigurationAdmin.class),
+				openIdConnectSessionLocalService);
 
 		AccessToken refreshedAccessToken = _createAccessToken();
 
@@ -242,12 +165,6 @@ public class OfflineOpenIdConnectSessionManagerTest {
 		RefreshToken refreshedRefreshToken = new RefreshToken(
 			RandomTestUtil.randomString());
 
-		OIDCTokens oidcTokens = new OIDCTokens(
-			refreshedIdTokenString, refreshedAccessToken,
-			refreshedRefreshToken);
-
-		Dictionary<String, Object> properties = new Hashtable<>();
-
 		OpenIdConnectSession openIdConnectSession = _createOpenIdConnectSession(
 			authServerWellKnownURI, clientId, companyId,
 			RandomTestUtil.randomString());
@@ -258,6 +175,8 @@ public class OfflineOpenIdConnectSessionManagerTest {
 			MockedStatic<OpenIdConnectTokenRequestUtil>
 				openIdConnectTokenRequestUtilMockedStatic = Mockito.mockStatic(
 					OpenIdConnectTokenRequestUtil.class)) {
+
+			Dictionary<String, Object> properties = new Hashtable<>();
 
 			openIdConnectProviderUtilMockedStatic.when(
 				() ->
@@ -278,7 +197,9 @@ public class OfflineOpenIdConnectSessionManagerTest {
 					Mockito.any(RefreshToken.class), Mockito.anyInt(),
 					Mockito.anyString())
 			).thenReturn(
-				oidcTokens
+				new OIDCTokens(
+					refreshedIdTokenString, refreshedAccessToken,
+					refreshedRefreshToken)
 			);
 
 			ReflectionTestUtil.invoke(
@@ -320,72 +241,23 @@ public class OfflineOpenIdConnectSessionManagerTest {
 	}
 
 	@Test
-	public void testExtendOpenIdConnectSessionWhenNoMatchingProviderConfiguration()
+	public void testExtendOpenIdConnectSessionWhenThereIsNoConfiguration()
 		throws Exception {
 
 		long companyId = RandomTestUtil.randomLong();
 		String authServerWellKnownURI = RandomTestUtil.randomString();
 		String clientId = RandomTestUtil.randomString();
 
-		OAuthClientEntry oAuthClientEntry = _createOAuthClientEntry(
-			authServerWellKnownURI, clientId, companyId);
-
-		OAuthClientEntryLocalService oAuthClientEntryLocalService =
-			Mockito.mock(OAuthClientEntryLocalService.class);
-
-		Mockito.when(
-			oAuthClientEntryLocalService.fetchOAuthClientEntry(
-				companyId, authServerWellKnownURI, clientId)
-		).thenReturn(
-			oAuthClientEntry
-		);
-
-		AuthorizationServerMetadataResolver
-			authorizationServerMetadataResolver = Mockito.mock(
-				AuthorizationServerMetadataResolver.class);
-
-		Mockito.when(
-			authorizationServerMetadataResolver.resolveOIDCProviderMetadata(
-				Mockito.anyString(), Mockito.anyLong(), Mockito.anyInt(),
-				Mockito.anyLong())
-		).thenReturn(
-			_createOIDCProviderMetadata()
-		);
-
 		OpenIdConnectSessionLocalService openIdConnectSessionLocalService =
 			Mockito.mock(OpenIdConnectSessionLocalService.class);
 
 		OfflineOpenIdConnectSessionManager offlineOpenIdConnectSessionManager =
-			new OfflineOpenIdConnectSessionManager();
-
-		ReflectionTestUtil.setFieldValue(
-			offlineOpenIdConnectSessionManager,
-			"_authorizationServerMetadataResolver",
-			authorizationServerMetadataResolver);
-		ReflectionTestUtil.setFieldValue(
-			offlineOpenIdConnectSessionManager, "_configurationAdmin",
-			Mockito.mock(ConfigurationAdmin.class));
-		ReflectionTestUtil.setFieldValue(
-			offlineOpenIdConnectSessionManager, "_oAuthClientEntryLocalService",
-			oAuthClientEntryLocalService);
-		ReflectionTestUtil.setFieldValue(
-			offlineOpenIdConnectSessionManager,
-			"_openIdConnectSessionLocalService",
-			openIdConnectSessionLocalService);
+			_createOfflineOpenIdConnectSessionManager(
+				authServerWellKnownURI, clientId, companyId,
+				Mockito.mock(ConfigurationAdmin.class),
+				openIdConnectSessionLocalService);
 
 		AccessToken refreshedAccessToken = _createAccessToken();
-
-		PlainJWT plainJWT = new PlainJWT(
-			new JWTClaimsSet.Builder(
-			).claim(
-				"sid", RandomTestUtil.randomString()
-			).issuer(
-				RandomTestUtil.randomString()
-			).build());
-
-		OIDCTokens oidcTokens = new OIDCTokens(
-			plainJWT.serialize(), refreshedAccessToken,
-			new RefreshToken(RandomTestUtil.randomString()));
 
 		OpenIdConnectSession openIdConnectSession = _createOpenIdConnectSession(
 			authServerWellKnownURI, clientId, companyId,
@@ -410,6 +282,14 @@ public class OfflineOpenIdConnectSessionManagerTest {
 				null
 			);
 
+			PlainJWT plainJWT = new PlainJWT(
+				new JWTClaimsSet.Builder(
+				).claim(
+					"sid", RandomTestUtil.randomString()
+				).issuer(
+					RandomTestUtil.randomString()
+				).build());
+
 			openIdConnectTokenRequestUtilMockedStatic.when(
 				() -> OpenIdConnectTokenRequestUtil.request(
 					Mockito.any(OIDCClientInformation.class),
@@ -417,7 +297,9 @@ public class OfflineOpenIdConnectSessionManagerTest {
 					Mockito.any(RefreshToken.class), Mockito.anyInt(),
 					Mockito.anyString())
 			).thenReturn(
-				oidcTokens
+				new OIDCTokens(
+					plainJWT.serialize(), refreshedAccessToken,
+					new RefreshToken(RandomTestUtil.randomString()))
 			);
 
 			ReflectionTestUtil.invoke(
@@ -632,6 +514,63 @@ public class OfflineOpenIdConnectSessionManagerTest {
 		);
 
 		return oAuthClientEntry;
+	}
+
+	private OfflineOpenIdConnectSessionManager
+			_createOfflineOpenIdConnectSessionManager(
+				String authServerWellKnownURI, String clientId, long companyId,
+				ConfigurationAdmin configurationAdmin,
+				OpenIdConnectSessionLocalService
+					openIdConnectSessionLocalService)
+		throws Exception {
+
+		OfflineOpenIdConnectSessionManager offlineOpenIdConnectSessionManager =
+			new OfflineOpenIdConnectSessionManager();
+
+		AuthorizationServerMetadataResolver
+			authorizationServerMetadataResolver = Mockito.mock(
+				AuthorizationServerMetadataResolver.class);
+
+		Mockito.when(
+			authorizationServerMetadataResolver.resolveOIDCProviderMetadata(
+				Mockito.anyString(), Mockito.anyLong(), Mockito.anyInt(),
+				Mockito.anyLong())
+		).thenReturn(
+			_createOIDCProviderMetadata()
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			offlineOpenIdConnectSessionManager,
+			"_authorizationServerMetadataResolver",
+			authorizationServerMetadataResolver);
+
+		ReflectionTestUtil.setFieldValue(
+			offlineOpenIdConnectSessionManager, "_configurationAdmin",
+			configurationAdmin);
+
+		OAuthClientEntryLocalService oAuthClientEntryLocalService =
+			Mockito.mock(OAuthClientEntryLocalService.class);
+
+		OAuthClientEntry oAuthClientEntry = _createOAuthClientEntry(
+			authServerWellKnownURI, clientId, companyId);
+
+		Mockito.when(
+			oAuthClientEntryLocalService.fetchOAuthClientEntry(
+				companyId, authServerWellKnownURI, clientId)
+		).thenReturn(
+			oAuthClientEntry
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			offlineOpenIdConnectSessionManager, "_oAuthClientEntryLocalService",
+			oAuthClientEntryLocalService);
+
+		ReflectionTestUtil.setFieldValue(
+			offlineOpenIdConnectSessionManager,
+			"_openIdConnectSessionLocalService",
+			openIdConnectSessionLocalService);
+
+		return offlineOpenIdConnectSessionManager;
 	}
 
 	private OIDCProviderMetadata _createOIDCProviderMetadata()

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/session/manager/OfflineOpenIdConnectSessionManagerTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/session/manager/OfflineOpenIdConnectSessionManagerTest.java
@@ -81,6 +81,8 @@ public class OfflineOpenIdConnectSessionManagerTest {
 				authServerWellKnownURI, clientId, oAuthClientEntryCompanyId,
 				configurationAdmin, openIdConnectSessionLocalService);
 
+		AccessToken accessToken = _createAccessToken();
+
 		OpenIdConnectSession openIdConnectSession = _createOpenIdConnectSession(
 			authServerWellKnownURI, clientId, oAuthClientEntryCompanyId,
 			RandomTestUtil.randomString());
@@ -96,8 +98,7 @@ public class OfflineOpenIdConnectSessionManagerTest {
 					Mockito.any(RefreshToken.class), Mockito.anyInt(),
 					Mockito.anyString())
 			).thenReturn(
-				new OIDCTokens(
-					RandomTestUtil.randomString(), _createAccessToken(), null)
+				new OIDCTokens(RandomTestUtil.randomString(), accessToken, null)
 			);
 
 			ReflectionTestUtil.invoke(
@@ -105,6 +106,21 @@ public class OfflineOpenIdConnectSessionManagerTest {
 				"_extendOpenIdConnectSession",
 				new Class<?>[] {OpenIdConnectSession.class},
 				openIdConnectSession);
+
+			ArgumentCaptor<Integer> tokenConnectionTimeoutArgumentCaptor =
+				ArgumentCaptor.forClass(Integer.class);
+
+			openIdConnectTokenRequestUtilMockedStatic.verify(
+				() -> OpenIdConnectTokenRequestUtil.request(
+					Mockito.any(OIDCClientInformation.class),
+					Mockito.any(OIDCProviderMetadata.class),
+					Mockito.any(RefreshToken.class),
+					tokenConnectionTimeoutArgumentCaptor.capture(),
+					Mockito.anyString()));
+
+			Assert.assertEquals(
+				Integer.valueOf(0),
+				tokenConnectionTimeoutArgumentCaptor.getValue());
 		}
 
 		ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(
@@ -122,6 +138,12 @@ public class OfflineOpenIdConnectSessionManagerTest {
 		Assert.assertTrue(
 			filterString.contains(
 				"(companyId=" + oAuthClientEntryCompanyId + ")"));
+
+		Mockito.verify(
+			openIdConnectSession
+		).setAccessToken(
+			accessToken.toJSONString()
+		);
 
 		Mockito.verify(
 			openIdConnectSessionLocalService, Mockito.never()
@@ -237,103 +259,6 @@ public class OfflineOpenIdConnectSessionManagerTest {
 			openIdConnectSession
 		).setSessionId(
 			refreshedSessionId
-		);
-	}
-
-	@Test
-	public void testExtendOpenIdConnectSessionWhenThereIsNoConfiguration()
-		throws Exception {
-
-		long companyId = RandomTestUtil.randomLong();
-		String authServerWellKnownURI = RandomTestUtil.randomString();
-		String clientId = RandomTestUtil.randomString();
-
-		OpenIdConnectSessionLocalService openIdConnectSessionLocalService =
-			Mockito.mock(OpenIdConnectSessionLocalService.class);
-
-		OfflineOpenIdConnectSessionManager offlineOpenIdConnectSessionManager =
-			_createOfflineOpenIdConnectSessionManager(
-				authServerWellKnownURI, clientId, companyId,
-				Mockito.mock(ConfigurationAdmin.class),
-				openIdConnectSessionLocalService);
-
-		AccessToken refreshedAccessToken = _createAccessToken();
-
-		OpenIdConnectSession openIdConnectSession = _createOpenIdConnectSession(
-			authServerWellKnownURI, clientId, companyId,
-			RandomTestUtil.randomString());
-
-		try (MockedStatic<OpenIdConnectProviderUtil>
-				openIdConnectProviderUtilMockedStatic = Mockito.mockStatic(
-					OpenIdConnectProviderUtil.class);
-			MockedStatic<OpenIdConnectTokenRequestUtil>
-				openIdConnectTokenRequestUtilMockedStatic = Mockito.mockStatic(
-					OpenIdConnectTokenRequestUtil.class)) {
-
-			openIdConnectProviderUtilMockedStatic.when(
-				() ->
-					OpenIdConnectProviderUtil.
-						getOpenIdConnectProviderConfigurationProperties(
-							Mockito.anyString(), Mockito.anyString(),
-							Mockito.anyLong(),
-							Mockito.any(ConfigurationAdmin.class),
-							Mockito.anyString(), Mockito.anyString())
-			).thenReturn(
-				null
-			);
-
-			PlainJWT plainJWT = new PlainJWT(
-				new JWTClaimsSet.Builder(
-				).claim(
-					"sid", RandomTestUtil.randomString()
-				).issuer(
-					RandomTestUtil.randomString()
-				).build());
-
-			openIdConnectTokenRequestUtilMockedStatic.when(
-				() -> OpenIdConnectTokenRequestUtil.request(
-					Mockito.any(OIDCClientInformation.class),
-					Mockito.any(OIDCProviderMetadata.class),
-					Mockito.any(RefreshToken.class), Mockito.anyInt(),
-					Mockito.anyString())
-			).thenReturn(
-				new OIDCTokens(
-					plainJWT.serialize(), refreshedAccessToken,
-					new RefreshToken(RandomTestUtil.randomString()))
-			);
-
-			ReflectionTestUtil.invoke(
-				offlineOpenIdConnectSessionManager,
-				"_extendOpenIdConnectSession",
-				new Class<?>[] {OpenIdConnectSession.class},
-				openIdConnectSession);
-
-			ArgumentCaptor<Integer> tokenConnectionTimeoutArgumentCaptor =
-				ArgumentCaptor.forClass(Integer.class);
-
-			openIdConnectTokenRequestUtilMockedStatic.verify(
-				() -> OpenIdConnectTokenRequestUtil.request(
-					Mockito.any(OIDCClientInformation.class),
-					Mockito.any(OIDCProviderMetadata.class),
-					Mockito.any(RefreshToken.class),
-					tokenConnectionTimeoutArgumentCaptor.capture(),
-					Mockito.anyString()));
-
-			Assert.assertEquals(
-				Integer.valueOf(0),
-				tokenConnectionTimeoutArgumentCaptor.getValue());
-		}
-
-		Mockito.verify(
-			openIdConnectSession
-		).setAccessToken(
-			refreshedAccessToken.toJSONString()
-		);
-
-		Mockito.verify(
-			openIdConnectSessionLocalService, Mockito.never()
-		).deleteOpenIdConnectSession(
-			openIdConnectSession
 		);
 	}
 

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/session/manager/OfflineOpenIdConnectSessionManagerTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/session/manager/OfflineOpenIdConnectSessionManagerTest.java
@@ -121,9 +121,21 @@ public class OfflineOpenIdConnectSessionManagerTest {
 		);
 
 		Mockito.when(
+			oAuthClientEntry.getInfoJSON()
+		).thenReturn(
+			"{\"client_id\": \"test-client\"}"
+		);
+
+		Mockito.when(
 			oAuthClientEntry.getMetadataCacheInSeconds()
 		).thenReturn(
 			3600
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getTokenRequestParametersJSON()
+		).thenReturn(
+			"{}"
 		);
 
 		OAuthClientEntryLocalService oAuthClientEntryLocalService =
@@ -186,9 +198,40 @@ public class OfflineOpenIdConnectSessionManagerTest {
 			"_openIdConnectSessionLocalService",
 			openIdConnectSessionLocalService);
 
-		ReflectionTestUtil.invoke(
-			offlineOpenIdConnectSessionManager, "_extendOpenIdConnectSession",
-			new Class<?>[] {OpenIdConnectSession.class}, openIdConnectSession);
+		OIDCTokens oidcTokens = new OIDCTokens(
+			RandomTestUtil.randomString(),
+			new AccessToken(
+				new AccessTokenType("Bearer"), RandomTestUtil.randomString(),
+				60, new Scope("openid")) {
+
+				@Override
+				public String toAuthorizationHeader() {
+					return null;
+				}
+
+			},
+			null);
+
+		try (MockedStatic<OpenIdConnectTokenRequestUtil>
+				openIdConnectTokenRequestUtilMockedStatic = Mockito.mockStatic(
+					OpenIdConnectTokenRequestUtil.class)) {
+
+			openIdConnectTokenRequestUtilMockedStatic.when(
+				() -> OpenIdConnectTokenRequestUtil.request(
+					Mockito.any(OIDCClientInformation.class),
+					Mockito.any(OIDCProviderMetadata.class),
+					Mockito.any(RefreshToken.class), Mockito.anyInt(),
+					Mockito.anyString())
+			).thenReturn(
+				oidcTokens
+			);
+
+			ReflectionTestUtil.invoke(
+				offlineOpenIdConnectSessionManager,
+				"_extendOpenIdConnectSession",
+				new Class<?>[] {OpenIdConnectSession.class},
+				openIdConnectSession);
+		}
 
 		ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(
 			String.class);
@@ -205,6 +248,12 @@ public class OfflineOpenIdConnectSessionManagerTest {
 		Assert.assertTrue(
 			filterString.contains(
 				"(companyId=" + oAuthClientEntryCompanyId + ")"));
+
+		Mockito.verify(
+			openIdConnectSessionLocalService, Mockito.never()
+		).deleteOpenIdConnectSession(
+			openIdConnectSession
+		);
 	}
 
 	@Test
@@ -437,6 +486,226 @@ public class OfflineOpenIdConnectSessionManagerTest {
 			openIdConnectSession
 		).setSessionId(
 			refreshedSessionId
+		);
+	}
+
+	@Test
+	public void testExtendOpenIdConnectSessionWhenNoMatchingProviderConfiguration()
+		throws Exception {
+
+		OpenIdConnectSession openIdConnectSession = Mockito.mock(
+			OpenIdConnectSession.class);
+
+		long companyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			openIdConnectSession.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		String authServerWellKnownURI = RandomTestUtil.randomString();
+
+		Mockito.when(
+			openIdConnectSession.getAuthServerWellKnownURI()
+		).thenReturn(
+			authServerWellKnownURI
+		);
+
+		String clientId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			openIdConnectSession.getClientId()
+		).thenReturn(
+			clientId
+		);
+
+		Mockito.when(
+			openIdConnectSession.getRefreshToken()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		OAuthClientEntry oAuthClientEntry = Mockito.mock(
+			OAuthClientEntry.class);
+
+		Mockito.when(
+			oAuthClientEntry.getOAuthClientEntryId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getAuthServerWellKnownURI()
+		).thenReturn(
+			authServerWellKnownURI
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getClientId()
+		).thenReturn(
+			clientId
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getInfoJSON()
+		).thenReturn(
+			"{\"client_id\": \"test-client\"}"
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getMetadataCacheInSeconds()
+		).thenReturn(
+			3600
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getTokenRequestParametersJSON()
+		).thenReturn(
+			"{}"
+		);
+
+		OAuthClientEntryLocalService oAuthClientEntryLocalService =
+			Mockito.mock(OAuthClientEntryLocalService.class);
+
+		Mockito.when(
+			oAuthClientEntryLocalService.fetchOAuthClientEntry(
+				companyId, authServerWellKnownURI, clientId)
+		).thenReturn(
+			oAuthClientEntry
+		);
+
+		OIDCProviderMetadata oidcProviderMetadata = new OIDCProviderMetadata(
+			new Issuer(RandomTestUtil.randomString()),
+			List.of(SubjectType.PUBLIC),
+			new URI(RandomTestUtil.randomString()));
+
+		oidcProviderMetadata.setTokenEndpointURI(
+			new URI(RandomTestUtil.randomString()));
+
+		AuthorizationServerMetadataResolver
+			authorizationServerMetadataResolver = Mockito.mock(
+				AuthorizationServerMetadataResolver.class);
+
+		Mockito.when(
+			authorizationServerMetadataResolver.resolveOIDCProviderMetadata(
+				Mockito.anyString(), Mockito.anyLong(), Mockito.anyInt(),
+				Mockito.anyLong())
+		).thenReturn(
+			oidcProviderMetadata
+		);
+
+		OpenIdConnectSessionLocalService openIdConnectSessionLocalService =
+			Mockito.mock(OpenIdConnectSessionLocalService.class);
+
+		OfflineOpenIdConnectSessionManager offlineOpenIdConnectSessionManager =
+			new OfflineOpenIdConnectSessionManager();
+
+		ReflectionTestUtil.setFieldValue(
+			offlineOpenIdConnectSessionManager,
+			"_authorizationServerMetadataResolver",
+			authorizationServerMetadataResolver);
+		ReflectionTestUtil.setFieldValue(
+			offlineOpenIdConnectSessionManager, "_configurationAdmin",
+			Mockito.mock(ConfigurationAdmin.class));
+		ReflectionTestUtil.setFieldValue(
+			offlineOpenIdConnectSessionManager, "_oAuthClientEntryLocalService",
+			oAuthClientEntryLocalService);
+		ReflectionTestUtil.setFieldValue(
+			offlineOpenIdConnectSessionManager,
+			"_openIdConnectSessionLocalService",
+			openIdConnectSessionLocalService);
+
+		AccessToken refreshedAccessToken = new AccessToken(
+			new AccessTokenType("Bearer"), RandomTestUtil.randomString(), 60,
+			new Scope("openid")) {
+
+			@Override
+			public String toAuthorizationHeader() {
+				return null;
+			}
+
+		};
+
+		PlainJWT plainJWT = new PlainJWT(
+			new JWTClaimsSet.Builder(
+			).claim(
+				"sid", RandomTestUtil.randomString()
+			).issuer(
+				RandomTestUtil.randomString()
+			).build());
+
+		OIDCTokens oidcTokens = new OIDCTokens(
+			plainJWT.serialize(), refreshedAccessToken,
+			new RefreshToken(RandomTestUtil.randomString()));
+
+		try (MockedStatic<OpenIdConnectProviderUtil>
+				openIdConnectProviderUtilMockedStatic = Mockito.mockStatic(
+					OpenIdConnectProviderUtil.class);
+			MockedStatic<OpenIdConnectTokenRequestUtil>
+				openIdConnectTokenRequestUtilMockedStatic = Mockito.mockStatic(
+					OpenIdConnectTokenRequestUtil.class)) {
+
+			openIdConnectProviderUtilMockedStatic.when(
+				() ->
+					OpenIdConnectProviderUtil.
+						getOpenIdConnectProviderConfigurationProperties(
+							Mockito.anyString(), Mockito.anyString(),
+							Mockito.anyLong(),
+							Mockito.any(ConfigurationAdmin.class),
+							Mockito.anyString(), Mockito.anyString())
+			).thenReturn(
+				null
+			);
+
+			openIdConnectTokenRequestUtilMockedStatic.when(
+				() -> OpenIdConnectTokenRequestUtil.request(
+					Mockito.any(OIDCClientInformation.class),
+					Mockito.any(OIDCProviderMetadata.class),
+					Mockito.any(RefreshToken.class), Mockito.anyInt(),
+					Mockito.anyString())
+			).thenReturn(
+				oidcTokens
+			);
+
+			ReflectionTestUtil.invoke(
+				offlineOpenIdConnectSessionManager,
+				"_extendOpenIdConnectSession",
+				new Class<?>[] {OpenIdConnectSession.class},
+				openIdConnectSession);
+
+			ArgumentCaptor<Integer> tokenConnectionTimeoutArgumentCaptor =
+				ArgumentCaptor.forClass(Integer.class);
+
+			openIdConnectTokenRequestUtilMockedStatic.verify(
+				() -> OpenIdConnectTokenRequestUtil.request(
+					Mockito.any(OIDCClientInformation.class),
+					Mockito.any(OIDCProviderMetadata.class),
+					Mockito.any(RefreshToken.class),
+					tokenConnectionTimeoutArgumentCaptor.capture(),
+					Mockito.anyString()));
+
+			Assert.assertEquals(
+				Integer.valueOf(0),
+				tokenConnectionTimeoutArgumentCaptor.getValue());
+		}
+
+		Mockito.verify(
+			openIdConnectSession
+		).setAccessToken(
+			refreshedAccessToken.toJSONString()
+		);
+
+		Mockito.verify(
+			openIdConnectSessionLocalService, Mockito.never()
+		).deleteOpenIdConnectSession(
+			openIdConnectSession
 		);
 	}
 

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/session/manager/OfflineOpenIdConnectSessionManagerTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/session/manager/OfflineOpenIdConnectSessionManagerTest.java
@@ -60,83 +60,12 @@ public class OfflineOpenIdConnectSessionManagerTest {
 	public void testExtendOpenIdConnectSession() throws Exception {
 		Assert.assertEquals(Long.valueOf(0), CompanyThreadLocal.getCompanyId());
 
-		OpenIdConnectSession openIdConnectSession = Mockito.mock(
-			OpenIdConnectSession.class);
-
 		long oAuthClientEntryCompanyId = RandomTestUtil.randomLong();
-
-		Mockito.when(
-			openIdConnectSession.getCompanyId()
-		).thenReturn(
-			oAuthClientEntryCompanyId
-		);
-
 		String authServerWellKnownURI = RandomTestUtil.randomString();
-
-		Mockito.when(
-			openIdConnectSession.getAuthServerWellKnownURI()
-		).thenReturn(
-			authServerWellKnownURI
-		);
-
 		String clientId = RandomTestUtil.randomString();
 
-		Mockito.when(
-			openIdConnectSession.getClientId()
-		).thenReturn(
-			clientId
-		);
-
-		Mockito.when(
-			openIdConnectSession.getRefreshToken()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
-
-		OAuthClientEntry oAuthClientEntry = Mockito.mock(
-			OAuthClientEntry.class);
-
-		Mockito.when(
-			oAuthClientEntry.getOAuthClientEntryId()
-		).thenReturn(
-			RandomTestUtil.randomLong()
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getCompanyId()
-		).thenReturn(
-			oAuthClientEntryCompanyId
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getAuthServerWellKnownURI()
-		).thenReturn(
-			authServerWellKnownURI
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getClientId()
-		).thenReturn(
-			clientId
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getInfoJSON()
-		).thenReturn(
-			"{\"client_id\": \"test-client\"}"
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getMetadataCacheInSeconds()
-		).thenReturn(
-			3600
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getTokenRequestParametersJSON()
-		).thenReturn(
-			"{}"
-		);
+		OAuthClientEntry oAuthClientEntry = _createOAuthClientEntry(
+			authServerWellKnownURI, clientId, oAuthClientEntryCompanyId);
 
 		OAuthClientEntryLocalService oAuthClientEntryLocalService =
 			Mockito.mock(OAuthClientEntryLocalService.class);
@@ -148,14 +77,6 @@ public class OfflineOpenIdConnectSessionManagerTest {
 			oAuthClientEntry
 		);
 
-		OIDCProviderMetadata oidcProviderMetadata = new OIDCProviderMetadata(
-			new Issuer(RandomTestUtil.randomString()),
-			List.of(SubjectType.PUBLIC),
-			new URI(RandomTestUtil.randomString()));
-
-		oidcProviderMetadata.setTokenEndpointURI(
-			new URI(RandomTestUtil.randomString()));
-
 		AuthorizationServerMetadataResolver
 			authorizationServerMetadataResolver = Mockito.mock(
 				AuthorizationServerMetadataResolver.class);
@@ -165,7 +86,7 @@ public class OfflineOpenIdConnectSessionManagerTest {
 				Mockito.anyString(), Mockito.anyLong(), Mockito.anyInt(),
 				Mockito.anyLong())
 		).thenReturn(
-			oidcProviderMetadata
+			_createOIDCProviderMetadata()
 		);
 
 		ConfigurationAdmin configurationAdmin = Mockito.mock(
@@ -199,18 +120,11 @@ public class OfflineOpenIdConnectSessionManagerTest {
 			openIdConnectSessionLocalService);
 
 		OIDCTokens oidcTokens = new OIDCTokens(
-			RandomTestUtil.randomString(),
-			new AccessToken(
-				new AccessTokenType("Bearer"), RandomTestUtil.randomString(),
-				60, new Scope("openid")) {
+			RandomTestUtil.randomString(), _createAccessToken(), null);
 
-				@Override
-				public String toAuthorizationHeader() {
-					return null;
-				}
-
-			},
-			null);
+		OpenIdConnectSession openIdConnectSession = _createOpenIdConnectSession(
+			authServerWellKnownURI, clientId, oAuthClientEntryCompanyId,
+			RandomTestUtil.randomString());
 
 		try (MockedStatic<OpenIdConnectTokenRequestUtil>
 				openIdConnectTokenRequestUtilMockedStatic = Mockito.mockStatic(
@@ -260,83 +174,12 @@ public class OfflineOpenIdConnectSessionManagerTest {
 	public void testExtendOpenIdConnectSessionRefreshesIdToken()
 		throws Exception {
 
-		OpenIdConnectSession openIdConnectSession = Mockito.mock(
-			OpenIdConnectSession.class);
-
 		long companyId = RandomTestUtil.randomLong();
-
-		Mockito.when(
-			openIdConnectSession.getCompanyId()
-		).thenReturn(
-			companyId
-		);
-
 		String authServerWellKnownURI = RandomTestUtil.randomString();
-
-		Mockito.when(
-			openIdConnectSession.getAuthServerWellKnownURI()
-		).thenReturn(
-			authServerWellKnownURI
-		);
-
 		String clientId = RandomTestUtil.randomString();
 
-		Mockito.when(
-			openIdConnectSession.getClientId()
-		).thenReturn(
-			clientId
-		);
-
-		Mockito.when(
-			openIdConnectSession.getRefreshToken()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
-
-		OAuthClientEntry oAuthClientEntry = Mockito.mock(
-			OAuthClientEntry.class);
-
-		Mockito.when(
-			oAuthClientEntry.getOAuthClientEntryId()
-		).thenReturn(
-			RandomTestUtil.randomLong()
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getCompanyId()
-		).thenReturn(
-			companyId
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getAuthServerWellKnownURI()
-		).thenReturn(
-			authServerWellKnownURI
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getClientId()
-		).thenReturn(
-			clientId
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getInfoJSON()
-		).thenReturn(
-			"{\"client_id\": \"test-client\"}"
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getMetadataCacheInSeconds()
-		).thenReturn(
-			3600
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getTokenRequestParametersJSON()
-		).thenReturn(
-			"{}"
-		);
+		OAuthClientEntry oAuthClientEntry = _createOAuthClientEntry(
+			authServerWellKnownURI, clientId, companyId);
 
 		OAuthClientEntryLocalService oAuthClientEntryLocalService =
 			Mockito.mock(OAuthClientEntryLocalService.class);
@@ -348,14 +191,6 @@ public class OfflineOpenIdConnectSessionManagerTest {
 			oAuthClientEntry
 		);
 
-		OIDCProviderMetadata oidcProviderMetadata = new OIDCProviderMetadata(
-			new Issuer(RandomTestUtil.randomString()),
-			List.of(SubjectType.PUBLIC),
-			new URI(RandomTestUtil.randomString()));
-
-		oidcProviderMetadata.setTokenEndpointURI(
-			new URI(RandomTestUtil.randomString()));
-
 		AuthorizationServerMetadataResolver
 			authorizationServerMetadataResolver = Mockito.mock(
 				AuthorizationServerMetadataResolver.class);
@@ -365,7 +200,7 @@ public class OfflineOpenIdConnectSessionManagerTest {
 				Mockito.anyString(), Mockito.anyLong(), Mockito.anyInt(),
 				Mockito.anyLong())
 		).thenReturn(
-			oidcProviderMetadata
+			_createOIDCProviderMetadata()
 		);
 
 		OpenIdConnectSessionLocalService openIdConnectSessionLocalService =
@@ -389,16 +224,7 @@ public class OfflineOpenIdConnectSessionManagerTest {
 			"_openIdConnectSessionLocalService",
 			openIdConnectSessionLocalService);
 
-		AccessToken refreshedAccessToken = new AccessToken(
-			new AccessTokenType("Bearer"), RandomTestUtil.randomString(), 60,
-			new Scope("openid")) {
-
-			@Override
-			public String toAuthorizationHeader() {
-				return null;
-			}
-
-		};
+		AccessToken refreshedAccessToken = _createAccessToken();
 
 		String refreshedIssuer = RandomTestUtil.randomString();
 		String refreshedSessionId = RandomTestUtil.randomString();
@@ -421,6 +247,10 @@ public class OfflineOpenIdConnectSessionManagerTest {
 			refreshedRefreshToken);
 
 		Dictionary<String, Object> properties = new Hashtable<>();
+
+		OpenIdConnectSession openIdConnectSession = _createOpenIdConnectSession(
+			authServerWellKnownURI, clientId, companyId,
+			RandomTestUtil.randomString());
 
 		try (MockedStatic<OpenIdConnectProviderUtil>
 				openIdConnectProviderUtilMockedStatic = Mockito.mockStatic(
@@ -493,83 +323,12 @@ public class OfflineOpenIdConnectSessionManagerTest {
 	public void testExtendOpenIdConnectSessionWhenNoMatchingProviderConfiguration()
 		throws Exception {
 
-		OpenIdConnectSession openIdConnectSession = Mockito.mock(
-			OpenIdConnectSession.class);
-
 		long companyId = RandomTestUtil.randomLong();
-
-		Mockito.when(
-			openIdConnectSession.getCompanyId()
-		).thenReturn(
-			companyId
-		);
-
 		String authServerWellKnownURI = RandomTestUtil.randomString();
-
-		Mockito.when(
-			openIdConnectSession.getAuthServerWellKnownURI()
-		).thenReturn(
-			authServerWellKnownURI
-		);
-
 		String clientId = RandomTestUtil.randomString();
 
-		Mockito.when(
-			openIdConnectSession.getClientId()
-		).thenReturn(
-			clientId
-		);
-
-		Mockito.when(
-			openIdConnectSession.getRefreshToken()
-		).thenReturn(
-			RandomTestUtil.randomString()
-		);
-
-		OAuthClientEntry oAuthClientEntry = Mockito.mock(
-			OAuthClientEntry.class);
-
-		Mockito.when(
-			oAuthClientEntry.getOAuthClientEntryId()
-		).thenReturn(
-			RandomTestUtil.randomLong()
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getCompanyId()
-		).thenReturn(
-			companyId
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getAuthServerWellKnownURI()
-		).thenReturn(
-			authServerWellKnownURI
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getClientId()
-		).thenReturn(
-			clientId
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getInfoJSON()
-		).thenReturn(
-			"{\"client_id\": \"test-client\"}"
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getMetadataCacheInSeconds()
-		).thenReturn(
-			3600
-		);
-
-		Mockito.when(
-			oAuthClientEntry.getTokenRequestParametersJSON()
-		).thenReturn(
-			"{}"
-		);
+		OAuthClientEntry oAuthClientEntry = _createOAuthClientEntry(
+			authServerWellKnownURI, clientId, companyId);
 
 		OAuthClientEntryLocalService oAuthClientEntryLocalService =
 			Mockito.mock(OAuthClientEntryLocalService.class);
@@ -581,14 +340,6 @@ public class OfflineOpenIdConnectSessionManagerTest {
 			oAuthClientEntry
 		);
 
-		OIDCProviderMetadata oidcProviderMetadata = new OIDCProviderMetadata(
-			new Issuer(RandomTestUtil.randomString()),
-			List.of(SubjectType.PUBLIC),
-			new URI(RandomTestUtil.randomString()));
-
-		oidcProviderMetadata.setTokenEndpointURI(
-			new URI(RandomTestUtil.randomString()));
-
 		AuthorizationServerMetadataResolver
 			authorizationServerMetadataResolver = Mockito.mock(
 				AuthorizationServerMetadataResolver.class);
@@ -598,7 +349,7 @@ public class OfflineOpenIdConnectSessionManagerTest {
 				Mockito.anyString(), Mockito.anyLong(), Mockito.anyInt(),
 				Mockito.anyLong())
 		).thenReturn(
-			oidcProviderMetadata
+			_createOIDCProviderMetadata()
 		);
 
 		OpenIdConnectSessionLocalService openIdConnectSessionLocalService =
@@ -622,16 +373,7 @@ public class OfflineOpenIdConnectSessionManagerTest {
 			"_openIdConnectSessionLocalService",
 			openIdConnectSessionLocalService);
 
-		AccessToken refreshedAccessToken = new AccessToken(
-			new AccessTokenType("Bearer"), RandomTestUtil.randomString(), 60,
-			new Scope("openid")) {
-
-			@Override
-			public String toAuthorizationHeader() {
-				return null;
-			}
-
-		};
+		AccessToken refreshedAccessToken = _createAccessToken();
 
 		PlainJWT plainJWT = new PlainJWT(
 			new JWTClaimsSet.Builder(
@@ -644,6 +386,10 @@ public class OfflineOpenIdConnectSessionManagerTest {
 		OIDCTokens oidcTokens = new OIDCTokens(
 			plainJWT.serialize(), refreshedAccessToken,
 			new RefreshToken(RandomTestUtil.randomString()));
+
+		OpenIdConnectSession openIdConnectSession = _createOpenIdConnectSession(
+			authServerWellKnownURI, clientId, companyId,
+			RandomTestUtil.randomString());
 
 		try (MockedStatic<OpenIdConnectProviderUtil>
 				openIdConnectProviderUtilMockedStatic = Mockito.mockStatic(
@@ -822,6 +568,118 @@ public class OfflineOpenIdConnectSessionManagerTest {
 			openIdConnectSession);
 
 		Mockito.verifyNoInteractions(openIdConnectSession);
+	}
+
+	private AccessToken _createAccessToken() {
+		return new AccessToken(
+			new AccessTokenType("Bearer"), RandomTestUtil.randomString(), 60,
+			new Scope("openid")) {
+
+			@Override
+			public String toAuthorizationHeader() {
+				return null;
+			}
+
+		};
+	}
+
+	private OAuthClientEntry _createOAuthClientEntry(
+		String authServerWellKnownURI, String clientId, long companyId) {
+
+		OAuthClientEntry oAuthClientEntry = Mockito.mock(
+			OAuthClientEntry.class);
+
+		Mockito.when(
+			oAuthClientEntry.getAuthServerWellKnownURI()
+		).thenReturn(
+			authServerWellKnownURI
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getClientId()
+		).thenReturn(
+			clientId
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getInfoJSON()
+		).thenReturn(
+			"{\"client_id\": \"test-client\"}"
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getMetadataCacheInSeconds()
+		).thenReturn(
+			3600
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getOAuthClientEntryId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			oAuthClientEntry.getTokenRequestParametersJSON()
+		).thenReturn(
+			"{}"
+		);
+
+		return oAuthClientEntry;
+	}
+
+	private OIDCProviderMetadata _createOIDCProviderMetadata()
+		throws Exception {
+
+		OIDCProviderMetadata oidcProviderMetadata = new OIDCProviderMetadata(
+			new Issuer(RandomTestUtil.randomString()),
+			List.of(SubjectType.PUBLIC),
+			new URI(RandomTestUtil.randomString()));
+
+		oidcProviderMetadata.setTokenEndpointURI(
+			new URI(RandomTestUtil.randomString()));
+
+		return oidcProviderMetadata;
+	}
+
+	private OpenIdConnectSession _createOpenIdConnectSession(
+		String authServerWellKnownURI, String clientId, long companyId,
+		String refreshToken) {
+
+		OpenIdConnectSession openIdConnectSession = Mockito.mock(
+			OpenIdConnectSession.class);
+
+		Mockito.when(
+			openIdConnectSession.getAuthServerWellKnownURI()
+		).thenReturn(
+			authServerWellKnownURI
+		);
+
+		Mockito.when(
+			openIdConnectSession.getClientId()
+		).thenReturn(
+			clientId
+		);
+
+		Mockito.when(
+			openIdConnectSession.getCompanyId()
+		).thenReturn(
+			companyId
+		);
+
+		Mockito.when(
+			openIdConnectSession.getRefreshToken()
+		).thenReturn(
+			refreshToken
+		);
+
+		return openIdConnectSession;
 	}
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90466

## What is being fixed

`OfflineOpenIdConnectSessionManager._extendOpenIdConnectSession` (the scheduler-driven OIDC token refresh) dereferenced the result of `OpenIdConnectProviderUtil.getOpenIdConnectProviderConfigurationProperties(...)` without a null check. The helper legitimately returns `null` when no `OpenIdConnectProviderConfiguration` matches the `OAuthClientEntry`'s `(companyId, discoveryEndpoint, clientId)` tuple — which is normal for entries created via Control Panel → Configuration → OAuth Client Admin (or the `oauthclient.oauthcliententry` JSONWS endpoint) instead of via System Settings → SSO → OpenID Connect Provider.

The resulting NPE was swallowed by the surrounding `catch (Exception)`, which then deleted the `OpenIdConnectSession` row. `OpenIdConnectSessionValidationFilter` invalidated the HTTP session on the next request, so the user was effectively logged out every scheduler tick (~5 min). LPD-79176 introduced the `tokenConnectionTimeout` lookup in 2025.q4.12; before that, the scheduler did not consult `ConfigurationAdmin` and a missing OSGi config was harmless.

## How it is being fixed

Mirror the null-guard the interactive auth path already has at `OpenIdConnectAuthenticationHandlerImpl.java:141-156`: extract `tokenConnectionTimeout` into a local defaulted to `0`, and only read `properties.get("tokenConnectionTimeout")` when `properties != null`. When no OSGi config matches, the request falls back to the default (matching pre-LPD-79176 behavior and the interactive path).

Two regression tests cover the path. The existing `testExtendOpenIdConnectSession` is extended with a `Mockito.verify(..., never()).deleteOpenIdConnectSession(...)` assertion plus the `getInfoJSON`/`getTokenRequestParametersJSON` mocks and a `MockedStatic<OpenIdConnectTokenRequestUtil>` so the call chain reaches the assertion. A new `testExtendOpenIdConnectSessionWhenNoMatchingProviderConfiguration` covers the happy path end-to-end and verifies that `tokenConnectionTimeout == 0` reaches `OpenIdConnectTokenRequestUtil.request(...)` and that the refreshed access token is written back. Both fail on master without the production fix and pass with it.