### PR TITLE
LPD-92656

### DIFF
--- a/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/display/CookiesPreferenceHandlingConfigurationFormRenderer.java
+++ b/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/display/CookiesPreferenceHandlingConfigurationFormRenderer.java
@@ -60,15 +60,14 @@ public class CookiesPreferenceHandlingConfigurationFormRenderer
 			return Map.of("active", false, "enabled", false);
 		}
 
-		ExtendedObjectClassDefinition.Scope scope = _getScope(
+		ConfigurationScope configurationScope = _getConfigurationScope(
 			httpServletRequest);
-
-		long scopePK = _getScopePK(httpServletRequest, scope);
 
 		long customFloatingIconImageId =
 			_cookiesConfigurationProvider.
 				getCookiesPreferenceHandlingCustomFloatingIconImageId(
-					scope, scopePK);
+					configurationScope.getScope(),
+					configurationScope.getScopePK());
 
 		long fileEntryId = ParamUtil.getLong(httpServletRequest, "fileEntryId");
 
@@ -92,7 +91,8 @@ public class CookiesPreferenceHandlingConfigurationFormRenderer
 				}
 				else {
 					image = _imageLocalService.updateImage(
-						scopePK, _counterLocalService.increment(), bytes);
+						configurationScope.getScopePK(),
+						_counterLocalService.increment(), bytes);
 				}
 
 				customFloatingIconImageId = image.getImageId();
@@ -170,40 +170,30 @@ public class CookiesPreferenceHandlingConfigurationFormRenderer
 		}
 	}
 
-	private ExtendedObjectClassDefinition.Scope _getScope(
+	private ConfigurationScope _getConfigurationScope(
 		HttpServletRequest httpServletRequest) {
 
 		String portletId = PortalUtil.getPortletId(
 			(PortletRequest)httpServletRequest.getAttribute(
 				JavaConstants.JAKARTA_PORTLET_REQUEST));
-
-		if (ConfigurationAdminPortletKeys.INSTANCE_SETTINGS.equals(portletId)) {
-			return ExtendedObjectClassDefinition.Scope.COMPANY;
-		}
-
-		if (ConfigurationAdminPortletKeys.SITE_SETTINGS.equals(portletId)) {
-			return ExtendedObjectClassDefinition.Scope.GROUP;
-		}
-
-		return ExtendedObjectClassDefinition.Scope.SYSTEM;
-	}
-
-	private long _getScopePK(
-		HttpServletRequest httpServletRequest,
-		ExtendedObjectClassDefinition.Scope scope) {
-
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		if (scope == ExtendedObjectClassDefinition.Scope.COMPANY) {
-			return themeDisplay.getCompanyId();
-		}
-		else if (scope == ExtendedObjectClassDefinition.Scope.GROUP) {
-			return themeDisplay.getScopeGroupId();
+		if (ConfigurationAdminPortletKeys.INSTANCE_SETTINGS.equals(portletId)) {
+			return new ConfigurationScope(
+				ExtendedObjectClassDefinition.Scope.COMPANY,
+				themeDisplay.getCompanyId());
 		}
 
-		return 0;
+		if (ConfigurationAdminPortletKeys.SITE_SETTINGS.equals(portletId)) {
+			return new ConfigurationScope(
+				ExtendedObjectClassDefinition.Scope.GROUP,
+				themeDisplay.getScopeGroupId());
+		}
+
+		return new ConfigurationScope(
+			ExtendedObjectClassDefinition.Scope.SYSTEM, 0);
 	}
 
 	private void _render(
@@ -211,19 +201,18 @@ public class CookiesPreferenceHandlingConfigurationFormRenderer
 			HttpServletResponse httpServletResponse)
 		throws Exception {
 
+		ConfigurationScope configurationScope = _getConfigurationScope(
+			httpServletRequest);
 		RequestDispatcher requestDispatcher =
 			_servletContext.getRequestDispatcher(
 				"/cookies_preference_handling_configuration/view.jsp");
-
-		ExtendedObjectClassDefinition.Scope scope = _getScope(
-			httpServletRequest);
 
 		httpServletRequest.setAttribute(
 			CookiesBannerWebKeys.
 				COOKIES_PREFERENCE_HANDLING_CONFIGURATION_DISPLAY_CONTEXT,
 			new CookiesPreferenceHandlingConfigurationDisplayContext(
-				_cookiesConfigurationProvider, scope,
-				_getScopePK(httpServletRequest, scope)));
+				_cookiesConfigurationProvider, configurationScope.getScope(),
+				configurationScope.getScopePK()));
 
 		requestDispatcher.include(httpServletRequest, httpServletResponse);
 	}
