### PR TITLE
LPD-91337 Follow up with renaming test class

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2Authorization.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2Authorization.java
@@ -51,5 +51,9 @@ public interface OAuth2Authorization
 
 			};
 
+	public java.util.List<String> getAudiencesList();
+
+	public void setAudiencesList(java.util.List<String> audiencesList);
+
 }
-// LIFERAY-SERVICE-BUILDER-HASH:737718859
+// LIFERAY-SERVICE-BUILDER-HASH:1898234286

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2AuthorizationModel.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2AuthorizationModel.java
@@ -222,6 +222,21 @@ public interface OAuth2AuthorizationModel
 	public void setAccessTokenExpirationDate(Date accessTokenExpirationDate);
 
 	/**
+	 * Returns the audiences of this o auth2 authorization.
+	 *
+	 * @return the audiences of this o auth2 authorization
+	 */
+	@AutoEscape
+	public String getAudiences();
+
+	/**
+	 * Sets the audiences of this o auth2 authorization.
+	 *
+	 * @param audiences the audiences of this o auth2 authorization
+	 */
+	public void setAudiences(String audiences);
+
+	/**
 	 * Returns the remote host info of this o auth2 authorization.
 	 *
 	 * @return the remote host info of this o auth2 authorization
@@ -331,4 +346,4 @@ public interface OAuth2AuthorizationModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1163386414
+// LIFERAY-SERVICE-BUILDER-HASH:1447082576

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2AuthorizationTable.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2AuthorizationTable.java
@@ -64,6 +64,8 @@ public class OAuth2AuthorizationTable
 		accessTokenExpirationDate = createColumn(
 			"accessTokenExpirationDate", Date.class, Types.TIMESTAMP,
 			Column.FLAG_DEFAULT);
+	public final Column<OAuth2AuthorizationTable, Clob> audiences =
+		createColumn("audiences", Clob.class, Types.CLOB, Column.FLAG_DEFAULT);
 	public final Column<OAuth2AuthorizationTable, String> remoteHostInfo =
 		createColumn(
 			"remoteHostInfo", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
@@ -95,4 +97,4 @@ public class OAuth2AuthorizationTable
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-479389449
+// LIFERAY-SERVICE-BUILDER-HASH:-48770570

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2AuthorizationWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2AuthorizationWrapper.java
@@ -47,6 +47,7 @@ public class OAuth2AuthorizationWrapper
 		attributes.put("accessTokenCreateDate", getAccessTokenCreateDate());
 		attributes.put(
 			"accessTokenExpirationDate", getAccessTokenExpirationDate());
+		attributes.put("audiences", getAudiences());
 		attributes.put("remoteHostInfo", getRemoteHostInfo());
 		attributes.put("remoteIPInfo", getRemoteIPInfo());
 		attributes.put("refreshTokenContent", getRefreshTokenContent());
@@ -131,6 +132,12 @@ public class OAuth2AuthorizationWrapper
 
 		if (accessTokenExpirationDate != null) {
 			setAccessTokenExpirationDate(accessTokenExpirationDate);
+		}
+
+		String audiences = (String)attributes.get("audiences");
+
+		if (audiences != null) {
+			setAudiences(audiences);
 		}
 
 		String remoteHostInfo = (String)attributes.get("remoteHostInfo");
@@ -224,6 +231,21 @@ public class OAuth2AuthorizationWrapper
 	@Override
 	public Date getAccessTokenExpirationDate() {
 		return model.getAccessTokenExpirationDate();
+	}
+
+	/**
+	 * Returns the audiences of this o auth2 authorization.
+	 *
+	 * @return the audiences of this o auth2 authorization
+	 */
+	@Override
+	public String getAudiences() {
+		return model.getAudiences();
+	}
+
+	@Override
+	public java.util.List<String> getAudiencesList() {
+		return model.getAudiencesList();
 	}
 
 	/**
@@ -432,6 +454,21 @@ public class OAuth2AuthorizationWrapper
 	}
 
 	/**
+	 * Sets the audiences of this o auth2 authorization.
+	 *
+	 * @param audiences the audiences of this o auth2 authorization
+	 */
+	@Override
+	public void setAudiences(String audiences) {
+		model.setAudiences(audiences);
+	}
+
+	@Override
+	public void setAudiencesList(java.util.List<String> audiencesList) {
+		model.setAudiencesList(audiencesList);
+	}
+
+	/**
 	 * Sets the company ID of this o auth2 authorization.
 	 *
 	 * @param companyId the company ID of this o auth2 authorization
@@ -607,4 +644,4 @@ public class OAuth2AuthorizationWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2094917622
+// LIFERAY-SERVICE-BUILDER-HASH:-1562478898

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2AuthorizationLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2AuthorizationLocalService.java
@@ -65,20 +65,6 @@ public interface OAuth2AuthorizationLocalService
 		Date refreshTokenExpirationDate);
 
 	/**
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link
-	 #addOAuth2Authorization(long, long, String, long, long,
-	 String, Date, Date, String, String, String, Date, Date,
-	 List)}
-	 */
-	@Deprecated
-	public OAuth2Authorization addOAuth2Authorization(
-		long companyId, long userId, String userName, long oAuth2ApplicationId,
-		long oAuth2ApplicationScopeAliasesId, String accessTokenContent,
-		Date accessTokenCreateDate, Date accessTokenExpirationDate,
-		String remoteIPInfo, String refreshTokenContent,
-		Date refreshTokenCreateDate, Date refreshTokenExpirationDate);
-
-	/**
 	 * Adds the o auth2 authorization to the database. Also notifies the appropriate model listeners.
 	 *
 	 * <p>
@@ -405,4 +391,4 @@ public interface OAuth2AuthorizationLocalService
 		String refreshTokenContent, String rememberDeviceContent);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1241700801
+// LIFERAY-SERVICE-BUILDER-HASH:-1375974007

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2AuthorizationLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2AuthorizationLocalService.java
@@ -56,11 +56,19 @@ public interface OAuth2AuthorizationLocalService
 	 *
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.oauth2.provider.service.impl.OAuth2AuthorizationLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the o auth2 authorization local service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link OAuth2AuthorizationLocalServiceUtil} if injection and service tracking are not available.
 	 */
