### PR TITLE
[FIPS] LPD-90290

### DIFF
--- a/modules/apps/analytics/analytics-settings-impl/src/main/java/com/liferay/analytics/settings/internal/security/auth/verifier/AnalyticsSecurityAuthVerifier.java
+++ b/modules/apps/analytics/analytics-settings-impl/src/main/java/com/liferay/analytics/settings/internal/security/auth/verifier/AnalyticsSecurityAuthVerifier.java
@@ -21,8 +21,10 @@ import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierResult;
 import com.liferay.portal.kernel.security.service.access.policy.ServiceAccessPolicy;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsValues;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -166,9 +168,12 @@ public class AnalyticsSecurityAuthVerifier implements AuthVerifier {
 			String signatureString, String timestamp)
 		throws Exception {
 
-		Signature signature = Signature.getInstance("DSA");
+		Signature signature = Signature.getInstance(
+			PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256_WITH_ECDSA :
+				DigesterUtil.DSA);
 
-		KeyFactory keyFactory = KeyFactory.getInstance("DSA");
+		KeyFactory keyFactory = KeyFactory.getInstance(
+			PropsValues.FIPS_ENABLED ? DigesterUtil.EC : DigesterUtil.DSA);
 
 		signature.initVerify(
 			keyFactory.generatePublic(

--- a/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/hashed/files/HashedFilesRegistryImpl.java
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/hashed/files/HashedFilesRegistryImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import jakarta.servlet.ServletContext;
@@ -336,7 +337,9 @@ public class HashedFilesRegistryImpl implements HashedFilesRegistry {
 
 		String hashesString = StringUtil.merge(hashesList, StringPool.PIPE);
 
-		byte[] hash = DigesterUtil.digestRaw(DigesterUtil.MD5, hashesString);
+		byte[] hash = DigesterUtil.digestRaw(
+			PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 : DigesterUtil.MD5,
+			hashesString);
 
 		byte[] truncatedHash = new byte[8];
 

--- a/modules/apps/frontend-js/frontend-js-web/src/test/java/com/liferay/frontend/js/web/internal/hashed/files/HashedFilesRegistryImplTest.java
+++ b/modules/apps/frontend-js/frontend-js-web/src/test/java/com/liferay/frontend/js/web/internal/hashed/files/HashedFilesRegistryImplTest.java
@@ -10,6 +10,9 @@ import com.liferay.frontend.js.web.test.util.FrontendJSWebTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -17,6 +20,8 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import jakarta.servlet.ServletContext;
 
 import java.net.URL;
+
+import java.security.MessageDigest;
 
 import java.util.Map;
 
@@ -78,6 +83,22 @@ public class HashedFilesRegistryImplTest {
 
 		Assert.assertNotNull(
 			hashedFilesRegistryImpl.getResource("/o/frontend-js-web/main.css"));
+	}
+
+	@Test
+	public void testGetServletContextHash() throws Exception {
+		Map<String, String> hashedFileURIs = HashMapBuilder.put(
+			"/o/frontend-js-web/main.css",
+			HashedFilesUtil.addHash(
+				"/o/frontend-js-web/main.css", RandomTestUtil.randomString())
+		).build();
+
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			() -> ReflectionTestUtil.invoke(
+				new HashedFilesRegistryImpl(), "_getServletContextHash",
+				new Class<?>[] {Map.class}, hashedFileURIs),
+			DigesterUtil.MD5, MessageDigest::getInstance, MessageDigest.class,
+			DigesterUtil.SHA_256);
 	}
 
 	private Map<String, HashedFilesRegistryImpl.DataBag> _mockDataBags(

--- a/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientASLocalMetadataLocalServiceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientASLocalMetadataLocalServiceImpl.java
@@ -23,8 +23,10 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -433,7 +435,9 @@ public class OAuthClientASLocalMetadataLocalServiceImpl
 			URI issuerURI = URI.create(issuer);
 
 			if (wellKnownURISuffix.equals("openid-configuration")) {
-				MessageDigest messageDigest = MessageDigest.getInstance("MD5");
+				MessageDigest messageDigest = MessageDigest.getInstance(
+					PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 :
+						DigesterUtil.MD5);
 
 				return StringBundler.concat(
 					issuerURI.getScheme(), "://", issuerURI.getAuthority(),

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtil.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtil.java
@@ -14,6 +14,8 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 
 import java.net.URI;
 
@@ -36,8 +38,9 @@ public class OpenIdConnectProviderUtil {
 			String issuer, String tokenEndpoint)
 		throws Exception {
 
-		MessageDigest messageDigest = MessageDigest.getInstance("MD5");
 		URI issuerURI = URI.create(issuer);
+		MessageDigest messageDigest = MessageDigest.getInstance(
+			PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 : DigesterUtil.MD5);
 
 		return StringBundler.concat(
 			issuerURI.getScheme(), "://", issuerURI.getAuthority(),

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtilTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtilTest.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.sso.openid.connect.internal.util;
+
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.security.MessageDigest;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class OpenIdConnectProviderUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGenerateLocalWellKnownURI() throws Exception {
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			() -> OpenIdConnectProviderUtil.generateLocalWellKnownURI(
+				"https://" + RandomTestUtil.randomString(),
+				RandomTestUtil.randomString()),
+			DigesterUtil.MD5, MessageDigest::getInstance, MessageDigest.class,
+			DigesterUtil.SHA_256);
+	}
+
+}

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/src/main/java/com/liferay/portal/security/sso/openid/connect/persistence/internal/upgrade/v2_0_0/OpenIdConnectSessionUpgradeProcess.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/src/main/java/com/liferay/portal/security/sso/openid/connect/persistence/internal/upgrade/v2_0_0/OpenIdConnectSessionUpgradeProcess.java
@@ -12,7 +12,9 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.net.URI;
@@ -93,7 +95,8 @@ public class OpenIdConnectSessionUpgradeProcess extends UpgradeProcess {
 		throws Exception {
 
 		URI issuerURI = URI.create(issuer);
-		MessageDigest messageDigest = MessageDigest.getInstance("MD5");
+		MessageDigest messageDigest = MessageDigest.getInstance(
+			PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 : DigesterUtil.MD5);
 
 		return StringBundler.concat(
 			issuerURI.getScheme(), "://", issuerURI.getAuthority(),

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/build.gradle
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":core:osgi-service-tracker-collections")
+	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-reflect")

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/SSHAPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/SSHAPasswordEncryptor.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.UnsupportedEncodingException;
@@ -44,7 +45,9 @@ public class SSHAPasswordEncryptor implements PasswordEncryptor {
 		byte[] saltBytes = getSaltBytes(encryptedPassword);
 
 		try {
-			MessageDigest messageDigest = MessageDigest.getInstance("SHA-1");
+			MessageDigest messageDigest = MessageDigest.getInstance(
+				PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 :
+					DigesterUtil.SHA_1);
 
 			byte[] plainTextPasswordBytes = plainTextPassword.getBytes(
 				DigesterUtil.ENCODING);

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
@@ -13,10 +13,14 @@ import com.liferay.portal.kernel.exception.PwdEncryptorException;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptorUtil;
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.security.MessageDigest;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -250,6 +254,22 @@ public class PasswordEncryptorUtilTest {
 			PasswordEncryptor.TYPE_SSHA, "password",
 			"2EWEKeVpSdd79PkTX5vaGXH5uQ028Smy/H1NmA==",
 			PasswordEncryptor.TYPE_SSHA);
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			_runTests(
+				PasswordEncryptor.TYPE_SSHA, "password",
+				"q0elUchHiEgZAZww57UMs6Jt+L45+785Q8YcVUf8VfcAAQIDBAUGBw==",
+				PasswordEncryptor.TYPE_SSHA);
+		}
+
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			() -> PasswordEncryptorUtil.encrypt(
+				PasswordEncryptor.TYPE_SSHA, "password", null),
+			DigesterUtil.SHA_1, MessageDigest::getInstance, MessageDigest.class,
+			DigesterUtil.SHA_256);
 	}
 
 	@Test

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtil.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtil.java
@@ -9,6 +9,8 @@ import com.liferay.petra.io.BigEndianCodec;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.security.SecureRandomUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.math.BigInteger;
@@ -28,8 +30,6 @@ import jodd.util.Base32;
  * @author Marta Medio
  */
 public class MFATimeBasedOTPUtil {
-
-	public static final String MFA_TIMEBASED_OTP_ALGORITHM = "HmacSHA1";
 
 	public static final int MFA_TIMEBASED_OTP_COUNTER = 30 * 1000;
 
@@ -74,8 +74,12 @@ public class MFATimeBasedOTPUtil {
 	}
 
 	private static byte[] _generateHMAC(byte[] key, String text) {
+		String algorithm =
+			PropsValues.FIPS_ENABLED ? DigesterUtil.HMAC_SHA_256 :
+				DigesterUtil.HMAC_SHA_1;
+
 		try {
-			Mac mac = Mac.getInstance(MFA_TIMEBASED_OTP_ALGORITHM);
+			Mac mac = Mac.getInstance(algorithm);
 
 			mac.init(new SecretKeySpec(key, "RAW"));
 
@@ -88,14 +92,12 @@ public class MFATimeBasedOTPUtil {
 		}
 		catch (InvalidKeyException invalidKeyException) {
 			throw new IllegalArgumentException(
-				"Invalid secret key for algorithm " +
-					MFA_TIMEBASED_OTP_ALGORITHM,
+				"Invalid secret key for algorithm " + algorithm,
 				invalidKeyException);
 		}
 		catch (NoSuchAlgorithmException noSuchAlgorithmException) {
 			throw new IllegalArgumentException(
-				"Invalid algorithm " + MFA_TIMEBASED_OTP_ALGORITHM,
-				noSuchAlgorithmException);
+				"Invalid algorithm " + algorithm, noSuchAlgorithmException);
 		}
 	}
 

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/test/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtilTest.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/test/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtilTest.java
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.multi.factor.authentication.timebased.otp.web.internal.util;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import javax.crypto.Mac;
+
+import jodd.util.Base32;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class MFATimeBasedOTPUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testVerifyTimeBasedOTP() throws Exception {
+		String sharedSecret = MFATimeBasedOTPUtil.generateSharedSecret(20);
+
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			() -> _generateCurrentOTP(sharedSecret), DigesterUtil.HMAC_SHA_1,
+			Mac::getInstance, Mac.class, DigesterUtil.HMAC_SHA_256);
+	}
+
+	private String _generateCurrentOTP(String sharedSecret) {
+		String timeCountHex = ReflectionTestUtil.invoke(
+			MFATimeBasedOTPUtil.class, "_getTimeCountHex",
+			new Class<?>[] {long.class},
+			System.currentTimeMillis() /
+				MFATimeBasedOTPUtil.MFA_TIMEBASED_OTP_COUNTER);
+
+		return ReflectionTestUtil.invoke(
+			MFATimeBasedOTPUtil.class, "_generateTimeBasedOTP",
+			new Class<?>[] {byte[].class, String.class},
+			Base32.decode(sharedSecret), timeCountHex);
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/events/CryptoStartupAction.java
+++ b/portal-impl/src/com/liferay/portal/events/CryptoStartupAction.java
@@ -8,6 +8,8 @@ package com.liferay.portal.events;
 import com.liferay.portal.kernel.events.SimpleAction;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 
 import java.security.NoSuchAlgorithmException;
 
@@ -20,12 +22,16 @@ public class CryptoStartupAction extends SimpleAction {
 
 	@Override
 	public void run(String[] ids) {
+		String algorithm =
+			PropsValues.FIPS_ENABLED ? DigesterUtil.HMAC_SHA_256 :
+				DigesterUtil.HMAC_SHA_1;
+
 		try {
-			Mac.getInstance("HmacSHA1");
+			Mac.getInstance(algorithm);
 		}
 		catch (NoSuchAlgorithmException noSuchAlgorithmException) {
 			_log.error(
-				"Unable to get Mac instance for algorithm HmacSHA1",
+				"Unable to get Mac instance for algorithm " + algorithm,
 				noSuchAlgorithmException);
 		}
 	}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/DigesterUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/DigesterUtil.java
@@ -29,9 +29,15 @@ import java.util.Objects;
  */
 public class DigesterUtil {
 
-	public static final String DEFAULT_ALGORITHM = "SHA";
+	public static final String DSA = "DSA";
+
+	public static final String EC = "EC";
 
 	public static final String ENCODING = StringPool.UTF8;
+
+	public static final String HMAC_SHA_1 = "HmacSHA1";
+
+	public static final String HMAC_SHA_256 = "HmacSHA256";
 
 	public static final String MD5 = "MD5";
 
@@ -41,16 +47,18 @@ public class DigesterUtil {
 
 	public static final String SHA_256 = "SHA-256";
 
+	public static final String SHA_256_WITH_ECDSA = "SHA256withECDSA";
+
 	public static String digest(ByteBuffer byteBuffer) {
-		return digest(DEFAULT_ALGORITHM, byteBuffer);
+		return digest(_getDefaultAlgorithm(), byteBuffer);
 	}
 
 	public static String digest(InputStream inputStream) {
-		return digest(DEFAULT_ALGORITHM, inputStream);
+		return digest(_getDefaultAlgorithm(), inputStream);
 	}
 
 	public static String digest(String text) {
-		return digest(DEFAULT_ALGORITHM, text);
+		return digest(_getDefaultAlgorithm(), text);
 	}
 
 	public static String digest(String algorithm, ByteBuffer byteBuffer) {
@@ -78,15 +86,15 @@ public class DigesterUtil {
 	}
 
 	public static String digestBase64(ByteBuffer byteBuffer) {
-		return digestBase64(DEFAULT_ALGORITHM, byteBuffer);
+		return digestBase64(_getDefaultAlgorithm(), byteBuffer);
 	}
 
 	public static String digestBase64(InputStream inputStream) {
-		return digestBase64(DEFAULT_ALGORITHM, inputStream);
+		return digestBase64(_getDefaultAlgorithm(), inputStream);
 	}
 
 	public static String digestBase64(String text) {
-		return digestBase64(DEFAULT_ALGORITHM, text);
+		return digestBase64(_getDefaultAlgorithm(), text);
 	}
 
 	public static String digestBase64(String algorithm, ByteBuffer byteBuffer) {
@@ -110,15 +118,15 @@ public class DigesterUtil {
 	}
 
 	public static String digestHex(ByteBuffer byteBuffer) {
-		return digestHex(DEFAULT_ALGORITHM, byteBuffer);
+		return digestHex(_getDefaultAlgorithm(), byteBuffer);
 	}
 
 	public static String digestHex(InputStream inputStream) {
-		return digestHex(DEFAULT_ALGORITHM, inputStream);
+		return digestHex(_getDefaultAlgorithm(), inputStream);
 	}
 
 	public static String digestHex(String text) {
-		return digestHex(DEFAULT_ALGORITHM, text);
+		return digestHex(_getDefaultAlgorithm(), text);
 	}
 
 	public static String digestHex(String algorithm, ByteBuffer byteBuffer) {
@@ -140,11 +148,11 @@ public class DigesterUtil {
 	}
 
 	public static byte[] digestRaw(ByteBuffer byteBuffer) {
-		return digestRaw(DEFAULT_ALGORITHM, byteBuffer);
+		return digestRaw(_getDefaultAlgorithm(), byteBuffer);
 	}
 
 	public static byte[] digestRaw(String text) {
-		return digestRaw(DEFAULT_ALGORITHM, text);
+		return digestRaw(_getDefaultAlgorithm(), text);
 	}
 
 	public static byte[] digestRaw(String algorithm, ByteBuffer byteBuffer) {
@@ -216,6 +224,14 @@ public class DigesterUtil {
 		}
 
 		return messageDigest.digest();
+	}
+
+	private static String _getDefaultAlgorithm() {
+		if (PropsValues.FIPS_ENABLED) {
+			return SHA_256;
+		}
+
+		return SHA;
 	}
 
 	private static final boolean _BASE_64 = Objects.equals(

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 98.0.0
+version 99.0.0

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/DigesterUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/DigesterUtilTest.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.util;
+
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+
+import java.security.MessageDigest;
+
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class DigesterUtilTest {
+
+	@Test
+	public void testDigestHex() throws Exception {
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			() -> DigesterUtil.digestHex(RandomTestUtil.randomString()),
+			DigesterUtil.SHA, MessageDigest::getInstance, MessageDigest.class,
+			DigesterUtil.SHA_256);
+	}
+
+}

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 32.6.1
+Bundle-Version: 32.7.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/kernel/test/util/FIPSAlgorithmTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/FIPSAlgorithmTestUtil.java
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.test.util;
+
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.lang.SafeCloseable;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Lucas Miranda
+ */
+public class FIPSAlgorithmTestUtil {
+
+	public static <T> void assertAlgorithmSwitch(
+			UnsafeRunnable<Exception> action, String algorithm,
+			UnsafeConsumer<String, Exception> algorithmCall,
+			Class<T> classToMock, String fipsAlgorithm)
+		throws Exception {
+
+		try (MockedStatic<T> mockedStatic = Mockito.mockStatic(
+				classToMock, Mockito.CALLS_REAL_METHODS)) {
+
+			action.run();
+
+			mockedStatic.verify(
+				() -> algorithmCall.accept(algorithm), Mockito.atLeastOnce());
+			mockedStatic.verify(
+				() -> algorithmCall.accept(fipsAlgorithm), Mockito.never());
+		}
+
+		try (MockedStatic<T> mockedStatic = Mockito.mockStatic(
+				classToMock, Mockito.CALLS_REAL_METHODS);
+			SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			action.run();
+
+			mockedStatic.verify(
+				() -> algorithmCall.accept(algorithm), Mockito.never());
+			mockedStatic.verify(
+				() -> algorithmCall.accept(fipsAlgorithm),
+				Mockito.atLeastOnce());
+		}
+	}
+
+}

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 10.7.0
+version 10.8.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90290

## Changes Made
  
  | Class | Change | Risk if hardcoded (no FIPS guard) |
  |---|---|---|
  | `DigesterUtil` | `DEFAULT_ALGORITHM`: SHA-256 (FIPS) / SHA (non-FIPS) | All stored SHA-1 digests fail re-verification — any code that hashed and later verifies with the default would silently break |
  | `SSHAPasswordEncryptor` | `MessageDigest`: SHA-256 (FIPS) / SHA-1 (non-FIPS) | All existing SSHA passwords become invalid — users locked out with no migration path |
  | `OAuthClientASLocalMetadataLocalServiceImpl` | `MessageDigest`: SHA-256 (FIPS) / MD5 (non-FIPS) | Generated well-known URIs differ from stored ones — existing OAuth client configurations break |
  | `MFATimeBasedOTPUtil` | `HmacSHA256` (FIPS) / `HmacSHA1` (non-FIPS) | All existing TOTP enrollments become invalid — users locked out until re-enrolled |
  | `AuthenticationUtil` | `HmacSHA256` (FIPS) / `HmacSHA1` via `Boolean.getBoolean` | Poshi TOTP tests fail against servers still using HmacSHA1 |
  | `CryptoStartupAction` | `Mac`: HmacSHA256 (FIPS) / HmacSHA1 (non-FIPS) | Startup probe tests the wrong algorithm for the environment — misaligned with the actual algorithm in use |
  | `OpenIdConnectProviderUtil` | `MessageDigest`: SHA-256 (FIPS) / MD5 (non-FIPS) | Generated well-known URIs differ from stored ones — existing OIDC configurations break |
  | `OpenIdConnectSessionUpgradeProcess` | `MessageDigest`: SHA-256 (FIPS) / MD5 (non-FIPS) | Upgrade generates SHA-256 URIs but existing rows have MD5 URIs — sessions fail to match during upgrade |
  | `AnalyticsSecurityAuthVerifier` | `Signature`: SHA256withECDSA / DSA; `KeyFactory`: EC / DSA | EC key factory rejects DSA key bytes — exception on every verification attempt against non-FIPS analytics servers |
  | `HashedFilesRegistryImpl` | `DigesterUtil`: SHA-256 (FIPS) / MD5 — not in ticket, added for consistency | Cache-busting hash changes on every deployment causing unnecessary cache misses — no functional breakage |

  ## Changes Not Made

  | Class | Reason |
  |---|---|
  | `HashUtil` | Non-security use (hash bucketing for data structures) — FIPS 140-3 does not prohibit MD5 in non-security contexts |
  | `CertificateToolImpl` | `getFingerprint()` is already parameterized (caller controls the algorithm) and has no callers — dead code |
  | `Jar.java` | Third-party build utility — SHA-1 use assessed as non-security (build artifact checksums, not cryptographic security) |
