### PR TITLE
LPD-93576 Evaluate the namespace in the captcha aria-labelledby

### DIFF
--- a/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
+++ b/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
@@ -45,7 +45,7 @@ String namespace = portletDisplay.getNamespace();
 		/>
 
 		<aui:input name="captchaId" type="hidden" value="<%= captchaId %>" />
-		<aui:input aria-labelledby='<%= namespace + "captchaLabel " + namespace + "captchaError" %>' class="form-control" ignoreRequestValue="<%= true %>" label="text-verification" name="captchaText" required="<%= true %>" size="10" type="text" value="" />
+		<aui:input aria-describedby='<%= namespace + "captchaError" %>' class="form-control" ignoreRequestValue="<%= true %>" label="text-verification" name="captchaText" required="<%= true %>" size="10" type="text" value="" />
 
 		<c:if test="<%= Validator.isNotNull(errorMessage) %>">
 			<p class="font-weight-semi-bold mt-1 text-danger" id="<%= namespace %>captchaError">

--- a/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
+++ b/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
@@ -13,6 +13,8 @@ String refreshCaptchaId = PortalUtil.generateRandomKey(request, "refreshCaptchaI
 
 String errorMessage = (String)request.getAttribute("liferay-captcha:captcha:errorMessage");
 String url = (String)request.getAttribute("liferay-captcha:captcha:url");
+
+String namespace = portletDisplay.getNamespace();
 %>
 
 <c:if test="<%= captchaEnabled %>">
@@ -43,10 +45,10 @@ String url = (String)request.getAttribute("liferay-captcha:captcha:url");
 		/>
 
 		<aui:input name="captchaId" type="hidden" value="<%= captchaId %>" />
-		<aui:input aria-labelledby="<portlet:namespace />captchaLabel <portlet:namespace />captchaError" class="form-control" ignoreRequestValue="<%= true %>" label="text-verification" name="captchaText" required="<%= true %>" size="10" type="text" value="" />
+		<aui:input aria-labelledby='<%= namespace + "captchaLabel " + namespace + "captchaError" %>' class="form-control" ignoreRequestValue="<%= true %>" label="text-verification" name="captchaText" required="<%= true %>" size="10" type="text" value="" />
 
 		<c:if test="<%= Validator.isNotNull(errorMessage) %>">
-			<p class="font-weight-semi-bold mt-1 text-danger" id="<portlet:namespace />captchaError">
+			<p class="font-weight-semi-bold mt-1 text-danger" id="<%= namespace %>captchaError">
 				<clay:icon
 					symbol="info-circle"
 				/>

--- a/modules/test/playwright/tests/login-web/main-captcha-enable/forgotPasswordCaptcha.spec.ts
+++ b/modules/test/playwright/tests/login-web/main-captcha-enable/forgotPasswordCaptcha.spec.ts
@@ -7,6 +7,58 @@ import {expect, test} from '@playwright/test';
 
 import {liferayConfig} from '../../../liferay.config';
 
+test(
+	'Check captcha input aria-describedby holds the evaluated namespace',
+	{tag: ['@LPD-93576']},
+	async ({page}) => {
+		await page.goto('/');
+
+		await page.getByRole('button', {name: 'Sign In'}).click();
+
+		await page.getByText('Forgot Password').click();
+
+		const namespace =
+			'_com_liferay_login_web_portlet_ForgotPasswordPortlet_';
+
+		const captchaText = page.locator(`[id="${namespace}captchaText"]`);
+
+		await expect(captchaText).toBeVisible();
+
+		// The namespace must be evaluated, not rendered as a literal JSP tag
+
+		await expect(captchaText).toHaveAttribute(
+			'aria-describedby',
+			`${namespace}captchaError`
+		);
+
+		// The field is named by its label
+
+		await expect(page.getByLabel('Text Verification')).toBeVisible();
+	}
+);
+
+test(
+	'Check captcha input requires a value before submitting',
+	{tag: ['@LPD-24714']},
+	async ({page}) => {
+		await page.goto('/');
+
+		await page.getByRole('button', {name: 'Sign In'}).click();
+
+		await page.getByText('Forgot Password').click();
+
+		await page.getByLabel('Email Address').fill('test@liferay.com');
+
+		// Submitting with an empty captcha must trigger client-side validation
+
+		await page.getByRole('button', {name: 'Send new password'}).click();
+
+		await expect(
+			page.getByText('The Text Verification field is required.')
+		).toBeVisible();
+	}
+);
+
 test('LPD-32888 Check captcha verification text is cleared after a wrong captcha', async ({
 	page,
 }) => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93576

## What Is Being Fixed

The simple captcha input rendered an invalid `aria-labelledby` attribute containing the literal text `<portlet:namespace />` instead of the evaluated portlet namespace. This is visible on the Forgot Password page: inspecting the captcha field shows the unresolved JSP tag in the attribute value.

The root cause is a regression from LPD-24714, which replaced a plain `<label>` plus `<input>` with a single `<aui:input>`. A JSP custom tag is not evaluated when it appears inside another custom tag's attribute value, so the nested `<portlet:namespace />` was emitted verbatim. That same change also deleted the explicit `<label id="...captchaLabel">`, so the `aria-labelledby` reference to `captchaLabel` no longer pointed at any element.

## How It Is Being Fixed

The change is split into three commits so each step is reviewable on its own.

1. **Evaluate the namespace in the captcha aria-labelledby** — the minimal fix for the reported bug. The namespace is resolved in a scriptlet via `portletDisplay.getNamespace()` and the `aria-labelledby` attribute (and the error message id) are built from that value. Nothing else is touched, so the field keeps its `aui:input` label and the LPD-24714 required validation is untouched.

2. **Link the captcha error through aria-describedby** — fixes the dangling reference left by LPD-24714. The `aria-labelledby` attribute still pointed at a `captchaLabel` element that no longer exists, which would give the field an empty accessible name when no error is shown. Switching the error link to `aria-describedby` lets the `aui:input` label name the field on its own (preserving the "The Text Verification field is required." validation message) and is the correct ARIA relationship for an error description.

3. **Add tests for the captcha namespace and required validation** — Playwright tests on the Forgot Password flow asserting the attribute holds the evaluated namespace and that the empty-submit required validation still fires.