### PR TITLE
LPD-92457 Cookies admin fixes: field order, Prechecked, reconsent URL

### DIFF
--- a/modules/apps/cookies/cookies-banner-web/build.gradle
+++ b/modules/apps/cookies/cookies-banner-web/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:cookies:cookies-api")
 	compileOnly project(":apps:cookies:cookies-impl")
+	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:frontend-js:frontend-js-loader-modules-extender-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")

--- a/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/definition/CookiesBannerConfigurationDDMFormDeclaration.java
+++ b/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/definition/CookiesBannerConfigurationDDMFormDeclaration.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/definition/CookiesBannerConfigurationDDMFormDeclaration.java
+++ b/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/definition/CookiesBannerConfigurationDDMFormDeclaration.java
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.cookies.banner.web.internal.configuration.admin.definition;
+
+import com.liferay.configuration.admin.definition.ConfigurationDDMFormDeclaration;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Álvaro Saugar
+ */
+@Component(
+	property = "configurationPid=com.liferay.cookies.configuration.banner.CookiesBannerConfiguration",
+	service = ConfigurationDDMFormDeclaration.class
+)
+public class CookiesBannerConfigurationDDMFormDeclaration
+	implements ConfigurationDDMFormDeclaration {
+
+	@Override
+	public Class<?> getDDMFormClass() {
+		return CookiesBannerConfigurationForm.class;
+	}
+
+}

--- a/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/definition/CookiesBannerConfigurationForm.java
+++ b/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/definition/CookiesBannerConfigurationForm.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/definition/CookiesBannerConfigurationForm.java
+++ b/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/definition/CookiesBannerConfigurationForm.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.cookies.banner.web.internal.configuration.admin.definition;
+
+import com.liferay.dynamic.data.mapping.annotations.DDMForm;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormLayout;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutColumn;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutPage;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutRow;
+
+/**
+ * @author Álvaro Saugar
+ */
+@DDMForm
+@DDMFormLayout(
+	paginationMode = com.liferay.dynamic.data.mapping.model.DDMFormLayout.SINGLE_PAGE_MODE,
+	value = {
+		@DDMFormLayoutPage(
+			{
+				@DDMFormLayoutRow(
+					{
+						@DDMFormLayoutColumn(
+							size = 12,
+							value = {
+								"title", "content", "privacyPolicyLink",
+								"linkDisplayText", "includeDeclineAllButton"
+							}
+						)
+					}
+				)
+			}
+		)
+	}
+)
+public interface CookiesBannerConfigurationForm {
+}

--- a/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/definition/CookiesConsentConfigurationDDMFormDeclaration.java
+++ b/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/definition/CookiesConsentConfigurationDDMFormDeclaration.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/definition/CookiesConsentConfigurationDDMFormDeclaration.java
+++ b/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/definition/CookiesConsentConfigurationDDMFormDeclaration.java
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.cookies.banner.web.internal.configuration.admin.definition;
+
+import com.liferay.configuration.admin.definition.ConfigurationDDMFormDeclaration;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Álvaro Saugar
+ */
+@Component(
+	property = "configurationPid=com.liferay.cookies.configuration.consent.CookiesConsentConfiguration",
+	service = ConfigurationDDMFormDeclaration.class
+)
+public class CookiesConsentConfigurationDDMFormDeclaration
+	implements ConfigurationDDMFormDeclaration {
+
+	@Override
+	public Class<?> getDDMFormClass() {
+		return CookiesConsentConfigurationForm.class;
+	}
+
+}

--- a/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/definition/CookiesConsentConfigurationForm.java
+++ b/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/definition/CookiesConsentConfigurationForm.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 

--- a/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/definition/CookiesConsentConfigurationForm.java
+++ b/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/configuration/admin/definition/CookiesConsentConfigurationForm.java
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.cookies.banner.web.internal.configuration.admin.definition;
+
+import com.liferay.dynamic.data.mapping.annotations.DDMForm;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormLayout;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutColumn;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutPage;
+import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutRow;
+
+/**
+ * @author Álvaro Saugar
+ */
+@DDMForm
+@DDMFormLayout(
+	paginationMode = com.liferay.dynamic.data.mapping.model.DDMFormLayout.SINGLE_PAGE_MODE,
+	value = {
+		@DDMFormLayoutPage(
+			{
+				@DDMFormLayoutRow(
+					{
+						@DDMFormLayoutColumn(
+							size = 12,
+							value = {
+								"title", "description", "cookiePolicyLink",
+								"linkDisplayText",
+								"strictlyNecessaryCookiesDescription",
+								"functionalCookiesDescription",
+								"functionalCookiesHideFromEndUser",
+								"functionalCookiesPrechecked",
+								"performanceCookiesDescription",
+								"performanceCookiesHideFromEndUser",
+								"performanceCookiesPrechecked",
+								"personalizationCookiesDescription",
+								"personalizationCookiesHideFromEndUser",
+								"personalizationCookiesPrechecked"
+							}
+						)
+					}
+				)
+			}
+		)
+	}
+)
+public interface CookiesConsentConfigurationForm {
+}

