### PR TITLE
LPD-91337-support

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/BaseAccessTokenGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/BaseAccessTokenGrantHandler.java
@@ -17,11 +17,15 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 import org.apache.cxf.rs.security.oauth2.common.Client;
 import org.apache.cxf.rs.security.oauth2.common.ServerAccessToken;
@@ -66,6 +70,38 @@ public abstract class BaseAccessTokenGrantHandler
 			OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_COMPANY_ID);
 
 		return Objects.equals(companyId1, companyId2);
+	}
+
+	protected ServerAccessToken createAccessTokenWithResources(
+		Client client, MultivaluedMap<String, String> params,
+		Supplier<ServerAccessToken> supplier) {
+
+		List<String> resources = params.get("resource");
+
+		if (ListUtil.isEmpty(resources)) {
+			return supplier.get();
+		}
+
+		List<String> originalRegisteredAudiences =
+			client.getRegisteredAudiences();
+
+		try {
+			List<String> mutableAudiences = new ArrayList<>(
+				originalRegisteredAudiences);
+
+			for (String resource : resources) {
+				if (!mutableAudiences.contains(resource)) {
+					mutableAudiences.add(resource);
+				}
+			}
+
+			client.setRegisteredAudiences(mutableAudiences);
+
+			return supplier.get();
+		}
+		finally {
+			client.setRegisteredAudiences(originalRegisteredAudiences);
+		}
 	}
 
 	protected abstract ServerAccessToken doCreateAccessToken(

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/BaseAccessTokenGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/BaseAccessTokenGrantHandler.java
@@ -8,6 +8,7 @@ package com.liferay.oauth2.provider.rest.internal.endpoint.access.token.grant.ha
 import com.liferay.oauth2.provider.constants.OAuth2ProviderActionKeys;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
+import com.liferay.oauth2.provider.rest.internal.endpoint.util.OAuth2ErrorUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -19,8 +20,13 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -82,25 +88,29 @@ public abstract class BaseAccessTokenGrantHandler
 			return supplier.get();
 		}
 
-		List<String> originalRegisteredAudiences =
-			client.getRegisteredAudiences();
+		for (String resource : resources) {
+			_validateResource(resource);
+		}
 
