### PR TITLE
LPD-91791 Honor configured columns when exporting audit events

### DIFF
--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
@@ -11,15 +11,18 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.LiferayResourceResponse;
 import com.liferay.portal.kernel.portlet.PortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.CSVUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -35,18 +38,23 @@ import jakarta.portlet.ResourceResponse;
 
 import java.sql.Timestamp;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Stian Sigvartsen
  */
 @Component(
+	configurationPid = "com.liferay.portal.security.audit.router.configuration.CSVLogMessageFormatterConfiguration",
 	property = {
 		"jakarta.portlet.name=" + AuditPortletKeys.AUDIT,
 		"mvc.command.name=/audit/export_audit_events"
@@ -55,6 +63,32 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class ExportAuditEventsMVCResourceCommand
 	extends BaseMVCResourceCommand {
+
+	@Activate
+	@Modified
+	protected void activate(Map<String, Object> properties) {
+		List<String> columns = new ArrayList<>();
+
+		String[] selectedColumns = GetterUtil.getStringValues(
+			properties.get("columns"));
+
+		if (selectedColumns.length < 1) {
+			selectedColumns = _functionsKeys.keySet(
+			).toArray(
+				new String[0]
+			);
+		}
+
+		for (String column : selectedColumns) {
+			String key = _functionsKeys.get(column);
+
+			if (key != null) {
+				columns.add(key);
+			}
+		}
+
+		_columns = columns.toArray(new String[0]);
+	}
 
 	@Override
 	protected void doServeResource(
@@ -68,7 +102,7 @@ public class ExportAuditEventsMVCResourceCommand
 					SessionMessages.KEY_SUFFIX_HIDE_DEFAULT_ERROR_MESSAGE);
 
 			String auditEventsCSV = _getAuditEventsCSV(
-				resourceRequest, resourceResponse);
+				_columns, resourceRequest, resourceResponse);
 
 			PortletResponseUtil.sendFile(
 				resourceRequest, resourceResponse, "audit_events.csv",
@@ -115,7 +149,8 @@ public class ExportAuditEventsMVCResourceCommand
 	}
 
 	private String _getAuditEventsCSV(
-			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+			String[] columns, ResourceRequest resourceRequest,
+			ResourceResponse resourceResponse)
 		throws Exception {
 
 		List<AuditEvent> auditEvents = _getAuditEvents(
@@ -142,7 +177,7 @@ public class ExportAuditEventsMVCResourceCommand
 		sb.append(StringPool.QUOTE);
 		sb.append(
 			StringUtil.merge(
-				_functions.keySet(),
+				columns,
 				StringPool.QUOTE + StringPool.COMMA + StringPool.QUOTE));
 		sb.append(StringPool.QUOTE);
 		sb.append(StringPool.NEW_LINE);
@@ -154,8 +189,18 @@ public class ExportAuditEventsMVCResourceCommand
 			sb.append(
 				StringUtil.merge(
 					TransformUtil.transform(
-						_functions.values(),
-						function -> function.apply(auditEvent)),
+						columns,
+						column -> {
+							Function<AuditEvent, String> function =
+								_functions.get(column);
+
+							if (function == null) {
+								return StringPool.BLANK;
+							}
+
+							return function.apply(auditEvent);
+						},
+						String.class),
 					StringPool.QUOTE + StringPool.COMMA + StringPool.QUOTE));
 			sb.append(StringPool.QUOTE);
 			sb.append(StringPool.NEW_LINE);
@@ -170,46 +215,117 @@ public class ExportAuditEventsMVCResourceCommand
 		return sb.toString();
 	}
 
+	private String _getUserEmailAddress(AuditEvent auditEvent) {
+		User user = _userLocalService.fetchUser(auditEvent.getUserId());
+
+		if (user == null) {
+			return StringPool.BLANK;
+		}
+
+		return user.getEmailAddress();
+	}
+
+	private String _getUserLogin(AuditEvent auditEvent) {
+		User user = _userLocalService.fetchUser(auditEvent.getUserId());
+
+		if (user == null) {
+			return StringPool.BLANK;
+		}
+
+		return user.getScreenName();
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		ExportAuditEventsMVCResourceCommand.class);
 
+	private static final Map<String, String> _functionsKeys =
+		LinkedHashMapBuilder.put(
+			"additionalInfo", "additional-information"
+		).put(
+			"className", "resource-name"
+		).put(
+			"classPK", "resource-id"
+		).put(
+			"clientHost", "client-host"
+		).put(
+			"clientIP", "client-ip"
+		).put(
+			"companyId", "company-id"
+		).put(
+			"eventType", "resource-action"
+		).put(
+			"message", "message"
+		).put(
+			"serverName", "server-name"
+		).put(
+			"serverPort", "server-port"
+		).put(
+			"sessionID", "session-id"
+		).put(
+			"timestamp", "create-date"
+		).put(
+			"userEmailAddress", "user-email-address"
+		).put(
+			"userId", "user-id"
+		).put(
+			"userLogin", "user-login"
+		).put(
+			"userName", "user-name"
+		).build();
+
+	private volatile String[] _columns;
 	private final LinkedHashMap<String, Function<AuditEvent, String>>
 		_functions =
 			LinkedHashMapBuilder.<String, Function<AuditEvent, String>>put(
-				"event-id",
-				auditEvent -> String.valueOf(auditEvent.getAuditEventId())
-			).put(
-				"create-date",
-				auditEvent -> _formatDate(auditEvent.getCreateDate())
-			).put(
-				"group-id",
-				auditEvent -> String.valueOf(auditEvent.getGroupId())
-			).put(
-				"resource-id", AuditEvent::getClassPK
-			).put(
-				"resource-name", AuditEvent::getClassName
-			).put(
-				"resource-action", AuditEvent::getEventType
-			).put(
-				"user-id", auditEvent -> String.valueOf(auditEvent.getUserId())
-			).put(
-				"user-name", AuditEvent::getUserName
+				"additional-information",
+				auditEvent -> StringUtil.removeFirst(
+					CSVUtil.encode(auditEvent.getAdditionalInfo()),
+					StringPool.QUOTE)
 			).put(
 				"client-host", AuditEvent::getClientHost
 			).put(
 				"client-ip", AuditEvent::getClientIP
 			).put(
+				"company-id",
+				auditEvent -> String.valueOf(auditEvent.getCompanyId())
+			).put(
+				"create-date",
+				auditEvent -> _formatDate(auditEvent.getCreateDate())
+			).put(
+				"event-id",
+				auditEvent -> String.valueOf(auditEvent.getAuditEventId())
+			).put(
+				"group-id",
+				auditEvent -> String.valueOf(auditEvent.getGroupId())
+			).put(
+				"message", AuditEvent::getMessage
+			).put(
+				"resource-action", AuditEvent::getEventType
+			).put(
+				"resource-id", AuditEvent::getClassPK
+			).put(
+				"resource-name", AuditEvent::getClassName
+			).put(
 				"server-name", AuditEvent::getServerName
+			).put(
+				"server-port",
+				auditEvent -> String.valueOf(auditEvent.getServerPort())
 			).put(
 				"session-id", AuditEvent::getSessionID
 			).put(
-				"additional-information",
-				auditEvent -> StringUtil.removeFirst(
-					CSVUtil.encode(auditEvent.getAdditionalInfo()),
-					StringPool.QUOTE)
+				"user-email-address", this::_getUserEmailAddress
+			).put(
+				"user-id", auditEvent -> String.valueOf(auditEvent.getUserId())
+			).put(
+				"user-login", this::_getUserLogin
+			).put(
+				"user-name", AuditEvent::getUserName
 			).build();
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
@@ -156,8 +156,8 @@ public class ExportAuditEventsMVCResourceCommand
 					TransformUtil.transform(
 						_functions.values(),
 						function -> function.apply(auditEvent)),
-					"\", \""));
-
+					StringPool.QUOTE + StringPool.COMMA + StringPool.QUOTE));
+			sb.append(StringPool.QUOTE);
 			sb.append(StringPool.NEW_LINE);
 
 			percentage = Math.min(10 + ((i * 90) / total), 99);

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
@@ -115,6 +115,59 @@ public class ExportAuditEventsMVCResourceCommand
 		}
 	}
 
