### PR TITLE
LPD-81414 Fix SAPEntryUpgradeProcessTest

### DIFF
--- a/modules/apps/portal-security/portal-security-service-access-policy-test/src/testIntegration/java/com/liferay/portal/security/service/access/policy/internal/upgrade/v3_0_1/test/SAPEntryUpgradeProcessTest.java
+++ b/modules/apps/portal-security/portal-security-service-access-policy-test/src/testIntegration/java/com/liferay/portal/security/service/access/policy/internal/upgrade/v3_0_1/test/SAPEntryUpgradeProcessTest.java
@@ -57,9 +57,8 @@ public class SAPEntryUpgradeProcessTest {
 
 		Company company = CompanyTestUtil.addCompany();
 
-		try (SafeCloseable safeCloseable =
-				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
-					company.getCompanyId())) {
+		try (SafeCloseable safeCloseable = CompanyThreadLocal.lock(
+				company.getCompanyId())) {
 
 			SAPEntry sapEntry = _sapEntryLocalService.fetchSAPEntry(
 				company.getCompanyId(),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-81414

## Failing Test

`com.liferay.portal.security.service.access.policy.internal.upgrade.v3_0_1.test.SAPEntryUpgradeProcessTest.testUpgradeProcessSystemRestClientTemplateObjectSAPEntry`

`modules/apps/portal-security/portal-security-service-access-policy-test/src/testIntegration/java/com/liferay/portal/security/service/access/policy/internal/upgrade/v3_0_1/test/SAPEntryUpgradeProcessTest.java`

```
com.liferay.portal.kernel.upgrade.UpgradeException: com.liferay.portal.kernel.exception.NoSuchUserException: No User exists with the key {companyId=57670794990246, type=0}
	at com.liferay.portal.kernel.upgrade.UpgradeProcess.upgrade(UpgradeProcess.java:130)
	at com.liferay.portal.security.service.access.policy.internal.upgrade.v3_0_1.test.SAPEntryUpgradeProcessTest._runUpgrade(SAPEntryUpgradeProcessTest.java:99)
	at com.liferay.portal.security.service.access.policy.internal.upgrade.v3_0_1.test.SAPEntryUpgradeProcessTest.testUpgradeProcessSystemRestClientTemplateObjectSAPEntry(SAPEntryUpgradeProcessTest.java:72)
...
Caused by: com.liferay.portal.kernel.exception.NoSuchUserException: No User exists with the key {companyId=57670794990246, type=0}
	at com.liferay.portal.service.impl.UserLocalServiceImpl.loadGetGuestUser(UserLocalServiceImpl.java:3146)
	at com.liferay.portal.service.impl.UserLocalServiceImpl.getGuestUserId(UserLocalServiceImpl.java:2502)
	at com.liferay.portal.security.service.access.policy.internal.upgrade.v3_0_1.SAPEntryUpgradeProcess.lambda$doUpgrade$0(SAPEntryUpgradeProcess.java:76)
	at com.liferay.portal.service.impl.CompanyLocalServiceImpl.forEachCompanyId(CompanyLocalServiceImpl.java:941)
	at com.liferay.portal.service.impl.CompanyLocalServiceImpl.forEachCompanyId(CompanyLocalServiceImpl.java:909)
```

## Root Cause

`SAPEntryUpgradeProcess.doUpgrade` iterates companies through `CompanyLocalServiceUtil.forEachCompanyId(consumer)`, the no-args overload. When `CompanyThreadLocal.isLocked()` is false, that overload falls back to `PortalInstancePool.getCompanyIds()`, which can contain stale company IDs from earlier tests. Calling `UserLocalServiceUtil.getGuestUserId` against one of those stale IDs throws `NoSuchUserException`.

The test was already wrapping the upgrade in `CompanyThreadLocal.setCompanyIdWithSafeCloseable(...)`, which sets the company on the thread but does not lock it, so the fallback to `PortalInstancePool` still kicked in.

## Fix

Replace `setCompanyIdWithSafeCloseable` with `CompanyThreadLocal.lock(companyId)`. `lock` sets the company *and* flips `isLocked()` to true, so both `DBPartitionUtil.forEachCompanyId` and `CompanyLocalServiceImpl.forEachCompanyId` short-circuit to the locked company and the upgrade only runs against the test's freshly created company.

- `modules/apps/portal-security/portal-security-service-access-policy-test/src/testIntegration/java/com/liferay/portal/security/service/access/policy/internal/upgrade/v3_0_1/test/SAPEntryUpgradeProcessTest.java`