### PR TITLE
LPD-89898 Account-Scoped Log Management

### DIFF
--- a/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
+++ b/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/dto/v1_0/converter/ObjectEntryDTOConverter.java
@@ -911,7 +911,7 @@ public class ObjectEntryDTOConverter
 
 				return TransformUtil.transformToArray(
 					_auditEventLocalService.getAuditEvents(
-						0, 0, 0, null, null, null, null, null,
+						0, null, 0, 0, null, null, null, null, null,
 						String.valueOf(objectEntry.getObjectEntryId()), null,
 						null, null, 0, null, false, QueryUtil.ALL_POS,
 						QueryUtil.ALL_POS),

--- a/modules/apps/portal-security-audit/portal-security-audit-api/src/main/java/com/liferay/portal/security/audit/AuditEvent.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-api/src/main/java/com/liferay/portal/security/audit/AuditEvent.java
@@ -16,6 +16,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface AuditEvent {
 
+	public long getAccountEntryId();
+
 	public String getAdditionalInfo();
 
 	public long getAuditEventId();
@@ -51,6 +53,8 @@ public interface AuditEvent {
 	public String getUserName();
 
 	public String getUserUuid();
+
+	public void setAccountEntryId(long accountEntryId);
 
 	public void setAdditionalInfo(String additionalInfo);
 

--- a/modules/apps/portal-security-audit/portal-security-audit-api/src/main/java/com/liferay/portal/security/audit/AuditEventManager.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-api/src/main/java/com/liferay/portal/security/audit/AuditEventManager.java
@@ -33,8 +33,8 @@ public interface AuditEventManager {
 				orderByComparator);
 
 	public List<AuditEvent> getAuditEvents(
-		long companyId, long groupId, long userId, String userName,
-		Date createDateGT, Date createDateLT, String eventType,
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, Date createDateGT, Date createDateLT, String eventType,
 		String className, String classPK, String clientHost, String clientIP,
 		String serverName, int serverPort, String sessionID, boolean andSearch,
 		int start, int end,
@@ -45,8 +45,8 @@ public interface AuditEventManager {
 	public int getAuditEventsCount(long companyId);
 
 	public int getAuditEventsCount(
-		long companyId, long groupId, long userId, String userName,
-		Date createDateGT, Date createDateLT, String eventType,
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, Date createDateGT, Date createDateLT, String eventType,
 		String className, String classPK, String clientHost, String clientIP,
 		String serverName, int serverPort, String sessionID, boolean andSearch);
 

--- a/modules/apps/portal-security-audit/portal-security-audit-api/src/main/resources/com/liferay/portal/security/audit/packageinfo
+++ b/modules/apps/portal-security-audit/portal-security-audit-api/src/main/resources/com/liferay/portal/security/audit/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 5.0.0

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/java/com/liferay/portal/security/audit/event/generators/util/AuditMessageBuilder.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-api/src/main/java/com/liferay/portal/security/audit/event/generators/util/AuditMessageBuilder.java
@@ -28,16 +28,17 @@ import java.util.List;
 public class AuditMessageBuilder {
 
 	public static AuditMessage buildAuditMessage(
-		long groupId, String eventType, String className, long classPK,
-		List<Attribute> attributes) {
+		long accountEntryId, long groupId, String eventType, String className,
+		long classPK, List<Attribute> attributes) {
 
 		return buildAuditMessage(
-			groupId, eventType, className, String.valueOf(classPK), attributes);
+			accountEntryId, groupId, eventType, className,
+			String.valueOf(classPK), attributes);
 	}
 
 	public static AuditMessage buildAuditMessage(
-		long groupId, String eventType, String className, String classPK,
-		List<Attribute> attributes) {
+		long accountEntryId, long groupId, String eventType, String className,
+		String classPK, List<Attribute> attributes) {
 
 		long companyId = CompanyThreadLocal.getCompanyId();
 
@@ -73,9 +74,32 @@ public class AuditMessageBuilder {
 				"attributes", _getAttributesJSONArray(attributes));
 		}
 
-		return new AuditMessage(
+		AuditMessage auditMessage = new AuditMessage(
 			eventType, companyId, groupId, realUserId, realUserName, className,
 			classPK, null, null, additionalInfoJSONObject);
+
+		if (accountEntryId > 0) {
+			auditMessage.setAccountEntryId(accountEntryId);
+		}
+
+		return auditMessage;
+	}
+
+	public static AuditMessage buildAuditMessage(
+		long groupId, String eventType, String className, long classPK,
+		List<Attribute> attributes) {
+
+		return buildAuditMessage(
+			0, groupId, eventType, className, String.valueOf(classPK),
+			attributes);
+	}
+
+	public static AuditMessage buildAuditMessage(
+		long groupId, String eventType, String className, String classPK,
+		List<Attribute> attributes) {
+
+		return buildAuditMessage(
+			0, groupId, eventType, className, classPK, attributes);
 	}
 
 	public static AuditMessage buildAuditMessage(

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventModel.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventModel.java
@@ -92,6 +92,20 @@ public interface AuditEventModel extends BaseModel<AuditEvent>, ShardedModel {
 	public void setCompanyId(long companyId);
 
 	/**
+	 * Returns the account entry ID of this audit event.
+	 *
+	 * @return the account entry ID of this audit event
+	 */
+	public long getAccountEntryId();
+
+	/**
+	 * Sets the account entry ID of this audit event.
+	 *
+	 * @param accountEntryId the account entry ID of this audit event
+	 */
+	public void setAccountEntryId(long accountEntryId);
+
+	/**
 	 * Returns the user ID of this audit event.
 	 *
 	 * @return the user ID of this audit event
@@ -305,4 +319,4 @@ public interface AuditEventModel extends BaseModel<AuditEvent>, ShardedModel {
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:102425204
+// LIFERAY-SERVICE-BUILDER-HASH:-170073589

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventTable.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventTable.java
@@ -30,6 +30,8 @@ public class AuditEventTable extends BaseTable<AuditEventTable> {
 		"groupId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<AuditEventTable, Long> companyId = createColumn(
 		"companyId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+	public final Column<AuditEventTable, Long> accountEntryId = createColumn(
+		"accountEntryId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<AuditEventTable, Long> userId = createColumn(
 		"userId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<AuditEventTable, String> userName = createColumn(
@@ -62,4 +64,4 @@ public class AuditEventTable extends BaseTable<AuditEventTable> {
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-842353748
+// LIFERAY-SERVICE-BUILDER-HASH:-247180787

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventWrapper.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/model/AuditEventWrapper.java
@@ -36,6 +36,7 @@ public class AuditEventWrapper
 		attributes.put("auditEventId", getAuditEventId());
 		attributes.put("groupId", getGroupId());
 		attributes.put("companyId", getCompanyId());
+		attributes.put("accountEntryId", getAccountEntryId());
 		attributes.put("userId", getUserId());
 		attributes.put("userName", getUserName());
 		attributes.put("createDate", getCreateDate());
@@ -71,6 +72,12 @@ public class AuditEventWrapper
 
 		if (companyId != null) {
 			setCompanyId(companyId);
+		}
+
+		Long accountEntryId = (Long)attributes.get("accountEntryId");
+
+		if (accountEntryId != null) {
+			setAccountEntryId(accountEntryId);
 		}
 
 		Long userId = (Long)attributes.get("userId");
@@ -155,6 +162,16 @@ public class AuditEventWrapper
 	@Override
 	public AuditEvent cloneWithOriginalValues() {
 		return wrap(model.cloneWithOriginalValues());
+	}
+
+	/**
+	 * Returns the account entry ID of this audit event.
+	 *
+	 * @return the account entry ID of this audit event
+	 */
+	@Override
+	public long getAccountEntryId() {
+		return model.getAccountEntryId();
 	}
 
 	/**
@@ -340,6 +357,16 @@ public class AuditEventWrapper
 	@Override
 	public void persist() {
 		model.persist();
+	}
+
+	/**
+	 * Sets the account entry ID of this audit event.
+	 *
+	 * @param accountEntryId the account entry ID of this audit event
+	 */
+	@Override
+	public void setAccountEntryId(long accountEntryId) {
+		model.setAccountEntryId(accountEntryId);
 	}
 
 	/**
@@ -533,4 +560,4 @@ public class AuditEventWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1416724512
+// LIFERAY-SERVICE-BUILDER-HASH:57412774

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalService.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalService.java
@@ -234,16 +234,16 @@ public interface AuditEventLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<AuditEvent> getAuditEvents(
-		long companyId, long groupId, long userId, String userName,
-		Date createDateGT, Date createDateLT, String eventType,
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, Date createDateGT, Date createDateLT, String eventType,
 		String className, String classPK, String clientHost, String clientIP,
 		String serverName, int serverPort, String sessionID, boolean andSearch,
 		int start, int end);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<AuditEvent> getAuditEvents(
-		long companyId, long groupId, long userId, String userName,
-		Date createDateGT, Date createDateLT, String eventType,
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, Date createDateGT, Date createDateLT, String eventType,
 		String className, String classPK, String clientHost, String clientIP,
 		String serverName, int serverPort, String sessionID, boolean andSearch,
 		int start, int end, OrderByComparator<AuditEvent> orderByComparator);
@@ -261,8 +261,8 @@ public interface AuditEventLocalService
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getAuditEventsCount(
-		long companyId, long groupId, long userId, String userName,
-		Date createDateGT, Date createDateLT, String eventType,
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, Date createDateGT, Date createDateLT, String eventType,
 		String className, String classPK, String clientHost, String clientIP,
 		String serverName, int serverPort, String sessionID, boolean andSearch);
 
@@ -298,4 +298,4 @@ public interface AuditEventLocalService
 	public AuditEvent updateAuditEvent(AuditEvent auditEvent);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1100172116
+// LIFERAY-SERVICE-BUILDER-HASH:1375810042

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalServiceUtil.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalServiceUtil.java
@@ -262,30 +262,32 @@ public class AuditEventLocalServiceUtil {
 	}
 
 	public static List<AuditEvent> getAuditEvents(
-		long companyId, long groupId, long userId, String userName,
-		java.util.Date createDateGT, java.util.Date createDateLT,
-		String eventType, String className, String classPK, String clientHost,
-		String clientIP, String serverName, int serverPort, String sessionID,
-		boolean andSearch, int start, int end) {
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, java.util.Date createDateGT,
+		java.util.Date createDateLT, String eventType, String className,
+		String classPK, String clientHost, String clientIP, String serverName,
+		int serverPort, String sessionID, boolean andSearch, int start,
+		int end) {
 
 		return getService().getAuditEvents(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch, start, end);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch, start, end);
 	}
 
 	public static List<AuditEvent> getAuditEvents(
-		long companyId, long groupId, long userId, String userName,
-		java.util.Date createDateGT, java.util.Date createDateLT,
-		String eventType, String className, String classPK, String clientHost,
-		String clientIP, String serverName, int serverPort, String sessionID,
-		boolean andSearch, int start, int end,
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, java.util.Date createDateGT,
+		java.util.Date createDateLT, String eventType, String className,
+		String classPK, String clientHost, String clientIP, String serverName,
+		int serverPort, String sessionID, boolean andSearch, int start, int end,
 		OrderByComparator<AuditEvent> orderByComparator) {
 
 		return getService().getAuditEvents(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch, start, end, orderByComparator);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch, start, end,
+			orderByComparator);
 	}
 
 	/**
@@ -302,16 +304,16 @@ public class AuditEventLocalServiceUtil {
 	}
 
 	public static int getAuditEventsCount(
-		long companyId, long groupId, long userId, String userName,
-		java.util.Date createDateGT, java.util.Date createDateLT,
-		String eventType, String className, String classPK, String clientHost,
-		String clientIP, String serverName, int serverPort, String sessionID,
-		boolean andSearch) {
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, java.util.Date createDateGT,
+		java.util.Date createDateLT, String eventType, String className,
+		String classPK, String clientHost, String clientIP, String serverName,
+		int serverPort, String sessionID, boolean andSearch) {
 
 		return getService().getAuditEventsCount(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch);
 	}
 
 	public static
@@ -362,4 +364,4 @@ public class AuditEventLocalServiceUtil {
 			AuditEventLocalServiceUtil.class, AuditEventLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-842539148
+// LIFERAY-SERVICE-BUILDER-HASH:1387982214

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalServiceWrapper.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventLocalServiceWrapper.java
@@ -311,37 +311,38 @@ public class AuditEventLocalServiceWrapper
 	public java.util.List
 		<com.liferay.portal.security.audit.storage.model.AuditEvent>
 			getAuditEvents(
-				long companyId, long groupId, long userId, String userName,
-				java.util.Date createDateGT, java.util.Date createDateLT,
-				String eventType, String className, String classPK,
-				String clientHost, String clientIP, String serverName,
-				int serverPort, String sessionID, boolean andSearch, int start,
-				int end) {
+				long companyId, long[] accountEntryIds, long groupId,
+				long userId, String userName, java.util.Date createDateGT,
+				java.util.Date createDateLT, String eventType, String className,
+				String classPK, String clientHost, String clientIP,
+				String serverName, int serverPort, String sessionID,
+				boolean andSearch, int start, int end) {
 
 		return _auditEventLocalService.getAuditEvents(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch, start, end);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch, start, end);
 	}
 
 	@Override
 	public java.util.List
 		<com.liferay.portal.security.audit.storage.model.AuditEvent>
 			getAuditEvents(
-				long companyId, long groupId, long userId, String userName,
-				java.util.Date createDateGT, java.util.Date createDateLT,
-				String eventType, String className, String classPK,
-				String clientHost, String clientIP, String serverName,
-				int serverPort, String sessionID, boolean andSearch, int start,
-				int end,
+				long companyId, long[] accountEntryIds, long groupId,
+				long userId, String userName, java.util.Date createDateGT,
+				java.util.Date createDateLT, String eventType, String className,
+				String classPK, String clientHost, String clientIP,
+				String serverName, int serverPort, String sessionID,
+				boolean andSearch, int start, int end,
 				com.liferay.portal.kernel.util.OrderByComparator
 					<com.liferay.portal.security.audit.storage.model.AuditEvent>
 						orderByComparator) {
 
 		return _auditEventLocalService.getAuditEvents(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch, start, end, orderByComparator);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch, start, end,
+			orderByComparator);
 	}
 
 	/**
@@ -361,16 +362,16 @@ public class AuditEventLocalServiceWrapper
 
 	@Override
 	public int getAuditEventsCount(
-		long companyId, long groupId, long userId, String userName,
-		java.util.Date createDateGT, java.util.Date createDateLT,
-		String eventType, String className, String classPK, String clientHost,
-		String clientIP, String serverName, int serverPort, String sessionID,
-		boolean andSearch) {
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, java.util.Date createDateGT,
+		java.util.Date createDateLT, String eventType, String className,
+		String classPK, String clientHost, String clientIP, String serverName,
+		int serverPort, String sessionID, boolean andSearch) {
 
 		return _auditEventLocalService.getAuditEventsCount(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch);
 	}
 
 	@Override
@@ -440,4 +441,4 @@ public class AuditEventLocalServiceWrapper
 	private AuditEventLocalService _auditEventLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1834371989
+// LIFERAY-SERVICE-BUILDER-HASH:-433178713

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventService.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventService.java
@@ -56,21 +56,22 @@ public interface AuditEventService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<AuditEvent> getAuditEvents(
-			long companyId, long groupId, long userId, String userName,
-			Date createDateGT, Date createDateLT, String eventType,
-			String className, String classPK, String clientHost,
-			String clientIP, String serverName, int serverPort,
-			String sessionID, boolean andSearch, int start, int end)
+			long companyId, long[] accountEntryIds, long groupId, long userId,
+			String userName, Date createDateGT, Date createDateLT,
+			String eventType, String className, String classPK,
+			String clientHost, String clientIP, String serverName,
+			int serverPort, String sessionID, boolean andSearch, int start,
+			int end)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<AuditEvent> getAuditEvents(
-			long companyId, long groupId, long userId, String userName,
-			Date createDateGT, Date createDateLT, String eventType,
-			String className, String classPK, String clientHost,
-			String clientIP, String serverName, int serverPort,
-			String sessionID, boolean andSearch, int start, int end,
-			OrderByComparator<AuditEvent> orderByComparator)
+			long companyId, long[] accountEntryIds, long groupId, long userId,
+			String userName, Date createDateGT, Date createDateLT,
+			String eventType, String className, String classPK,
+			String clientHost, String clientIP, String serverName,
+			int serverPort, String sessionID, boolean andSearch, int start,
+			int end, OrderByComparator<AuditEvent> orderByComparator)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -78,11 +79,11 @@ public interface AuditEventService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getAuditEventsCount(
-			long companyId, long groupId, long userId, String userName,
-			Date createDateGT, Date createDateLT, String eventType,
-			String className, String classPK, String clientHost,
-			String clientIP, String serverName, int serverPort,
-			String sessionID, boolean andSearch)
+			long companyId, long[] accountEntryIds, long groupId, long userId,
+			String userName, Date createDateGT, Date createDateLT,
+			String eventType, String className, String classPK,
+			String clientHost, String clientIP, String serverName,
+			int serverPort, String sessionID, boolean andSearch)
 		throws PortalException;
 
 	/**
@@ -93,4 +94,4 @@ public interface AuditEventService extends BaseService {
 	public String getOSGiServiceIdentifier();
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-23106901
+// LIFERAY-SERVICE-BUILDER-HASH:-969580563

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventServiceUtil.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventServiceUtil.java
@@ -48,33 +48,35 @@ public class AuditEventServiceUtil {
 	}
 
 	public static List<AuditEvent> getAuditEvents(
-			long companyId, long groupId, long userId, String userName,
-			java.util.Date createDateGT, java.util.Date createDateLT,
-			String eventType, String className, String classPK,
-			String clientHost, String clientIP, String serverName,
-			int serverPort, String sessionID, boolean andSearch, int start,
-			int end)
+			long companyId, long[] accountEntryIds, long groupId, long userId,
+			String userName, java.util.Date createDateGT,
+			java.util.Date createDateLT, String eventType, String className,
+			String classPK, String clientHost, String clientIP,
+			String serverName, int serverPort, String sessionID,
+			boolean andSearch, int start, int end)
 		throws PortalException {
 
 		return getService().getAuditEvents(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch, start, end);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch, start, end);
 	}
 
 	public static List<AuditEvent> getAuditEvents(
-			long companyId, long groupId, long userId, String userName,
-			java.util.Date createDateGT, java.util.Date createDateLT,
-			String eventType, String className, String classPK,
-			String clientHost, String clientIP, String serverName,
-			int serverPort, String sessionID, boolean andSearch, int start,
-			int end, OrderByComparator<AuditEvent> orderByComparator)
+			long companyId, long[] accountEntryIds, long groupId, long userId,
+			String userName, java.util.Date createDateGT,
+			java.util.Date createDateLT, String eventType, String className,
+			String classPK, String clientHost, String clientIP,
+			String serverName, int serverPort, String sessionID,
+			boolean andSearch, int start, int end,
+			OrderByComparator<AuditEvent> orderByComparator)
 		throws PortalException {
 
 		return getService().getAuditEvents(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch, start, end, orderByComparator);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch, start, end,
+			orderByComparator);
 	}
 
 	public static int getAuditEventsCount(long companyId)
@@ -84,17 +86,18 @@ public class AuditEventServiceUtil {
 	}
 
 	public static int getAuditEventsCount(
-			long companyId, long groupId, long userId, String userName,
-			java.util.Date createDateGT, java.util.Date createDateLT,
-			String eventType, String className, String classPK,
-			String clientHost, String clientIP, String serverName,
-			int serverPort, String sessionID, boolean andSearch)
+			long companyId, long[] accountEntryIds, long groupId, long userId,
+			String userName, java.util.Date createDateGT,
+			java.util.Date createDateLT, String eventType, String className,
+			String classPK, String clientHost, String clientIP,
+			String serverName, int serverPort, String sessionID,
+			boolean andSearch)
 		throws PortalException {
 
 		return getService().getAuditEventsCount(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch);
 	}
 
 	/**
@@ -114,4 +117,4 @@ public class AuditEventServiceUtil {
 		new Snapshot<>(AuditEventServiceUtil.class, AuditEventService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:2129421729
+// LIFERAY-SERVICE-BUILDER-HASH:2085786549

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventServiceWrapper.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/AuditEventServiceWrapper.java
@@ -52,39 +52,40 @@ public class AuditEventServiceWrapper
 	public java.util.List
 		<com.liferay.portal.security.audit.storage.model.AuditEvent>
 				getAuditEvents(
-					long companyId, long groupId, long userId, String userName,
-					java.util.Date createDateGT, java.util.Date createDateLT,
-					String eventType, String className, String classPK,
-					String clientHost, String clientIP, String serverName,
-					int serverPort, String sessionID, boolean andSearch,
-					int start, int end)
+					long companyId, long[] accountEntryIds, long groupId,
+					long userId, String userName, java.util.Date createDateGT,
+					java.util.Date createDateLT, String eventType,
+					String className, String classPK, String clientHost,
+					String clientIP, String serverName, int serverPort,
+					String sessionID, boolean andSearch, int start, int end)
 			throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _auditEventService.getAuditEvents(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch, start, end);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch, start, end);
 	}
 
 	@Override
 	public java.util.List
 		<com.liferay.portal.security.audit.storage.model.AuditEvent>
 				getAuditEvents(
-					long companyId, long groupId, long userId, String userName,
-					java.util.Date createDateGT, java.util.Date createDateLT,
-					String eventType, String className, String classPK,
-					String clientHost, String clientIP, String serverName,
-					int serverPort, String sessionID, boolean andSearch,
-					int start, int end,
+					long companyId, long[] accountEntryIds, long groupId,
+					long userId, String userName, java.util.Date createDateGT,
+					java.util.Date createDateLT, String eventType,
+					String className, String classPK, String clientHost,
+					String clientIP, String serverName, int serverPort,
+					String sessionID, boolean andSearch, int start, int end,
 					com.liferay.portal.kernel.util.OrderByComparator
 						<com.liferay.portal.security.audit.storage.model.
 							AuditEvent> orderByComparator)
 			throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _auditEventService.getAuditEvents(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch, start, end, orderByComparator);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch, start, end,
+			orderByComparator);
 	}
 
 	@Override
@@ -96,17 +97,18 @@ public class AuditEventServiceWrapper
 
 	@Override
 	public int getAuditEventsCount(
-			long companyId, long groupId, long userId, String userName,
-			java.util.Date createDateGT, java.util.Date createDateLT,
-			String eventType, String className, String classPK,
-			String clientHost, String clientIP, String serverName,
-			int serverPort, String sessionID, boolean andSearch)
+			long companyId, long[] accountEntryIds, long groupId, long userId,
+			String userName, java.util.Date createDateGT,
+			java.util.Date createDateLT, String eventType, String className,
+			String classPK, String clientHost, String clientIP,
+			String serverName, int serverPort, String sessionID,
+			boolean andSearch)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _auditEventService.getAuditEventsCount(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch);
 	}
 
 	/**
@@ -132,4 +134,4 @@ public class AuditEventServiceWrapper
 	private AuditEventService _auditEventService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-687197414
+// LIFERAY-SERVICE-BUILDER-HASH:-1823489156

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/persistence/AuditEventPersistence.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/persistence/AuditEventPersistence.java
@@ -134,6 +134,117 @@ public interface AuditEventPersistence extends BasePersistence<AuditEvent> {
 	public int countByCompanyId(long companyId);
 
 	/**
+	 * Returns all the audit events where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @return the matching audit events
+	 */
+	public java.util.List<AuditEvent> findByC_A(
+		long companyId, long accountEntryId);
+
+	/**
+	 * Returns a range of all the audit events where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.security.audit.storage.model.impl.AuditEventModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of audit events
+	 * @param end the upper bound of the range of audit events (not inclusive)
+	 * @return the range of matching audit events
+	 */
+	public java.util.List<AuditEvent> findByC_A(
+		long companyId, long accountEntryId, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the audit events where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.security.audit.storage.model.impl.AuditEventModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of audit events
+	 * @param end the upper bound of the range of audit events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching audit events
+	 */
+	public java.util.List<AuditEvent> findByC_A(
+		long companyId, long accountEntryId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<AuditEvent>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the audit events where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.security.audit.storage.model.impl.AuditEventModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of audit events
+	 * @param end the upper bound of the range of audit events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching audit events
+	 */
+	public java.util.List<AuditEvent> findByC_A(
+		long companyId, long accountEntryId, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<AuditEvent>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first audit event in the ordered set where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching audit event
+	 * @throws NoSuchEventException if a matching audit event could not be found
+	 */
+	public AuditEvent findByC_A_First(
+			long companyId, long accountEntryId,
+			com.liferay.portal.kernel.util.OrderByComparator<AuditEvent>
+				orderByComparator)
+		throws NoSuchEventException;
+
+	/**
+	 * Returns the first audit event in the ordered set where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching audit event, or <code>null</code> if a matching audit event could not be found
+	 */
+	public AuditEvent fetchByC_A_First(
+		long companyId, long accountEntryId,
+		com.liferay.portal.kernel.util.OrderByComparator<AuditEvent>
+			orderByComparator);
+
+	/**
+	 * Removes all the audit events where companyId = &#63; and accountEntryId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 */
+	public void removeByC_A(long companyId, long accountEntryId);
+
+	/**
+	 * Returns the number of audit events where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @return the number of matching audit events
+	 */
+	public int countByC_A(long companyId, long accountEntryId);
+
+	/**
 	 * Creates a new audit event with the primary key. Does not add the audit event to the database.
 	 *
 	 * @param auditEventId the primary key for the new audit event
@@ -171,4 +282,4 @@ public interface AuditEventPersistence extends BasePersistence<AuditEvent> {
 	public AuditEvent fetchByPrimaryKey(long auditEventId);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:792168537
+// LIFERAY-SERVICE-BUILDER-HASH:-1250329251

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/persistence/AuditEventUtil.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/java/com/liferay/portal/security/audit/storage/service/persistence/AuditEventUtil.java
@@ -247,6 +247,142 @@ public class AuditEventUtil {
 	}
 
 	/**
+	 * Returns all the audit events where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @return the matching audit events
+	 */
+	public static List<AuditEvent> findByC_A(
+		long companyId, long accountEntryId) {
+
+		return getPersistence().findByC_A(companyId, accountEntryId);
+	}
+
+	/**
+	 * Returns a range of all the audit events where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.security.audit.storage.model.impl.AuditEventModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of audit events
+	 * @param end the upper bound of the range of audit events (not inclusive)
+	 * @return the range of matching audit events
+	 */
+	public static List<AuditEvent> findByC_A(
+		long companyId, long accountEntryId, int start, int end) {
+
+		return getPersistence().findByC_A(
+			companyId, accountEntryId, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the audit events where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.security.audit.storage.model.impl.AuditEventModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of audit events
+	 * @param end the upper bound of the range of audit events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching audit events
+	 */
+	public static List<AuditEvent> findByC_A(
+		long companyId, long accountEntryId, int start, int end,
+		OrderByComparator<AuditEvent> orderByComparator) {
+
+		return getPersistence().findByC_A(
+			companyId, accountEntryId, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the audit events where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>com.liferay.portal.kernel.dao.orm.QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>com.liferay.portal.security.audit.storage.model.impl.AuditEventModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of audit events
+	 * @param end the upper bound of the range of audit events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching audit events
+	 */
+	public static List<AuditEvent> findByC_A(
+		long companyId, long accountEntryId, int start, int end,
+		OrderByComparator<AuditEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByC_A(
+			companyId, accountEntryId, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first audit event in the ordered set where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching audit event
+	 * @throws NoSuchEventException if a matching audit event could not be found
+	 */
+	public static AuditEvent findByC_A_First(
+			long companyId, long accountEntryId,
+			OrderByComparator<AuditEvent> orderByComparator)
+		throws com.liferay.portal.security.audit.storage.exception.
+			NoSuchEventException {
+
+		return getPersistence().findByC_A_First(
+			companyId, accountEntryId, orderByComparator);
+	}
+
+	/**
+	 * Returns the first audit event in the ordered set where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching audit event, or <code>null</code> if a matching audit event could not be found
+	 */
+	public static AuditEvent fetchByC_A_First(
+		long companyId, long accountEntryId,
+		OrderByComparator<AuditEvent> orderByComparator) {
+
+		return getPersistence().fetchByC_A_First(
+			companyId, accountEntryId, orderByComparator);
+	}
+
+	/**
+	 * Removes all the audit events where companyId = &#63; and accountEntryId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 */
+	public static void removeByC_A(long companyId, long accountEntryId) {
+		getPersistence().removeByC_A(companyId, accountEntryId);
+	}
+
+	/**
+	 * Returns the number of audit events where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @return the number of matching audit events
+	 */
+	public static int countByC_A(long companyId, long accountEntryId) {
+		return getPersistence().countByC_A(companyId, accountEntryId);
+	}
+
+	/**
 	 * Creates a new audit event with the primary key. Does not add the audit event to the database.
 	 *
 	 * @param auditEventId the primary key for the new audit event
@@ -309,4 +445,4 @@ public class AuditEventUtil {
 	private static volatile AuditEventPersistence _persistence;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1400441528
+// LIFERAY-SERVICE-BUILDER-HASH:355467570

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/resources/com/liferay/portal/security/audit/storage/model/packageinfo
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/resources/com/liferay/portal/security/audit/storage/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.2.0
+version 3.3.0

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/resources/com/liferay/portal/security/audit/storage/service/packageinfo
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-api/src/main/resources/com/liferay/portal/security/audit/storage/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 4.0.0

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/build.gradle
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:account:account-api")
 	compileOnly project(":apps:portal-security-audit:portal-security-audit-api")
 	compileOnly project(":apps:portal-security-audit:portal-security-audit-storage-api")
 	compileOnly project(":apps:portal:portal-aop-api")

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/service.xml
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/service.xml
@@ -16,6 +16,7 @@
 		<!-- Audit fields -->
 
 		<column name="companyId" type="long" />
+		<column name="accountEntryId" type="long" />
 		<column name="userId" type="long" />
 		<column name="userName" type="String" />
 		<column name="createDate" type="Date" />
@@ -43,6 +44,10 @@
 
 		<finder name="CompanyId" return-type="Collection">
 			<finder-column name="companyId" />
+		</finder>
+		<finder name="C_A" return-type="Collection">
+			<finder-column name="companyId" />
+			<finder-column name="accountEntryId" />
 		</finder>
 	</entity>
 </service-builder>

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/AuditEventManagerImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/internal/AuditEventManagerImpl.java
@@ -93,8 +93,8 @@ public class AuditEventManagerImpl implements AuditEventManager {
 
 	@Override
 	public List<AuditEvent> getAuditEvents(
-		long companyId, long groupId, long userId, String userName,
-		Date createDateGT, Date createDateLT, String eventType,
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, Date createDateGT, Date createDateLT, String eventType,
 		String className, String classPK, String clientHost, String clientIP,
 		String serverName, int serverPort, String sessionID, boolean andSearch,
 		int start, int end,
@@ -104,10 +104,10 @@ public class AuditEventManagerImpl implements AuditEventManager {
 
 		return _translate(
 			_auditEventLocalService.getAuditEvents(
-				companyId, groupId, userId, userName, createDateGT,
-				createDateLT, eventType, className, classPK, clientHost,
-				clientIP, serverName, serverPort, sessionID, andSearch, start,
-				end, orderByComparator));
+				companyId, accountEntryIds, groupId, userId, userName,
+				createDateGT, createDateLT, eventType, className, classPK,
+				clientHost, clientIP, serverName, serverPort, sessionID,
+				andSearch, start, end, orderByComparator));
 	}
 
 	@Override
@@ -117,16 +117,16 @@ public class AuditEventManagerImpl implements AuditEventManager {
 
 	@Override
 	public int getAuditEventsCount(
-		long companyId, long groupId, long userId, String userName,
-		Date createDateGT, Date createDateLT, String eventType,
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, Date createDateGT, Date createDateLT, String eventType,
 		String className, String classPK, String clientHost, String clientIP,
 		String serverName, int serverPort, String sessionID,
 		boolean andSearch) {
 
 		return _auditEventLocalService.getAuditEventsCount(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch);
 	}
 
 	private AuditEvent _createAuditEvent(

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/model/impl/AuditEventCacheModel.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/model/impl/AuditEventCacheModel.java
@@ -53,7 +53,7 @@ public class AuditEventCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(33);
+		StringBundler sb = new StringBundler(35);
 
 		sb.append("{auditEventId=");
 		sb.append(auditEventId);
@@ -61,6 +61,8 @@ public class AuditEventCacheModel
 		sb.append(groupId);
 		sb.append(", companyId=");
 		sb.append(companyId);
+		sb.append(", accountEntryId=");
+		sb.append(accountEntryId);
 		sb.append(", userId=");
 		sb.append(userId);
 		sb.append(", userName=");
@@ -99,6 +101,7 @@ public class AuditEventCacheModel
 		auditEventImpl.setAuditEventId(auditEventId);
 		auditEventImpl.setGroupId(groupId);
 		auditEventImpl.setCompanyId(companyId);
+		auditEventImpl.setAccountEntryId(accountEntryId);
 		auditEventImpl.setUserId(userId);
 
 		if (userName == null) {
@@ -195,6 +198,8 @@ public class AuditEventCacheModel
 
 		companyId = objectInput.readLong();
 
+		accountEntryId = objectInput.readLong();
+
 		userId = objectInput.readLong();
 		userName = objectInput.readUTF();
 		createDate = objectInput.readLong();
@@ -218,6 +223,8 @@ public class AuditEventCacheModel
 		objectOutput.writeLong(groupId);
 
 		objectOutput.writeLong(companyId);
+
+		objectOutput.writeLong(accountEntryId);
 
 		objectOutput.writeLong(userId);
 
@@ -299,6 +306,7 @@ public class AuditEventCacheModel
 	public long auditEventId;
 	public long groupId;
 	public long companyId;
+	public long accountEntryId;
 	public long userId;
 	public String userName;
 	public long createDate;
@@ -314,4 +322,4 @@ public class AuditEventCacheModel
 	public String additionalInfo;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2002660291
+// LIFERAY-SERVICE-BUILDER-HASH:-1408129140

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/model/impl/AuditEventModelImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/model/impl/AuditEventModelImpl.java
@@ -64,13 +64,14 @@ public class AuditEventModelImpl
 
 	public static final Object[][] TABLE_COLUMNS = {
 		{"auditEventId", Types.BIGINT}, {"groupId", Types.BIGINT},
-		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
-		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
-		{"eventType", Types.VARCHAR}, {"className", Types.VARCHAR},
-		{"classPK", Types.VARCHAR}, {"message", Types.VARCHAR},
-		{"clientHost", Types.VARCHAR}, {"clientIP", Types.VARCHAR},
-		{"serverName", Types.VARCHAR}, {"serverPort", Types.INTEGER},
-		{"sessionID", Types.VARCHAR}, {"additionalInfo", Types.CLOB}
+		{"companyId", Types.BIGINT}, {"accountEntryId", Types.BIGINT},
+		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP}, {"eventType", Types.VARCHAR},
+		{"className", Types.VARCHAR}, {"classPK", Types.VARCHAR},
+		{"message", Types.VARCHAR}, {"clientHost", Types.VARCHAR},
+		{"clientIP", Types.VARCHAR}, {"serverName", Types.VARCHAR},
+		{"serverPort", Types.INTEGER}, {"sessionID", Types.VARCHAR},
+		{"additionalInfo", Types.CLOB}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -80,6 +81,7 @@ public class AuditEventModelImpl
 		TABLE_COLUMNS_MAP.put("auditEventId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("accountEntryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
@@ -96,7 +98,7 @@ public class AuditEventModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table Audit_AuditEvent (auditEventId LONG not null primary key,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,eventType VARCHAR(75) null,className VARCHAR(200) null,classPK VARCHAR(75) null,message STRING null,clientHost VARCHAR(255) null,clientIP VARCHAR(255) null,serverName VARCHAR(255) null,serverPort INTEGER,sessionID VARCHAR(255) null,additionalInfo TEXT null)";
+		"create table Audit_AuditEvent (auditEventId LONG not null primary key,groupId LONG,companyId LONG,accountEntryId LONG,userId LONG,userName VARCHAR(200) null,createDate DATE null,eventType VARCHAR(75) null,className VARCHAR(200) null,classPK VARCHAR(75) null,message STRING null,clientHost VARCHAR(255) null,clientIP VARCHAR(255) null,serverName VARCHAR(255) null,serverPort INTEGER,sessionID VARCHAR(255) null,additionalInfo TEXT null)";
 
 	public static final String TABLE_SQL_DROP = "drop table Audit_AuditEvent";
 
@@ -118,14 +120,20 @@ public class AuditEventModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long COMPANYID_COLUMN_BITMASK = 1L;
+	public static final long ACCOUNTENTRYID_COLUMN_BITMASK = 1L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long COMPANYID_COLUMN_BITMASK = 2L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long CREATEDATE_COLUMN_BITMASK = 2L;
+	public static final long CREATEDATE_COLUMN_BITMASK = 4L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -238,6 +246,8 @@ public class AuditEventModelImpl
 				"auditEventId", AuditEvent::getAuditEventId);
 			attributeGetterFunctions.put("groupId", AuditEvent::getGroupId);
 			attributeGetterFunctions.put("companyId", AuditEvent::getCompanyId);
+			attributeGetterFunctions.put(
+				"accountEntryId", AuditEvent::getAccountEntryId);
 			attributeGetterFunctions.put("userId", AuditEvent::getUserId);
 			attributeGetterFunctions.put("userName", AuditEvent::getUserName);
 			attributeGetterFunctions.put(
@@ -281,6 +291,9 @@ public class AuditEventModelImpl
 			attributeSetterBiConsumers.put(
 				"companyId",
 				(BiConsumer<AuditEvent, Long>)AuditEvent::setCompanyId);
+			attributeSetterBiConsumers.put(
+				"accountEntryId",
+				(BiConsumer<AuditEvent, Long>)AuditEvent::setAccountEntryId);
 			attributeSetterBiConsumers.put(
 				"userId", (BiConsumer<AuditEvent, Long>)AuditEvent::setUserId);
 			attributeSetterBiConsumers.put(
@@ -379,6 +392,31 @@ public class AuditEventModelImpl
 	public long getOriginalCompanyId() {
 		return GetterUtil.getLong(
 			this.<Long>getColumnOriginalValue("companyId"));
+	}
+
+	@JSON
+	@Override
+	public long getAccountEntryId() {
+		return _accountEntryId;
+	}
+
+	@Override
+	public void setAccountEntryId(long accountEntryId) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_accountEntryId = accountEntryId;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public long getOriginalAccountEntryId() {
+		return GetterUtil.getLong(
+			this.<Long>getColumnOriginalValue("accountEntryId"));
 	}
 
 	@JSON
@@ -701,6 +739,7 @@ public class AuditEventModelImpl
 		auditEventImpl.setAuditEventId(getAuditEventId());
 		auditEventImpl.setGroupId(getGroupId());
 		auditEventImpl.setCompanyId(getCompanyId());
+		auditEventImpl.setAccountEntryId(getAccountEntryId());
 		auditEventImpl.setUserId(getUserId());
 		auditEventImpl.setUserName(getUserName());
 		auditEventImpl.setCreateDate(getCreateDate());
@@ -729,6 +768,8 @@ public class AuditEventModelImpl
 		auditEventImpl.setGroupId(this.<Long>getColumnOriginalValue("groupId"));
 		auditEventImpl.setCompanyId(
 			this.<Long>getColumnOriginalValue("companyId"));
+		auditEventImpl.setAccountEntryId(
+			this.<Long>getColumnOriginalValue("accountEntryId"));
 		auditEventImpl.setUserId(this.<Long>getColumnOriginalValue("userId"));
 		auditEventImpl.setUserName(
 			this.<String>getColumnOriginalValue("userName"));
@@ -834,6 +875,8 @@ public class AuditEventModelImpl
 		auditEventCacheModel.groupId = getGroupId();
 
 		auditEventCacheModel.companyId = getCompanyId();
+
+		auditEventCacheModel.accountEntryId = getAccountEntryId();
 
 		auditEventCacheModel.userId = getUserId();
 
@@ -992,6 +1035,7 @@ public class AuditEventModelImpl
 	private long _auditEventId;
 	private long _groupId;
 	private long _companyId;
+	private long _accountEntryId;
 	private long _userId;
 	private String _userName;
 	private Date _createDate;
@@ -1037,6 +1081,7 @@ public class AuditEventModelImpl
 		_columnOriginalValues.put("auditEventId", _auditEventId);
 		_columnOriginalValues.put("groupId", _groupId);
 		_columnOriginalValues.put("companyId", _companyId);
+		_columnOriginalValues.put("accountEntryId", _accountEntryId);
 		_columnOriginalValues.put("userId", _userId);
 		_columnOriginalValues.put("userName", _userName);
 		_columnOriginalValues.put("createDate", _createDate);
@@ -1069,31 +1114,33 @@ public class AuditEventModelImpl
 
 		columnBitmasks.put("companyId", 4L);
 
-		columnBitmasks.put("userId", 8L);
+		columnBitmasks.put("accountEntryId", 8L);
 
-		columnBitmasks.put("userName", 16L);
+		columnBitmasks.put("userId", 16L);
 
-		columnBitmasks.put("createDate", 32L);
+		columnBitmasks.put("userName", 32L);
 
-		columnBitmasks.put("eventType", 64L);
+		columnBitmasks.put("createDate", 64L);
 
-		columnBitmasks.put("className", 128L);
+		columnBitmasks.put("eventType", 128L);
 
-		columnBitmasks.put("classPK", 256L);
+		columnBitmasks.put("className", 256L);
 
-		columnBitmasks.put("message", 512L);
+		columnBitmasks.put("classPK", 512L);
 
-		columnBitmasks.put("clientHost", 1024L);
+		columnBitmasks.put("message", 1024L);
 
-		columnBitmasks.put("clientIP", 2048L);
+		columnBitmasks.put("clientHost", 2048L);
 
-		columnBitmasks.put("serverName", 4096L);
+		columnBitmasks.put("clientIP", 4096L);
 
-		columnBitmasks.put("serverPort", 8192L);
+		columnBitmasks.put("serverName", 8192L);
 
-		columnBitmasks.put("sessionID", 16384L);
+		columnBitmasks.put("serverPort", 16384L);
 
-		columnBitmasks.put("additionalInfo", 32768L);
+		columnBitmasks.put("sessionID", 32768L);
+
+		columnBitmasks.put("additionalInfo", 65536L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}
@@ -1102,4 +1149,4 @@ public class AuditEventModelImpl
 	private AuditEvent _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1923590353
+// LIFERAY-SERVICE-BUILDER-HASH:-12607326

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/http/AuditEventServiceHttp.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/http/AuditEventServiceHttp.java
@@ -137,8 +137,9 @@ public class AuditEventServiceHttp {
 	public static java.util.List
 		<com.liferay.portal.security.audit.storage.model.AuditEvent>
 				getAuditEvents(
-					HttpPrincipal httpPrincipal, long companyId, long groupId,
-					long userId, String userName, java.util.Date createDateGT,
+					HttpPrincipal httpPrincipal, long companyId,
+					long[] accountEntryIds, long groupId, long userId,
+					String userName, java.util.Date createDateGT,
 					java.util.Date createDateLT, String eventType,
 					String className, String classPK, String clientHost,
 					String clientIP, String serverName, int serverPort,
@@ -151,10 +152,10 @@ public class AuditEventServiceHttp {
 				_getAuditEventsParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, companyId, groupId, userId, userName, createDateGT,
-				createDateLT, eventType, className, classPK, clientHost,
-				clientIP, serverName, serverPort, sessionID, andSearch, start,
-				end);
+				methodKey, companyId, accountEntryIds, groupId, userId,
+				userName, createDateGT, createDateLT, eventType, className,
+				classPK, clientHost, clientIP, serverName, serverPort,
+				sessionID, andSearch, start, end);
 
 			Object returnObj = null;
 
@@ -189,8 +190,9 @@ public class AuditEventServiceHttp {
 	public static java.util.List
 		<com.liferay.portal.security.audit.storage.model.AuditEvent>
 				getAuditEvents(
-					HttpPrincipal httpPrincipal, long companyId, long groupId,
-					long userId, String userName, java.util.Date createDateGT,
+					HttpPrincipal httpPrincipal, long companyId,
+					long[] accountEntryIds, long groupId, long userId,
+					String userName, java.util.Date createDateGT,
 					java.util.Date createDateLT, String eventType,
 					String className, String classPK, String clientHost,
 					String clientIP, String serverName, int serverPort,
@@ -206,10 +208,10 @@ public class AuditEventServiceHttp {
 				_getAuditEventsParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, companyId, groupId, userId, userName, createDateGT,
-				createDateLT, eventType, className, classPK, clientHost,
-				clientIP, serverName, serverPort, sessionID, andSearch, start,
-				end, orderByComparator);
+				methodKey, companyId, accountEntryIds, groupId, userId,
+				userName, createDateGT, createDateLT, eventType, className,
+				classPK, clientHost, clientIP, serverName, serverPort,
+				sessionID, andSearch, start, end, orderByComparator);
 
 			Object returnObj = null;
 
@@ -282,12 +284,12 @@ public class AuditEventServiceHttp {
 	}
 
 	public static int getAuditEventsCount(
-			HttpPrincipal httpPrincipal, long companyId, long groupId,
-			long userId, String userName, java.util.Date createDateGT,
-			java.util.Date createDateLT, String eventType, String className,
-			String classPK, String clientHost, String clientIP,
-			String serverName, int serverPort, String sessionID,
-			boolean andSearch)
+			HttpPrincipal httpPrincipal, long companyId, long[] accountEntryIds,
+			long groupId, long userId, String userName,
+			java.util.Date createDateGT, java.util.Date createDateLT,
+			String eventType, String className, String classPK,
+			String clientHost, String clientIP, String serverName,
+			int serverPort, String sessionID, boolean andSearch)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
@@ -296,9 +298,10 @@ public class AuditEventServiceHttp {
 				_getAuditEventsCountParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, companyId, groupId, userId, userName, createDateGT,
-				createDateLT, eventType, className, classPK, clientHost,
-				clientIP, serverName, serverPort, sessionID, andSearch);
+				methodKey, companyId, accountEntryIds, groupId, userId,
+				userName, createDateGT, createDateLT, eventType, className,
+				classPK, clientHost, clientIP, serverName, serverPort,
+				sessionID, andSearch);
 
 			Object returnObj = null;
 
@@ -340,7 +343,7 @@ public class AuditEventServiceHttp {
 		};
 	private static final Class<?>[] _getAuditEventsParameterTypes2 =
 		new Class[] {
-			long.class, long.class, long.class, String.class,
+			long.class, long[].class, long.class, long.class, String.class,
 			java.util.Date.class, java.util.Date.class, String.class,
 			String.class, String.class, String.class, String.class,
 			String.class, int.class, String.class, boolean.class, int.class,
@@ -348,7 +351,7 @@ public class AuditEventServiceHttp {
 		};
 	private static final Class<?>[] _getAuditEventsParameterTypes3 =
 		new Class[] {
-			long.class, long.class, long.class, String.class,
+			long.class, long[].class, long.class, long.class, String.class,
 			java.util.Date.class, java.util.Date.class, String.class,
 			String.class, String.class, String.class, String.class,
 			String.class, int.class, String.class, boolean.class, int.class,
@@ -358,11 +361,11 @@ public class AuditEventServiceHttp {
 		new Class[] {long.class};
 	private static final Class<?>[] _getAuditEventsCountParameterTypes5 =
 		new Class[] {
-			long.class, long.class, long.class, String.class,
+			long.class, long[].class, long.class, long.class, String.class,
 			java.util.Date.class, java.util.Date.class, String.class,
 			String.class, String.class, String.class, String.class,
 			String.class, int.class, String.class, boolean.class
 		};
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2047162558
+// LIFERAY-SERVICE-BUILDER-HASH:277103503

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventLocalServiceImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventLocalServiceImpl.java
@@ -82,31 +82,31 @@ public class AuditEventLocalServiceImpl extends AuditEventLocalServiceBaseImpl {
 
 	@Override
 	public List<AuditEvent> getAuditEvents(
-		long companyId, long groupId, long userId, String userName,
-		Date createDateGT, Date createDateLT, String eventType,
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, Date createDateGT, Date createDateLT, String eventType,
 		String className, String classPK, String clientHost, String clientIP,
 		String serverName, int serverPort, String sessionID, boolean andSearch,
 		int start, int end) {
 
 		return getAuditEvents(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch, start, end,
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch, start, end,
 			new AuditEventCreateDateComparator());
 	}
 
 	@Override
 	public List<AuditEvent> getAuditEvents(
-		long companyId, long groupId, long userId, String userName,
-		Date createDateGT, Date createDateLT, String eventType,
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, Date createDateGT, Date createDateLT, String eventType,
 		String className, String classPK, String clientHost, String clientIP,
 		String serverName, int serverPort, String sessionID, boolean andSearch,
 		int start, int end, OrderByComparator<AuditEvent> orderByComparator) {
 
 		DynamicQuery dynamicQuery = _buildDynamicQuery(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch);
 
 		return dynamicQuery(dynamicQuery, start, end, orderByComparator);
 	}
@@ -118,23 +118,23 @@ public class AuditEventLocalServiceImpl extends AuditEventLocalServiceBaseImpl {
 
 	@Override
 	public int getAuditEventsCount(
-		long companyId, long groupId, long userId, String userName,
-		Date createDateGT, Date createDateLT, String eventType,
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, Date createDateGT, Date createDateLT, String eventType,
 		String className, String classPK, String clientHost, String clientIP,
 		String serverName, int serverPort, String sessionID,
 		boolean andSearch) {
 
 		DynamicQuery dynamicQuery = _buildDynamicQuery(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch);
 
 		return (int)dynamicQueryCount(dynamicQuery);
 	}
 
 	private DynamicQuery _buildDynamicQuery(
-		long companyId, long groupId, long userId, String userName,
-		Date createDateGT, Date createDateLT, String eventType,
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, Date createDateGT, Date createDateLT, String eventType,
 		String className, String classPK, String clientHost, String clientIP,
 		String serverName, int serverPort, String sessionID,
 		boolean andSearch) {
@@ -232,6 +232,17 @@ public class AuditEventLocalServiceImpl extends AuditEventLocalServiceBaseImpl {
 			dynamicQuery.add(property.eq(companyId));
 		}
 
+		if ((accountEntryIds != null) && (accountEntryIds.length > 0)) {
+			Property property = PropertyFactoryUtil.forName("accountEntryId");
+
+			if (accountEntryIds.length == 1) {
+				dynamicQuery.add(property.eq(accountEntryIds[0]));
+			}
+			else {
+				dynamicQuery.add(property.in(accountEntryIds));
+			}
+		}
+
 		if (createDateGT != null) {
 			Property property = PropertyFactoryUtil.forName("createDate");
 
@@ -254,6 +265,7 @@ public class AuditEventLocalServiceImpl extends AuditEventLocalServiceBaseImpl {
 
 		auditEvent.setGroupId(auditMessage.getGroupId());
 		auditEvent.setCompanyId(auditMessage.getCompanyId());
+		auditEvent.setAccountEntryId(auditMessage.getAccountEntryId());
 		auditEvent.setUserId(auditMessage.getUserId());
 		auditEvent.setUserName(auditMessage.getUserName());
 		auditEvent.setCreateDate(auditMessage.getTimestamp());

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventServiceImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventServiceImpl.java
@@ -5,13 +5,19 @@
 
 package com.liferay.portal.security.audit.storage.service.impl;
 
+import com.liferay.account.constants.AccountConstants;
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.role.AccountRolePermissionThreadLocal;
+import com.liferay.account.service.AccountEntryLocalService;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.security.audit.storage.model.AuditEvent;
 import com.liferay.portal.security.audit.storage.service.base.AuditEventServiceBaseImpl;
@@ -41,15 +47,14 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 
 		PermissionChecker permissionChecker = getPermissionChecker();
 
-		if (!(permissionChecker.isCompanyAdmin(companyId) ||
-			  _userLocalService.hasRoleUser(
-				  companyId, RoleConstants.ANALYTICS_ADMINISTRATOR,
-				  permissionChecker.getUserId(), true))) {
-
-			throw new PrincipalException();
+		if (_hasCrossAccountAuditViewPermission(companyId, permissionChecker)) {
+			return auditEventLocalService.getAuditEvents(companyId, start, end);
 		}
 
-		return auditEventLocalService.getAuditEvents(companyId, start, end);
+		return auditEventLocalService.getAuditEvents(
+			companyId, _getAllowedAccountEntryIds(permissionChecker), 0, 0,
+			null, null, null, null, null, null, null, null, null, 0, null, true,
+			start, end);
 	}
 
 	@Override
@@ -60,88 +65,164 @@ public class AuditEventServiceImpl extends AuditEventServiceBaseImpl {
 
 		PermissionChecker permissionChecker = getPermissionChecker();
 
-		if (!(permissionChecker.isCompanyAdmin(companyId) ||
-			  _userLocalService.hasRoleUser(
-				  companyId, RoleConstants.ANALYTICS_ADMINISTRATOR,
-				  permissionChecker.getUserId(), true))) {
-
-			throw new PrincipalException();
+		if (_hasCrossAccountAuditViewPermission(companyId, permissionChecker)) {
+			return auditEventLocalService.getAuditEvents(
+				companyId, start, end, orderByComparator);
 		}
 
 		return auditEventLocalService.getAuditEvents(
-			companyId, start, end, orderByComparator);
+			companyId, _getAllowedAccountEntryIds(permissionChecker), 0, 0,
+			null, null, null, null, null, null, null, null, null, 0, null, true,
+			start, end, orderByComparator);
 	}
 
 	@Override
 	public List<AuditEvent> getAuditEvents(
-			long companyId, long groupId, long userId, String userName,
-			Date createDateGT, Date createDateLT, String eventType,
-			String className, String classPK, String clientHost,
-			String clientIP, String serverName, int serverPort,
-			String sessionID, boolean andSearch, int start, int end)
+			long companyId, long[] accountEntryIds, long groupId, long userId,
+			String userName, Date createDateGT, Date createDateLT,
+			String eventType, String className, String classPK,
+			String clientHost, String clientIP, String serverName,
+			int serverPort, String sessionID, boolean andSearch, int start,
+			int end)
 		throws PortalException {
 
-		PermissionChecker permissionChecker = getPermissionChecker();
-
-		if (!(permissionChecker.isCompanyAdmin(companyId) ||
-			  _userLocalService.hasRoleUser(
-				  companyId, RoleConstants.ANALYTICS_ADMINISTRATOR,
-				  permissionChecker.getUserId(), true))) {
-
-			throw new PrincipalException();
-		}
-
 		return auditEventLocalService.getAuditEvents(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch, start, end);
+			companyId, _filterAccountEntryIds(companyId, accountEntryIds),
+			groupId, userId, userName, createDateGT, createDateLT, eventType,
+			className, classPK, clientHost, clientIP, serverName, serverPort,
+			sessionID, andSearch, start, end);
 	}
 
 	@Override
 	public List<AuditEvent> getAuditEvents(
-			long companyId, long groupId, long userId, String userName,
-			Date createDateGT, Date createDateLT, String eventType,
-			String className, String classPK, String clientHost,
-			String clientIP, String serverName, int serverPort,
-			String sessionID, boolean andSearch, int start, int end,
-			OrderByComparator<AuditEvent> orderByComparator)
+			long companyId, long[] accountEntryIds, long groupId, long userId,
+			String userName, Date createDateGT, Date createDateLT,
+			String eventType, String className, String classPK,
+			String clientHost, String clientIP, String serverName,
+			int serverPort, String sessionID, boolean andSearch, int start,
+			int end, OrderByComparator<AuditEvent> orderByComparator)
 		throws PortalException {
 
-		PermissionChecker permissionChecker = getPermissionChecker();
-
-		if (!(permissionChecker.isCompanyAdmin(companyId) ||
-			  _userLocalService.hasRoleUser(
-				  companyId, RoleConstants.ANALYTICS_ADMINISTRATOR,
-				  permissionChecker.getUserId(), true))) {
-
-			throw new PrincipalException();
-		}
-
 		return auditEventLocalService.getAuditEvents(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch, start, end, orderByComparator);
+			companyId, _filterAccountEntryIds(companyId, accountEntryIds),
+			groupId, userId, userName, createDateGT, createDateLT, eventType,
+			className, classPK, clientHost, clientIP, serverName, serverPort,
+			sessionID, andSearch, start, end, orderByComparator);
 	}
 
 	@Override
 	public int getAuditEventsCount(long companyId) throws PortalException {
-		return auditEventLocalService.getAuditEventsCount(companyId);
+		PermissionChecker permissionChecker = getPermissionChecker();
+
+		if (_hasCrossAccountAuditViewPermission(companyId, permissionChecker)) {
+			return auditEventLocalService.getAuditEventsCount(companyId);
+		}
+
+		return auditEventLocalService.getAuditEventsCount(
+			companyId, _getAllowedAccountEntryIds(permissionChecker), 0, 0,
+			null, null, null, null, null, null, null, null, null, 0, null,
+			true);
 	}
 
 	@Override
 	public int getAuditEventsCount(
-			long companyId, long groupId, long userId, String userName,
-			Date createDateGT, Date createDateLT, String eventType,
-			String className, String classPK, String clientHost,
-			String clientIP, String serverName, int serverPort,
-			String sessionID, boolean andSearch)
+			long companyId, long[] accountEntryIds, long groupId, long userId,
+			String userName, Date createDateGT, Date createDateLT,
+			String eventType, String className, String classPK,
+			String clientHost, String clientIP, String serverName,
+			int serverPort, String sessionID, boolean andSearch)
 		throws PortalException {
 
 		return auditEventLocalService.getAuditEventsCount(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch);
+			companyId, _filterAccountEntryIds(companyId, accountEntryIds),
+			groupId, userId, userName, createDateGT, createDateLT, eventType,
+			className, classPK, clientHost, clientIP, serverName, serverPort,
+			sessionID, andSearch);
 	}
+
+	private long[] _filterAccountEntryIds(
+			long companyId, long[] requestedAccountEntryIds)
+		throws PortalException {
+
+		PermissionChecker permissionChecker = getPermissionChecker();
+
+		if (_hasCrossAccountAuditViewPermission(companyId, permissionChecker)) {
+			return requestedAccountEntryIds;
+		}
+
+		long[] allowedAccountEntryIds = _getAllowedAccountEntryIds(
+			permissionChecker);
+
+		if (ArrayUtil.isEmpty(requestedAccountEntryIds)) {
+			return allowedAccountEntryIds;
+		}
+
+		for (long requestedAccountEntryId : requestedAccountEntryIds) {
+			if (!ArrayUtil.contains(
+					allowedAccountEntryIds, requestedAccountEntryId)) {
+
+				throw new PrincipalException.MustHavePermission(
+					permissionChecker.getUserId(), AccountEntry.class.getName(),
+					requestedAccountEntryId, "VIEW_AUDIT_LOG");
+			}
+		}
+
+		return requestedAccountEntryIds;
+	}
+
+	private long[] _getAllowedAccountEntryIds(
+			PermissionChecker permissionChecker)
+		throws PortalException {
+
+		long permissionAccountEntryId =
+			AccountRolePermissionThreadLocal.getAccountEntryId();
+
+		if (permissionAccountEntryId !=
+				AccountConstants.ACCOUNT_ENTRY_ID_DEFAULT) {
+
+			return new long[] {permissionAccountEntryId};
+		}
+
+		List<AccountEntry> accountEntries =
+			_accountEntryLocalService.getUserAccountEntries(
+				permissionChecker.getUserId(),
+				AccountConstants.PARENT_ACCOUNT_ENTRY_ID_DEFAULT, null,
+				new String[] {
+					AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS,
+					AccountConstants.ACCOUNT_ENTRY_TYPE_PERSON
+				},
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		if (accountEntries.isEmpty()) {
+			return new long[] {AccountConstants.ACCOUNT_ENTRY_ID_DEFAULT};
+		}
+
+		long[] accountEntryIds = new long[accountEntries.size()];
+
+		for (int i = 0; i < accountEntries.size(); i++) {
+			AccountEntry accountEntry = accountEntries.get(i);
+
+			accountEntryIds[i] = accountEntry.getAccountEntryId();
+		}
+
+		return accountEntryIds;
+	}
+
+	private boolean _hasCrossAccountAuditViewPermission(
+			long companyId, PermissionChecker permissionChecker)
+		throws PortalException {
+
+		if (permissionChecker.isCompanyAdmin(companyId)) {
+			return true;
+		}
+
+		return _userLocalService.hasRoleUser(
+			companyId, RoleConstants.ANALYTICS_ADMINISTRATOR,
+			permissionChecker.getUserId(), true);
+	}
+
+	@Reference
+	private AccountEntryLocalService _accountEntryLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/persistence/impl/AuditEventPersistenceImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/persistence/impl/AuditEventPersistenceImpl.java
@@ -219,6 +219,166 @@ public class AuditEventPersistenceImpl
 			dummyFinderCache, new Object[] {companyId});
 	}
 
+	private FinderPath _finderPathWithPaginationFindByC_A;
+	private FinderPath _finderPathWithoutPaginationFindByC_A;
+	private FinderPath _finderPathCountByC_A;
+	private CollectionPersistenceFinder<AuditEvent>
+		_collectionPersistenceFinderByC_A;
+
+	/**
+	 * Returns all the audit events where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @return the matching audit events
+	 */
+	@Override
+	public List<AuditEvent> findByC_A(long companyId, long accountEntryId) {
+		return findByC_A(
+			companyId, accountEntryId, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			null);
+	}
+
+	/**
+	 * Returns a range of all the audit events where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AuditEventModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of audit events
+	 * @param end the upper bound of the range of audit events (not inclusive)
+	 * @return the range of matching audit events
+	 */
+	@Override
+	public List<AuditEvent> findByC_A(
+		long companyId, long accountEntryId, int start, int end) {
+
+		return findByC_A(companyId, accountEntryId, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the audit events where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AuditEventModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of audit events
+	 * @param end the upper bound of the range of audit events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching audit events
+	 */
+	@Override
+	public List<AuditEvent> findByC_A(
+		long companyId, long accountEntryId, int start, int end,
+		OrderByComparator<AuditEvent> orderByComparator) {
+
+		return findByC_A(
+			companyId, accountEntryId, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the audit events where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AuditEventModelImpl</code>.
+	 * </p>
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @param start the lower bound of the range of audit events
+	 * @param end the upper bound of the range of audit events (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching audit events
+	 */
+	@Override
+	public List<AuditEvent> findByC_A(
+		long companyId, long accountEntryId, int start, int end,
+		OrderByComparator<AuditEvent> orderByComparator,
+		boolean useFinderCache) {
+
+		return _collectionPersistenceFinderByC_A.find(
+			dummyFinderCache, new Object[] {companyId, accountEntryId}, start,
+			end, orderByComparator, useFinderCache);
+	}
+
+	/**
+	 * Returns the first audit event in the ordered set where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching audit event
+	 * @throws NoSuchEventException if a matching audit event could not be found
+	 */
+	@Override
+	public AuditEvent findByC_A_First(
+			long companyId, long accountEntryId,
+			OrderByComparator<AuditEvent> orderByComparator)
+		throws NoSuchEventException {
+
+		AuditEvent auditEvent = fetchByC_A_First(
+			companyId, accountEntryId, orderByComparator);
+
+		if (auditEvent != null) {
+			return auditEvent;
+		}
+
+		throw new NoSuchEventException(
+			_collectionPersistenceFinderByC_A.buildNoSuchKeyMessage(
+				_NO_SUCH_ENTITY_WITH_KEY,
+				new Object[] {companyId, accountEntryId}));
+	}
+
+	/**
+	 * Returns the first audit event in the ordered set where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching audit event, or <code>null</code> if a matching audit event could not be found
+	 */
+	@Override
+	public AuditEvent fetchByC_A_First(
+		long companyId, long accountEntryId,
+		OrderByComparator<AuditEvent> orderByComparator) {
+
+		return _collectionPersistenceFinderByC_A.fetchFirst(
+			dummyFinderCache, new Object[] {companyId, accountEntryId},
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the audit events where companyId = &#63; and accountEntryId = &#63; from the database.
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 */
+	@Override
+	public void removeByC_A(long companyId, long accountEntryId) {
+		_collectionPersistenceFinderByC_A.remove(
+			dummyFinderCache, new Object[] {companyId, accountEntryId});
+	}
+
+	/**
+	 * Returns the number of audit events where companyId = &#63; and accountEntryId = &#63;.
+	 *
+	 * @param companyId the company ID
+	 * @param accountEntryId the account entry ID
+	 * @return the number of matching audit events
+	 */
+	@Override
+	public int countByC_A(long companyId, long accountEntryId) {
+		return _collectionPersistenceFinderByC_A.count(
+			dummyFinderCache, new Object[] {companyId, accountEntryId});
+	}
+
 	public AuditEventPersistenceImpl() {
 		setModelClass(AuditEvent.class);
 
@@ -434,6 +594,37 @@ public class AuditEventPersistenceImpl
 					"auditEvent.", "companyId", FinderColumn.Type.LONG, "=",
 					true, true, AuditEvent::getCompanyId));
 
+		_finderPathWithPaginationFindByC_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByC_A",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"companyId", "accountEntryId"}, true);
+
+		_finderPathWithoutPaginationFindByC_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByC_A",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "accountEntryId"}, true);
+
+		_finderPathCountByC_A = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByC_A",
+			new String[] {Long.class.getName(), Long.class.getName()},
+			new String[] {"companyId", "accountEntryId"}, false);
+
+		_collectionPersistenceFinderByC_A = new CollectionPersistenceFinder<>(
+			this, _finderPathWithPaginationFindByC_A,
+			_finderPathWithoutPaginationFindByC_A, _finderPathCountByC_A,
+			_SQL_SELECT_AUDITEVENT_WHERE, _SQL_COUNT_AUDITEVENT_WHERE,
+			AuditEventModelImpl.ORDER_BY_JPQL, _ENTITY_ALIAS_PREFIX, "",
+			new FinderColumn<>(
+				"auditEvent.", "companyId", FinderColumn.Type.LONG, "=", true,
+				true, AuditEvent::getCompanyId),
+			new FinderColumn<>(
+				"auditEvent.", "accountEntryId", FinderColumn.Type.LONG, "=",
+				true, true, AuditEvent::getAccountEntryId));
+
 		AuditEventUtil.setPersistence(this);
 	}
 
@@ -491,4 +682,4 @@ public class AuditEventPersistenceImpl
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1365205996
+// LIFERAY-SERVICE-BUILDER-HASH:1175175687

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/module-hbm.xml
@@ -9,6 +9,7 @@
 		</id>
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="accountEntryId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userName" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="createDate" type="org.hibernate.type.TimestampType" />

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -5,6 +5,7 @@
 		<field name="auditEventId" type="long" />
 		<field name="groupId" type="long" />
 		<field name="companyId" type="long" />
+		<field name="accountEntryId" type="long" />
 		<field name="userId" type="long" />
 		<field name="userName" type="String">
 			<hint name="max-length">200</hint>

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/sql/indexes.sql
@@ -1,1 +1,1 @@
-create index IX_8FE31EDF on Audit_AuditEvent (companyId);
+create index IX_E7F5A093 on Audit_AuditEvent (companyId, accountEntryId);

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/META-INF/sql/tables.sql
@@ -2,6 +2,7 @@ create table Audit_AuditEvent (
 	auditEventId LONG not null primary key,
 	groupId LONG,
 	companyId LONG,
+	accountEntryId LONG,
 	userId LONG,
 	userName VARCHAR(200) null,
 	createDate DATE null,

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/service.properties
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.portal.security.audit.storage.service
-    build.number=2
-    build.date=1343264257622
+    build.number=3
+    build.date=1778872269967

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-test/build.gradle
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-test/build.gradle
@@ -1,4 +1,6 @@
 dependencies {
+	testIntegrationImplementation project(":apps:account:account-api")
+	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-api")
 	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-storage-api")
 	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-storage-service")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-test/src/testIntegration/java/com/liferay/portal/security/audit/storage/service/persistence/test/AuditEventPersistenceTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-test/src/testIntegration/java/com/liferay/portal/security/audit/storage/service/persistence/test/AuditEventPersistenceTest.java
@@ -118,6 +118,8 @@ public class AuditEventPersistenceTest {
 
 		newAuditEvent.setCompanyId(RandomTestUtil.nextLong());
 
+		newAuditEvent.setAccountEntryId(RandomTestUtil.nextLong());
+
 		newAuditEvent.setUserId(RandomTestUtil.nextLong());
 
 		newAuditEvent.setUserName(RandomTestUtil.randomString());
@@ -157,6 +159,9 @@ public class AuditEventPersistenceTest {
 		Assert.assertEquals(
 			existingAuditEvent.getCompanyId(), newAuditEvent.getCompanyId());
 		Assert.assertEquals(
+			existingAuditEvent.getAccountEntryId(),
+			newAuditEvent.getAccountEntryId());
+		Assert.assertEquals(
 			existingAuditEvent.getUserId(), newAuditEvent.getUserId());
 		Assert.assertEquals(
 			existingAuditEvent.getUserName(), newAuditEvent.getUserName());
@@ -194,6 +199,14 @@ public class AuditEventPersistenceTest {
 	}
 
 	@Test
+	public void testCountByC_A() throws Exception {
+		_persistence.countByC_A(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong());
+
+		_persistence.countByC_A(0L, 0L);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		AuditEvent newAuditEvent = addAuditEvent();
 
@@ -219,10 +232,11 @@ public class AuditEventPersistenceTest {
 	protected OrderByComparator<AuditEvent> getOrderByComparator() {
 		return OrderByComparatorFactoryUtil.create(
 			"Audit_AuditEvent", "auditEventId", true, "groupId", true,
-			"companyId", true, "userId", true, "userName", true, "createDate",
-			true, "eventType", true, "className", true, "classPK", true,
-			"message", true, "clientHost", true, "clientIP", true, "serverName",
-			true, "serverPort", true, "sessionID", true);
+			"companyId", true, "accountEntryId", true, "userId", true,
+			"userName", true, "createDate", true, "eventType", true,
+			"className", true, "classPK", true, "message", true, "clientHost",
+			true, "clientIP", true, "serverName", true, "serverPort", true,
+			"sessionID", true);
 	}
 
 	@Test
@@ -443,6 +457,8 @@ public class AuditEventPersistenceTest {
 
 		auditEvent.setCompanyId(RandomTestUtil.nextLong());
 
+		auditEvent.setAccountEntryId(RandomTestUtil.nextLong());
+
 		auditEvent.setUserId(RandomTestUtil.nextLong());
 
 		auditEvent.setUserName(RandomTestUtil.randomString());
@@ -479,4 +495,4 @@ public class AuditEventPersistenceTest {
 	private ClassLoader _dynamicQueryClassLoader;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:100818432
+// LIFERAY-SERVICE-BUILDER-HASH:-730317485

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-test/src/testIntegration/java/com/liferay/portal/security/audit/storage/service/test/AuditEventAccountScopeLocalServiceTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-test/src/testIntegration/java/com/liferay/portal/security/audit/storage/service/test/AuditEventAccountScopeLocalServiceTest.java
@@ -1,0 +1,122 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.audit.storage.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.security.audit.storage.model.AuditEvent;
+import com.liferay.portal.security.audit.storage.service.AuditEventLocalService;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * @author Rafael Praxedes
+ */
+@RunWith(Arquillian.class)
+public class AuditEventAccountScopeLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		BundleContext bundleContext = FrameworkUtil.getBundle(
+			AuditEventAccountScopeLocalServiceTest.class
+		).getBundleContext();
+
+		_auditEventLocalService = bundleContext.getService(
+			bundleContext.getServiceReference(AuditEventLocalService.class));
+
+		_companyId = PortalUtil.getDefaultCompanyId();
+		_eventType = "TEST_" + RandomTestUtil.randomString();
+
+		_accountEntryIdA = RandomTestUtil.randomLong();
+		_accountEntryIdB = RandomTestUtil.randomLong();
+
+		_addAuditEvent(_accountEntryIdA);
+		_addAuditEvent(_accountEntryIdA);
+		_addAuditEvent(_accountEntryIdB);
+		_addAuditEvent(0);
+	}
+
+	@Test
+	public void testFilterByMultipleAccountEntryIds() throws Exception {
+		List<AuditEvent> auditEvents = _auditEventLocalService.getAuditEvents(
+			_companyId, new long[] {_accountEntryIdA, _accountEntryIdB}, 0, 0,
+			null, null, null, _eventType, null, null, null, null, null, 0, null,
+			true, 0, Integer.MAX_VALUE);
+
+		Assert.assertEquals(auditEvents.toString(), 3, auditEvents.size());
+
+		for (AuditEvent auditEvent : auditEvents) {
+			long accountEntryId = auditEvent.getAccountEntryId();
+
+			Assert.assertTrue(
+				"Unexpected accountEntryId " + accountEntryId,
+				(accountEntryId == _accountEntryIdA) ||
+				(accountEntryId == _accountEntryIdB));
+		}
+	}
+
+	@Test
+	public void testFilterBySingleAccountEntryId() throws Exception {
+		List<AuditEvent> auditEvents = _auditEventLocalService.getAuditEvents(
+			_companyId, new long[] {_accountEntryIdA}, 0, 0, null, null, null,
+			_eventType, null, null, null, null, null, 0, null, true, 0,
+			Integer.MAX_VALUE);
+
+		Assert.assertEquals(auditEvents.toString(), 2, auditEvents.size());
+
+		for (AuditEvent auditEvent : auditEvents) {
+			Assert.assertEquals(
+				_accountEntryIdA, auditEvent.getAccountEntryId());
+		}
+	}
+
+	@Test
+	public void testNoFilterReturnsAllForEventType() throws Exception {
+		List<AuditEvent> auditEvents = _auditEventLocalService.getAuditEvents(
+			_companyId, null, 0, 0, null, null, null, _eventType, null, null,
+			null, null, null, 0, null, true, 0, Integer.MAX_VALUE);
+
+		Assert.assertEquals(auditEvents.toString(), 4, auditEvents.size());
+	}
+
+	private void _addAuditEvent(long accountEntryId) {
+		AuditEvent auditEvent = _auditEventLocalService.createAuditEvent(
+			RandomTestUtil.randomLong());
+
+		auditEvent.setCompanyId(_companyId);
+		auditEvent.setAccountEntryId(accountEntryId);
+		auditEvent.setEventType(_eventType);
+		auditEvent.setCreateDate(new Date());
+
+		_auditEventLocalService.addAuditEvent(auditEvent);
+	}
+
+	private long _accountEntryIdA;
+	private long _accountEntryIdB;
+	private AuditEventLocalService _auditEventLocalService;
+	private long _companyId;
+	private String _eventType;
+
+}

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-test/src/testIntegration/java/com/liferay/portal/security/audit/storage/service/test/AuditEventServicePermissionTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-test/src/testIntegration/java/com/liferay/portal/security/audit/storage/service/test/AuditEventServicePermissionTest.java
@@ -1,0 +1,168 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.audit.storage.service.test;
+
+import com.liferay.account.constants.AccountConstants;
+import com.liferay.account.model.AccountEntry;
+import com.liferay.account.service.AccountEntryLocalService;
+import com.liferay.account.service.AccountEntryUserRelLocalService;
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.security.audit.storage.model.AuditEvent;
+import com.liferay.portal.security.audit.storage.service.AuditEventLocalService;
+import com.liferay.portal.security.audit.storage.service.AuditEventService;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+
+/**
+ * @author Rafael Praxedes
+ */
+@RunWith(Arquillian.class)
+public class AuditEventServicePermissionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		BundleContext bundleContext = FrameworkUtil.getBundle(
+			AuditEventServicePermissionTest.class
+		).getBundleContext();
+
+		_accountEntryLocalService = bundleContext.getService(
+			bundleContext.getServiceReference(AccountEntryLocalService.class));
+		_accountEntryUserRelLocalService = bundleContext.getService(
+			bundleContext.getServiceReference(
+				AccountEntryUserRelLocalService.class));
+		_auditEventLocalService = bundleContext.getService(
+			bundleContext.getServiceReference(AuditEventLocalService.class));
+		_auditEventService = bundleContext.getService(
+			bundleContext.getServiceReference(AuditEventService.class));
+		_userLocalService = bundleContext.getService(
+			bundleContext.getServiceReference(UserLocalService.class));
+
+		_companyId = PortalUtil.getDefaultCompanyId();
+		_eventType = "TEST_" + RandomTestUtil.randomString();
+
+		_accountEntryA = _addAccountEntry();
+		_accountEntryB = _addAccountEntry();
+
+		_accountAUser = UserTestUtil.addUser();
+
+		_accountEntryUserRelLocalService.addAccountEntryUserRel(
+			_accountEntryA.getAccountEntryId(), _accountAUser.getUserId());
+
+		_addAuditEvent(_accountEntryA.getAccountEntryId());
+		_addAuditEvent(_accountEntryB.getAccountEntryId());
+		_addAuditEvent(AccountConstants.ACCOUNT_ENTRY_ID_DEFAULT);
+	}
+
+	@Test(expected = PrincipalException.MustHavePermission.class)
+	public void testAccountAdminRequestingForbiddenAccountThrows()
+		throws Exception {
+
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(_accountAUser));
+
+		_auditEventService.getAuditEvents(
+			_companyId, new long[] {_accountEntryB.getAccountEntryId()}, 0, 0,
+			null, null, null, _eventType, null, null, null, null, null, 0, null,
+			true, 0, Integer.MAX_VALUE);
+	}
+
+	@Test
+	public void testAccountAdminSeesOnlyOwnAccountEvents() throws Exception {
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(_accountAUser));
+
+		List<AuditEvent> auditEvents = _auditEventService.getAuditEvents(
+			_companyId, new long[] {_accountEntryA.getAccountEntryId()}, 0, 0,
+			null, null, null, _eventType, null, null, null, null, null, 0, null,
+			true, 0, Integer.MAX_VALUE);
+
+		for (AuditEvent auditEvent : auditEvents) {
+			Assert.assertEquals(
+				_accountEntryA.getAccountEntryId(),
+				auditEvent.getAccountEntryId());
+		}
+	}
+
+	@Test
+	public void testCompanyAdminSeesAllEvents() throws Exception {
+		User adminUser = _userLocalService.getUserByEmailAddress(
+			_companyId, "test@liferay.com");
+
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(adminUser));
+
+		List<AuditEvent> auditEvents = _auditEventService.getAuditEvents(
+			_companyId, null, 0, 0, null, null, null, _eventType, null, null,
+			null, null, null, 0, null, true, 0, Integer.MAX_VALUE);
+
+		Assert.assertEquals(auditEvents.toString(), 3, auditEvents.size());
+	}
+
+	private AccountEntry _addAccountEntry() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		return _accountEntryLocalService.addAccountEntry(
+			RandomTestUtil.randomString(), serviceContext.getUserId(), 0,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), null,
+			RandomTestUtil.randomString() + "@liferay.com", null, null,
+			AccountConstants.ACCOUNT_ENTRY_TYPE_BUSINESS,
+			WorkflowConstants.STATUS_APPROVED, serviceContext);
+	}
+
+	private void _addAuditEvent(long accountEntryId) {
+		AuditEvent auditEvent = _auditEventLocalService.createAuditEvent(
+			RandomTestUtil.randomLong());
+
+		auditEvent.setCompanyId(_companyId);
+		auditEvent.setAccountEntryId(accountEntryId);
+		auditEvent.setEventType(_eventType);
+		auditEvent.setCreateDate(new Date());
+
+		_auditEventLocalService.addAuditEvent(auditEvent);
+	}
+
+	private User _accountAUser;
+	private AccountEntry _accountEntryA;
+	private AccountEntry _accountEntryB;
+	private AccountEntryLocalService _accountEntryLocalService;
+	private AccountEntryUserRelLocalService _accountEntryUserRelLocalService;
+	private AuditEventLocalService _auditEventLocalService;
+	private AuditEventService _auditEventService;
+	private long _companyId;
+	private String _eventType;
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/portal-security-audit/portal-security-audit-wiring/build.gradle
+++ b/modules/apps/portal-security-audit/portal-security-audit-wiring/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:account:account-api")
 	compileOnly project(":apps:portal-security-audit:portal-security-audit-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")

--- a/modules/apps/portal-security-audit/portal-security-audit-wiring/src/main/java/com/liferay/portal/security/audit/wiring/internal/servlet/filter/AuditFilter.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-wiring/src/main/java/com/liferay/portal/security/audit/wiring/internal/servlet/filter/AuditFilter.java
@@ -5,6 +5,8 @@
 
 package com.liferay.portal.security.audit.wiring.internal.servlet.filter;
 
+import com.liferay.account.constants.AccountConstants;
+import com.liferay.account.role.AccountRolePermissionThreadLocal;
 import com.liferay.petra.lang.CentralizedThreadLocal;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
@@ -21,6 +23,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.BaseFilter;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.servlet.TryFilter;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.kernel.util.PrefsPropsUtil;
@@ -71,6 +74,9 @@ public class AuditFilter extends BaseFilter implements TryFilter {
 
 		AuditRequestThreadLocal auditRequestThreadLocal =
 			AuditRequestThreadLocal.getAuditThreadLocal();
+
+		auditRequestThreadLocal.setAccountEntryId(
+			_getAccountEntryId(httpServletRequest));
 
 		auditRequestThreadLocal.setClientHost(
 			httpServletRequest.getRemoteHost());
@@ -164,6 +170,18 @@ public class AuditFilter extends BaseFilter implements TryFilter {
 	@Override
 	protected Log getLog() {
 		return _log;
+	}
+
+	private long _getAccountEntryId(HttpServletRequest httpServletRequest) {
+		long accountEntryId =
+			AccountRolePermissionThreadLocal.getAccountEntryId();
+
+		if (accountEntryId != AccountConstants.ACCOUNT_ENTRY_ID_DEFAULT) {
+			return accountEntryId;
+		}
+
+		return GetterUtil.getLong(
+			httpServletRequest.getParameter("accountEntryId"));
 	}
 
 	private String _getUserLogin(User user) {

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/AuditEventManagerUtil.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/AuditEventManagerUtil.java
@@ -45,8 +45,8 @@ public class AuditEventManagerUtil {
 	}
 
 	public static List<AuditEvent> getAuditEvents(
-		long companyId, long groupId, long userId, String userName,
-		Date createDateGT, Date createDateLT, String eventType,
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, Date createDateGT, Date createDateLT, String eventType,
 		String className, String classPK, String clientHost, String clientIP,
 		String serverName, int serverPort, String sessionID, boolean andSearch,
 		int start, int end,
@@ -57,9 +57,10 @@ public class AuditEventManagerUtil {
 		AuditEventManager auditEventManager = _auditEventManagerSnapshot.get();
 
 		return auditEventManager.getAuditEvents(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch, start, end, orderByComparator);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch, start, end,
+			orderByComparator);
 	}
 
 	public static int getAuditEventsCount(long companyId) {
@@ -69,8 +70,8 @@ public class AuditEventManagerUtil {
 	}
 
 	public static int getAuditEventsCount(
-		long companyId, long groupId, long userId, String userName,
-		Date createDateGT, Date createDateLT, String eventType,
+		long companyId, long[] accountEntryIds, long groupId, long userId,
+		String userName, Date createDateGT, Date createDateLT, String eventType,
 		String className, String classPK, String clientHost, String clientIP,
 		String serverName, int serverPort, String sessionID,
 		boolean andSearch) {
@@ -78,9 +79,9 @@ public class AuditEventManagerUtil {
 		AuditEventManager auditEventManager = _auditEventManagerSnapshot.get();
 
 		return auditEventManager.getAuditEventsCount(
-			companyId, groupId, userId, userName, createDateGT, createDateLT,
-			eventType, className, classPK, clientHost, clientIP, serverName,
-			serverPort, sessionID, andSearch);
+			companyId, accountEntryIds, groupId, userId, userName, createDateGT,
+			createDateLT, eventType, className, classPK, clientHost, clientIP,
+			serverName, serverPort, sessionID, andSearch);
 	}
 
 	private static final Snapshot<AuditEventManager>

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/display/context/AuditDisplayContext.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/display/context/AuditDisplayContext.java
@@ -67,6 +67,17 @@ public class AuditDisplayContext {
 		_yesterday.add(Calendar.DATE, -1);
 	}
 
+	public long getAccountEntryId() {
+		if (_accountEntryId != null) {
+			return _accountEntryId;
+		}
+
+		_accountEntryId = _getParamWithOrWithoutNamespace(
+			ParamUtil::getLong, "accountEntryId", 0L);
+
+		return _accountEntryId;
+	}
+
 	public String getClassName() {
 		if (_className != null) {
 			return _className;
@@ -238,18 +249,20 @@ public class AuditDisplayContext {
 
 			_searchContainer.setResultsAndTotal(
 				() -> AuditEventManagerUtil.getAuditEvents(
-					_themeDisplay.getCompanyId(), getGroupId(), getUserId(),
-					getUserName(), startDate, endDate, getEventType(),
-					getClassName(), getClassPK(), getClientHost(),
-					getClientIP(), getServerName(), getServerPort(), null,
-					displayTerms.isAndOperator(), range[0], range[1],
-					new AuditEventCreateDateComparator()),
+					_themeDisplay.getCompanyId(),
+					_toAccountEntryIds(getAccountEntryId()), getGroupId(),
+					getUserId(), getUserName(), startDate, endDate,
+					getEventType(), getClassName(), getClassPK(),
+					getClientHost(), getClientIP(), getServerName(),
+					getServerPort(), null, displayTerms.isAndOperator(),
+					range[0], range[1], new AuditEventCreateDateComparator()),
 				AuditEventManagerUtil.getAuditEventsCount(
-					_themeDisplay.getCompanyId(), getGroupId(), getUserId(),
-					getUserName(), startDate, endDate, getEventType(),
-					getClassName(), getClassPK(), getClientHost(),
-					getClientIP(), getServerName(), getServerPort(), null,
-					displayTerms.isAndOperator()));
+					_themeDisplay.getCompanyId(),
+					_toAccountEntryIds(getAccountEntryId()), getGroupId(),
+					getUserId(), getUserName(), startDate, endDate,
+					getEventType(), getClassName(), getClassPK(),
+					getClientHost(), getClientIP(), getServerName(),
+					getServerPort(), null, displayTerms.isAndOperator()));
 		}
 		else {
 			String keywords = displayTerms.getKeywords();
@@ -259,13 +272,15 @@ public class AuditDisplayContext {
 
 			_searchContainer.setResultsAndTotal(
 				() -> AuditEventManagerUtil.getAuditEvents(
-					_themeDisplay.getCompanyId(), getGroupId(),
+					_themeDisplay.getCompanyId(),
+					_toAccountEntryIds(getAccountEntryId()), getGroupId(),
 					Long.valueOf(number), keywords, null, null, keywords,
 					keywords, keywords, keywords, keywords, keywords,
 					Integer.valueOf(number), null, false, range[0], range[1],
 					new AuditEventCreateDateComparator()),
 				AuditEventManagerUtil.getAuditEventsCount(
-					_themeDisplay.getCompanyId(), getGroupId(),
+					_themeDisplay.getCompanyId(),
+					_toAccountEntryIds(getAccountEntryId()), getGroupId(),
 					Long.valueOf(number), keywords, null, null, keywords,
 					keywords, keywords, keywords, keywords, keywords,
 					Integer.valueOf(number), null, false));
@@ -461,6 +476,8 @@ public class AuditDisplayContext {
 			PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE + "startDateYear",
 			getStartDateYear()
 		).setParameter(
+			"accountEntryId", getAccountEntryId()
+		).setParameter(
 			"className", getClassName()
 		).setParameter(
 			"classPK", getClassPK()
@@ -485,6 +502,15 @@ public class AuditDisplayContext {
 		return _portletURL;
 	}
 
+	private long[] _toAccountEntryIds(long accountEntryId) {
+		if (accountEntryId <= 0) {
+			return null;
+		}
+
+		return new long[] {accountEntryId};
+	}
+
+	private Long _accountEntryId;
 	private String _className;
 	private String _classPK;
 	private String _clientHost;

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
@@ -182,6 +182,9 @@ public class ExportAuditEventsMVCResourceCommand
 				"create-date",
 				auditEvent -> _formatDate(auditEvent.getCreateDate())
 			).put(
+				"account-id",
+				auditEvent -> String.valueOf(auditEvent.getAccountEntryId())
+			).put(
 				"group-id",
 				auditEvent -> String.valueOf(auditEvent.getGroupId())
 			).put(

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/event_search.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/event_search.jsp
@@ -20,6 +20,8 @@ SearchContainer<?> searchContainer = (SearchContainer<?>)request.getAttribute("l
 
 	<aui:input label="user-name" name="userName" value="<%= auditDisplayContext.getUserName() %>" />
 
+	<aui:input label="account-id" name="accountEntryId" value="<%= (auditDisplayContext.getAccountEntryId() != 0) ? String.valueOf(auditDisplayContext.getAccountEntryId()) : StringPool.BLANK %>" />
+
 	<aui:input label="group-id" name="groupId" value="<%= (auditDisplayContext.getGroupId() != 0) ? String.valueOf(auditDisplayContext.getGroupId()) : StringPool.BLANK %>" />
 
 	<aui:input label="resource-id" name="classPK" value="<%= auditDisplayContext.getClassPK() %>" />

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/view_audit_event.jsp
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/resources/META-INF/resources/view_audit_event.jsp
@@ -51,6 +51,10 @@ renderResponse.setTitle((auditEvent == null) ? "audit-event" : auditEvent.getEve
 				<%= dateTimeFormat.format(auditEvent.getCreateDate()) %>
 			</aui:field-wrapper>
 
+			<aui:field-wrapper label="account-id">
+				<%= auditEvent.getAccountEntryId() %>
+			</aui:field-wrapper>
+
 			<aui:field-wrapper label="group-id">
 				<%= auditEvent.getGroupId() %>
 			</aui:field-wrapper>

--- a/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessage.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessage.java
@@ -35,6 +35,7 @@ public class AuditMessage implements Serializable {
 	public AuditMessage(String message) throws JSONException {
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(message);
 
+		_accountEntryId = jsonObject.getLong(_ACCOUNT_ENTRY_ID);
 		_additionalInfoJSONObject = jsonObject.getJSONObject(_ADDITIONAL_INFO);
 		_className = jsonObject.getString(_CLASS_NAME);
 		_classPK = jsonObject.getString(_CLASS_PK);
@@ -93,6 +94,7 @@ public class AuditMessage implements Serializable {
 		AuditRequestThreadLocal auditRequestThreadLocal =
 			AuditRequestThreadLocal.getAuditThreadLocal();
 
+		_accountEntryId = auditRequestThreadLocal.getAccountEntryId();
 		_clientHost = auditRequestThreadLocal.getClientHost();
 		_clientIP = auditRequestThreadLocal.getClientIP();
 		_serverName = auditRequestThreadLocal.getServerName();
@@ -181,6 +183,10 @@ public class AuditMessage implements Serializable {
 			message, null, additionalInfoJSONObject);
 	}
 
+	public long getAccountEntryId() {
+		return _accountEntryId;
+	}
+
 	public JSONObject getAdditionalInfo() {
 		return _additionalInfoJSONObject;
 	}
@@ -247,6 +253,10 @@ public class AuditMessage implements Serializable {
 
 	public String getUserName() {
 		return _userName;
+	}
+
+	public void setAccountEntryId(long accountEntryId) {
+		_accountEntryId = accountEntryId;
 	}
 
 	public void setAdditionalInfo(JSONObject additionalInfoJSONObject) {
@@ -323,6 +333,8 @@ public class AuditMessage implements Serializable {
 
 	public JSONObject toJSONObject() {
 		return JSONUtil.put(
+			_ACCOUNT_ENTRY_ID, _accountEntryId
+		).put(
 			_ADDITIONAL_INFO, _additionalInfoJSONObject
 		).put(
 			_CLASS_NAME, _className
@@ -360,6 +372,8 @@ public class AuditMessage implements Serializable {
 	private DateFormat _getDateFormat() {
 		return DateFormatFactoryUtil.getSimpleDateFormat(_DATE_FORMAT);
 	}
+
+	private static final String _ACCOUNT_ENTRY_ID = "accountEntryId";
 
 	private static final String _ADDITIONAL_INFO = "additionalInfo";
 
@@ -399,6 +413,7 @@ public class AuditMessage implements Serializable {
 
 	private static final Log _log = LogFactoryUtil.getLog(AuditMessage.class);
 
+	private long _accountEntryId;
 	private JSONObject _additionalInfoJSONObject;
 	private String _className;
 	private String _classPK;

--- a/portal-kernel/src/com/liferay/portal/kernel/audit/AuditRequestThreadLocal.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/audit/AuditRequestThreadLocal.java
@@ -28,6 +28,10 @@ public class AuditRequestThreadLocal {
 		_auditRequest.remove();
 	}
 
+	public long getAccountEntryId() {
+		return _accountEntryId;
+	}
+
 	public String getClientHost() {
 		return _clientHost;
 	}
@@ -66,6 +70,10 @@ public class AuditRequestThreadLocal {
 
 	public String getSessionID() {
 		return _sessionID;
+	}
+
+	public void setAccountEntryId(long accountEntryId) {
+		_accountEntryId = accountEntryId;
 	}
 
 	public void setClientHost(String clientHost) {
@@ -112,6 +120,7 @@ public class AuditRequestThreadLocal {
 		new CentralizedThreadLocal<>(
 			AuditRequestThreadLocal.class + "._auditRequest");
 
+	private long _accountEntryId;
 	private String _clientHost;
 	private String _clientIP;
 	private String _queryString;

--- a/portal-kernel/src/com/liferay/portal/kernel/audit/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/audit/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 9.1.0


### PR DESCRIPTION
## Summary

Closes [LPD-89898](https://liferay.atlassian.net/browse/LPD-89898). Adds per-`AccountEntry` scoping to the Liferay audit framework so account-scoped users cannot read other accounts' audit log entries. The change is platform-wide (the audit framework itself); AI Hub stories under [LPD-65216](https://liferay.atlassian.net/browse/LPD-65216) become consumers.

The design follows existing Liferay precedents — schema and finder mirror `commerce-product-service`'s `CommerceCatalog`; the read-narrowing algorithm mirrors `AccountRoleSearchPermissionFilterContributor`.

## Changes by layer

### Schema (Service Builder)

- Added `accountEntryId` column to the `AuditEvent` entity (`portal-security-audit-storage-service/service.xml`) plus a `C_A` finder on `(companyId, accountEntryId)`.
- Service Builder regenerated the model, persistence, SQL upgrade, and packageinfo (storage-api `model` minor bump 3.2.0 → 3.3.0; `service` major bump 3.1.0 → 4.0.0).
- The composite index `(companyId, accountEntryId)` keeps the common UI query path fast.

### Context propagation

- Extended `AuditMessage` and `AuditRequestThreadLocal` in `portal-kernel` with `accountEntryId` (packageinfo 9.0.0 → 9.1.0).
- `AuditFilter` resolves the account context from `AccountRolePermissionThreadLocal` → request param `accountEntryId` → `AccountConstants.ACCOUNT_ENTRY_ID_DEFAULT` and populates the thread-local for every request.
- `AuditMessageBuilder` exposes an overload that accepts an explicit `accountEntryId` for producers that already know the account.

### Read authorization

- `AuditEventLocalServiceImpl` now accepts `long[] accountEntryIds` on `getAuditEvents` / `getAuditEventsCount`; the dynamic query applies `eq` (single) or `in` (multiple).
- `AuditEventServiceImpl` mirrors the algorithm in `AccountRoleSearchPermissionFilterContributor`:
  1. Company admin or Analytics admin → pass-through.
  2. Otherwise, intersect with the caller's accounts via `AccountEntryLocalService.getUserAccountEntries(...)` (BUSINESS + PERSON types).
  3. Explicit forbidden `accountEntryId` → `PrincipalException.MustHavePermission`.
- System events (`accountEntryId == 0`) remain visible only to cross-account viewers.

### Consumers

- `AuditDisplayContext` and `event_search.jsp` add an **Account ID** filter input that round-trips via the portlet URL.
- `view_audit_event.jsp` shows the account ID in the detail panel.
- `ExportAuditEventsMVCResourceCommand` adds an `account-id` CSV column.
- `ObjectEntryDTOConverter` passes `null` for the new `accountEntryIds` parameter when assembling the embedded audit-history array — the existing `classPK` filter already narrows to the entry.

### Breaking change

- `AuditEventManager`'s `getAuditEvents` and `getAuditEventsCount` signatures gained a `long[] accountEntryIds` parameter between `companyId` and `groupId`. The full `# breaking` annotation lives on commit `822ac70`; `portal-security-audit-api` packageinfo was bumped 4.1.0 → 5.0.0.
- The kernel `AuditEvent` interface (`portal-security-audit-api`) adds `getAccountEntryId` / `setAccountEntryId`. The dynamic-proxy adapter in `AuditEventAutoEscapeBeanHandler` routes calls through to the Service Builder model.

## Test plan

### Automated

```bash
cd modules/apps/portal-security-audit/portal-security-audit-storage-test

# Local-service filter (3 cases: single account, multi-account IN, no filter)
../../../../gradlew testIntegration --tests AuditEventAccountScopeLocalServiceTest

# Remote-service authorization (3 cases: company admin, account admin allowed, account admin forbidden)
../../../../gradlew testIntegration --tests AuditEventServicePermissionTest
```

### Manual smoke

Deploy the affected modules: `ant install-portal-snapshot` from `portal-kernel`, then `gw deploy` on each of the touched OSGi modules. Restart the bundle so portal-kernel changes take effect.

1. **Cross-account view (global admin):** Sign in as the global admin → open the **Audit Events** portlet. All rows must be visible, including `accountEntryId = 0` system rows. Use the new **Account ID** filter input to narrow to a specific account.
2. **Account isolation:** Create Account A and Account B; assign user `alice` to A only. Emit one audit event per scope:
   - `accountEntryId = A` (e.g., update an object in an account-scoped definition).
   - `accountEntryId = B`.
   - `accountEntryId = 0` (a global setting change).

   Sign in as `alice` → the Audit Events grid lists only the Account A row. The Account B row and the system row must not be visible.
3. **Forbidden-account tamper:** As `alice`, manually set the URL parameter `accountEntryId=<B>` on the portlet → the response is an empty grid; a direct service-layer call would throw `PrincipalException.MustHavePermission`.
4. **Object REST API:** `curl -u alice:... /o/object-admin/v1.0/<defId>/object-entries/<entryFromB>` → the embedded `auditEvents` array does not leak Account B entries.
5. **CSV export:** Trigger an export from the global admin's audit grid → the new `account-id` column appears and matches the on-screen value.

### Migration check

- Existing audit rows backfill to `accountEntryId = 0` (default column value generated by Service Builder upgrade).
- Legacy rows remain visible to cross-account viewers only — confirmed by the test that asserts the global admin sees 3 rows including the `0` row.
- No backwards-compatibility shim required: producers that don't pass `accountEntryId` write events with `accountEntryId = 0` (system events) and remain visible to global admins.

### Out of scope

- No standalone audit REST endpoint exists today; not created here.
- AI Hub audit producers ([LPD-65216](https://liferay.atlassian.net/browse/LPD-65216), [LPD-89835](https://liferay.atlassian.net/browse/LPD-89835), [LPD-89838](https://liferay.atlassian.net/browse/LPD-89838)) will populate `accountEntryId` through the new `AuditMessageBuilder` overload once rebased onto this branch.

## Commit layout

10 module-scoped commits, with all Service Builder regenerated files isolated in commit `4fd207d - Autogenerated`:

| | Commit | Module / source type |
|---|---|---|
| 1 | `0a6d9d7` | portal-kernel |
| 2 | `822ac70` | portal-security-audit-api — **breaking** |
| 3 | `a898c21` | portal-security-audit-storage-service |
| 4 | `4fd207d` | portal-security-audit-storage-service — Autogenerated |
| 5 | `ef86868` | portal-security-audit-event-generators-api |
| 6 | `f167b58` | portal-security-audit-wiring |
| 7 | `61fd363` | portal-security-audit-storage-test |
| 8 | `2171a04` | portal-security-audit-web — java |
| 9 | `f1a8b62` | portal-security-audit-web — JSP |
| 10 | `aaa11dc` | object-rest-impl |