+	private String _buildCSV(
+		List<AuditEvent> auditEvents, String[] columns,
+		ProgressTracker progressTracker) {
+
+		int percentage = 10;
+		int total = auditEvents.size();
+
+		if (progressTracker != null) {
+			progressTracker.setPercent(percentage);
+		}
+
+		StringBundler sb = new StringBundler((auditEvents.size() * 3) + 4);
+
+		sb.append(
+			StringUtil.merge(
+				TransformUtil.transform(columns, CSVUtil::encode, String.class),
+				StringPool.COMMA));
+		sb.append(StringPool.NEW_LINE);
+
+		for (int i = 0; i < auditEvents.size(); i++) {
+			AuditEvent auditEvent = auditEvents.get(i);
+
+			sb.append(
+				StringUtil.merge(
+					TransformUtil.transform(
+						columns,
+						column -> {
+							Function<AuditEvent, String> function =
+								_functions.get(column);
+
+							if (function == null) {
+								return StringPool.BLANK;
+							}
+
+							String value = function.apply(auditEvent);
+
+							return CSVUtil.encode(value);
+						},
+						String.class),
+					StringPool.COMMA));
+
+			sb.append(StringPool.NEW_LINE);
+
+			percentage = Math.min(10 + ((i * 90) / total), 99);
+
+			if (progressTracker != null) {
+				progressTracker.setPercent(percentage);
+			}
+		}
+
+		return sb.toString();
+	}
+
 	private String _formatDate(Date date) {
 		if (date instanceof Timestamp) {
 			date = new Date(date.getTime());
@@ -167,52 +220,11 @@ public class ExportAuditEventsMVCResourceCommand
 
 		progressTracker.start(resourceRequest);
 
-		int percentage = 10;
-		int total = auditEvents.size();
-
-		progressTracker.setPercent(percentage);
-
-		StringBundler sb = new StringBundler((auditEvents.size() * 3) + 4);
-
-		sb.append(StringPool.QUOTE);
-		sb.append(
-			StringUtil.merge(
-				columns,
-				StringPool.QUOTE + StringPool.COMMA + StringPool.QUOTE));
-		sb.append(StringPool.QUOTE);
-		sb.append(StringPool.NEW_LINE);
-
-		for (int i = 0; i < auditEvents.size(); i++) {
-			AuditEvent auditEvent = auditEvents.get(i);
-
-			sb.append(StringPool.QUOTE);
-			sb.append(
-				StringUtil.merge(
-					TransformUtil.transform(
-						columns,
-						column -> {
-							Function<AuditEvent, String> function =
-								_functions.get(column);
-
-							if (function == null) {
-								return StringPool.BLANK;
-							}
-
-							return function.apply(auditEvent);
-						},
-						String.class),
-					StringPool.QUOTE + StringPool.COMMA + StringPool.QUOTE));
-			sb.append(StringPool.QUOTE);
-			sb.append(StringPool.NEW_LINE);
-
-			percentage = Math.min(10 + ((i * 90) / total), 99);
-
-			progressTracker.setPercent(percentage);
-		}
+		String csv = _buildCSV(auditEvents, columns, progressTracker);
 
 		progressTracker.finish(resourceRequest);
 
-		return sb.toString();
+		return csv;
 	}
 
 	private String _getUserEmailAddress(AuditEvent auditEvent) {
@@ -277,10 +289,7 @@ public class ExportAuditEventsMVCResourceCommand
 	private final LinkedHashMap<String, Function<AuditEvent, String>>
 		_functions =
 			LinkedHashMapBuilder.<String, Function<AuditEvent, String>>put(
-				"additional-information",
-				auditEvent -> StringUtil.removeFirst(
-					CSVUtil.encode(auditEvent.getAdditionalInfo()),
-					StringPool.QUOTE)
+				"additional-information", AuditEvent::getAdditionalInfo
 			).put(
 				"client-host", AuditEvent::getClientHost
 			).put(

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
@@ -72,13 +72,12 @@ public class ExportAuditEventsMVCResourceCommand
 			properties.get("columns"));
 
 		if (ArrayUtil.isEmpty(selectedColumns)) {
-			Set<String> keys = _functionsKeys.keySet();
+			Set<String> keys = _functions.keySet();
 
 			selectedColumns = keys.toArray(new String[0]);
 		}
 
-		_columns = TransformUtil.transform(
-			selectedColumns, _functionsKeys::get, String.class);
+		_columns = selectedColumns;
 	}
 
 	@Override
@@ -135,13 +134,9 @@ public class ExportAuditEventsMVCResourceCommand
 							Function<AuditEvent, String> function =
 								_functions.get(column);
 
-							if (function == null) {
-								return StringPool.BLANK;
-							}
-
-							String value = function.apply(auditEvent);
-
-							return CSVUtil.encode(GetterUtil.getString(value));
+							return CSVUtil.encode(
+								GetterUtil.getString(
+									function.apply(auditEvent)));
 						},
 						String.class),
 					StringPool.COMMA));
