### PR TITLE
LPD-91332

### DIFF
--- a/modules/apps/mcp/mcp-server-rest-impl/build.gradle
+++ b/modules/apps/mcp/mcp-server-rest-impl/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:mcp:mcp-server-rest-api")
+	compileOnly project(":apps:oauth2-provider:oauth2-provider-api")
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/constants/MCPServerConstants.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/constants/MCPServerConstants.java
@@ -23,4 +23,9 @@ public class MCPServerConstants {
 	public static final String EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROMPT =
 		"L_MCP_SERVER_PROMPT";
 
+	public static final String MCP_PATH = "/o/mcp";
+
+	public static final String WELL_KNOWN_PROTECTED_RESOURCE_PATH =
+		"/o/.well-known/oauth-protected-resource";
+
 }

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/constants/MCPServerConstants.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/constants/MCPServerConstants.java
@@ -23,9 +23,9 @@ public class MCPServerConstants {
 	public static final String EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROMPT =
 		"L_MCP_SERVER_PROMPT";
 
-	public static final String MCP_PATH = "/o/mcp";
+	public static final String MCP_PATH = "/mcp";
 
 	public static final String WELL_KNOWN_PROTECTED_RESOURCE_PATH =
-		"/o/.well-known/oauth-protected-resource";
+		"/.well-known/oauth-protected-resource";
 
 }

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPProtectedResourceMetadataServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPProtectedResourceMetadataServlet.java
@@ -70,9 +70,9 @@ public class MCPProtectedResourceMetadataServlet extends HttpServlet {
 		httpServletResponse.setHeader(
 			HttpHeaders.CACHE_CONTROL, "public, max-age=300");
 
-		try (PrintWriter printWriter = httpServletResponse.getWriter()) {
-			printWriter.write(metadataJSONObject.toString());
-		}
+		PrintWriter printWriter = httpServletResponse.getWriter();
+
+		printWriter.write(metadataJSONObject.toString());
 	}
 
 	@Reference

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPProtectedResourceMetadataServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPProtectedResourceMetadataServlet.java
@@ -1,0 +1,81 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.mcp.server.rest.internal.servlet;
+
+import com.liferay.mcp.server.rest.internal.constants.MCPServerConstants;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.Portal;
+
+import jakarta.servlet.Servlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Publishes the OAuth 2.0 Protected Resource Metadata document (RFC 9728) for
+ * the MCP server. Mounted at <code>/.well-known/oauth-protected-resource</code>
+ * and <code>/.well-known/oauth-protected-resource/*</code> so clients reach the
+ * doc whether they construct the path-suffix variant from the
+ * <code>https://&lt;host&gt;/mcp</code> resource URI or hit the bare well-known
+ * URL.
+ *
+ * @author Jorge García Jiménez
+ */
+@Component(
+	property = {
+		"osgi.http.whiteboard.servlet.name=com.liferay.mcp.server.rest.internal.servlet.MCPProtectedResourceMetadataServlet",
+		"osgi.http.whiteboard.servlet.pattern=/.well-known/oauth-protected-resource",
+		"osgi.http.whiteboard.servlet.pattern=/.well-known/oauth-protected-resource/*"
+	},
+	service = Servlet.class
+)
+public class MCPProtectedResourceMetadataServlet extends HttpServlet {
+
+	@Override
+	protected void doGet(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException {
+
+		String portalURL =
+			_portal.getPortalURL(httpServletRequest) + _portal.getPathContext();
+
+		String resource = portalURL + MCPServerConstants.MCP_PATH;
+
+		JSONObject metadataJSONObject = JSONUtil.put(
+			"authorization_servers", JSONUtil.putAll(portalURL)
+		).put(
+			"bearer_methods_supported", JSONUtil.putAll("header")
+		).put(
+			"resource", resource
+		).put(
+			"resource_name", "Liferay MCP Server"
+		);
+
+		httpServletResponse.setCharacterEncoding(StringPool.UTF8);
+		httpServletResponse.setContentType(ContentTypes.APPLICATION_JSON);
+		httpServletResponse.setHeader(
+			HttpHeaders.CACHE_CONTROL, "public, max-age=300");
+
+		try (PrintWriter printWriter = httpServletResponse.getWriter()) {
+			printWriter.write(metadataJSONObject.toString());
+		}
+	}
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPProtectedResourceMetadataServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPProtectedResourceMetadataServlet.java
@@ -7,9 +7,10 @@ package com.liferay.mcp.server.rest.internal.servlet;
 
 import com.liferay.mcp.server.rest.internal.constants.MCPServerConstants;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -19,7 +20,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
-import java.io.PrintWriter;
+
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -45,34 +47,68 @@ import org.osgi.service.component.annotations.Reference;
 public class MCPProtectedResourceMetadataServlet extends HttpServlet {
 
 	@Override
-	protected void doGet(
+	protected void service(
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws IOException {
 
-		String portalURL =
-			_portal.getPortalURL(httpServletRequest) + _portal.getPathContext();
+		if (!FeatureFlagManagerUtil.isEnabled(
+				_portal.getCompanyId(httpServletRequest), "LPD-63415")) {
 
-		String resource = portalURL + MCPServerConstants.MCP_PATH;
+			httpServletResponse.sendError(HttpServletResponse.SC_NOT_FOUND);
 
-		JSONObject metadataJSONObject = JSONUtil.put(
-			"authorization_servers", JSONUtil.putAll(portalURL)
-		).put(
-			"bearer_methods_supported", JSONUtil.putAll("header")
-		).put(
-			"resource", resource
-		).put(
-			"resource_name", "Liferay MCP Server"
-		);
+			return;
+		}
+
+		httpServletResponse.setHeader(
+			"Access-Control-Allow-Headers", "Authorization, Content-Type");
+		httpServletResponse.setHeader(
+			"Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");
+		httpServletResponse.setHeader("Access-Control-Allow-Origin", "*");
+		httpServletResponse.setHeader("Access-Control-Max-Age", "300");
+
+		String method = httpServletRequest.getMethod();
+
+		if (Objects.equals(method, "OPTIONS")) {
+			httpServletResponse.setStatus(HttpServletResponse.SC_NO_CONTENT);
+
+			return;
+		}
+
+		if (!Objects.equals(method, "GET") && !Objects.equals(method, "HEAD")) {
+			httpServletResponse.setHeader("Allow", "GET, HEAD, OPTIONS");
+			httpServletResponse.sendError(
+				HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+
+			return;
+		}
 
 		httpServletResponse.setCharacterEncoding(StringPool.UTF8);
 		httpServletResponse.setContentType(ContentTypes.APPLICATION_JSON);
 		httpServletResponse.setHeader(
 			HttpHeaders.CACHE_CONTROL, "public, max-age=300");
+		httpServletResponse.setStatus(HttpServletResponse.SC_OK);
 
-		PrintWriter printWriter = httpServletResponse.getWriter();
+		if (Objects.equals(method, "GET")) {
+			String portalURL =
+				_portal.getPortalURL(httpServletRequest) +
+					_portal.getPathContext();
 
-		printWriter.write(metadataJSONObject.toString());
+			ServletResponseUtil.write(
+				httpServletResponse,
+				JSONUtil.put(
+					"authorization_servers", JSONUtil.putAll(portalURL)
+				).put(
+					"bearer_methods_supported", JSONUtil.putAll("header")
+				).put(
+					"resource",
+					portalURL + Portal.PATH_MODULE + MCPServerConstants.MCP_PATH
+				).put(
+					"resource_name", "Liferay MCP Server"
+				).toString());
+		}
+
+		httpServletResponse.flushBuffer();
 	}
 
 	@Reference

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
@@ -165,13 +165,13 @@ public class MCPServerServlet extends HttpServlet {
 			return false;
 		}
 
-		String[] parts = authorization.trim(
-		).split(
-			"\\s+"
-		);
+		String trimmedAuthorization = authorization.trim();
 
-		if ((parts.length != 2) ||
-			!StringUtil.equalsIgnoreCase(parts[0], "Bearer")) {
+		int spaceIndex = trimmedAuthorization.indexOf(' ');
+
+		if ((spaceIndex == -1) ||
+			!StringUtil.equalsIgnoreCase(
+				trimmedAuthorization.substring(0, spaceIndex), "Bearer")) {
 
 			_sendInvalidTokenChallenge(
 				httpServletRequest, httpServletResponse,
@@ -180,7 +180,9 @@ public class MCPServerServlet extends HttpServlet {
 			return false;
 		}
 
-		String accessToken = parts[1];
+		String accessToken = trimmedAuthorization.substring(
+			spaceIndex + 1
+		).trim();
 
 		OAuth2Authorization oAuth2Authorization =
 			_oAuth2AuthorizationLocalService.

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
@@ -130,7 +130,9 @@ public class MCPServerServlet extends HttpServlet {
 			return;
 		}
 
-		if (!_authenticate(httpServletRequest, httpServletResponse)) {
+		if (!_authenticate(
+				companyId, httpServletRequest, httpServletResponse)) {
+
 			return;
 		}
 
@@ -150,7 +152,7 @@ public class MCPServerServlet extends HttpServlet {
 	}
 
 	private boolean _authenticate(
-			HttpServletRequest httpServletRequest,
+			long companyId, HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws IOException {
 
@@ -185,8 +187,7 @@ public class MCPServerServlet extends HttpServlet {
 				fetchOAuth2AuthorizationByAccessTokenContent(accessToken);
 
 		if ((oAuth2Authorization == null) ||
-			(oAuth2Authorization.getCompanyId() != _portal.getCompanyId(
-				httpServletRequest)) ||
+			(oAuth2Authorization.getCompanyId() != companyId) ||
 			OAuth2AuthorizationConstants.ACCESS_TOKEN_CONTENT_EXPIRED_TOKEN.
 				equals(oAuth2Authorization.getAccessTokenContent())) {
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
@@ -11,6 +11,9 @@ import com.liferay.mcp.server.rest.dto.v1_0.Tool;
 import com.liferay.mcp.server.rest.internal.configuration.MCPServerConfiguration;
 import com.liferay.mcp.server.rest.internal.constants.MCPServerConstants;
 import com.liferay.mcp.server.rest.internal.util.ToolSetUtil;
+import com.liferay.oauth2.provider.constants.OAuth2AuthorizationConstants;
+import com.liferay.oauth2.provider.model.OAuth2Authorization;
+import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -25,6 +28,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -55,6 +59,7 @@ import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -125,6 +130,10 @@ public class MCPServerServlet extends HttpServlet {
 			return;
 		}
 
+		if (!_authenticate(httpServletRequest, httpServletResponse)) {
+			return;
+		}
+
 		ObjectEntry mcpServerProfileObjectEntry =
 			_getMCPServerProfileObjectEntry(companyId, httpServletRequest);
 
@@ -138,6 +147,84 @@ public class MCPServerServlet extends HttpServlet {
 			httpServletRequest, companyId, mcpServerProfileObjectEntry);
 
 		servlet.service(httpServletRequest, httpServletResponse);
+	}
+
+	private boolean _authenticate(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException {
+
+		String authorization = httpServletRequest.getHeader("Authorization");
+
+		if (Validator.isBlank(authorization)) {
+			_sendUnauthenticatedChallenge(
+				httpServletRequest, httpServletResponse);
+
+			return false;
+		}
+
+		String[] parts = authorization.trim(
+		).split(
+			"\\s+"
+		);
+
+		if ((parts.length != 2) ||
+			!StringUtil.equalsIgnoreCase(parts[0], "Bearer")) {
+
+			_sendInvalidTokenChallenge(
+				httpServletRequest, httpServletResponse,
+				"Authorization header is not a Bearer token");
+
+			return false;
+		}
+
+		String accessToken = parts[1];
+
+		OAuth2Authorization oAuth2Authorization =
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent(accessToken);
+
+		if ((oAuth2Authorization == null) ||
+			(oAuth2Authorization.getCompanyId() != _portal.getCompanyId(
+				httpServletRequest)) ||
+			OAuth2AuthorizationConstants.ACCESS_TOKEN_CONTENT_EXPIRED_TOKEN.
+				equals(oAuth2Authorization.getAccessTokenContent())) {
+
+			_sendInvalidTokenChallenge(
+				httpServletRequest, httpServletResponse,
+				"Access token is unknown or revoked");
+
+			return false;
+		}
+
+		Date expirationDate =
+			oAuth2Authorization.getAccessTokenExpirationDate();
+
+		if ((expirationDate != null) &&
+			(expirationDate.getTime() < System.currentTimeMillis())) {
+
+			_sendInvalidTokenChallenge(
+				httpServletRequest, httpServletResponse,
+				"Access token has expired");
+
+			return false;
+		}
+
+		String mcpResourceURI =
+			_portal.getPortalURL(httpServletRequest) +
+				_portal.getPathContext() + MCPServerConstants.MCP_PATH;
+
+		List<String> audiences = oAuth2Authorization.getAudiencesList();
+
+		if ((audiences == null) || !audiences.contains(mcpResourceURI)) {
+			_sendInvalidTokenChallenge(
+				httpServletRequest, httpServletResponse,
+				"Access token is not bound to this MCP server");
+
+			return false;
+		}
+
+		return true;
 	}
 
 	private Servlet _buildServlet(
@@ -443,6 +530,38 @@ public class MCPServerServlet extends HttpServlet {
 		}
 	}
 
+	private void _sendInvalidTokenChallenge(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, String description)
+		throws IOException {
+
+		httpServletResponse.setHeader(
+			HttpHeaders.WWW_AUTHENTICATE,
+			StringBundler.concat(
+				"Bearer realm=\"mcp\", resource_metadata=\"",
+				_portal.getPortalURL(httpServletRequest),
+				_portal.getPathContext(),
+				MCPServerConstants.WELL_KNOWN_PROTECTED_RESOURCE_PATH, "\", ",
+				"error=\"invalid_token\", error_description=\"", description,
+				"\""));
+		httpServletResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+	}
+
+	private void _sendUnauthenticatedChallenge(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException {
+
+		httpServletResponse.setHeader(
+			HttpHeaders.WWW_AUTHENTICATE,
+			StringBundler.concat(
+				"Bearer realm=\"mcp\", resource_metadata=\"",
+				_portal.getPortalURL(httpServletRequest),
+				_portal.getPathContext(),
+				MCPServerConstants.WELL_KNOWN_PROTECTED_RESOURCE_PATH, "\""));
+		httpServletResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		MCPServerServlet.class);
 
@@ -450,6 +569,9 @@ public class MCPServerServlet extends HttpServlet {
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;
+
+	@Reference
+	private OAuth2AuthorizationLocalService _oAuth2AuthorizationLocalService;
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
@@ -156,7 +156,8 @@ public class MCPServerServlet extends HttpServlet {
 			HttpServletResponse httpServletResponse)
 		throws IOException {
 
-		String authorization = httpServletRequest.getHeader("Authorization");
+		String authorization = httpServletRequest.getHeader(
+			HttpHeaders.AUTHORIZATION);
 
 		if (Validator.isBlank(authorization)) {
 			_sendUnauthenticatedChallenge(
@@ -165,14 +166,9 @@ public class MCPServerServlet extends HttpServlet {
 			return false;
 		}
 
-		String trimmedAuthorization = authorization.trim();
+		authorization = authorization.trim();
 
-		int spaceIndex = trimmedAuthorization.indexOf(' ');
-
-		if ((spaceIndex == -1) ||
-			!StringUtil.equalsIgnoreCase(
-				trimmedAuthorization.substring(0, spaceIndex), "Bearer")) {
-
+		if (!StringUtil.startsWith(authorization, "Bearer ")) {
 			_sendInvalidTokenChallenge(
 				httpServletRequest, httpServletResponse,
 				"Authorization header is not a Bearer token");
@@ -180,13 +176,12 @@ public class MCPServerServlet extends HttpServlet {
 			return false;
 		}
 
-		String accessToken = trimmedAuthorization.substring(
-			spaceIndex + 1
-		).trim();
+		String accessTokenContent = authorization.substring("Bearer ".length());
 
 		OAuth2Authorization oAuth2Authorization =
 			_oAuth2AuthorizationLocalService.
-				fetchOAuth2AuthorizationByAccessTokenContent(accessToken);
+				fetchOAuth2AuthorizationByAccessTokenContent(
+					accessTokenContent);
 
 		if ((oAuth2Authorization == null) ||
 			(oAuth2Authorization.getCompanyId() != companyId) ||
@@ -213,9 +208,9 @@ public class MCPServerServlet extends HttpServlet {
 			return false;
 		}
 
-		String mcpResourceURI =
-			_portal.getPortalURL(httpServletRequest) +
-				_portal.getPathContext() + MCPServerConstants.MCP_PATH;
+		String mcpResourceURI = StringBundler.concat(
+			_portal.getPortalURL(httpServletRequest), _portal.getPathContext(),
+			Portal.PATH_MODULE, MCPServerConstants.MCP_PATH);
 
 		List<String> audiences = oAuth2Authorization.getAudiencesList();
 
@@ -543,7 +538,7 @@ public class MCPServerServlet extends HttpServlet {
 			StringBundler.concat(
 				"Bearer realm=\"mcp\", resource_metadata=\"",
 				_portal.getPortalURL(httpServletRequest),
-				_portal.getPathContext(),
+				_portal.getPathContext(), Portal.PATH_MODULE,
 				MCPServerConstants.WELL_KNOWN_PROTECTED_RESOURCE_PATH, "\", ",
 				"error=\"invalid_token\", error_description=\"", description,
 				"\""));
@@ -560,7 +555,7 @@ public class MCPServerServlet extends HttpServlet {
 			StringBundler.concat(
 				"Bearer realm=\"mcp\", resource_metadata=\"",
 				_portal.getPortalURL(httpServletRequest),
-				_portal.getPathContext(),
+				_portal.getPathContext(), Portal.PATH_MODULE,
 				MCPServerConstants.WELL_KNOWN_PROTECTED_RESOURCE_PATH, "\""));
 		httpServletResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 	}


### PR DESCRIPTION
Jira: https://liferay.atlassian.net/browse/LPD-91332

Enforce Bearer token validation and audience-binding on the MCP server endpoint `/o/mcp`:

- Validate the Bearer token and require its `aud` to contain the canonical `/o/mcp` URI for the request host.
- On missing / invalid / wrong-audience tokens, respond `401 Unauthorized` with `WWW-Authenticate: Bearer realm=…, resource_metadata="…"` pointing to the deployed `/.well-known/oauth-protected-resource` URL.
- Use `/o/mcp` as the canonical MCP URI.

> ⚠ Depends on both `LPD-91337-bind` (for the persisted/introspected `aud`) and `LPD-91289-service` (for the resource_metadata URL). Both must be merged first.