+	public OAuth2Authorization addOAuth2Authorization(
+		long companyId, long userId, String userName, long oAuth2ApplicationId,
+		long oAuth2ApplicationScopeAliasesId, String accessTokenContent,
+		Date accessTokenCreateDate, Date accessTokenExpirationDate,
+		List<String> audiences, String remoteHostInfo, String remoteIPInfo,
+		String refreshTokenContent, Date refreshTokenCreateDate,
+		Date refreshTokenExpirationDate);
 
 	/**
 	 * @deprecated As of Mueller (7.2.x), replaced by {@link
-	 #addOAuth2Authorization(long, long, String, long,long,
-	 String, Date, Date, String, String, String, Date, Date)}
+	 #addOAuth2Authorization(long, long, String, long, long,
+	 String, Date, Date, String, String, String, Date, Date,
+	 List)}
 	 */
 	@Deprecated
 	public OAuth2Authorization addOAuth2Authorization(
@@ -68,13 +76,6 @@ public interface OAuth2AuthorizationLocalService
 		long oAuth2ApplicationScopeAliasesId, String accessTokenContent,
 		Date accessTokenCreateDate, Date accessTokenExpirationDate,
 		String remoteIPInfo, String refreshTokenContent,
-		Date refreshTokenCreateDate, Date refreshTokenExpirationDate);
-
-	public OAuth2Authorization addOAuth2Authorization(
-		long companyId, long userId, String userName, long oAuth2ApplicationId,
-		long oAuth2ApplicationScopeAliasesId, String accessTokenContent,
-		Date accessTokenCreateDate, Date accessTokenExpirationDate,
-		String remoteHostInfo, String remoteIPInfo, String refreshTokenContent,
 		Date refreshTokenCreateDate, Date refreshTokenExpirationDate);
 
 	/**
@@ -404,4 +405,4 @@ public interface OAuth2AuthorizationLocalService
 		String refreshTokenContent, String rememberDeviceContent);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1337510262
+// LIFERAY-SERVICE-BUILDER-HASH:1241700801

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2AuthorizationLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2AuthorizationLocalServiceUtil.java
@@ -54,29 +54,6 @@ public class OAuth2AuthorizationLocalServiceUtil {
 	}
 
 	/**
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link
-	 #addOAuth2Authorization(long, long, String, long, long,
-	 String, Date, Date, String, String, String, Date, Date,
-	 List)}
-	 */
-	@Deprecated
-	public static OAuth2Authorization addOAuth2Authorization(
-		long companyId, long userId, String userName, long oAuth2ApplicationId,
-		long oAuth2ApplicationScopeAliasesId, String accessTokenContent,
-		java.util.Date accessTokenCreateDate,
-		java.util.Date accessTokenExpirationDate, String remoteIPInfo,
-		String refreshTokenContent, java.util.Date refreshTokenCreateDate,
-		java.util.Date refreshTokenExpirationDate) {
-
-		return getService().addOAuth2Authorization(
-			companyId, userId, userName, oAuth2ApplicationId,
-			oAuth2ApplicationScopeAliasesId, accessTokenContent,
-			accessTokenCreateDate, accessTokenExpirationDate, remoteIPInfo,
-			refreshTokenContent, refreshTokenCreateDate,
-			refreshTokenExpirationDate);
-	}
-
-	/**
 	 * Adds the o auth2 authorization to the database. Also notifies the appropriate model listeners.
 	 *
 	 * <p>
@@ -565,4 +542,4 @@ public class OAuth2AuthorizationLocalServiceUtil {
 			OAuth2AuthorizationLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:231210767
+// LIFERAY-SERVICE-BUILDER-HASH:1114366708

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2AuthorizationLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2AuthorizationLocalServiceUtil.java
@@ -36,11 +36,28 @@ public class OAuth2AuthorizationLocalServiceUtil {
 	 *
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.oauth2.provider.service.impl.OAuth2AuthorizationLocalServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
+	public static OAuth2Authorization addOAuth2Authorization(
+		long companyId, long userId, String userName, long oAuth2ApplicationId,
+		long oAuth2ApplicationScopeAliasesId, String accessTokenContent,
+		java.util.Date accessTokenCreateDate,
+		java.util.Date accessTokenExpirationDate, List<String> audiences,
+		String remoteHostInfo, String remoteIPInfo, String refreshTokenContent,
+		java.util.Date refreshTokenCreateDate,
+		java.util.Date refreshTokenExpirationDate) {
+
+		return getService().addOAuth2Authorization(
+			companyId, userId, userName, oAuth2ApplicationId,
+			oAuth2ApplicationScopeAliasesId, accessTokenContent,
+			accessTokenCreateDate, accessTokenExpirationDate, audiences,
+			remoteHostInfo, remoteIPInfo, refreshTokenContent,
+			refreshTokenCreateDate, refreshTokenExpirationDate);
+	}
 
 	/**
 	 * @deprecated As of Mueller (7.2.x), replaced by {@link
-	 #addOAuth2Authorization(long, long, String, long,long,
-	 String, Date, Date, String, String, String, Date, Date)}
+	 #addOAuth2Authorization(long, long, String, long, long,
+	 String, Date, Date, String, String, String, Date, Date,
+	 List)}
 	 */
 	@Deprecated
 	public static OAuth2Authorization addOAuth2Authorization(
@@ -56,23 +73,6 @@ public class OAuth2AuthorizationLocalServiceUtil {
 			oAuth2ApplicationScopeAliasesId, accessTokenContent,
 			accessTokenCreateDate, accessTokenExpirationDate, remoteIPInfo,
 			refreshTokenContent, refreshTokenCreateDate,
-			refreshTokenExpirationDate);
-	}
-
-	public static OAuth2Authorization addOAuth2Authorization(
-		long companyId, long userId, String userName, long oAuth2ApplicationId,
-		long oAuth2ApplicationScopeAliasesId, String accessTokenContent,
-		java.util.Date accessTokenCreateDate,
-		java.util.Date accessTokenExpirationDate, String remoteHostInfo,
-		String remoteIPInfo, String refreshTokenContent,
-		java.util.Date refreshTokenCreateDate,
-		java.util.Date refreshTokenExpirationDate) {
-
-		return getService().addOAuth2Authorization(
-			companyId, userId, userName, oAuth2ApplicationId,
-			oAuth2ApplicationScopeAliasesId, accessTokenContent,
-			accessTokenCreateDate, accessTokenExpirationDate, remoteHostInfo,
-			remoteIPInfo, refreshTokenContent, refreshTokenCreateDate,
 			refreshTokenExpirationDate);
 	}
 
@@ -565,4 +565,4 @@ public class OAuth2AuthorizationLocalServiceUtil {
 			OAuth2AuthorizationLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-730488698
+// LIFERAY-SERVICE-BUILDER-HASH:231210767

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2AuthorizationLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2AuthorizationLocalServiceWrapper.java
@@ -29,10 +29,31 @@ public class OAuth2AuthorizationLocalServiceWrapper
 		_oAuth2AuthorizationLocalService = oAuth2AuthorizationLocalService;
 	}
 
+	@Override
+	public com.liferay.oauth2.provider.model.OAuth2Authorization
+		addOAuth2Authorization(
+			long companyId, long userId, String userName,
+			long oAuth2ApplicationId, long oAuth2ApplicationScopeAliasesId,
+			String accessTokenContent, java.util.Date accessTokenCreateDate,
+			java.util.Date accessTokenExpirationDate,
+			java.util.List<String> audiences, String remoteHostInfo,
+			String remoteIPInfo, String refreshTokenContent,
+			java.util.Date refreshTokenCreateDate,
+			java.util.Date refreshTokenExpirationDate) {
+
+		return _oAuth2AuthorizationLocalService.addOAuth2Authorization(
+			companyId, userId, userName, oAuth2ApplicationId,
+			oAuth2ApplicationScopeAliasesId, accessTokenContent,
+			accessTokenCreateDate, accessTokenExpirationDate, audiences,
+			remoteHostInfo, remoteIPInfo, refreshTokenContent,
+			refreshTokenCreateDate, refreshTokenExpirationDate);
+	}
+
 	/**
 	 * @deprecated As of Mueller (7.2.x), replaced by {@link
-	 #addOAuth2Authorization(long, long, String, long,long,
-	 String, Date, Date, String, String, String, Date, Date)}
+	 #addOAuth2Authorization(long, long, String, long, long,
+	 String, Date, Date, String, String, String, Date, Date,
+	 List)}
 	 */
 	@Deprecated
 	@Override
@@ -50,25 +71,6 @@ public class OAuth2AuthorizationLocalServiceWrapper
 			oAuth2ApplicationScopeAliasesId, accessTokenContent,
 			accessTokenCreateDate, accessTokenExpirationDate, remoteIPInfo,
 			refreshTokenContent, refreshTokenCreateDate,