@@ -228,7 +223,7 @@ public class ExportAuditEventsMVCResourceCommand
 		return user.getEmailAddress();
 	}
 
-	private String _getUserLogin(AuditEvent auditEvent) {
+	private String _getUserScreenName(AuditEvent auditEvent) {
 		User user = _userLocalService.fetchUser(auditEvent.getUserId());
 
 		if (user == null) {
@@ -241,79 +236,44 @@ public class ExportAuditEventsMVCResourceCommand
 	private static final Log _log = LogFactoryUtil.getLog(
 		ExportAuditEventsMVCResourceCommand.class);
 
-	private static final Map<String, String> _functionsKeys =
-		LinkedHashMapBuilder.put(
-			"additionalInfo", "additional-information"
-		).put(
-			"className", "resource-name"
-		).put(
-			"classPK", "resource-id"
-		).put(
-			"clientHost", "client-host"
-		).put(
-			"clientIP", "client-ip"
-		).put(
-			"companyId", "company-id"
-		).put(
-			"eventType", "resource-action"
-		).put(
-			"message", "message"
-		).put(
-			"serverName", "server-name"
-		).put(
-			"serverPort", "server-port"
-		).put(
-			"sessionID", "session-id"
-		).put(
-			"timestamp", "create-date"
-		).put(
-			"userEmailAddress", "user-email-address"
-		).put(
-			"userId", "user-id"
-		).put(
-			"userLogin", "user-login"
-		).put(
-			"userName", "user-name"
-		).build();
-
 	private volatile String[] _columns;
 	private final LinkedHashMap<String, Function<AuditEvent, String>>
 		_functions =
 			LinkedHashMapBuilder.<String, Function<AuditEvent, String>>put(
-				"additional-information", AuditEvent::getAdditionalInfo
+				"additionalInfo", AuditEvent::getAdditionalInfo
 			).put(
-				"client-host", AuditEvent::getClientHost
+				"className", AuditEvent::getClassName
 			).put(
-				"client-ip", AuditEvent::getClientIP
+				"classPK", AuditEvent::getClassPK
 			).put(
-				"company-id",
+				"clientHost", AuditEvent::getClientHost
+			).put(
+				"clientIP", AuditEvent::getClientIP
+			).put(
+				"companyId",
 				auditEvent -> String.valueOf(auditEvent.getCompanyId())
 			).put(
-				"create-date",
-				auditEvent -> _formatDate(auditEvent.getCreateDate())
+				"eventType", AuditEvent::getEventType
 			).put(
 				"message", AuditEvent::getMessage
 			).put(
-				"resource-action", AuditEvent::getEventType
+				"serverName", AuditEvent::getServerName
 			).put(
-				"resource-id", AuditEvent::getClassPK
-			).put(
-				"resource-name", AuditEvent::getClassName
-			).put(
-				"server-name", AuditEvent::getServerName
-			).put(
-				"server-port",
+				"serverPort",
 				auditEvent -> String.valueOf(auditEvent.getServerPort())
 			).put(
-				"session-id", AuditEvent::getSessionID
+				"sessionID", AuditEvent::getSessionID
 			).put(
-				"user-email-address", this::_getUserEmailAddress
+				"timestamp",
+				auditEvent -> _formatDate(auditEvent.getCreateDate())
 			).put(
-				"user-id", auditEvent -> String.valueOf(auditEvent.getUserId())
+				"userEmailAddress", this::_getUserEmailAddress
 			).put(
-				"user-login", this::_getUserLogin
+				"userId", auditEvent -> String.valueOf(auditEvent.getUserId())
 			).put(
-				"user-name", AuditEvent::getUserName
+				"userLogin", this::_getUserScreenName
+			).put(
+				"userName", AuditEvent::getUserName
 			).build();
 
 	@Reference

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
@@ -67,8 +67,6 @@ public class ExportAuditEventsMVCResourceCommand
 	@Activate
 	@Modified
 	protected void activate(Map<String, Object> properties) {
-		List<String> columns = new ArrayList<>();
-
 		String[] selectedColumns = GetterUtil.getStringValues(
 			properties.get("columns"));
 
@@ -78,6 +76,8 @@ public class ExportAuditEventsMVCResourceCommand
 				new String[0]
 			);
 		}
+
+		List<String> columns = new ArrayList<>();
 
 		for (String column : selectedColumns) {
 			String key = _functionsKeys.get(column);
@@ -120,7 +120,6 @@ public class ExportAuditEventsMVCResourceCommand
 		ProgressTracker progressTracker) {
 
 		int percentage = 10;
-		int total = auditEvents.size();
 
 		if (progressTracker != null) {
 			progressTracker.setPercent(percentage);
@@ -158,9 +157,9 @@ public class ExportAuditEventsMVCResourceCommand
 
 			sb.append(StringPool.NEW_LINE);
 
-			percentage = Math.min(10 + ((i * 90) / total), 99);
-
 			if (progressTracker != null) {
+				percentage = Math.min(10 + ((i * 90) / auditEvents.size()), 99);
+
 				progressTracker.setPercent(percentage);
 			}
 		}

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
@@ -119,10 +119,8 @@ public class ExportAuditEventsMVCResourceCommand
 		List<AuditEvent> auditEvents, String[] columns,
 		ProgressTracker progressTracker) {
 
-		int percentage = 10;
-
 		if (progressTracker != null) {
-			progressTracker.setPercent(percentage);
+			progressTracker.setPercent(10);
 		}
 
 		StringBundler sb = new StringBundler((auditEvents.size() * 2) + 2);
@@ -158,9 +156,8 @@ public class ExportAuditEventsMVCResourceCommand
 			sb.append(StringPool.NEW_LINE);
 
 			if (progressTracker != null) {
-				percentage = Math.min(10 + ((i * 90) / auditEvents.size()), 99);
-
-				progressTracker.setPercent(percentage);
+				progressTracker.setPercent(
+					Math.min(10 + ((i * 90) / auditEvents.size()), 99));
 			}
 		}
 

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
@@ -141,7 +141,7 @@ public class ExportAuditEventsMVCResourceCommand
 
 							String value = function.apply(auditEvent);
 
-							return CSVUtil.encode(value);
+							return CSVUtil.encode(GetterUtil.getString(value));
 						},
 						String.class),
 					StringPool.COMMA));
