### PR TITLE
LPD-86189 Fix BaseMVCActionCommandTestCase under DB partition

### DIFF
--- a/modules/dxp/apps/saml/saml-test/src/testIntegration/java/com/liferay/saml/web/internal/portlet/action/test/BaseMVCActionCommandTestCase.java
+++ b/modules/dxp/apps/saml/saml-test/src/testIntegration/java/com/liferay/saml/web/internal/portlet/action/test/BaseMVCActionCommandTestCase.java
@@ -11,7 +11,6 @@ import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
@@ -46,7 +45,6 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 
 import org.springframework.mock.web.MockMultipartHttpServletRequest;
@@ -58,20 +56,36 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 
 	@Test
 	public void testProcessAction() throws Exception {
-		Assume.assumeFalse(PropsValues.DATABASE_PARTITION_ENABLED);
-
 		T baseModel = addBaseModel();
+		User user = TestPropsValues.getUser();
 
-		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-					RandomTestUtil.randomLong())) {
+		if (PropsValues.DATABASE_PARTITION_ENABLED) {
+			Company company = CompanyTestUtil.addCompany(false);
 
-			_assertException(
-				() -> _processAction(
-					baseModel,
-					_companyLocalService.createCompany(
-						CompanyThreadLocal.getCompanyId()),
-					TestPropsValues.getUser()));
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						company.getCompanyId())) {
+
+				_assertException(
+					() -> _processAction(
+						addBaseModel(),
+						_companyLocalService.getCompanyById(
+							PortalInstancePool.getDefaultCompanyId()),
+						user));
+			}
+		}
+		else {
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						RandomTestUtil.randomLong())) {
+
+				_assertException(
+					() -> _processAction(
+						baseModel,
+						_companyLocalService.createCompany(
+							CompanyThreadLocal.getCompanyId()),
+						user));
+			}
 		}
 
 		Company company = _companyLocalService.getCompanyById(
@@ -81,53 +95,7 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 			() -> _processAction(
 				baseModel, company, UserTestUtil.addUser(company)));
 
-		_processAction(baseModel, company, TestPropsValues.getUser());
-
-		assertProcessAction(
-			fetchBaseModel(GetterUtil.getLong(baseModel.getPrimaryKeyObj())));
-	}
-
-	@Test
-	public void testProcessActionDBPartitionEnabled() throws Exception {
-		Assume.assumeTrue(PropsValues.DATABASE_PARTITION_ENABLED);
-
-		Layout layout = _layoutLocalService.getLayout(
-			TestPropsValues.getPlid());
-
-		LayoutSet layoutSet = layout.getLayoutSet();
-
-		User user = TestPropsValues.getUser();
-
-		Company crossTenantCompany = CompanyTestUtil.addCompany(true);
-
-		try {
-			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-						crossTenantCompany.getCompanyId())) {
-
-				_assertException(
-					() -> _processAction(
-						addBaseModel(),
-						_companyLocalService.getCompanyById(
-							PortalInstancePool.getDefaultCompanyId()),
-						user, layout, layoutSet));
-			}
-		}
-		finally {
-			_companyLocalService.deleteCompany(crossTenantCompany);
-		}
-
-		Company company = _companyLocalService.getCompanyById(
-			TestPropsValues.getCompanyId());
-
-		T baseModel = addBaseModel();
-
-		_assertException(
-			() -> _processAction(
-				baseModel, company, UserTestUtil.addUser(company), layout,
-				layoutSet));
-
-		_processAction(baseModel, company, user, layout, layoutSet);
+		_processAction(baseModel, company, user);
 
 		assertProcessAction(
 			fetchBaseModel(GetterUtil.getLong(baseModel.getPrimaryKeyObj())));