-			refreshTokenExpirationDate);
-	}
-
-	@Override
-	public com.liferay.oauth2.provider.model.OAuth2Authorization
-		addOAuth2Authorization(
-			long companyId, long userId, String userName,
-			long oAuth2ApplicationId, long oAuth2ApplicationScopeAliasesId,
-			String accessTokenContent, java.util.Date accessTokenCreateDate,
-			java.util.Date accessTokenExpirationDate, String remoteHostInfo,
-			String remoteIPInfo, String refreshTokenContent,
-			java.util.Date refreshTokenCreateDate,
-			java.util.Date refreshTokenExpirationDate) {
-
-		return _oAuth2AuthorizationLocalService.addOAuth2Authorization(
-			companyId, userId, userName, oAuth2ApplicationId,
-			oAuth2ApplicationScopeAliasesId, accessTokenContent,
-			accessTokenCreateDate, accessTokenExpirationDate, remoteHostInfo,
-			remoteIPInfo, refreshTokenContent, refreshTokenCreateDate,
 			refreshTokenExpirationDate);
 	}
 
@@ -680,4 +682,4 @@ public class OAuth2AuthorizationLocalServiceWrapper
 	private OAuth2AuthorizationLocalService _oAuth2AuthorizationLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:731460654
+// LIFERAY-SERVICE-BUILDER-HASH:65684863

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2AuthorizationLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2AuthorizationLocalServiceWrapper.java
@@ -50,31 +50,6 @@ public class OAuth2AuthorizationLocalServiceWrapper
 	}
 
 	/**
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link
-	 #addOAuth2Authorization(long, long, String, long, long,
-	 String, Date, Date, String, String, String, Date, Date,
-	 List)}
-	 */
-	@Deprecated
-	@Override
-	public com.liferay.oauth2.provider.model.OAuth2Authorization
-		addOAuth2Authorization(
-			long companyId, long userId, String userName,
-			long oAuth2ApplicationId, long oAuth2ApplicationScopeAliasesId,
-			String accessTokenContent, java.util.Date accessTokenCreateDate,
-			java.util.Date accessTokenExpirationDate, String remoteIPInfo,
-			String refreshTokenContent, java.util.Date refreshTokenCreateDate,
-			java.util.Date refreshTokenExpirationDate) {
-
-		return _oAuth2AuthorizationLocalService.addOAuth2Authorization(
-			companyId, userId, userName, oAuth2ApplicationId,
-			oAuth2ApplicationScopeAliasesId, accessTokenContent,
-			accessTokenCreateDate, accessTokenExpirationDate, remoteIPInfo,
-			refreshTokenContent, refreshTokenCreateDate,
-			refreshTokenExpirationDate);
-	}
-
-	/**
 	 * Adds the o auth2 authorization to the database. Also notifies the appropriate model listeners.
 	 *
 	 * <p>
@@ -682,4 +657,4 @@ public class OAuth2AuthorizationLocalServiceWrapper
 	private OAuth2AuthorizationLocalService _oAuth2AuthorizationLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:65684863
+// LIFERAY-SERVICE-BUILDER-HASH:1435454984

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/model/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/model/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 4.3.0

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 6.0.0

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/introspect/message/body/TokenIntrospectionJSONProviderMessageBodyWriter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/introspect/message/body/TokenIntrospectionJSONProviderMessageBodyWriter.java
@@ -26,7 +26,6 @@ import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -105,20 +104,13 @@ public class TokenIntrospectionJSONProviderMessageBodyWriter
 			audience.removeIf(String::isEmpty);
 
 			if (!audience.isEmpty()) {
-				StringBundler audienceSB;
 
-				if (audience.size() == 1) {
-					audienceSB = new StringBundler(7);
+				// Always emit as a JSON array, even for a single audience,
+				// so resource servers (MCP) can rely on a stable shape.
 
-					Iterator<String> iterator = audience.iterator();
+				StringBundler audienceSB = new StringBundler(5);
 
-					_append(audienceSB, "aud", iterator.next());
-				}
-				else {
-					audienceSB = new StringBundler(5);
-
-					_append(audienceSB, "aud", audience);
-				}
+				_append(audienceSB, "aud", audience);
 
 				sb.append(audienceSB);
 			}

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/introspect/message/body/TokenIntrospectionJSONProviderMessageBodyWriter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/introspect/message/body/TokenIntrospectionJSONProviderMessageBodyWriter.java
@@ -104,10 +104,6 @@ public class TokenIntrospectionJSONProviderMessageBodyWriter
 			audience.removeIf(String::isEmpty);
 
 			if (!audience.isEmpty()) {
-
-				// Always emit as a JSON array, even for a single audience,
-				// so resource servers (MCP) can rely on a stable shape.
-
 				StringBundler audienceSB = new StringBundler(5);
 
 				_append(audienceSB, "aud", audience);

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -901,7 +901,7 @@ public class LiferayOAuthDataProvider
 						registrationAccessToken, DateUtil.newDate(),
 						DateUtil.newDate(
 							System.currentTimeMillis() + Time.YEAR),
-						remoteHost, remoteAddr, null, null, null);
+						null, remoteHost, remoteAddr, null, null, null);
 				}
 			}
 
@@ -1768,17 +1768,8 @@ public class LiferayOAuthDataProvider
 				oAuth2Application.getOAuth2ApplicationId(),
 				oAuth2Application.getOAuth2ApplicationScopeAliasesId(),
 				serverAccessToken.getTokenKey(), createDate, expirationDate,
-				remoteHost, remoteAddr, null, null, null);
-
-		List<String> audiences = serverAccessToken.getAudiences();
-
-		if (ListUtil.isNotEmpty(audiences)) {
-			oAuth2Authorization.setAudiencesList(audiences);
-
-			oAuth2Authorization =
-				_oAuth2AuthorizationLocalService.updateOAuth2Authorization(
-					oAuth2Authorization);
-		}
+				serverAccessToken.getAudiences(), remoteHost, remoteAddr, null,
+				null, null);
 
 		List<String> scopeAliasesList =
 			OAuthUtils.convertPermissionsToScopeList(

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -1504,6 +1504,12 @@ public class LiferayOAuthDataProvider
 			client, oAuth2Authorization.getAccessTokenContent(), lifetime,
 			issuedAt);
 
+		List<String> audiencesList = oAuth2Authorization.getAudiencesList();
+
+		if (!audiencesList.isEmpty()) {
+			serverAccessToken.setAudiences(audiencesList);
+		}
+
 		serverAccessToken.setSubject(
 			_populateUserSubject(
 				oAuth2Authorization.getCompanyId(),
@@ -1718,6 +1724,8 @@ public class LiferayOAuthDataProvider
 				serverAccessToken.getTokenKey());
 			oAuth2Authorization.setAccessTokenCreateDate(createDate);
 			oAuth2Authorization.setAccessTokenExpirationDate(expirationDate);
+			oAuth2Authorization.setAudiencesList(
+				serverAccessToken.getAudiences());
 
 			_oAuth2AuthorizationLocalService.updateOAuth2Authorization(
 				oAuth2Authorization);
@@ -1761,6 +1769,16 @@ public class LiferayOAuthDataProvider
 				oAuth2Application.getOAuth2ApplicationScopeAliasesId(),
 				serverAccessToken.getTokenKey(), createDate, expirationDate,
 				remoteHost, remoteAddr, null, null, null);
+
+		List<String> audiences = serverAccessToken.getAudiences();
+
+		if (ListUtil.isNotEmpty(audiences)) {
+			oAuth2Authorization.setAudiencesList(audiences);
+
+			oAuth2Authorization =
+				_oAuth2AuthorizationLocalService.updateOAuth2Authorization(
+					oAuth2Authorization);
+		}
 
 		List<String> scopeAliasesList =
 			OAuthUtils.convertPermissionsToScopeList(

--- a/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay OAuth2 Provider Service
 Bundle-SymbolicName: com.liferay.oauth2.provider.service
 Bundle-Version: 4.0.109
-Liferay-Require-SchemaVersion: 4.2.7
+Liferay-Require-SchemaVersion: 4.2.8
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/oauth2-provider/oauth2-provider-service/service.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/service.xml
@@ -99,6 +99,7 @@
 		<column name="accessTokenContentHash" type="long" />
 		<column name="accessTokenCreateDate" type="Date" />
 		<column name="accessTokenExpirationDate" type="Date" />
+		<column name="audiences" type="String" />
 		<column name="remoteHostInfo" type="String" />
 		<column name="remoteIPInfo" type="String" />
 		<column name="refreshTokenContent" type="String" />

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
@@ -144,6 +144,11 @@ public class OAuth2ServiceUpgradeStepRegistrator
 			UpgradeProcessFactory.alterColumnType(
 				"OAuth2Application", "externalReferenceCode",
 				"VARCHAR(1000) null"));
+
+		registry.register(
+			"4.2.7", "4.2.8",
+			UpgradeProcessFactory.addColumns(
+				"OAuth2Authorization", "audiences TEXT null"));
 	}
 
 	@Reference

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2AuthorizationCacheModel.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2AuthorizationCacheModel.java
@@ -55,7 +55,7 @@ public class OAuth2AuthorizationCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(37);
+		StringBundler sb = new StringBundler(39);
 
 		sb.append("{oAuth2AuthorizationId=");
 		sb.append(oAuth2AuthorizationId);
@@ -79,6 +79,8 @@ public class OAuth2AuthorizationCacheModel
 		sb.append(accessTokenCreateDate);
 		sb.append(", accessTokenExpirationDate=");
 		sb.append(accessTokenExpirationDate);
+		sb.append(", audiences=");
+		sb.append(audiences);
 		sb.append(", remoteHostInfo=");
 		sb.append(remoteHostInfo);
 		sb.append(", remoteIPInfo=");
@@ -149,6 +151,13 @@ public class OAuth2AuthorizationCacheModel
 		else {
 			oAuth2AuthorizationImpl.setAccessTokenExpirationDate(
 				new Date(accessTokenExpirationDate));
+		}
+
+		if (audiences == null) {
+			oAuth2AuthorizationImpl.setAudiences("");
+		}
+		else {
+			oAuth2AuthorizationImpl.setAudiences(audiences);
 		}
 
 		if (remoteHostInfo == null) {
@@ -224,6 +233,7 @@ public class OAuth2AuthorizationCacheModel
 		accessTokenContentHash = objectInput.readLong();
 		accessTokenCreateDate = objectInput.readLong();
 		accessTokenExpirationDate = objectInput.readLong();
+		audiences = (String)objectInput.readObject();
 		remoteHostInfo = objectInput.readUTF();
 		remoteIPInfo = objectInput.readUTF();
 		refreshTokenContent = (String)objectInput.readObject();
@@ -265,6 +275,13 @@ public class OAuth2AuthorizationCacheModel
 		objectOutput.writeLong(accessTokenContentHash);
 		objectOutput.writeLong(accessTokenCreateDate);
 		objectOutput.writeLong(accessTokenExpirationDate);
+
+		if (audiences == null) {
+			objectOutput.writeObject("");
+		}
+		else {
+			objectOutput.writeObject(audiences);
+		}
 
 		if (remoteHostInfo == null) {
 			objectOutput.writeUTF("");
@@ -310,6 +327,7 @@ public class OAuth2AuthorizationCacheModel
 	public long accessTokenContentHash;
 	public long accessTokenCreateDate;
 	public long accessTokenExpirationDate;
+	public String audiences;
 	public String remoteHostInfo;
 	public String remoteIPInfo;
 	public String refreshTokenContent;
@@ -319,4 +337,4 @@ public class OAuth2AuthorizationCacheModel
 	public String rememberDeviceContent;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1014306663
+// LIFERAY-SERVICE-BUILDER-HASH:-1982545885

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2AuthorizationImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2AuthorizationImpl.java
@@ -5,6 +5,12 @@
 
 package com.liferay.oauth2.provider.model.impl;
 
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringPool;
+import com.liferay.petra.string.StringUtil;
+
+import java.util.List;
+
 /**
  * The extended model implementation for the OAuth2Authorization service.
  * Represents a row in the &quot;OAuth2Authorization&quot; database table, with
@@ -21,6 +27,10 @@ package com.liferay.oauth2.provider.model.impl;
  */
 public class OAuth2AuthorizationImpl extends OAuth2AuthorizationBaseImpl {
 
+	public List<String> getAudiencesList() {
+		return StringUtil.split(getAudiences(), CharPool.NEW_LINE);
+	}
+
 	@Override
 	public void setAccessTokenContent(String accessTokenContent) {
 		super.setAccessTokenContent(accessTokenContent);
@@ -31,6 +41,10 @@ public class OAuth2AuthorizationImpl extends OAuth2AuthorizationBaseImpl {
 		else {
 			setAccessTokenContentHash(0);
 		}
+	}
+
+	public void setAudiencesList(List<String> audiencesList) {
+		setAudiences(StringUtil.merge(audiencesList, StringPool.NEW_LINE));
 	}
 
 	@Override

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2AuthorizationImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2AuthorizationImpl.java
@@ -27,6 +27,7 @@ import java.util.List;
  */
 public class OAuth2AuthorizationImpl extends OAuth2AuthorizationBaseImpl {
 
+	@Override
 	public List<String> getAudiencesList() {
 		return StringUtil.split(getAudiences(), CharPool.NEW_LINE);
 	}
@@ -43,6 +44,7 @@ public class OAuth2AuthorizationImpl extends OAuth2AuthorizationBaseImpl {
 		}
 	}
 
+	@Override
 	public void setAudiencesList(List<String> audiencesList) {
 		setAudiences(StringUtil.merge(audiencesList, StringPool.NEW_LINE));
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2AuthorizationModelImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2AuthorizationModelImpl.java
@@ -69,8 +69,8 @@ public class OAuth2AuthorizationModelImpl
 		{"accessTokenContentHash", Types.BIGINT},
 		{"accessTokenCreateDate", Types.TIMESTAMP},
 		{"accessTokenExpirationDate", Types.TIMESTAMP},
-		{"remoteHostInfo", Types.VARCHAR}, {"remoteIPInfo", Types.VARCHAR},
-		{"refreshTokenContent", Types.CLOB},
+		{"audiences", Types.CLOB}, {"remoteHostInfo", Types.VARCHAR},
+		{"remoteIPInfo", Types.VARCHAR}, {"refreshTokenContent", Types.CLOB},
 		{"refreshTokenContentHash", Types.BIGINT},
 		{"refreshTokenCreateDate", Types.TIMESTAMP},
 		{"refreshTokenExpirationDate", Types.TIMESTAMP},
@@ -92,6 +92,7 @@ public class OAuth2AuthorizationModelImpl
 		TABLE_COLUMNS_MAP.put("accessTokenContentHash", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("accessTokenCreateDate", Types.TIMESTAMP);
 		TABLE_COLUMNS_MAP.put("accessTokenExpirationDate", Types.TIMESTAMP);
+		TABLE_COLUMNS_MAP.put("audiences", Types.CLOB);
 		TABLE_COLUMNS_MAP.put("remoteHostInfo", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("remoteIPInfo", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("refreshTokenContent", Types.CLOB);
@@ -102,7 +103,7 @@ public class OAuth2AuthorizationModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table OAuth2Authorization (oAuth2AuthorizationId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,oAuth2ApplicationId LONG,oA2AScopeAliasesId LONG,accessTokenContent TEXT null,accessTokenContentHash LONG,accessTokenCreateDate DATE null,accessTokenExpirationDate DATE null,remoteHostInfo VARCHAR(255) null,remoteIPInfo VARCHAR(75) null,refreshTokenContent TEXT null,refreshTokenContentHash LONG,refreshTokenCreateDate DATE null,refreshTokenExpirationDate DATE null,rememberDeviceContent VARCHAR(75) null)";
+		"create table OAuth2Authorization (oAuth2AuthorizationId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,oAuth2ApplicationId LONG,oA2AScopeAliasesId LONG,accessTokenContent TEXT null,accessTokenContentHash LONG,accessTokenCreateDate DATE null,accessTokenExpirationDate DATE null,audiences TEXT null,remoteHostInfo VARCHAR(255) null,remoteIPInfo VARCHAR(75) null,refreshTokenContent TEXT null,refreshTokenContentHash LONG,refreshTokenCreateDate DATE null,refreshTokenExpirationDate DATE null,rememberDeviceContent VARCHAR(75) null)";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table OAuth2Authorization";
@@ -318,6 +319,8 @@ public class OAuth2AuthorizationModelImpl
 				"accessTokenExpirationDate",
 				OAuth2Authorization::getAccessTokenExpirationDate);
 			attributeGetterFunctions.put(
+				"audiences", OAuth2Authorization::getAudiences);
+			attributeGetterFunctions.put(
 				"remoteHostInfo", OAuth2Authorization::getRemoteHostInfo);
 			attributeGetterFunctions.put(
 				"remoteIPInfo", OAuth2Authorization::getRemoteIPInfo);
@@ -399,6 +402,10 @@ public class OAuth2AuthorizationModelImpl
 				"accessTokenExpirationDate",
 				(BiConsumer<OAuth2Authorization, Date>)
 					OAuth2Authorization::setAccessTokenExpirationDate);
+			attributeSetterBiConsumers.put(
+				"audiences",
+				(BiConsumer<OAuth2Authorization, String>)
+					OAuth2Authorization::setAudiences);
 			attributeSetterBiConsumers.put(
 				"remoteHostInfo",
 				(BiConsumer<OAuth2Authorization, String>)
@@ -656,6 +663,25 @@ public class OAuth2AuthorizationModelImpl
 	}
 
 	@Override
+	public String getAudiences() {
+		if (_audiences == null) {
+			return "";
+		}
+		else {
+			return _audiences;
+		}
+	}
+
+	@Override
+	public void setAudiences(String audiences) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_audiences = audiences;
+	}
+
+	@Override
 	public String getRemoteHostInfo() {
 		if (_remoteHostInfo == null) {
 			return "";
@@ -867,6 +893,7 @@ public class OAuth2AuthorizationModelImpl
 			getAccessTokenCreateDate());
 		oAuth2AuthorizationImpl.setAccessTokenExpirationDate(
 			getAccessTokenExpirationDate());
+		oAuth2AuthorizationImpl.setAudiences(getAudiences());
 		oAuth2AuthorizationImpl.setRemoteHostInfo(getRemoteHostInfo());
 		oAuth2AuthorizationImpl.setRemoteIPInfo(getRemoteIPInfo());
 		oAuth2AuthorizationImpl.setRefreshTokenContent(
@@ -912,6 +939,8 @@ public class OAuth2AuthorizationModelImpl
 			this.<Date>getColumnOriginalValue("accessTokenCreateDate"));
 		oAuth2AuthorizationImpl.setAccessTokenExpirationDate(
 			this.<Date>getColumnOriginalValue("accessTokenExpirationDate"));
+		oAuth2AuthorizationImpl.setAudiences(
+			this.<String>getColumnOriginalValue("audiences"));
 		oAuth2AuthorizationImpl.setRemoteHostInfo(
 			this.<String>getColumnOriginalValue("remoteHostInfo"));
 		oAuth2AuthorizationImpl.setRemoteIPInfo(
@@ -1069,6 +1098,14 @@ public class OAuth2AuthorizationModelImpl
 				Long.MIN_VALUE;
 		}
 
+		oAuth2AuthorizationCacheModel.audiences = getAudiences();
+
+		String audiences = oAuth2AuthorizationCacheModel.audiences;
+
+		if ((audiences != null) && (audiences.length() == 0)) {
+			oAuth2AuthorizationCacheModel.audiences = null;
+		}
+
 		oAuth2AuthorizationCacheModel.remoteHostInfo = getRemoteHostInfo();
 
 		String remoteHostInfo = oAuth2AuthorizationCacheModel.remoteHostInfo;
@@ -1207,6 +1244,7 @@ public class OAuth2AuthorizationModelImpl
 	private long _accessTokenContentHash;
 	private Date _accessTokenCreateDate;
 	private Date _accessTokenExpirationDate;
+	private String _audiences;
 	private String _remoteHostInfo;
 	private String _remoteIPInfo;
 	private String _refreshTokenContent;
@@ -1261,6 +1299,7 @@ public class OAuth2AuthorizationModelImpl
 			"accessTokenCreateDate", _accessTokenCreateDate);
 		_columnOriginalValues.put(
 			"accessTokenExpirationDate", _accessTokenExpirationDate);
+		_columnOriginalValues.put("audiences", _audiences);
 		_columnOriginalValues.put("remoteHostInfo", _remoteHostInfo);
 		_columnOriginalValues.put("remoteIPInfo", _remoteIPInfo);
 		_columnOriginalValues.put("refreshTokenContent", _refreshTokenContent);
@@ -1318,19 +1357,21 @@ public class OAuth2AuthorizationModelImpl
 
 		columnBitmasks.put("accessTokenExpirationDate", 1024L);
 
-		columnBitmasks.put("remoteHostInfo", 2048L);
+		columnBitmasks.put("audiences", 2048L);
 
-		columnBitmasks.put("remoteIPInfo", 4096L);
+		columnBitmasks.put("remoteHostInfo", 4096L);
 
-		columnBitmasks.put("refreshTokenContent", 8192L);
+		columnBitmasks.put("remoteIPInfo", 8192L);
 
-		columnBitmasks.put("refreshTokenContentHash", 16384L);
+		columnBitmasks.put("refreshTokenContent", 16384L);
 
-		columnBitmasks.put("refreshTokenCreateDate", 32768L);
+		columnBitmasks.put("refreshTokenContentHash", 32768L);
 
-		columnBitmasks.put("refreshTokenExpirationDate", 65536L);
+		columnBitmasks.put("refreshTokenCreateDate", 65536L);
 
-		columnBitmasks.put("rememberDeviceContent", 131072L);
+		columnBitmasks.put("refreshTokenExpirationDate", 131072L);
+
+		columnBitmasks.put("rememberDeviceContent", 262144L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}
@@ -1339,4 +1380,4 @@ public class OAuth2AuthorizationModelImpl
 	private OAuth2Authorization _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1759293294
+// LIFERAY-SERVICE-BUILDER-HASH:-1922040889

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2AuthorizationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2AuthorizationLocalServiceImpl.java
@@ -39,29 +39,6 @@ import org.osgi.service.component.annotations.Modified;
 public class OAuth2AuthorizationLocalServiceImpl
 	extends OAuth2AuthorizationLocalServiceBaseImpl {
 
-	/**
-	 * @deprecated As of Mueller (7.2.x), replaced by {@link
-	 *             #addOAuth2Authorization(long, long, String, long, long,
-	 *             String, Date, Date, String, String, String, Date, Date,
-	 *             List)}
-	 */
-	@Deprecated
-	@Override
-	public OAuth2Authorization addOAuth2Authorization(
-		long companyId, long userId, String userName, long oAuth2ApplicationId,
-		long oAuth2ApplicationScopeAliasesId, String accessTokenContent,
-		Date accessTokenCreateDate, Date accessTokenExpirationDate,
-		String remoteIPInfo, String refreshTokenContent,
-		Date refreshTokenCreateDate, Date refreshTokenExpirationDate) {
-
-		return addOAuth2Authorization(
-			companyId, userId, userName, oAuth2ApplicationId,
-			oAuth2ApplicationScopeAliasesId, accessTokenContent,
-			accessTokenCreateDate, accessTokenExpirationDate, null, null,
-			remoteIPInfo, refreshTokenContent, refreshTokenCreateDate,
-			refreshTokenExpirationDate);
-	}
-
 	@Override
 	public OAuth2Authorization addOAuth2Authorization(
 		long companyId, long userId, String userName, long oAuth2ApplicationId,

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2AuthorizationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2AuthorizationLocalServiceImpl.java
@@ -41,8 +41,9 @@ public class OAuth2AuthorizationLocalServiceImpl
 
 	/**
 	 * @deprecated As of Mueller (7.2.x), replaced by {@link
-	 *             #addOAuth2Authorization(long, long, String, long,long,
-	 *             String, Date, Date, String, String, String, Date, Date)}
+	 *             #addOAuth2Authorization(long, long, String, long, long,
+	 *             String, Date, Date, String, String, String, Date, Date,
+	 *             List)}
 	 */
 	@Deprecated
 	@Override
@@ -56,7 +57,7 @@ public class OAuth2AuthorizationLocalServiceImpl
 		return addOAuth2Authorization(
 			companyId, userId, userName, oAuth2ApplicationId,
 			oAuth2ApplicationScopeAliasesId, accessTokenContent,
-			accessTokenCreateDate, accessTokenExpirationDate, null,
+			accessTokenCreateDate, accessTokenExpirationDate, null, null,
 			remoteIPInfo, refreshTokenContent, refreshTokenCreateDate,
 			refreshTokenExpirationDate);
 	}
@@ -66,8 +67,9 @@ public class OAuth2AuthorizationLocalServiceImpl
 		long companyId, long userId, String userName, long oAuth2ApplicationId,
 		long oAuth2ApplicationScopeAliasesId, String accessTokenContent,
 		Date accessTokenCreateDate, Date accessTokenExpirationDate,
-		String remoteHostInfo, String remoteIPInfo, String refreshTokenContent,
-		Date refreshTokenCreateDate, Date refreshTokenExpirationDate) {
+		List<String> audiences, String remoteHostInfo, String remoteIPInfo,
+		String refreshTokenContent, Date refreshTokenCreateDate,
+		Date refreshTokenExpirationDate) {
 
 		long oAuth2AuthorizationId = counterLocalService.increment(
 			OAuth2Authorization.class.getName());
@@ -86,6 +88,11 @@ public class OAuth2AuthorizationLocalServiceImpl
 		oAuth2Authorization.setAccessTokenCreateDate(accessTokenCreateDate);
 		oAuth2Authorization.setAccessTokenExpirationDate(
 			accessTokenExpirationDate);
+
+		if (audiences != null) {
+			oAuth2Authorization.setAudiencesList(audiences);
+		}
+
 		oAuth2Authorization.setRemoteHostInfo(remoteHostInfo);
 		oAuth2Authorization.setRemoteIPInfo(remoteIPInfo);
 		oAuth2Authorization.setRefreshTokenContent(refreshTokenContent);

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/module-hbm.xml
@@ -60,6 +60,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="accessTokenContentHash" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="accessTokenCreateDate" type="org.hibernate.type.TimestampType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="accessTokenExpirationDate" type="org.hibernate.type.TimestampType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="audiences" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="remoteHostInfo" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="remoteIPInfo" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="refreshTokenContent" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -71,6 +71,9 @@
 		<field name="accessTokenContentHash" type="long" />
 		<field name="accessTokenCreateDate" type="Date" />
 		<field name="accessTokenExpirationDate" type="Date" />
+		<field name="audiences" type="String">
+			<hint-collection name="CLOB" />
+		</field>
 		<field name="remoteHostInfo" type="String">
 			<hint name="max-length">255</hint>
 		</field>

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/tables.sql
@@ -55,6 +55,7 @@ create table OAuth2Authorization (
 	accessTokenContentHash LONG,
 	accessTokenCreateDate DATE null,
 	accessTokenExpirationDate DATE null,
+	audiences TEXT null,
 	remoteHostInfo VARCHAR(255) null,
 	remoteIPInfo VARCHAR(75) null,
 	refreshTokenContent TEXT null,

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/service.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.oauth2.provider.service
-    build.number=1
-    build.date=1511982781730
+    build.number=3
+    build.date=1778151133558

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseClientTestCase.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseClientTestCase.java
@@ -97,6 +97,12 @@ public abstract class BaseClientTestCase {
 		_bundleActivator.stop(_bundleContext);
 	}
 
+	protected static WebTarget getIntrospectWebTarget() {
+		WebTarget webTarget = getOAuth2WebTarget();
+
+		return webTarget.path("introspect");
+	}
+
 	protected static Invocation.Builder getInvocationBuilder(
 		String hostname, WebTarget webTarget,
 		Function<Invocation.Builder, Invocation.Builder>

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
@@ -129,7 +129,7 @@ public abstract class BaseTestPreparatorBundleActivator
 				oAuth2Application.getOAuth2ApplicationId(),
 				oAuth2Application.getOAuth2ApplicationScopeAliasesId(),
 				accessTokenContent, accessTokenCreateDate,
-				accessTokenExpirationDate, "localhost", "127.0.0.1",
+				accessTokenExpirationDate, null, "localhost", "127.0.0.1",
 				refreshTokenContent, refreshTokenCreateDate,
 				refreshTokenExpirationDate);
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
@@ -3,11 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.oauth2.provider.resource.test;
+package com.liferay.oauth2.provider.client.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.oauth2.provider.client.test.BaseClientTestCase;
-import com.liferay.oauth2.provider.client.test.BaseTestPreparatorBundleActivator;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
@@ -41,7 +39,7 @@ import org.osgi.framework.BundleActivator;
  * @author Jorge García Jiménez
  */
 @RunWith(Arquillian.class)
-public class ResourceIndicatorsTest extends BaseClientTestCase {
+public class TokenAudienceTest extends BaseClientTestCase {
 
 	@ClassRule
 	@Rule
@@ -49,7 +47,7 @@ public class ResourceIndicatorsTest extends BaseClientTestCase {
 		new LiferayIntegrationTestRule();
 
 	@Test
-	public void testIntrospectionEmitsAudAsJSONArray() throws Exception {
+	public void testTokenIntrospectionAudience() throws Exception {
 		WebTarget tokenWebTarget = getTokenWebTarget();
 
 		Invocation.Builder tokenInvocationBuilder = tokenWebTarget.request();
@@ -97,16 +95,13 @@ public class ResourceIndicatorsTest extends BaseClientTestCase {
 
 		JSONArray audJSONArray = jsonObject.getJSONArray("aud");
 
-		Assert.assertNotNull(
-			"introspection response missing aud", audJSONArray);
+		Assert.assertNotNull(audJSONArray);
 		Assert.assertEquals(1, audJSONArray.length());
 		Assert.assertEquals(_RESOURCE_URI, audJSONArray.getString(0));
 	}
 
 	@Test
-	public void testTokenWithMalformedResourceReturnsInvalidTarget()
-		throws Exception {
-
+	public void testTokenRequestWithInvalidResource() throws Exception {
 		WebTarget tokenWebTarget = getTokenWebTarget();
 
 		Invocation.Builder invocationBuilder = tokenWebTarget.request();
@@ -133,18 +128,18 @@ public class ResourceIndicatorsTest extends BaseClientTestCase {
 
 	@Override
 	protected BundleActivator getBundleActivator() {
-		return new ResourceIndicatorsTestPreparatorBundleActivator();
+		return new TokenAudienceTestPreparatorBundleActivator();
 	}
 
 	private static final String _CLIENT_ID =
-		"oauthResourceIndicatorsTestApplication";
+		"oauthTokenAudienceTestApplication";
 
 	private static final String _CLIENT_SECRET =
-		"oauthResourceIndicatorsTestApplicationSecret";
+		"oauthTokenAudienceTestApplicationSecret";
 
 	private static final String _RESOURCE_URI = "https://mcp.example.com/o/mcp";
 
-	private class ResourceIndicatorsTestPreparatorBundleActivator
+	private class TokenAudienceTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
 
 		@Override

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenIntrospectionTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenIntrospectionTest.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -20,7 +21,6 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
 import java.util.Collections;
@@ -57,18 +57,22 @@ public class TokenIntrospectionTest extends BaseClientTestCase {
 
 		Assert.assertNotNull(token);
 
-		Invocation.Builder invocationBuilder =
-			_getTokenIntrospectionWebTarget().request();
+		WebTarget webTarget = getIntrospectWebTarget();
 
-		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
-
-		formData.add("client_id", applicationClientId);
-		formData.add("client_secret", "oauthTestApplicationSecret");
-		formData.add("token", token);
+		Invocation.Builder invocationBuilder = webTarget.request();
 
 		invocationBuilder.header("Origin", RandomTestUtil.randomString());
 
-		Response response = invocationBuilder.post(Entity.form(formData));
+		Response response = invocationBuilder.post(
+			Entity.form(
+				new MultivaluedHashMap<>(
+					HashMapBuilder.put(
+						"client_id", applicationClientId
+					).put(
+						"client_secret", "oauthTestApplicationSecret"
+					).put(
+						"token", token
+					).build())));
 
 		Assert.assertEquals(
 			Response.Status.OK.getStatusCode(), response.getStatus());
@@ -93,16 +97,20 @@ public class TokenIntrospectionTest extends BaseClientTestCase {
 
 		Assert.assertNotNull(token);
 
-		Invocation.Builder invocationBuilder =
-			_getTokenIntrospectionWebTarget().request();
+		WebTarget webTarget = getIntrospectWebTarget();
 
-		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
+		Invocation.Builder invocationBuilder = webTarget.request();
 
-		formData.add("client_id", applicationClientId);
-		formData.add("client_secret", StringPool.BLANK);
-		formData.add("token", token);
-
-		Response response = invocationBuilder.post(Entity.form(formData));
+		Response response = invocationBuilder.post(
+			Entity.form(
+				new MultivaluedHashMap<>(
+					HashMapBuilder.put(
+						"client_id", applicationClientId
+					).put(
+						"client_secret", StringPool.BLANK
+					).put(
+						"token", token
+					).build())));
 
 		Assert.assertEquals(
 			Response.Status.OK.getStatusCode(), response.getStatus());
@@ -115,16 +123,6 @@ public class TokenIntrospectionTest extends BaseClientTestCase {
 	protected BundleActivator getBundleActivator() {
 		return new TokenIntrospectionTest.
 			TokenIntrospectionTestPreparatorBundleActivator();
-	}
-
-	private WebTarget _getTokenIntrospectionWebTarget() {
-		WebTarget webTarget = getWebTarget();
-
-		webTarget = webTarget.path("o");
-		webTarget = webTarget.path("oauth2");
-		webTarget = webTarget.path("introspect");
-
-		return webTarget;
 	}
 
 	private User _user;

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/resource/test/OAuth2ResourceIndicatorsTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/resource/test/OAuth2ResourceIndicatorsTest.java
@@ -1,0 +1,157 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.resource.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.client.test.BaseClientTestCase;
+import com.liferay.oauth2.provider.client.test.BaseTestPreparatorBundleActivator;
+import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.BundleActivator;
+
+/**
+ * @author Jorge García Jiménez
+ */
+@RunWith(Arquillian.class)
+public class OAuth2ResourceIndicatorsTest extends BaseClientTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testIntrospectionEmitsAudAsJSONArray() throws Exception {
+		MultivaluedMap<String, String> tokenFormData =
+			new MultivaluedHashMap<>();
+
+		tokenFormData.add("client_id", _CLIENT_ID);
+		tokenFormData.add("client_secret", _CLIENT_SECRET);
+		tokenFormData.add("grant_type", "client_credentials");
+		tokenFormData.add("resource", _RESOURCE_URI);
+
+		Invocation.Builder tokenInvocationBuilder =
+			getTokenWebTarget().request();
+
+		Response tokenResponse = tokenInvocationBuilder.post(
+			Entity.form(tokenFormData));
+
+		Assert.assertEquals(200, tokenResponse.getStatus());
+
+		String accessToken = parseTokenString(tokenResponse);
+
+		Assert.assertNotNull(accessToken);
+
+		MultivaluedMap<String, String> introspectFormData =
+			new MultivaluedHashMap<>();
+
+		introspectFormData.add("client_id", _CLIENT_ID);
+		introspectFormData.add("client_secret", _CLIENT_SECRET);
+		introspectFormData.add("token", accessToken);
+
+		Invocation.Builder introspectInvocationBuilder =
+			_getIntrospectionWebTarget().request();
+
+		Response introspectResponse = introspectInvocationBuilder.post(
+			Entity.form(introspectFormData));
+
+		Assert.assertEquals(200, introspectResponse.getStatus());
+
+		JSONObject jsonObject = parseJSONObject(introspectResponse);
+
+		Assert.assertTrue(jsonObject.getBoolean("active"));
+
+		JSONArray audJSONArray = jsonObject.getJSONArray("aud");
+
+		Assert.assertNotNull(
+			"introspection response missing aud", audJSONArray);
+		Assert.assertEquals(1, audJSONArray.length());
+		Assert.assertEquals(_RESOURCE_URI, audJSONArray.getString(0));
+	}
+
+	@Test
+	public void testTokenWithMalformedResourceReturnsInvalidTarget()
+		throws Exception {
+
+		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
+
+		formData.add("client_id", _CLIENT_ID);
+		formData.add("client_secret", _CLIENT_SECRET);
+		formData.add("grant_type", "client_credentials");
+		formData.add("resource", "https://mcp.example.com/#fragment");
+
+		Invocation.Builder invocationBuilder = getTokenWebTarget().request();
+
+		Response response = invocationBuilder.post(Entity.form(formData));
+
+		Assert.assertEquals(400, response.getStatus());
+		Assert.assertEquals("invalid_target", parseError(response));
+	}
+
+	@Override
+	protected BundleActivator getBundleActivator() {
+		return new OAuth2ResourceIndicatorsTestPreparatorBundleActivator();
+	}
+
+	private WebTarget _getIntrospectionWebTarget() {
+		WebTarget webTarget = getWebTarget();
+
+		webTarget = webTarget.path("o");
+		webTarget = webTarget.path("oauth2");
+
+		return webTarget.path("introspect");
+	}
+
+	private static final String _CLIENT_ID =
+		"oauthResourceIndicatorsTestApplication";
+
+	private static final String _CLIENT_SECRET =
+		"oauthResourceIndicatorsTestApplicationSecret";
+
+	private static final String _RESOURCE_URI = "https://mcp.example.com/o/mcp";
+
+	private class OAuth2ResourceIndicatorsTestPreparatorBundleActivator
+		extends BaseTestPreparatorBundleActivator {
+
+		@Override
+		protected void prepareTest() throws Exception {
+			long companyId = TestPropsValues.getCompanyId();
+
+			User user = UserTestUtil.getAdminUser(companyId);
+
+			createOAuth2Application(
+				companyId, user, _CLIENT_ID, _CLIENT_SECRET,
+				Collections.singletonList(GrantType.CLIENT_CREDENTIALS),
+				"client_secret_post", null, Arrays.asList(), false,
+				Collections.singletonList("everything"), false);
+		}
+
+	}
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/resource/test/ResourceIndicatorsTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/resource/test/ResourceIndicatorsTest.java
@@ -9,19 +9,21 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.client.test.BaseClientTestCase;
 import com.liferay.oauth2.provider.client.test.BaseTestPreparatorBundleActivator;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
 import java.util.Arrays;
@@ -39,7 +41,7 @@ import org.osgi.framework.BundleActivator;
  * @author Jorge García Jiménez
  */
 @RunWith(Arquillian.class)
-public class OAuth2ResourceIndicatorsTest extends BaseClientTestCase {
+public class ResourceIndicatorsTest extends BaseClientTestCase {
 
 	@ClassRule
 	@Rule
@@ -48,19 +50,22 @@ public class OAuth2ResourceIndicatorsTest extends BaseClientTestCase {
 
 	@Test
 	public void testIntrospectionEmitsAudAsJSONArray() throws Exception {
-		MultivaluedMap<String, String> tokenFormData =
-			new MultivaluedHashMap<>();
+		WebTarget tokenWebTarget = getTokenWebTarget();
 
-		tokenFormData.add("client_id", _CLIENT_ID);
-		tokenFormData.add("client_secret", _CLIENT_SECRET);
-		tokenFormData.add("grant_type", "client_credentials");
-		tokenFormData.add("resource", _RESOURCE_URI);
-
-		Invocation.Builder tokenInvocationBuilder =
-			getTokenWebTarget().request();
+		Invocation.Builder tokenInvocationBuilder = tokenWebTarget.request();
 
 		Response tokenResponse = tokenInvocationBuilder.post(
-			Entity.form(tokenFormData));
+			Entity.form(
+				new MultivaluedHashMap<>(
+					HashMapBuilder.put(
+						"client_id", _CLIENT_ID
+					).put(
+						"client_secret", _CLIENT_SECRET
+					).put(
+						"grant_type", "client_credentials"
+					).put(
+						"resource", _RESOURCE_URI
+					).build())));
 
 		Assert.assertEquals(200, tokenResponse.getStatus());
 
@@ -68,18 +73,21 @@ public class OAuth2ResourceIndicatorsTest extends BaseClientTestCase {
 
 		Assert.assertNotNull(accessToken);
 
-		MultivaluedMap<String, String> introspectFormData =
-			new MultivaluedHashMap<>();
-
-		introspectFormData.add("client_id", _CLIENT_ID);
-		introspectFormData.add("client_secret", _CLIENT_SECRET);
-		introspectFormData.add("token", accessToken);
+		WebTarget introspectWebTarget = getIntrospectWebTarget();
 
 		Invocation.Builder introspectInvocationBuilder =
-			_getIntrospectionWebTarget().request();
+			introspectWebTarget.request();
 
 		Response introspectResponse = introspectInvocationBuilder.post(
-			Entity.form(introspectFormData));
+			Entity.form(
+				new MultivaluedHashMap<>(
+					HashMapBuilder.put(
+						"client_id", _CLIENT_ID
+					).put(
+						"client_secret", _CLIENT_SECRET
+					).put(
+						"token", accessToken
+					).build())));
 
 		Assert.assertEquals(200, introspectResponse.getStatus());
 
@@ -99,16 +107,25 @@ public class OAuth2ResourceIndicatorsTest extends BaseClientTestCase {
 	public void testTokenWithMalformedResourceReturnsInvalidTarget()
 		throws Exception {
 
-		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
+		WebTarget tokenWebTarget = getTokenWebTarget();
 
-		formData.add("client_id", _CLIENT_ID);
-		formData.add("client_secret", _CLIENT_SECRET);
-		formData.add("grant_type", "client_credentials");
-		formData.add("resource", "https://mcp.example.com/#fragment");
+		Invocation.Builder invocationBuilder = tokenWebTarget.request();
 
-		Invocation.Builder invocationBuilder = getTokenWebTarget().request();
-
-		Response response = invocationBuilder.post(Entity.form(formData));
+		Response response = invocationBuilder.post(
+			Entity.form(
+				new MultivaluedHashMap<>(
+					HashMapBuilder.put(
+						"client_id", _CLIENT_ID
+					).put(
+						"client_secret", _CLIENT_SECRET
+					).put(
+						"grant_type", "client_credentials"
+					).put(
+						"resource",
+						StringBundler.concat(
+							"https://", RandomTestUtil.randomString(), "/#",
+							RandomTestUtil.randomString())
+					).build())));
 
 		Assert.assertEquals(400, response.getStatus());
 		Assert.assertEquals("invalid_target", parseError(response));
@@ -116,16 +133,7 @@ public class OAuth2ResourceIndicatorsTest extends BaseClientTestCase {
 
 	@Override
 	protected BundleActivator getBundleActivator() {
-		return new OAuth2ResourceIndicatorsTestPreparatorBundleActivator();
-	}
-
-	private WebTarget _getIntrospectionWebTarget() {
-		WebTarget webTarget = getWebTarget();
-
-		webTarget = webTarget.path("o");
-		webTarget = webTarget.path("oauth2");
-
-		return webTarget.path("introspect");
+		return new ResourceIndicatorsTestPreparatorBundleActivator();
 	}
 
 	private static final String _CLIENT_ID =
@@ -136,7 +144,7 @@ public class OAuth2ResourceIndicatorsTest extends BaseClientTestCase {
 
 	private static final String _RESOURCE_URI = "https://mcp.example.com/o/mcp";
 
-	private class OAuth2ResourceIndicatorsTestPreparatorBundleActivator
+	private class ResourceIndicatorsTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
 
 		@Override


### PR DESCRIPTION
Jira: https://liferay.atlassian.net/browse/LPD-91337

Renames `ResourceIndicatorsTest` to `TokenAudienceTest` and moves it from `com.liferay.oauth2.provider.resource.test` into `com.liferay.oauth2.provider.client.test`, matching the existing conventions in `oauth2-provider-test`:

- Standalone behavior tests live in `client.test`, where the bulk of the suite sits. The only other packages holding `BaseClientTestCase` subclasses — `dynamic.registration.test` and `token.endpoint.test` — are cohesive groups with their own base test case, so a separate `resource.test` package wasn't warranted for a single test.
- `TokenAudienceTest` follows the `Token*Test` form of its closest analog, `TokenIntrospectionTest`, and names the concept under test with the module's own vocabulary — the `audience` / `aud` claim (`BearerTokenProvider.getAudiences()`, `TokenIntrospectionJSONProviderMessageBodyWriter`). "Resource Indicators" had no precedent in the codebase, and "Resource" is already overloaded (e.g. `GrantResourceOwnerKillSwitchTest`).

The class exercises the OAuth2 `resource` request parameter (RFC 8707):

- `testIntrospectionEmitsAudAsJSONArray` — a valid `resource` binds into the token's `aud` claim, emitted as a JSON array.
- `testTokenWithMalformedResourceReturnsInvalidTarget` — a malformed `resource` (URI with fragment) is rejected with `invalid_target`.

The internal OAuth2 application identifiers are renamed to match: `oauthResourceIndicatorsTestApplication[Secret]` → `oauthTokenAudienceTestApplication[Secret]`.

## Notes

Builds on top of #2858 (LPD-91337-bind) — the 11 LPD-91337 commits appear in this PR because they have not landed on appsec/master yet. The rename itself is the last commit (`10384489e`).