--- a/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/servlet/taglib/CookiesConfigurationConfirmJSPDynamicInclude.java
+++ b/modules/apps/cookies/cookies-banner-web/src/main/java/com/liferay/cookies/banner/web/internal/servlet/taglib/CookiesConfigurationConfirmJSPDynamicInclude.java
@@ -6,6 +6,8 @@
 package com.liferay.cookies.banner.web.internal.servlet.taglib;
 
 import com.liferay.configuration.admin.constants.ConfigurationAdminPortletKeys;
+import com.liferay.cookies.banner.web.internal.constants.CookiesBannerWebKeys;
+import com.liferay.cookies.banner.web.internal.display.context.CookiesPreferenceHandlingConfigurationDisplayContext;
 import com.liferay.cookies.configuration.CookiesConfigurationProvider;
 import com.liferay.cookies.configuration.CookiesPreferenceHandlingConfiguration;
 import com.liferay.cookies.configuration.banner.CookiesBannerConfiguration;
@@ -73,6 +75,12 @@ public class CookiesConfigurationConfirmJSPDynamicInclude
 
 			return;
 		}
+
+		httpServletRequest.setAttribute(
+			CookiesBannerWebKeys.
+				COOKIES_PREFERENCE_HANDLING_CONFIGURATION_DISPLAY_CONTEXT,
+			new CookiesPreferenceHandlingConfigurationDisplayContext(
+				_cookiesConfigurationProvider, scope, scopePK));
 
 		super.include(httpServletRequest, httpServletResponse, key);
 	}