@@ -181,17 +149,6 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 	private void _processAction(T baseModel, Company company, User user)
 		throws Exception {
 
-		Layout layout = _layoutLocalService.getLayout(
-			TestPropsValues.getPlid());
-
-		_processAction(baseModel, company, user, layout, layout.getLayoutSet());
-	}
-
-	private void _processAction(
-			T baseModel, Company company, User user, Layout layout,
-			LayoutSet layoutSet)
-		throws Exception {
-
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
 
@@ -210,11 +167,14 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 		mockLiferayPortletActionRequest.setAttribute(
 			WebKeys.PORTLET_ID, SamlPortletKeys.SAML_ADMIN);
 
+		Layout layout = _layoutLocalService.getLayout(
+			TestPropsValues.getPlid());
+
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
 		themeDisplay.setCompany(company);
 		themeDisplay.setLayout(layout);
-		themeDisplay.setLayoutSet(layoutSet);
+		themeDisplay.setLayoutSet(layout.getLayoutSet());
 		themeDisplay.setSiteGroupId(layout.getGroupId());
 		themeDisplay.setUser(user);
 
@@ -243,8 +203,13 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 							return method.invoke(_portal, args);
 						}))) {
 
-			PermissionThreadLocal.setPermissionChecker(
-				PermissionCheckerFactoryUtil.create(user));
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						user.getCompanyId())) {
+
+				PermissionThreadLocal.setPermissionChecker(
+					PermissionCheckerFactoryUtil.create(user));
+			}
 
 			MVCActionCommand mvcActionCommand = getMVCActionCommand();
 

--- a/modules/dxp/apps/saml/saml-test/src/testIntegration/java/com/liferay/saml/web/internal/portlet/action/test/BaseMVCActionCommandTestCase.java
+++ b/modules/dxp/apps/saml/saml-test/src/testIntegration/java/com/liferay/saml/web/internal/portlet/action/test/BaseMVCActionCommandTestCase.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
@@ -45,6 +46,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import org.springframework.mock.web.MockMultipartHttpServletRequest;
@@ -56,49 +58,56 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 
 	@Test
 	public void testProcessAction() throws Exception {
+		Assume.assumeFalse(PropsValues.DATABASE_PARTITION_ENABLED);
+
 		T baseModel = addBaseModel();
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					RandomTestUtil.randomLong())) {
+
+			_assertException(
+				() -> _processAction(
+					baseModel,
+					_companyLocalService.createCompany(
+						CompanyThreadLocal.getCompanyId()),
+					TestPropsValues.getUser()));
+		}
+
+		_testProcessAction(baseModel);
+	}
+
+	@Test
+	public void testProcessActionDBPartitionEnabled() throws Exception {
+		Assume.assumeTrue(PropsValues.DATABASE_PARTITION_ENABLED);
+
+		Layout layout = _layoutLocalService.getLayout(
+			TestPropsValues.getPlid());
+
+		LayoutSet layoutSet = layout.getLayoutSet();
+
 		User user = TestPropsValues.getUser();
 
-		if (PropsValues.DATABASE_PARTITION_ENABLED) {
-			Company company = CompanyTestUtil.addCompany(false);
+		Company crossTenantCompany = CompanyTestUtil.addCompany(true);
 
+		try {
 			try (SafeCloseable safeCloseable =
 					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-						company.getCompanyId())) {
+						crossTenantCompany.getCompanyId())) {
 
 				_assertException(
 					() -> _processAction(
 						addBaseModel(),
 						_companyLocalService.getCompanyById(
 							PortalInstancePool.getDefaultCompanyId()),
-						user));
+						user, layout, layoutSet));
 			}
 		}
-		else {
-			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-						RandomTestUtil.randomLong())) {
-
-				_assertException(
-					() -> _processAction(
-						baseModel,
-						_companyLocalService.createCompany(
-							CompanyThreadLocal.getCompanyId()),
-						user));
-			}
+		finally {
+			_companyLocalService.deleteCompany(crossTenantCompany);
 		}
 
-		Company company = _companyLocalService.getCompanyById(
-			TestPropsValues.getCompanyId());
-
-		_assertException(
-			() -> _processAction(
-				baseModel, company, UserTestUtil.addUser(company)));
-
-		_processAction(baseModel, company, user);
-
-		assertProcessAction(
-			fetchBaseModel(GetterUtil.getLong(baseModel.getPrimaryKeyObj())));
+		_testProcessAction(addBaseModel());
 	}
 
 	protected abstract T addBaseModel();
