### PR TITLE
LPD-91374 Fix NPE in click-to-chat LogoutPreAction during lockout

### DIFF
--- a/modules/apps/click-to-chat/click-to-chat-test/src/testIntegration/java/com/liferay/click/to/chat/web/internal/events/test/LogoutPreActionTest.java
+++ b/modules/apps/click-to-chat/click-to-chat-test/src/testIntegration/java/com/liferay/click/to/chat/web/internal/events/test/LogoutPreActionTest.java
@@ -87,6 +87,39 @@ public class LogoutPreActionTest {
 				"test-cookie", _mockHttpServletRequest));
 	}
 
+	@Test
+	public void testLogoutWithoutThemeDisplay() throws Exception {
+		_mockHttpServletRequest.removeAttribute(WebKeys.THEME_DISPLAY);
+		_mockHttpServletRequest.setAttribute(
+			WebKeys.COMPANY_ID, TestPropsValues.getCompanyId());
+
+		_assertCookiesExist();
+
+		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
+				new ConfigurationTemporarySwapper(
+					"com.liferay.click.to.chat.web.internal.configuration." +
+						"ClickToChatConfiguration",
+					HashMapDictionaryBuilder.<String, Object>put(
+						"chatProviderId", "intercom"
+					).put(
+						"enabled", true
+					).build())) {
+
+			AuthenticatedSessionManagerUtil.logout(
+				_mockHttpServletRequest, new MockHttpServletResponse());
+		}
+
+		Assert.assertNull(
+			CookiesManagerUtil.getCookieValue(
+				"intercom-id-test", _mockHttpServletRequest));
+		Assert.assertNull(
+			CookiesManagerUtil.getCookieValue(
+				"intercom-session-test", _mockHttpServletRequest));
+		Assert.assertNotNull(
+			CookiesManagerUtil.getCookieValue(
+				"test-cookie", _mockHttpServletRequest));
+	}
+
 	private void _assertCookiesExist() {
 		Assert.assertNotNull(
 			CookiesManagerUtil.getCookieValue(

--- a/modules/apps/click-to-chat/click-to-chat-web/src/main/java/com/liferay/click/to/chat/web/internal/events/LogoutPreAction.java
+++ b/modules/apps/click-to-chat/click-to-chat-web/src/main/java/com/liferay/click/to/chat/web/internal/events/LogoutPreAction.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
 import com.liferay.portal.kernel.events.Action;
 import com.liferay.portal.kernel.events.LifecycleAction;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -31,13 +32,24 @@ public class LogoutPreAction extends Action {
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {
 
+		long companyId;
+		long groupId;
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
+		if (themeDisplay != null) {
+			companyId = themeDisplay.getCompanyId();
+			groupId = themeDisplay.getSiteGroupId();
+		}
+		else {
+			companyId = PortalUtil.getCompanyId(httpServletRequest);
+			groupId = 0;
+		}
+
 		ClickToChatConfiguration clickToChatConfiguration =
 			ClickToChatConfigurationUtil.getClickToChatConfiguration(
-				themeDisplay.getCompanyId(), themeDisplay.getSiteGroupId());
+				companyId, groupId);
 
 		if ((clickToChatConfiguration == null) ||
 			!clickToChatConfiguration.enabled() ||


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91374

## What is being fixed

When a locked user makes any request, `LockoutFilter` calls `AuthenticatedSessionManagerUtil.logout(...)`, which fires every `logout.events.pre` `LifecycleAction`. The click-to-chat `LogoutPreAction` reads `WebKeys.THEME_DISPLAY` and immediately calls `themeDisplay.getCompanyId()` and `themeDisplay.getSiteGroupId()`. The `ThemeDisplay` request attribute is not populated yet at the filter stage, so the call throws a `NullPointerException` that escapes the filter. The response is committed empty (HTTP 200, 0 bytes — a blank white screen), and the locked user can no longer navigate, sign in, or reach the login page.

## How it is being fixed

Resolve `companyId` from `PortalUtil.getCompanyId(httpServletRequest)` when `ThemeDisplay` is absent, and use `0` as the group id so `ClickToChatConfigurationUtil.getClickToChatConfiguration` falls back to the company-level configuration. The remaining behaviour (early-return on disabled or non-intercom configurations, intercom-cookie cleanup) is unchanged. The narrowest fix is in the offending action, leaving `LockoutFilter` and `AuthenticatedSessionManagerUtil` alone. A new integration test, `testLogoutWithoutThemeDisplay`, drives the lockout-filter call site by removing `WebKeys.THEME_DISPLAY` from the request before invoking `AuthenticatedSessionManagerUtil.logout`.

## Notes

Local pr-check reports PASS on source-format, per-module-deploy, integration-test-compile, and java-unit-test. Structural smoke fails on two pre-existing portal-impl tests on master `4bbe5ccc700f6` (`Log4jConfigUtilTest` coverage assertion and `ConfigurationEnvBuilderTest.testBuildContent` missing overrides for `AIHubCellConfiguration` and `MCPServerConfiguration`). Neither touches click-to-chat-web.