--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner_configuration/js/CookiesBannerConfiguration.js
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner_configuration/js/CookiesBannerConfiguration.js
@@ -64,7 +64,7 @@ export default function ({
 
 		toggleSwitch.addEventListener('click', notifyCookiePreferenceUpdate);
 
-		toggleSwitch.checked = toggleSwitch.dataset.prechecked;
+		toggleSwitch.checked = toggleSwitch.dataset.prechecked === 'true';
 
 		getCookie(userConfigCookieName).then((cookie) => {
 			if (cookie) {

--- a/modules/test/playwright/tests/cookies-banner-web/main/cookiesBannerConsentPanel.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/main/cookiesBannerConsentPanel.spec.ts
@@ -83,68 +83,6 @@ test(
 );
 
 test(
-	'Verify Force Re-Consent request succeeds when saving Cookie Banner configuration',
-	{tag: '@LPD-92457'},
-	async ({page, systemSettingsPage}) => {
-		await systemSettingsPage.goToSystemSetting('Privacy', 'Cookie Banner');
-
-		// Wait for the DDM form to mount before submitting
-
-		await page.getByLabel('Title', {exact: true}).waitFor();
-
-		// Mark the form as dirty so the save triggers the confirmation modal.
-		// A direct input event on the SystemSettingsPortlet form is the
-		// simplest way to flip the formChanged flag the dynamic include
-		// listens for; DDM-rendered inputs do not always bubble input events
-		// out of the React form when driven by Playwright.
-
-		await page.evaluate(() => {
-			const form = document.querySelector<HTMLFormElement>(
-				'form[name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_fm"]'
-			);
-
-			form?.dispatchEvent(new Event('input', {bubbles: true}));
-		});
-
-		const saveButton = page.getByRole('button', {name: 'Save'});
-
-		if (await saveButton.isVisible()) {
-			await saveButton.dispatchEvent('click');
-		}
-		else {
-			await page
-				.getByRole('button', {name: 'Update'})
-				.dispatchEvent('click');
-		}
-
-		// The confirmation modal opens; check the Force Re-Consent box so the
-		// dynamic include fires the force-reconsent fetch before submitting
-
-		const modal = page.getByRole('alertdialog');
-
-		await modal.waitFor({state: 'visible', timeout: 10000});
-
-		await modal.getByLabel('Force re-consent for all users.').check();
-
-		// Catch the force-reconsent fetch the OK button triggers. On the
-		// original bug the URL fell back to "" and the browser resolved it to
-		// /o/ with a 404; the fix populates the resource URL so this returns
-		// 200.
-
-		const reconsentResponsePromise = page.waitForResponse(
-			(response) => response.url().includes('force_reconsent'),
-			{timeout: 10000}
-		);
-
-		await modal.getByRole('button', {name: 'OK'}).click();
-
-		const reconsentResponse = await reconsentResponsePromise;
-
-		expect(reconsentResponse.status()).toBe(200);
-	}
-);
-
-test(
 	'Escape texts in Cookie Panel to avoid XSS injections',
 	{tag: '@LPD-69399'},
 	async ({page, systemSettingsPage}) => {
@@ -281,42 +219,6 @@ test(
 
 			await expectCookieConsentPanelButtons(consentPanelFooter);
 		});
-	}
-);
-
-test(
-	'Verify optional cookie toggles default to unchecked in the Consent Panel',
-	{tag: '@LPD-92457'},
-	async ({page}) => {
-		await page.goto('/');
-
-		const cookiesBanner = page.locator(
-			'div[role="dialog"][aria-modal="true"]'
-		);
-
-		await cookiesBanner.waitFor();
-
-		await cookiesBanner
-			.getByRole('button', {name: 'Configuration'})
-			.click();
-
-		const configurationFrame = page.frameLocator(
-			'#cookiesBannerConfiguration iframe'
-		);
-
-		for (const cookieKey of cookieKeys) {
-			const toggle = configurationFrame.locator(
-				`[data-cookie-key="${cookieKey}"]`
-			);
-
-			await expect(toggle).not.toBeChecked();
-		}
-
-		// Dismiss the Configuration modal so afterEach can navigate
-
-		await page
-			.getByRole('button', {name: 'Use Necessary Cookies Only'})
-			.click();
 	}
 );
 
@@ -619,6 +521,99 @@ test(
 );
 
 test(
+	'Verify Force Re-Consent request succeeds when saving Cookie Banner configuration',
+	{tag: '@LPD-92457'},
+	async ({page, systemSettingsPage}) => {
+		await systemSettingsPage.goToSystemSetting('Privacy', 'Cookie Banner');
+
+		// Wait for the DDM form to mount before submitting
+
+		await page.getByLabel('Title', {exact: true}).waitFor();
+
+		// Mark the form as dirty so the save triggers the confirmation modal.
+		// A direct input event on the SystemSettingsPortlet form is the
+		// simplest way to flip the formChanged flag the dynamic include
+		// listens for; DDM-rendered inputs do not always bubble input events
+		// out of the React form when driven by Playwright.
+
+		await page.evaluate(() => {
+			const form = document.querySelector<HTMLFormElement>(
+				'form[name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_fm"]'
+			);
+
+			form?.dispatchEvent(new Event('input', {bubbles: true}));
+		});
+
+		const saveButton = page.getByRole('button', {name: 'Save'});
+
+		if (await saveButton.isVisible()) {
+			await saveButton.dispatchEvent('click');
+		}
+		else {
+			await page
+				.getByRole('button', {name: 'Update'})
+				.dispatchEvent('click');
+		}
+
+		// The confirmation modal opens; check the Force Re-Consent box so the
+		// dynamic include fires the force-reconsent fetch before submitting
+
+		const modal = page.getByRole('alertdialog');
+
+		await modal.waitFor({state: 'visible', timeout: 10000});
+
+		await modal.getByLabel('Force re-consent for all users.').check();
+
+		// Catch the force-reconsent fetch the OK button triggers. On the
+		// original bug the URL fell back to "" and the browser resolved it to
+		// /o/ with a 404; the fix populates the resource URL so this returns
+		// 200.
+
+		const reconsentResponsePromise = page.waitForResponse(
+			(response) => response.url().includes('force_reconsent'),
+			{timeout: 10000}
+		);
+
+		await modal.getByRole('button', {name: 'OK'}).click();
+
+		const reconsentResponse = await reconsentResponsePromise;
+
+		expect(reconsentResponse.status()).toBe(200);
+	}
+);
+
+test(
+	'Verify Global Privacy Control can only be edited when Consent Manager is enabled',
+	{tag: '@LPD-86511'},
+	async ({consentManagerConfigurationPage}) => {
+		await consentManagerConfigurationPage.goTo();
+
+		const acceptAllButton = consentManagerConfigurationPage.page.getByRole(
+			'button',
+			{
+				name: 'Accept All',
+			}
+		);
+
+		await acceptAllButton.click();
+
+		await expect(acceptAllButton).not.toBeVisible();
+
+		await consentManagerConfigurationPage.enabledCheckbox.setChecked(false);
+
+		await expect(
+			consentManagerConfigurationPage.globalPrivacyControlEnabledCheckbox
+		).not.toBeEnabled();
+
+		await consentManagerConfigurationPage.enabledCheckbox.setChecked(true);
+
+		await expect(
+			consentManagerConfigurationPage.globalPrivacyControlEnabledCheckbox
+		).toBeEnabled();
+	}
+);
+
+test(
 	'Verify Global Privacy Control is visible and can be enabled',
 	{tag: '@LPD-86511'},
 	async ({consentManagerConfigurationPage}) => {
@@ -654,33 +649,38 @@ test(
 );
 
 test(
-	'Verify Global Privacy Control can only be edited when Consent Manager is enabled',
-	{tag: '@LPD-86511'},
-	async ({consentManagerConfigurationPage}) => {
-		await consentManagerConfigurationPage.goTo();
+	'Verify optional cookie toggles default to unchecked in the Consent Panel',
+	{tag: '@LPD-92457'},
+	async ({page}) => {
+		await page.goto('/');
 
-		const acceptAllButton = consentManagerConfigurationPage.page.getByRole(
-			'button',
-			{
-				name: 'Accept All',
-			}
+		const cookiesBanner = page.locator(
+			'div[role="dialog"][aria-modal="true"]'
 		);
 
-		await acceptAllButton.click();
+		await cookiesBanner.waitFor();
 
-		await expect(acceptAllButton).not.toBeVisible();
+		await cookiesBanner
+			.getByRole('button', {name: 'Configuration'})
+			.click();
 
-		await consentManagerConfigurationPage.enabledCheckbox.setChecked(false);
+		const configurationFrame = page.frameLocator(
+			'#cookiesBannerConfiguration iframe'
+		);
 
-		await expect(
-			consentManagerConfigurationPage.globalPrivacyControlEnabledCheckbox
-		).not.toBeEnabled();
+		for (const cookieKey of cookieKeys) {
+			const toggle = configurationFrame.locator(
+				`[data-cookie-key="${cookieKey}"]`
+			);
 
-		await consentManagerConfigurationPage.enabledCheckbox.setChecked(true);
+			await expect(toggle).not.toBeChecked();
+		}
 
-		await expect(
-			consentManagerConfigurationPage.globalPrivacyControlEnabledCheckbox
-		).toBeEnabled();
+		// Dismiss the Configuration modal so afterEach can navigate
+
+		await page
+			.getByRole('button', {name: 'Use Necessary Cookies Only'})
+			.click();
 	}
 );
 

--- a/modules/test/playwright/tests/cookies-banner-web/main/cookiesBannerConsentPanel.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/main/cookiesBannerConsentPanel.spec.ts
@@ -223,6 +223,40 @@ test(
 );
 
 test(
+	'Verify optional cookie toggles default to unchecked in the Consent Panel',
+	{tag: '@LPD-92457'},
+	async ({page}) => {
+		await page.goto('/');
+
+		const cookiesBanner = page.locator(
+			'div[role="dialog"][aria-modal="true"]'
+		);
+
+		await cookiesBanner.waitFor();
+
+		await cookiesBanner.getByRole('button', {name: 'Configuration'}).click();
+
+		const configurationFrame = page.frameLocator(
+			'#cookiesBannerConfiguration iframe'
+		);
+
+		for (const cookieKey of cookieKeys) {
+			const toggle = configurationFrame.locator(
+				`[data-cookie-key="${cookieKey}"]`
+			);
+
+			await expect(toggle).not.toBeChecked();
+		}
+
+		// Dismiss the Configuration modal so afterEach can navigate
+
+		await page
+			.getByRole('button', {name: 'Use Necessary Cookies Only'})
+			.click();
+	}
+);
+
+test(
 	'Verify Cookie Preferences can be saved from the new Consent Manager page',
 	{tag: '@LPD-60007'},
 	async ({accountSettingsPage, page}) => {

--- a/modules/test/playwright/tests/cookies-banner-web/main/cookiesBannerConsentPanel.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/main/cookiesBannerConsentPanel.spec.ts
@@ -296,7 +296,9 @@ test(
 
 		await cookiesBanner.waitFor();
 
-		await cookiesBanner.getByRole('button', {name: 'Configuration'}).click();
+		await cookiesBanner
+			.getByRole('button', {name: 'Configuration'})
+			.click();
 
 		const configurationFrame = page.frameLocator(
 			'#cookiesBannerConfiguration iframe'

--- a/modules/test/playwright/tests/cookies-banner-web/main/cookiesBannerConsentPanel.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/main/cookiesBannerConsentPanel.spec.ts
@@ -83,6 +83,68 @@ test(
 );
 
 test(
+	'Verify Force Re-Consent request succeeds when saving Cookie Banner configuration',
+	{tag: '@LPD-92457'},
+	async ({page, systemSettingsPage}) => {
+		await systemSettingsPage.goToSystemSetting('Privacy', 'Cookie Banner');
+
+		// Wait for the DDM form to mount before submitting
+
+		await page.getByLabel('Title', {exact: true}).waitFor();
+
+		// Mark the form as dirty so the save triggers the confirmation modal.
+		// A direct input event on the SystemSettingsPortlet form is the
+		// simplest way to flip the formChanged flag the dynamic include
+		// listens for; DDM-rendered inputs do not always bubble input events
+		// out of the React form when driven by Playwright.
+
+		await page.evaluate(() => {
+			const form = document.querySelector<HTMLFormElement>(
+				'form[name="_com_liferay_configuration_admin_web_portlet_SystemSettingsPortlet_fm"]'
+			);
+
+			form?.dispatchEvent(new Event('input', {bubbles: true}));
+		});
+
+		const saveButton = page.getByRole('button', {name: 'Save'});
+
+		if (await saveButton.isVisible()) {
+			await saveButton.dispatchEvent('click');
+		}
+		else {
+			await page
+				.getByRole('button', {name: 'Update'})
+				.dispatchEvent('click');
+		}
+
+		// The confirmation modal opens; check the Force Re-Consent box so the
+		// dynamic include fires the force-reconsent fetch before submitting
+
+		const modal = page.getByRole('alertdialog');
+
+		await modal.waitFor({state: 'visible', timeout: 10000});
+
+		await modal.getByLabel('Force re-consent for all users.').check();
+
+		// Catch the force-reconsent fetch the OK button triggers. On the
+		// original bug the URL fell back to "" and the browser resolved it to
+		// /o/ with a 404; the fix populates the resource URL so this returns
+		// 200.
+
+		const reconsentResponsePromise = page.waitForResponse(
+			(response) => response.url().includes('force_reconsent'),
+			{timeout: 10000}
+		);
+
+		await modal.getByRole('button', {name: 'OK'}).click();
+
+		const reconsentResponse = await reconsentResponsePromise;
+
+		expect(reconsentResponse.status()).toBe(200);
+	}
+);
+
+test(
 	'Escape texts in Cookie Panel to avoid XSS injections',
 	{tag: '@LPD-69399'},
 	async ({page, systemSettingsPage}) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92457

   ## What Is Being Fixed

   Three independent issues on the Cookies admin configuration pages:

   1. Field order. The Cookie Banner and Cookie Panel configuration forms rendered fields in alphabetical method-declaration order from the OCD interface, which did not match the desired admin UX (Title and content first, then categories grouped with their toggles).

   2. Prechecked toggles. In the cookie consent panel modal, the three optional category toggles (Functional, Performance, Personalization) always rendered as checked regardless of the *CookiesPrechecked configuration value.

   3. Force re-consent URL. Saving Cookie Banner or Cookie Panel configurations opened the "These changes will take effect immediately. Do you want to continue?" modal with a "Force re-consent for all users" checkbox. Clicking OK with the checkbox checked issued a POST to an
   empty URL that the browser resolved to /o/, producing a 404.

   ## How It Is Being Fixed

   For the field order, a ConfigurationDDMFormDeclaration component is registered per configurationPid that points to a @DDMForm + @DDMFormLayout interface listing field ids in the intended order. The OCD interfaces in cookies-api stay in alphabetical method order so
   JavaTermOrderCheck is satisfied, and field ids are unchanged so existing saved configurations need no migration.

   For the Prechecked bug, the JavaScript assigned dataset.prechecked (always a string) directly to .checked. The literal string "false" is truthy in JavaScript, leaving every toggle checked regardless of configuration. The comparison now reads dataset.prechecked === 'true'.

   For the force-reconsent URL bug, the JSP that renders the confirmation modal reads the URL from cookiesPreferenceHandlingConfigurationDisplayContext on the request. That attribute was only set by CookiesPreferenceHandlingConfigurationFormRenderer, which only handles the
   Consent Manager page. The dynamic include now sets the same display context for all three Cookies configurations where the modal is injected, so the URL is populated regardless of which page is being edited. The MVCResourceCommand was already registered for the three
   configuration-admin portlets, so the resolved URL routes correctly from every entry point.

   Two Playwright specs are added: one asserting that the optional toggles default to unchecked when no Prechecked override is configured, and one asserting that the force-reconsent fetch returns HTTP 200 after the Cookie Banner save modal confirmation.