@@ -149,6 +158,17 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 	private void _processAction(T baseModel, Company company, User user)
 		throws Exception {
 
+		Layout layout = _layoutLocalService.getLayout(
+			TestPropsValues.getPlid());
+
+		_processAction(baseModel, company, user, layout, layout.getLayoutSet());
+	}
+
+	private void _processAction(
+			T baseModel, Company company, User user, Layout layout,
+			LayoutSet layoutSet)
+		throws Exception {
+
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
 
@@ -167,14 +187,11 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 		mockLiferayPortletActionRequest.setAttribute(
 			WebKeys.PORTLET_ID, SamlPortletKeys.SAML_ADMIN);
 
-		Layout layout = _layoutLocalService.getLayout(
-			TestPropsValues.getPlid());
-
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
 		themeDisplay.setCompany(company);
 		themeDisplay.setLayout(layout);
-		themeDisplay.setLayoutSet(layout.getLayoutSet());
+		themeDisplay.setLayoutSet(layoutSet);
 		themeDisplay.setSiteGroupId(layout.getGroupId());
 		themeDisplay.setUser(user);
 
@@ -203,13 +220,8 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 							return method.invoke(_portal, args);
 						}))) {
 
-			try (SafeCloseable safeCloseable =
-					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-						user.getCompanyId())) {
-
-				PermissionThreadLocal.setPermissionChecker(
-					PermissionCheckerFactoryUtil.create(user));
-			}
+			PermissionThreadLocal.setPermissionChecker(
+				PermissionCheckerFactoryUtil.create(user));
 
 			MVCActionCommand mvcActionCommand = getMVCActionCommand();
 
@@ -221,6 +233,20 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 			PermissionThreadLocal.setPermissionChecker(
 				originalPermissionChecker);
 		}
+	}
+
+	private void _testProcessAction(T baseModel) throws Exception {
+		Company company = _companyLocalService.getCompanyById(
+			TestPropsValues.getCompanyId());
+
+		_assertException(
+			() -> _processAction(
+				baseModel, company, UserTestUtil.addUser(company)));
+
+		_processAction(baseModel, company, TestPropsValues.getUser());
+
+		assertProcessAction(
+			fetchBaseModel(GetterUtil.getLong(baseModel.getPrimaryKeyObj())));
 	}
 
 	@Inject

--- a/modules/dxp/apps/saml/saml-test/src/testIntegration/java/com/liferay/saml/web/internal/portlet/action/test/BaseMVCActionCommandTestCase.java
+++ b/modules/dxp/apps/saml/saml-test/src/testIntegration/java/com/liferay/saml/web/internal/portlet/action/test/BaseMVCActionCommandTestCase.java
@@ -7,9 +7,11 @@ package com.liferay.saml.web.internal.portlet.action.test;
 
 import com.liferay.petra.function.UnsafeRunnable;
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.instance.PortalInstancePool;
 import com.liferay.portal.kernel.model.BaseModel;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
@@ -23,6 +25,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
@@ -31,6 +34,7 @@ import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.ProxyUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
@@ -42,6 +46,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 import org.springframework.mock.web.MockMultipartHttpServletRequest;
@@ -53,6 +58,8 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 
 	@Test
 	public void testProcessAction() throws Exception {
+		Assume.assumeFalse(PropsValues.DATABASE_PARTITION_ENABLED);
+
 		T baseModel = addBaseModel();
 
 		try (SafeCloseable safeCloseable =
@@ -75,6 +82,52 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 				baseModel, company, UserTestUtil.addUser(company)));
 
 		_processAction(baseModel, company, TestPropsValues.getUser());