@@ -291,12 +291,6 @@ public class ExportAuditEventsMVCResourceCommand
 			).put(
 				"create-date",
 				auditEvent -> _formatDate(auditEvent.getCreateDate())
-			).put(
-				"event-id",
-				auditEvent -> String.valueOf(auditEvent.getAuditEventId())
-			).put(
-				"group-id",
-				auditEvent -> String.valueOf(auditEvent.getGroupId())
 			).put(
 				"message", AuditEvent::getMessage
 			).put(

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.CSVUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -38,11 +39,11 @@ import jakarta.portlet.ResourceResponse;
 
 import java.sql.Timestamp;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 import org.osgi.service.component.annotations.Activate;
@@ -70,24 +71,14 @@ public class ExportAuditEventsMVCResourceCommand
 		String[] selectedColumns = GetterUtil.getStringValues(
 			properties.get("columns"));
 
-		if (selectedColumns.length < 1) {
-			selectedColumns = _functionsKeys.keySet(
-			).toArray(
-				new String[0]
-			);
+		if (ArrayUtil.isEmpty(selectedColumns)) {
+			Set<String> keys = _functionsKeys.keySet();
+
+			selectedColumns = keys.toArray(new String[0]);
 		}
 
-		List<String> columns = new ArrayList<>();
-
-		for (String column : selectedColumns) {
-			String key = _functionsKeys.get(column);
-
-			if (key != null) {
-				columns.add(key);
-			}
-		}
-
-		_columns = columns.toArray(new String[0]);
+		_columns = TransformUtil.transform(
+			selectedColumns, _functionsKeys::get, String.class);
 	}
 
 	@Override
@@ -123,7 +114,9 @@ public class ExportAuditEventsMVCResourceCommand
 			progressTracker.setPercent(10);
 		}
 