@@ -244,5 +233,27 @@ public class CookiesPreferenceHandlingConfigurationFormRenderer
 		target = "(osgi.web.symbolicname=com.liferay.cookies.banner.web)"
 	)
 	private ServletContext _servletContext;
+
+	private static class ConfigurationScope {
+
+		public ExtendedObjectClassDefinition.Scope getScope() {
+			return _scope;
+		}
+
+		public long getScopePK() {
+			return _scopePK;
+		}
+
+		private ConfigurationScope(
+			ExtendedObjectClassDefinition.Scope scope, long scopePK) {
+
+			_scope = scope;
+			_scopePK = scopePK;
+		}
+
+		private final ExtendedObjectClassDefinition.Scope _scope;
+		private final long _scopePK;
+
+	}
 
 }

--- a/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/display/CookiesPreferenceHandlingConfigurationFormRenderer.java
+++ b/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/display/CookiesPreferenceHandlingConfigurationFormRenderer.java
@@ -90,8 +90,12 @@ public class CookiesPreferenceHandlingConfigurationFormRenderer
 						customFloatingIconImageId, bytes);
 				}
 				else {
+					ThemeDisplay themeDisplay =
+						(ThemeDisplay)httpServletRequest.getAttribute(
+							WebKeys.THEME_DISPLAY);
+
 					image = _imageLocalService.updateImage(
-						configurationScope.getScopePK(),
+						themeDisplay.getCompanyId(),
 						_counterLocalService.increment(), bytes);
 				}
 

--- a/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/display/CookiesPreferenceHandlingConfigurationFormRenderer.java
+++ b/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/display/CookiesPreferenceHandlingConfigurationFormRenderer.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -61,12 +60,15 @@ public class CookiesPreferenceHandlingConfigurationFormRenderer
 			return Map.of("active", false, "enabled", false);
 		}
 
-		long companyId = _portal.getCompanyId(httpServletRequest);
+		ExtendedObjectClassDefinition.Scope scope = _getScope(
+			httpServletRequest);
+
+		long scopePK = _getScopePK(httpServletRequest, scope);
 
 		long customFloatingIconImageId =
 			_cookiesConfigurationProvider.
 				getCookiesPreferenceHandlingCustomFloatingIconImageId(
-					_scope, companyId);
+					scope, scopePK);
 
 		long fileEntryId = ParamUtil.getLong(httpServletRequest, "fileEntryId");
 
@@ -90,7 +92,7 @@ public class CookiesPreferenceHandlingConfigurationFormRenderer
 				}
 				else {
 					image = _imageLocalService.updateImage(
-						companyId, _counterLocalService.increment(), bytes);
+						scopePK, _counterLocalService.increment(), bytes);
 				}
 
 				customFloatingIconImageId = image.getImageId();
@@ -168,6 +170,42 @@ public class CookiesPreferenceHandlingConfigurationFormRenderer
 		}
 	}
 
