### PR TITLE
LPD-92251 Close JSONWS user enumeration by unifying 404 responses

### DIFF
--- a/modules/apps/portal-remote/portal-remote-json-web-service-web/src/main/java/com/liferay/portal/remote/json/web/service/web/internal/JSONWebServiceServiceAction.java
+++ b/modules/apps/portal-remote/portal-remote-json-web-service-web/src/main/java/com/liferay/portal/remote/json/web/service/web/internal/JSONWebServiceServiceAction.java
@@ -84,31 +84,15 @@ public class JSONWebServiceServiceAction extends JSONServiceAction {
 			if (throwable instanceof NoSuchJSONWebServiceException) {
 				status = HttpServletResponse.SC_NOT_FOUND;
 			}
-			else if (throwable instanceof NoSuchModelException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(getThrowableMessage(throwable), throwable);
-				}
-
-				httpServletResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
-
-				if (PropsValues.JSON_SERVICE_SERIALIZE_THROWABLE) {
-					return JSONFactoryUtil.serializeThrowable(throwable);
-				}
-
-				return JSONFactoryUtil.getNullJSON();
-			}
-			else if (throwable instanceof PrincipalException ||
+			else if (throwable instanceof NoSuchModelException ||
+					 throwable instanceof PrincipalException ||
 					 throwable instanceof SecurityException) {
 
 				if (_log.isDebugEnabled()) {
 					_log.debug(getThrowableMessage(throwable), throwable);
 				}
 
-				httpServletResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
-
-				if (PropsValues.JSON_SERVICE_SERIALIZE_THROWABLE) {
-					return JSONFactoryUtil.serializeThrowable(throwable);
-				}
+				httpServletResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
 
 				return JSONFactoryUtil.getNullJSON();
 			}

--- a/modules/apps/portal-remote/portal-remote-json-web-service-web/src/test/java/com/liferay/portal/remote/json/web/service/web/internal/FooService.java
+++ b/modules/apps/portal-remote/portal-remote-json-web-service-web/src/test/java/com/liferay/portal/remote/json/web/service/web/internal/FooService.java
@@ -6,6 +6,8 @@
 package com.liferay.portal.remote.json.web.service.web.internal;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.NoSuchModelException;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -172,6 +174,10 @@ public class FooService {
 		return "m-1";
 	}
 
+	public static String noSuchModel() throws NoSuchModelException {
+		throw new NoSuchModelException();
+	}
+
 	public static String nullLover(String name, int number) {
 		if (name == null) {
 			return "null!";
@@ -184,9 +190,17 @@ public class FooService {
 		return null;
 	}
 
+	public static String principalDenied() throws PrincipalException {
+		throw new PrincipalException();
+	}
+
 	public static String search(String name, String... params) {
 		return StringBundler.concat(
 			"search ", name, ">", StringUtil.merge(params));
+	}
+
+	public static String securityDenied() {
+		throw new SecurityException();
 	}
 
 	public static String srvcctx(ServiceContext serviceContext) {

--- a/modules/apps/portal-remote/portal-remote-json-web-service-web/src/test/java/com/liferay/portal/remote/json/web/service/web/internal/JSONWebServiceServiceActionTest.java
+++ b/modules/apps/portal-remote/portal-remote-json-web-service-web/src/test/java/com/liferay/portal/remote/json/web/service/web/internal/JSONWebServiceServiceActionTest.java
@@ -7,6 +7,7 @@ package com.liferay.portal.remote.json.web.service.web.internal;
 
 import com.liferay.petra.memory.DeleteFileFinalizeAction;
 import com.liferay.petra.memory.FinalizeManager;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.kernel.test.FinalizeManagerUtil;
 import com.liferay.portal.kernel.test.GCUtil;
@@ -19,6 +20,7 @@ import com.liferay.portal.remote.json.web.service.JSONWebServiceAction;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.File;
 
@@ -148,6 +150,21 @@ public class JSONWebServiceServiceActionTest
 	}
 
 	@Test
+	public void testNoSuchModelExceptionReturnsNotFound() throws Exception {
+		_assertNotFoundResponse("/foo/no-such-model");
+	}
+
+	@Test
+	public void testPrincipalExceptionReturnsNotFound() throws Exception {
+		_assertNotFoundResponse("/foo/principal-denied");
+	}
+
+	@Test
+	public void testSecurityExceptionReturnsNotFound() throws Exception {
+		_assertNotFoundResponse("/foo/security-denied");
+	}
+
+	@Test
 	public void testServletContextInvoker1() throws Exception {
 		testServletContextInvoker("somectx", true, "/foo/hello-world");
 	}
@@ -267,6 +284,30 @@ public class JSONWebServiceServiceActionTest
 			"\"Welcome 173 to Jupiter\"",
 			_jsonWebServiceServiceAction.getJSON(
 				mockHttpServletRequest, new MockHttpServletResponse()));
+	}
+
+	private void _assertNotFoundResponse(String path) throws Exception {
+		registerActionClass(FooService.class);
+
+		String json = toJSON(
+			LinkedHashMapBuilder.<String, Object>put(
+				path, new LinkedHashMap<>()
+			).build());
+
+		MockHttpServletRequest mockHttpServletRequest =
+			createInvokerHttpServletRequest(json);
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		String result = _jsonWebServiceServiceAction.getJSON(
+			mockHttpServletRequest, mockHttpServletResponse);
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_NOT_FOUND,
+			mockHttpServletResponse.getStatus());
+
+		Assert.assertEquals(JSONFactoryUtil.getNullJSON(), result);
 	}
 
 	private FileItem _createFileItem(String content) throws Exception {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92251

## What is being fixed

The JSONWS catch block returned `404` for `NoSuchModelException` and
`403` for `PrincipalException` or `SecurityException`. An authenticated
low-privilege caller could probe `get-user-by-email-address` against
arbitrary emails and tell from the `403`-vs-`404` split alone whether
each email mapped to a real account, enumerating users one request at a
time. The split is generic to JSONWS — any service whose method throws
`NoSuchModelException` for missing data and `PrincipalException` for
forbidden access leaks the same existence bit for its own resource
type.

## How it is being fixed

Collapse the two leaking catch branches in
`JSONWebServiceServiceAction.getJSON()` so that `NoSuchModelException`,
`PrincipalException`, and `SecurityException` all return the same
response: `404` with a null JSON body. Choose `404` because it does not
by itself imply existence. Ignore `JSON_SERVICE_SERIALIZE_THROWABLE` on
this merged branch so the exception type does not leak through the
body either; the property still applies to the generic `500` fallback.
Three unit tests in `JSONWebServiceServiceActionTest` lock the new
behavior in for each exception type.