-		StringBundler sb = new StringBundler((auditEvents.size() * 2) + 2);
+		int total = auditEvents.size();
+
+		StringBundler sb = new StringBundler((total * 2) + 2);
 
 		sb.append(
 			StringUtil.merge(
@@ -131,9 +124,9 @@ public class ExportAuditEventsMVCResourceCommand
 				StringPool.COMMA));
 		sb.append(StringPool.NEW_LINE);
 
-		for (int i = 0; i < auditEvents.size(); i++) {
-			AuditEvent auditEvent = auditEvents.get(i);
+		int count = 0;
 
+		for (AuditEvent auditEvent : auditEvents) {
 			sb.append(
 				StringUtil.merge(
 					TransformUtil.transform(
@@ -157,8 +150,10 @@ public class ExportAuditEventsMVCResourceCommand
 
 			if (progressTracker != null) {
 				progressTracker.setPercent(
-					Math.min(10 + ((i * 90) / auditEvents.size()), 99));
+					Math.min(10 + ((count * 90) / total), 99));
 			}
+
+			count++;
 		}
 
 		return sb.toString();

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/main/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommand.java
@@ -125,7 +125,7 @@ public class ExportAuditEventsMVCResourceCommand
 			progressTracker.setPercent(percentage);
 		}
 
-		StringBundler sb = new StringBundler((auditEvents.size() * 3) + 4);
+		StringBundler sb = new StringBundler((auditEvents.size() * 2) + 2);
 
 		sb.append(
 			StringUtil.merge(

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/test/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommandTest.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/test/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommandTest.java
@@ -1,0 +1,91 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.audit.web.internal.portlet.action;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.ProgressTracker;
+import com.liferay.portal.security.audit.AuditEvent;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Caio Farias
+ */
+public class ExportAuditEventsMVCResourceCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testBuildCSV() {
+		AuditEvent firstAuditEvent = Mockito.mock(AuditEvent.class);
+
+		long firstUserId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			firstAuditEvent.getUserId()
+		).thenReturn(
+			firstUserId
+		);
+
+		String firstUserName = RandomTestUtil.randomString();
+
+		Mockito.when(
+			firstAuditEvent.getUserName()
+		).thenReturn(
+			firstUserName
+		);
+
+		AuditEvent secondAuditEvent = Mockito.mock(AuditEvent.class);
+
+		long secondUserId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			secondAuditEvent.getUserId()
+		).thenReturn(
+			secondUserId
+		);
+
+		String secondUserName = RandomTestUtil.randomString();
+
+		Mockito.when(
+			secondAuditEvent.getUserName()
+		).thenReturn(
+			secondUserName
+		);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"user-name,user-id\n", firstUserName, StringPool.COMMA,
+				firstUserId, "\n", secondUserName, StringPool.COMMA,
+				secondUserId, "\n"),
+			_buildCSV(
+				new String[] {"user-name", "user-id"},
+				Arrays.asList(firstAuditEvent, secondAuditEvent)));
+	}
+
+	private String _buildCSV(String[] columns, List<AuditEvent> auditEvents) {
+		return ReflectionTestUtil.invoke(
+			new ExportAuditEventsMVCResourceCommand(), "_buildCSV",
+			new Class<?>[] {List.class, String[].class, ProgressTracker.class},
+			auditEvents, columns, null);
+	}
+
+}

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/test/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommandTest.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/test/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommandTest.java
@@ -35,47 +35,17 @@ public class ExportAuditEventsMVCResourceCommandTest {
 
 	@Test
 	public void testBuildCSV() {
-		AuditEvent firstAuditEvent = Mockito.mock(AuditEvent.class);
-		long firstUserId = RandomTestUtil.randomLong();
-
-		Mockito.when(
-			firstAuditEvent.getUserId()
-		).thenReturn(
-			firstUserId
-		);
-
-		String firstUserName = RandomTestUtil.randomString();
-
-		Mockito.when(
-			firstAuditEvent.getUserName()
-		).thenReturn(
-			firstUserName
-		);
-
-		AuditEvent secondAuditEvent = Mockito.mock(AuditEvent.class);
-		long secondUserId = RandomTestUtil.randomLong();
-
-		Mockito.when(
-			secondAuditEvent.getUserId()
-		).thenReturn(
-			secondUserId
-		);
-
-		String secondUserName = RandomTestUtil.randomString();
-
-		Mockito.when(
-			secondAuditEvent.getUserName()
-		).thenReturn(
-			secondUserName
-		);
+		AuditEvent auditEvent1 = _mockAuditEvent();
+		AuditEvent auditEvent2 = _mockAuditEvent();
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				"user-name,user-id\n", firstUserName, StringPool.COMMA,
-				firstUserId, "\n", secondUserName, StringPool.COMMA,
-				secondUserId, "\n"),
+				"user-name,user-id\n", auditEvent1.getUserName(),
+				StringPool.COMMA, auditEvent1.getUserId(), "\n",
+				auditEvent2.getUserName(), StringPool.COMMA,
+				auditEvent2.getUserId(), "\n"),
 			_buildCSV(
-				Arrays.asList(firstAuditEvent, secondAuditEvent),
+				Arrays.asList(auditEvent1, auditEvent2),
 				new String[] {"user-name", "user-id"}));
 	}
 