+
+		assertProcessAction(
+			fetchBaseModel(GetterUtil.getLong(baseModel.getPrimaryKeyObj())));
+	}
+
+	@Test
+	public void testProcessActionDBPartitionEnabled() throws Exception {
+		Assume.assumeTrue(PropsValues.DATABASE_PARTITION_ENABLED);
+
+		Layout layout = _layoutLocalService.getLayout(
+			TestPropsValues.getPlid());
+
+		LayoutSet layoutSet = layout.getLayoutSet();
+
+		User user = TestPropsValues.getUser();
+
+		Company crossTenantCompany = CompanyTestUtil.addCompany(true);
+
+		try {
+			try (SafeCloseable safeCloseable =
+					CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+						crossTenantCompany.getCompanyId())) {
+
+				_assertException(
+					() -> _processAction(
+						addBaseModel(),
+						_companyLocalService.getCompanyById(
+							PortalInstancePool.getDefaultCompanyId()),
+						user, layout, layoutSet));
+			}
+		}
+		finally {
+			_companyLocalService.deleteCompany(crossTenantCompany);
+		}
+
+		Company company = _companyLocalService.getCompanyById(
+			TestPropsValues.getCompanyId());
+
+		T baseModel = addBaseModel();
+
+		_assertException(
+			() -> _processAction(
+				baseModel, company, UserTestUtil.addUser(company), layout,
+				layoutSet));
+
+		_processAction(baseModel, company, user, layout, layoutSet);
 
 		assertProcessAction(
 			fetchBaseModel(GetterUtil.getLong(baseModel.getPrimaryKeyObj())));
@@ -128,6 +181,17 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 	private void _processAction(T baseModel, Company company, User user)
 		throws Exception {
 
+		Layout layout = _layoutLocalService.getLayout(
+			TestPropsValues.getPlid());
+
+		_processAction(baseModel, company, user, layout, layout.getLayoutSet());
+	}
+
+	private void _processAction(
+			T baseModel, Company company, User user, Layout layout,
+			LayoutSet layoutSet)
+		throws Exception {
+
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			new MockLiferayPortletActionRequest();
 
@@ -149,14 +213,9 @@ public abstract class BaseMVCActionCommandTestCase<T extends BaseModel<?>> {
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
 		themeDisplay.setCompany(company);
-
-		Layout layout = _layoutLocalService.getLayout(
-			TestPropsValues.getPlid());
-
 		themeDisplay.setLayout(layout);
-		themeDisplay.setLayoutSet(layout.getLayoutSet());
+		themeDisplay.setLayoutSet(layoutSet);
 		themeDisplay.setSiteGroupId(layout.getGroupId());
-
 		themeDisplay.setUser(user);
 
 		mockLiferayPortletActionRequest.setAttribute(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86189

## What is being fixed

The four SAML MVC action command integration tests (`Update`/`Delete`
× `IdpSpConnection`/`SpIdpConnection`) fail when DB partitioning is
enabled.

The shared `BaseMVCActionCommandTestCase.testProcessAction` simulates
cross-tenant rejection by setting `CompanyThreadLocal` to
`RandomTestUtil.randomLong()` and invoking the action against that
fake company. Under non-partitioned mode the action's first model
lookup still finds the record (single schema), the permission gate
fires, and `PrincipalException` is thrown. Under partitioning the
random ID is not a valid partition, so the very first DB call blows
up with `SQLGrammarException` or `NoSuchModelException` before any
permission check runs.

## How it is being fixed

Following @rafaprax's review on the previous round (#2828), the test
is split into two `@Test` methods gated by the canonical
`Assume(PropsValues.DATABASE_PARTITION_ENABLED)` idiom already used
across `CompanyLocalServiceTest`:

- `testProcessAction` runs only when partitioning is disabled
  (`assumeFalse`). Its body is the original LPD-82612 form —
  cross-tenant via `RandomTestUtil.randomLong()`, non-admin, success.

- `testProcessActionDBPartitionEnabled` runs only when partitioning
  is enabled (`assumeTrue`). It provisions a real second company via
  `CompanyTestUtil.addCompany(true)`, swaps `CompanyThreadLocal` to
  that company for the cross-tenant assertion, and uses
  `PortalInstancePool.getDefaultCompanyId()` as the request's
  `WebKeys.COMPANY_ID` so `PortalImpl.getCompanyId(actionRequest)`
  accepts it. `Layout`, `LayoutSet`, and `TestPropsValues.getUser()`
  are pre-fetched from the default partition and threaded through a
  5-arg `_processAction` overload so the cross-tenant invocation
  does not trigger partition-routed DB calls. The new company is
  cleaned up in a `finally` block to satisfy DataGuard.

Verified locally with all four affected tests under both
`database.partition.enabled=true` and `database.partition.enabled=false`.

This supersedes #2828.