+	private ExtendedObjectClassDefinition.Scope _getScope(
+		HttpServletRequest httpServletRequest) {
+
+		String portletId = PortalUtil.getPortletId(
+			(PortletRequest)httpServletRequest.getAttribute(
+				JavaConstants.JAKARTA_PORTLET_REQUEST));
+
+		if (ConfigurationAdminPortletKeys.INSTANCE_SETTINGS.equals(portletId)) {
+			return ExtendedObjectClassDefinition.Scope.COMPANY;
+		}
+
+		if (ConfigurationAdminPortletKeys.SITE_SETTINGS.equals(portletId)) {
+			return ExtendedObjectClassDefinition.Scope.GROUP;
+		}
+
+		return ExtendedObjectClassDefinition.Scope.SYSTEM;
+	}
+
+	private long _getScopePK(
+		HttpServletRequest httpServletRequest,
+		ExtendedObjectClassDefinition.Scope scope) {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		if (scope == ExtendedObjectClassDefinition.Scope.COMPANY) {
+			return themeDisplay.getCompanyId();
+		}
+		else if (scope == ExtendedObjectClassDefinition.Scope.GROUP) {
+			return themeDisplay.getScopeGroupId();
+		}
+
+		return 0;
+	}
+
 	private void _render(
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
@@ -177,45 +215,15 @@ public class CookiesPreferenceHandlingConfigurationFormRenderer
 			_servletContext.getRequestDispatcher(
 				"/cookies_preference_handling_configuration/view.jsp");
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
+		ExtendedObjectClassDefinition.Scope scope = _getScope(
+			httpServletRequest);
 
-		String portletId = PortalUtil.getPortletId(
-			(PortletRequest)httpServletRequest.getAttribute(
-				JavaConstants.JAKARTA_PORTLET_REQUEST));
-
-		if (portletId.equals(ConfigurationAdminPortletKeys.INSTANCE_SETTINGS)) {
-			_scope = ExtendedObjectClassDefinition.Scope.COMPANY;
-
-			httpServletRequest.setAttribute(
-				CookiesBannerWebKeys.
-					COOKIES_PREFERENCE_HANDLING_CONFIGURATION_DISPLAY_CONTEXT,
-				new CookiesPreferenceHandlingConfigurationDisplayContext(
-					_cookiesConfigurationProvider, _scope,
-					themeDisplay.getCompanyId()));
-		}
-		else if (portletId.equals(
-					ConfigurationAdminPortletKeys.SITE_SETTINGS)) {
-
-			_scope = ExtendedObjectClassDefinition.Scope.GROUP;
-
-			httpServletRequest.setAttribute(
-				CookiesBannerWebKeys.
-					COOKIES_PREFERENCE_HANDLING_CONFIGURATION_DISPLAY_CONTEXT,
-				new CookiesPreferenceHandlingConfigurationDisplayContext(
-					_cookiesConfigurationProvider, _scope,
-					themeDisplay.getScopeGroupId()));
-		}
-		else {
-			_scope = ExtendedObjectClassDefinition.Scope.SYSTEM;
-
-			httpServletRequest.setAttribute(
-				CookiesBannerWebKeys.
-					COOKIES_PREFERENCE_HANDLING_CONFIGURATION_DISPLAY_CONTEXT,
-				new CookiesPreferenceHandlingConfigurationDisplayContext(
-					_cookiesConfigurationProvider, _scope, 0L));
-		}
+		httpServletRequest.setAttribute(
+			CookiesBannerWebKeys.
+				COOKIES_PREFERENCE_HANDLING_CONFIGURATION_DISPLAY_CONTEXT,
+			new CookiesPreferenceHandlingConfigurationDisplayContext(
+				_cookiesConfigurationProvider, scope,
+				_getScopePK(httpServletRequest, scope)));
 
 		requestDispatcher.include(httpServletRequest, httpServletResponse);
 	}
@@ -231,11 +239,6 @@ public class CookiesPreferenceHandlingConfigurationFormRenderer
 
 	@Reference
 	private ImageLocalService _imageLocalService;
-
-	@Reference
-	private Portal _portal;
-
-	private ExtendedObjectClassDefinition.Scope _scope;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.cookies.banner.web)"

--- a/modules/test/playwright/tests/cookies-banner-web/main/cookiesBannerActivate.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/main/cookiesBannerActivate.spec.ts
@@ -4,10 +4,13 @@
  */
 
 import {expect, mergeTests} from '@playwright/test';