-		try {
-			List<String> mutableAudiences = new ArrayList<>(
-				originalRegisteredAudiences);
+		List<String> registeredAudiences = client.getRegisteredAudiences();
 
+		if (ListUtil.isNotEmpty(registeredAudiences)) {
 			for (String resource : resources) {
-				if (!mutableAudiences.contains(resource)) {
-					mutableAudiences.add(resource);
+				if (!registeredAudiences.contains(resource)) {
+					OAuth2ErrorUtil.reportInvalidRequestError(
+						"The resource parameter is not a registered audience",
+						"invalid_target", Response.Status.BAD_REQUEST);
 				}
 			}
+		}
 
-			client.setRegisteredAudiences(mutableAudiences);
+		try {
+			client.setRegisteredAudiences(new ArrayList<>(resources));
 
 			return supplier.get();
 		}
 		finally {
-			client.setRegisteredAudiences(originalRegisteredAudiences);
+			client.setRegisteredAudiences(registeredAudiences);
 		}
 	}
 
@@ -168,6 +178,27 @@ public abstract class BaseAccessTokenGrantHandler
 
 	@Reference
 	protected UserLocalService userLocalService;
+
+	private void _validateResource(String resource) {
+		if (!Validator.isBlank(resource)) {
+			try {
+				URI uri = new URI(resource);
+
+				if (uri.isAbsolute() && (uri.getFragment() == null)) {
+					return;
+				}
+			}
+			catch (URISyntaxException uriSyntaxException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(uriSyntaxException);
+				}
+			}
+		}
+
+		OAuth2ErrorUtil.reportInvalidRequestError(
+			"The resource parameter must be an absolute URI without a fragment",
+			"invalid_target", Response.Status.BAD_REQUEST);
+	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseAccessTokenGrantHandler.class);

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayAuthorizationAccessTokenCodeGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayAuthorizationAccessTokenCodeGrantHandler.java
@@ -13,11 +13,9 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -69,34 +67,10 @@ public class LiferayAuthorizationAccessTokenCodeGrantHandler
 	protected ServerAccessToken doCreateAccessToken(
 		Client client, MultivaluedMap<String, String> params) {
 
-		List<String> resources = params.get("resource");
-
-		if (ListUtil.isEmpty(resources)) {
-			return _authorizationCodeGrantHandler.createAccessToken(
-				client, params);
-		}
-
-		List<String> originalRegisteredAudiences =
-			client.getRegisteredAudiences();
-
-		try {
-			List<String> mutableAudiences = new ArrayList<>(
-				originalRegisteredAudiences);
-
-			for (String resource : resources) {
-				if (!mutableAudiences.contains(resource)) {
-					mutableAudiences.add(resource);
-				}
-			}
-
-			client.setRegisteredAudiences(mutableAudiences);
-
-			return _authorizationCodeGrantHandler.createAccessToken(
-				client, params);
-		}
-		finally {
-			client.setRegisteredAudiences(originalRegisteredAudiences);
-		}
+		return createAccessTokenWithResources(
+			client, params,
+			() -> _authorizationCodeGrantHandler.createAccessToken(
+				client, params));
 	}
 
 	@Override

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayAuthorizationAccessTokenCodeGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayAuthorizationAccessTokenCodeGrantHandler.java
@@ -13,9 +13,11 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -67,7 +69,32 @@ public class LiferayAuthorizationAccessTokenCodeGrantHandler
 	protected ServerAccessToken doCreateAccessToken(
 		Client client, MultivaluedMap<String, String> params) {
 
-		return _authorizationCodeGrantHandler.createAccessToken(client, params);
+		String resource = params.getFirst("resource");
+
+		if (Validator.isNull(resource)) {
+			return _authorizationCodeGrantHandler.createAccessToken(
+				client, params);
+		}
+
+		List<String> originalRegisteredAudiences =
+			client.getRegisteredAudiences();
+
+		try {
+			List<String> mutableAudiences = new ArrayList<>(
+				originalRegisteredAudiences);
+
+			if (!mutableAudiences.contains(resource)) {
+				mutableAudiences.add(resource);
+			}
+
+			client.setRegisteredAudiences(mutableAudiences);
+
+			return _authorizationCodeGrantHandler.createAccessToken(
+				client, params);
+		}
+		finally {
+			client.setRegisteredAudiences(originalRegisteredAudiences);
+		}
 	}
 
 	@Override

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayAuthorizationAccessTokenCodeGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayAuthorizationAccessTokenCodeGrantHandler.java
@@ -13,7 +13,7 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.ListUtil;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
@@ -69,9 +69,9 @@ public class LiferayAuthorizationAccessTokenCodeGrantHandler
 	protected ServerAccessToken doCreateAccessToken(
 		Client client, MultivaluedMap<String, String> params) {
 
-		String resource = params.getFirst("resource");
+		List<String> resources = params.get("resource");
 
-		if (Validator.isNull(resource)) {
+		if (ListUtil.isEmpty(resources)) {
 			return _authorizationCodeGrantHandler.createAccessToken(
 				client, params);
 		}
@@ -83,8 +83,10 @@ public class LiferayAuthorizationAccessTokenCodeGrantHandler
 			List<String> mutableAudiences = new ArrayList<>(
 				originalRegisteredAudiences);
 
-			if (!mutableAudiences.contains(resource)) {
-				mutableAudiences.add(resource);
+			for (String resource : resources) {
+				if (!mutableAudiences.contains(resource)) {
+					mutableAudiences.add(resource);
+				}
 			}
 
 			client.setRegisteredAudiences(mutableAudiences);

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayClientCredentialsAccessTokenGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayClientCredentialsAccessTokenGrantHandler.java
@@ -9,11 +9,9 @@ import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.rest.internal.endpoint.liferay.LiferayOAuthDataProvider;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -56,34 +54,10 @@ public class LiferayClientCredentialsAccessTokenGrantHandler
 	protected ServerAccessToken doCreateAccessToken(
 		Client client, MultivaluedMap<String, String> params) {
 
-		List<String> resources = params.get("resource");
-
-		if (ListUtil.isEmpty(resources)) {
-			return _clientCredentialsGrantHandler.createAccessToken(
-				client, params);
-		}
-
-		List<String> originalRegisteredAudiences =
-			client.getRegisteredAudiences();
-
-		try {
-			List<String> mutableAudiences = new ArrayList<>(
-				originalRegisteredAudiences);
-
-			for (String resource : resources) {
-				if (!mutableAudiences.contains(resource)) {
-					mutableAudiences.add(resource);
-				}
-			}
-
-			client.setRegisteredAudiences(mutableAudiences);
-
-			return _clientCredentialsGrantHandler.createAccessToken(
-				client, params);
-		}
-		finally {
-			client.setRegisteredAudiences(originalRegisteredAudiences);
-		}
+		return createAccessTokenWithResources(
+			client, params,
+			() -> _clientCredentialsGrantHandler.createAccessToken(
+				client, params));
 	}
 
 	@Override

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayClientCredentialsAccessTokenGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayClientCredentialsAccessTokenGrantHandler.java
@@ -9,9 +9,11 @@ import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.rest.internal.endpoint.liferay.LiferayOAuthDataProvider;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +56,32 @@ public class LiferayClientCredentialsAccessTokenGrantHandler
 	protected ServerAccessToken doCreateAccessToken(
 		Client client, MultivaluedMap<String, String> params) {
 
-		return _clientCredentialsGrantHandler.createAccessToken(client, params);
+		String resource = params.getFirst("resource");
+
+		if (Validator.isNull(resource)) {
+			return _clientCredentialsGrantHandler.createAccessToken(
+				client, params);
+		}
+
+		List<String> originalRegisteredAudiences =
+			client.getRegisteredAudiences();
+
+		try {
+			List<String> mutableAudiences = new ArrayList<>(
+				originalRegisteredAudiences);
+
+			if (!mutableAudiences.contains(resource)) {
+				mutableAudiences.add(resource);
+			}
+
+			client.setRegisteredAudiences(mutableAudiences);
+
+			return _clientCredentialsGrantHandler.createAccessToken(
+				client, params);
+		}
+		finally {
+			client.setRegisteredAudiences(originalRegisteredAudiences);
+		}
 	}
 
 	@Override

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayClientCredentialsAccessTokenGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayClientCredentialsAccessTokenGrantHandler.java
@@ -9,7 +9,7 @@ import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.rest.internal.endpoint.liferay.LiferayOAuthDataProvider;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.ListUtil;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
@@ -56,9 +56,9 @@ public class LiferayClientCredentialsAccessTokenGrantHandler
 	protected ServerAccessToken doCreateAccessToken(
 		Client client, MultivaluedMap<String, String> params) {
 
-		String resource = params.getFirst("resource");
+		List<String> resources = params.get("resource");
 
-		if (Validator.isNull(resource)) {
+		if (ListUtil.isEmpty(resources)) {
 			return _clientCredentialsGrantHandler.createAccessToken(
 				client, params);
 		}
@@ -70,8 +70,10 @@ public class LiferayClientCredentialsAccessTokenGrantHandler
 			List<String> mutableAudiences = new ArrayList<>(
 				originalRegisteredAudiences);
 
-			if (!mutableAudiences.contains(resource)) {
-				mutableAudiences.add(resource);
+			for (String resource : resources) {
+				if (!mutableAudiences.contains(resource)) {
+					mutableAudiences.add(resource);
+				}
 			}
 
 			client.setRegisteredAudiences(mutableAudiences);

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -70,6 +70,8 @@ import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
 
 import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import java.nio.charset.StandardCharsets;
 
@@ -988,6 +990,8 @@ public class LiferayOAuthDataProvider
 	protected ServerAccessToken doCreateAccessToken(
 		AccessTokenRegistration accessTokenRegistration) {
 
+		_validateAudiences(accessTokenRegistration.getAudiences());
+
 		ServerAccessToken serverAccessToken = _createOpaqueServerAccessToken(
 			accessTokenRegistration.getAudiences(),
 			accessTokenRegistration.getClient(),
@@ -1787,6 +1791,39 @@ public class LiferayOAuthDataProvider
 
 			throw new OAuthServiceException(
 				portalException.getMessage(), portalException);
+		}
+	}
+
+	private void _validateAudiences(List<String> audiences) {
+		if (ListUtil.isEmpty(audiences)) {
+			return;
+		}
+
+		for (String audience : audiences) {
+			if (Validator.isBlank(audience)) {
+				continue;
+			}
+
+			URI uri;
+
+			try {
+				uri = new URI(audience);
+			}
+			catch (URISyntaxException uriSyntaxException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(uriSyntaxException);
+				}
+
+				OAuth2ErrorUtil.reportInvalidRequestError(
+					audience, "invalid_target", Response.Status.BAD_REQUEST);
+
+				return;
+			}
+
+			if (!uri.isAbsolute() || audience.contains(StringPool.POUND)) {
+				OAuth2ErrorUtil.reportInvalidRequestError(
+					audience, "invalid_target", Response.Status.BAD_REQUEST);
+			}
 		}
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -1801,7 +1801,8 @@ public class LiferayOAuthDataProvider
 
 		for (String audience : audiences) {
 			if (Validator.isBlank(audience)) {
-				continue;
+				OAuth2ErrorUtil.reportInvalidRequestError(
+					audience, "invalid_target", Response.Status.BAD_REQUEST);
 			}
 
 			URI uri;

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -1805,23 +1805,20 @@ public class LiferayOAuthDataProvider
 					audience, "invalid_target", Response.Status.BAD_REQUEST);
 			}
 
-			URI uri;
-
 			try {
-				uri = new URI(audience);
+				URI uri = new URI(audience);
+
+				if (!uri.isAbsolute() || audience.contains(StringPool.POUND)) {
+					OAuth2ErrorUtil.reportInvalidRequestError(
+						audience, "invalid_target",
+						Response.Status.BAD_REQUEST);
+				}
 			}
 			catch (URISyntaxException uriSyntaxException) {
 				if (_log.isDebugEnabled()) {
 					_log.debug(uriSyntaxException);
 				}
 
-				OAuth2ErrorUtil.reportInvalidRequestError(
-					audience, "invalid_target", Response.Status.BAD_REQUEST);
-
-				return;
-			}
-
-			if (!uri.isAbsolute() || audience.contains(StringPool.POUND)) {
 				OAuth2ErrorUtil.reportInvalidRequestError(
 					audience, "invalid_target", Response.Status.BAD_REQUEST);
 			}

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -70,8 +70,6 @@ import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
 
 import java.net.HttpURLConnection;
-import java.net.URI;
-import java.net.URISyntaxException;
 
 import java.nio.charset.StandardCharsets;
 
@@ -990,8 +988,6 @@ public class LiferayOAuthDataProvider
 	protected ServerAccessToken doCreateAccessToken(
 		AccessTokenRegistration accessTokenRegistration) {
 
-		_validateAudiences(accessTokenRegistration.getAudiences());
-
 		ServerAccessToken serverAccessToken = _createOpaqueServerAccessToken(
 			accessTokenRegistration.getAudiences(),
 			accessTokenRegistration.getClient(),
@@ -1791,37 +1787,6 @@ public class LiferayOAuthDataProvider
 
 			throw new OAuthServiceException(
 				portalException.getMessage(), portalException);
-		}
-	}
-
-	private void _validateAudiences(List<String> audiences) {
-		if (ListUtil.isEmpty(audiences)) {
-			return;
-		}
-
-		for (String audience : audiences) {
-			if (Validator.isBlank(audience)) {
-				OAuth2ErrorUtil.reportInvalidRequestError(
-					audience, "invalid_target", Response.Status.BAD_REQUEST);
-			}
-
-			try {
-				URI uri = new URI(audience);
-
-				if (!uri.isAbsolute() || audience.contains(StringPool.POUND)) {
-					OAuth2ErrorUtil.reportInvalidRequestError(
-						audience, "invalid_target",
-						Response.Status.BAD_REQUEST);
-				}
-			}
-			catch (URISyntaxException uriSyntaxException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(uriSyntaxException);
-				}
-
-				OAuth2ErrorUtil.reportInvalidRequestError(
-					audience, "invalid_target", Response.Status.BAD_REQUEST);
-			}
 		}
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
@@ -55,7 +55,8 @@ public class TokenAudienceTest extends BaseClientTestCase {
 		_testTokenIntrospectionAudience(
 			Collections.singletonList(_RESOURCE_URI));
 		_testTokenIntrospectionAudience(
-			Arrays.asList(_RESOURCE_URI, _RESOURCE_URI_2));
+			Arrays.asList(
+				_RESOURCE_URI, "https://" + RandomTestUtil.randomString()));
 	}
 
 	@Test
@@ -202,9 +203,9 @@ public class TokenAudienceTest extends BaseClientTestCase {
 		Assert.assertNotNull(audJSONArray);
 		Assert.assertEquals(resources.size(), audJSONArray.length());
 
-		List<String> audiences = JSONUtil.toStringList(audJSONArray);
+		List<String> audiencesList = JSONUtil.toStringList(audJSONArray);
 
-		Assert.assertTrue(audiences.containsAll(resources));
+		Assert.assertTrue(audiencesList.containsAll(resources));
 	}
 
 	private void _testTokenRequestWithInvalidResource(String resource)
@@ -235,10 +236,8 @@ public class TokenAudienceTest extends BaseClientTestCase {
 
 	private static final String _CLIENT_SECRET = RandomTestUtil.randomString();
 
-	private static final String _RESOURCE_URI = "https://mcp.example.com/o/mcp";
-
-	private static final String _RESOURCE_URI_2 =
-		"https://api.example.com/o/api";
+	private static final String _RESOURCE_URI =
+		"https://" + RandomTestUtil.randomString();
 
 	private class TokenAudienceTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
@@ -8,14 +8,17 @@ package com.liferay.oauth2.provider.client.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import jakarta.ws.rs.client.Entity;
@@ -26,6 +29,7 @@ import jakarta.ws.rs.core.Response;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -48,6 +52,30 @@ public class TokenAudienceTest extends BaseClientTestCase {
 
 	@Test
 	public void testTokenIntrospectionAudience() throws Exception {
+		_testTokenIntrospectionAudience(
+			Collections.singletonList(_RESOURCE_URI));
+		_testTokenIntrospectionAudience(
+			Arrays.asList(_RESOURCE_URI, _RESOURCE_URI_2));
+	}
+
+	@Test
+	public void testTokenIntrospectionAudienceWithAuthorizationCodeGrant()
+		throws Exception {
+
+		String authorizationCode = parseAuthorizationCodeString(
+			getCodeResponse(
+				TestPropsValues.getUser(
+				).getEmailAddress(),
+				PropsValues.DEFAULT_ADMIN_PASSWORD, null,
+				getCodeFunction(
+					webTarget -> webTarget.queryParam(
+						"client_id", _CLIENT_ID
+					).queryParam(
+						"response_type", "code"
+					))));
+
+		Assert.assertNotNull(authorizationCode);
+
 		WebTarget tokenWebTarget = getTokenWebTarget();
 
 		Invocation.Builder tokenInvocationBuilder = tokenWebTarget.request();
@@ -60,7 +88,9 @@ public class TokenAudienceTest extends BaseClientTestCase {
 					).put(
 						"client_secret", _CLIENT_SECRET
 					).put(
-						"grant_type", "client_credentials"
+						"code", authorizationCode
+					).put(
+						"grant_type", "authorization_code"
 					).put(
 						"resource", _RESOURCE_URI
 					).build())));
@@ -102,6 +132,84 @@ public class TokenAudienceTest extends BaseClientTestCase {
 
 	@Test
 	public void testTokenRequestWithInvalidResource() throws Exception {
+		_testTokenRequestWithInvalidResource(StringPool.SPACE);
+		_testTokenRequestWithInvalidResource(
+			StringBundler.concat(
+				"https://", RandomTestUtil.randomString(), "/#",
+				RandomTestUtil.randomString()));
+		_testTokenRequestWithInvalidResource(RandomTestUtil.randomString());
+	}
+
+	@Override
+	protected BundleActivator getBundleActivator() {
+		return new TokenAudienceTestPreparatorBundleActivator();
+	}
+
+	private void _testTokenIntrospectionAudience(List<String> resources)
+		throws Exception {
+
+		MultivaluedHashMap<String, String> tokenFormData =
+			new MultivaluedHashMap<>(
+				HashMapBuilder.put(
+					"client_id", _CLIENT_ID
+				).put(
+					"client_secret", _CLIENT_SECRET
+				).put(
+					"grant_type", "client_credentials"
+				).build());
+
+		for (String resource : resources) {
+			tokenFormData.add("resource", resource);
+		}
+
+		WebTarget tokenWebTarget = getTokenWebTarget();
+
+		Invocation.Builder tokenInvocationBuilder = tokenWebTarget.request();
+
+		Response tokenResponse = tokenInvocationBuilder.post(
+			Entity.form(tokenFormData));
+
+		Assert.assertEquals(200, tokenResponse.getStatus());
+
+		String accessToken = parseTokenString(tokenResponse);
+
+		Assert.assertNotNull(accessToken);
+
+		WebTarget introspectWebTarget = getIntrospectWebTarget();
+
+		Invocation.Builder introspectInvocationBuilder =
+			introspectWebTarget.request();
+
+		Response introspectResponse = introspectInvocationBuilder.post(
+			Entity.form(
+				new MultivaluedHashMap<>(
+					HashMapBuilder.put(
+						"client_id", _CLIENT_ID
+					).put(
+						"client_secret", _CLIENT_SECRET
+					).put(
+						"token", accessToken
+					).build())));
+
+		Assert.assertEquals(200, introspectResponse.getStatus());
+
+		JSONObject jsonObject = parseJSONObject(introspectResponse);
+
+		Assert.assertTrue(jsonObject.getBoolean("active"));
+
+		JSONArray audJSONArray = jsonObject.getJSONArray("aud");
+
+		Assert.assertNotNull(audJSONArray);
+		Assert.assertEquals(resources.size(), audJSONArray.length());
+
+		List<String> audiences = JSONUtil.toStringList(audJSONArray);
+
+		Assert.assertTrue(audiences.containsAll(resources));
+	}
+
+	private void _testTokenRequestWithInvalidResource(String resource)
+		throws Exception {
+
 		WebTarget tokenWebTarget = getTokenWebTarget();
 
 		Invocation.Builder invocationBuilder = tokenWebTarget.request();
@@ -116,19 +224,11 @@ public class TokenAudienceTest extends BaseClientTestCase {
 					).put(
 						"grant_type", "client_credentials"
 					).put(
-						"resource",
-						StringBundler.concat(
-							"https://", RandomTestUtil.randomString(), "/#",
-							RandomTestUtil.randomString())
+						"resource", resource
 					).build())));
 
 		Assert.assertEquals(400, response.getStatus());
 		Assert.assertEquals("invalid_target", parseError(response));
-	}
-
-	@Override
-	protected BundleActivator getBundleActivator() {
-		return new TokenAudienceTestPreparatorBundleActivator();
 	}
 
 	private static final String _CLIENT_ID = RandomTestUtil.randomString();
@@ -136,6 +236,9 @@ public class TokenAudienceTest extends BaseClientTestCase {
 	private static final String _CLIENT_SECRET = RandomTestUtil.randomString();
 
 	private static final String _RESOURCE_URI = "https://mcp.example.com/o/mcp";
+
+	private static final String _RESOURCE_URI_2 =
+		"https://api.example.com/o/api";
 
 	private class TokenAudienceTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
@@ -148,8 +251,10 @@ public class TokenAudienceTest extends BaseClientTestCase {
 
 			createOAuth2Application(
 				companyId, user, _CLIENT_ID, _CLIENT_SECRET,
-				Collections.singletonList(GrantType.CLIENT_CREDENTIALS),
-				"client_secret_post", null, Arrays.asList(), false,
+				Arrays.asList(
+					GrantType.CLIENT_CREDENTIALS, GrantType.AUTHORIZATION_CODE),
+				"client_secret_post", null,
+				Collections.singletonList("http://redirecturi:8080"), false,
 				Collections.singletonList("everything"), false);
 		}
 


### PR DESCRIPTION
Jira: https://liferay.atlassian.net/browse/LPD-91337

Honor the RFC 8707 `resource` parameter on the OAuth 2.0 token endpoint:

- Validate each `resource` value as an absolute URI without a fragment; reject blank or malformed values with `400 invalid_target` (RFC 8707 §2).
- Enforce the client's registered audiences as an allowlist when present; reject unregistered resources with `400 invalid_target`.
- Bind every requested `resource` value as a token audience on both the `authorization_code` and `client_credentials` flows. The values are routed through the client's registered audiences (which Apache CXF binds in full) instead of CXF's `audience` request parameter, which CXF reads with `params.getFirst` and would drop every value past the first.
- Integration tests covering single- and multi-resource introspection, the `authorization_code` flow audience binding, and invalid `resource` rejection.

Depends on `LPD-91337-bind`, merged to master on 2026-05-28 via [brianchandotcom/liferay-portal#175255](https://github.com/brianchandotcom/liferay-portal/pull/175346).