@@ -84,6 +54,24 @@ public class ExportAuditEventsMVCResourceCommandTest {
 			new ExportAuditEventsMVCResourceCommand(), "_buildCSV",
 			new Class<?>[] {List.class, String[].class, ProgressTracker.class},
 			auditEvents, columns, null);
+	}
+
+	private AuditEvent _mockAuditEvent() {
+		AuditEvent auditEvent = Mockito.mock(AuditEvent.class);
+
+		Mockito.when(
+			auditEvent.getUserId()
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Mockito.when(
+			auditEvent.getUserName()
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		return auditEvent;
 	}
 
 }

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/test/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommandTest.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/test/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommandTest.java
@@ -36,7 +36,6 @@ public class ExportAuditEventsMVCResourceCommandTest {
 	@Test
 	public void testBuildCSV() {
 		AuditEvent firstAuditEvent = Mockito.mock(AuditEvent.class);
-
 		long firstUserId = RandomTestUtil.randomLong();
 
 		Mockito.when(
@@ -54,7 +53,6 @@ public class ExportAuditEventsMVCResourceCommandTest {
 		);
 
 		AuditEvent secondAuditEvent = Mockito.mock(AuditEvent.class);
-
 		long secondUserId = RandomTestUtil.randomLong();
 
 		Mockito.when(
@@ -77,11 +75,11 @@ public class ExportAuditEventsMVCResourceCommandTest {
 				firstUserId, "\n", secondUserName, StringPool.COMMA,
 				secondUserId, "\n"),
 			_buildCSV(
-				new String[] {"user-name", "user-id"},
-				Arrays.asList(firstAuditEvent, secondAuditEvent)));
+				Arrays.asList(firstAuditEvent, secondAuditEvent),
+				new String[] {"user-name", "user-id"}));
 	}
 
-	private String _buildCSV(String[] columns, List<AuditEvent> auditEvents) {
+	private String _buildCSV(List<AuditEvent> auditEvents, String[] columns) {
 		return ReflectionTestUtil.invoke(
 			new ExportAuditEventsMVCResourceCommand(), "_buildCSV",
 			new Class<?>[] {List.class, String[].class, ProgressTracker.class},

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/test/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommandTest.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/test/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommandTest.java
@@ -49,6 +49,25 @@ public class ExportAuditEventsMVCResourceCommandTest {
 				new String[] {"user-name", "user-id"}));
 	}
 
+	@Test
+	public void testBuildCSVWhenColumnValueIsNull() {
+		AuditEvent auditEvent = Mockito.mock(AuditEvent.class);
+
+		long userId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			auditEvent.getUserId()
+		).thenReturn(
+			userId
+		);
+
+		Assert.assertEquals(
+			StringBundler.concat("user-name,user-id\n,", userId, "\n"),
+			_buildCSV(
+				Arrays.asList(auditEvent),
+				new String[] {"user-name", "user-id"}));
+	}
+
 	private String _buildCSV(List<AuditEvent> auditEvents, String[] columns) {
 		return ReflectionTestUtil.invoke(
 			new ExportAuditEventsMVCResourceCommand(), "_buildCSV",

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/test/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommandTest.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-web/src/test/java/com/liferay/portal/security/audit/web/internal/portlet/action/ExportAuditEventsMVCResourceCommandTest.java
@@ -40,13 +40,13 @@ public class ExportAuditEventsMVCResourceCommandTest {
 
 		Assert.assertEquals(
 			StringBundler.concat(
-				"user-name,user-id\n", auditEvent1.getUserName(),
+				"userName,userId\n", auditEvent1.getUserName(),
 				StringPool.COMMA, auditEvent1.getUserId(), "\n",
 				auditEvent2.getUserName(), StringPool.COMMA,
 				auditEvent2.getUserId(), "\n"),
 			_buildCSV(
 				Arrays.asList(auditEvent1, auditEvent2),
-				new String[] {"user-name", "user-id"}));
+				new String[] {"userName", "userId"}));
 	}
 
 	@Test
@@ -62,10 +62,10 @@ public class ExportAuditEventsMVCResourceCommandTest {
 		);
 
 		Assert.assertEquals(
-			StringBundler.concat("user-name,user-id\n,", userId, "\n"),
+			StringBundler.concat("userName,userId\n,", userId, "\n"),
 			_buildCSV(
 				Arrays.asList(auditEvent),
-				new String[] {"user-name", "user-id"}));
+				new String[] {"userName", "userId"}));
 	}
 
 	private String _buildCSV(List<AuditEvent> auditEvents, String[] columns) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91791

## Why

The audit event CSV export emitted a malformed row format and ignored the columns configured in the CSV Logging Message Formatter, so exports did not reflect the administrator's configuration.

## Key changes

- Drive export columns from `CSVLogMessageFormatterConfiguration`, keyed by its column names, so the CSV matches the configured columns and order.
- Reformat each row with `CSVUtil.encode` joined by commas, replacing the previous malformed quoting.
- Encode null field values as empty cells via `GetterUtil.getString`, preventing shifted columns.
- Extract `_buildCSV` and add unit tests covering the format and null handling.