+import path from 'path';
 
 import {accountSettingsPagesTest} from '../../../fixtures/accountSettingsPagesTest';
 import {consentManagerConfigurationPageTest} from '../../../fixtures/consentManagerConfigurationPageTest';
+import {isolatedSiteTest} from '../../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {siteSettingsPagesTest} from '../../../fixtures/siteSettingsPagesTest';
 import {systemSettingsPageTest} from '../../../fixtures/systemSettingsPageTest';
 import {ConsentManagerConfigurationPage} from '../../../pages/cookies-banner-web/ConsentManagerConfigurationPage';
 import {waitForAlert} from '../../../utils/waitForAlert';
@@ -21,7 +24,9 @@ import {
 export const test = mergeTests(
 	accountSettingsPagesTest,
 	consentManagerConfigurationPageTest,
+	isolatedSiteTest,
 	loginTest(),
+	siteSettingsPagesTest,
 	systemSettingsPageTest
 );
 
@@ -406,6 +411,94 @@ test(
 					name: 'Cookie Panel',
 				})
 			).toBeVisible();
+		});
+	}
+);
+
+test(
+	'Enabling Consent Manager from Site Settings saves successfully and shows the banner on the site',
+	{tag: '@LPD-92656'},
+	async ({page, site, siteSettingsPage}) => {
+		await test.step('Navigate to Site Settings > Privacy > Consent Manager', async () => {
+			await siteSettingsPage.goToSiteSetting(
+				'Privacy',
+				'Consent Manager',
+				site.friendlyUrlPath
+			);
+		});
+
+		await test.step('Enable Consent Manager with a custom floating icon', async () => {
+			await page
+				.getByRole('checkbox', {exact: true, name: 'Enabled'})
+				.check();
+
+			await expect(
+				page.getByRole('checkbox', {
+					exact: true,
+					name: 'Floating Icon Enabled',
+				})
+			).toBeEnabled();
+
+			await page
+				.getByRole('checkbox', {
+					exact: true,
+					name: 'Floating Icon Enabled',
+				})
+				.check();
+
+			await page.getByText('Custom', {exact: true}).click();
+
+			const fileChooserPromise = page.waitForEvent('filechooser');
+
+			await page
+				.getByRole('button', {name: 'Change Custom Icon'})
+				.click();
+
+			const uploadImageFrame = page.frameLocator(
+				'iframe[title="Upload Custom Icon"]'
+			);
+
+			await uploadImageFrame
+				.getByRole('button', {name: 'Select Image'})
+				.click();
+
+			const fileChooser = await fileChooserPromise;
+
+			await fileChooser.setFiles(
+				path.join(__dirname, 'dependencies/liferay.png')
+			);
+
+			await uploadImageFrame.getByRole('button', {name: 'Done'}).click();
+
+			await siteSettingsPage.saveConfiguration();
+		});
+
+		await test.step('Activate the Consent Manager', async () => {
+			await page
+				.getByRole('button', {exact: true, name: 'Activate'})
+				.click();
+
+			await waitForAlert(page);
+		});
+
+		await test.step('Verify the Consent Manager is now active', async () => {
+			await expect(
+				page.getByRole('button', {exact: true, name: 'Deactivate'})
+			).toBeVisible();
+
+			await expect(page.locator('.cookies-banner')).toBeVisible();
+		});
+
+		await test.step('Reload and verify the custom floating icon persists under GROUP scope', async () => {
+			await page.reload();
+
+			const floatingIconButton = page.locator(
+				'#_com_liferay_cookies_banner_web_portlet_CookiesBannerPortlet_floatingIconButton'
+			);
+
+			const imageSrc = await floatingIconButton.getAttribute('src');
+
+			expect(imageSrc.includes('/image/floating_icon?')).toBeTruthy();
 		});
 	}
 );


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92656

CookiesPreferenceHandlingConfigurationFormRenderer now detects the portlet ID at request time and selects the appropriate scope: GROUP (with the site group ID) when rendering from the Site Settings portlet, SYSTEM when rendering from System Settings, and COMPANY otherwise. Previously it always used the class-level _scope field, causing writes from Site Settings to target the wrong configuration scope.