### PR TITLE
LPD-93569 Fix intermittent OAuth2 provider shortcut upgrade failure

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/upgrade/registry/OAuth2ProviderShortcutUpgradeStepRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/upgrade/registry/OAuth2ProviderShortcutUpgradeStepRegistrator.java
@@ -7,6 +7,7 @@ package com.liferay.oauth2.provider.shortcut.internal.upgrade.registry;
 
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.shortcut.internal.upgrade.v1_0_0.OAuth2ApplicationAnalyticsCloudUpgradeProcess;
+import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
@@ -40,6 +41,11 @@ public class OAuth2ProviderShortcutUpgradeStepRegistrator
 
 	@Reference
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
+
+	@Reference(
+		target = "(&(release.bundle.symbolic.name=com.liferay.oauth2.provider.service)(release.schema.version>=4.2.8))"
+	)
+	private Release _release;
 
 	@Reference
 	private ResourcePermissionLocalService _resourcePermissionLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93569

## What Is Being Fixed

Upgrading a database with the db_upgrade_client (or any upgrade.database.auto.run boot) fails intermittently with "Unknown column 'oauth2auth0_.audiences' in 'field list'" while running the com.liferay.oauth2.provider.shortcut module upgrade.

## How It Is Being Fixed

The shortcut upgrade process deletes and recreates OAuth2 applications through OAuth2ApplicationLocalService, and deleting an application loads its OAuth2Authorization rows through Hibernate, whose mapping includes the audiences column that the com.liferay.oauth2.provider.service 4.2.8 schema upgrade adds. When both modules are upgraded in the same run, the shortcut upgrade can execute before the service schema upgrade and hit the missing column. The registrator now references a Release for com.liferay.oauth2.provider.service at schema version 4.2.8 or higher, so the component stays inactive — and its upgrade steps stay unregistered — until the column exists. Verified at runtime by replaying the customer scenario locally: with the audiences column dropped and the Release rows reverted, an auto-run boot executes the service schema upgrade first and the shortcut upgrade 45 ms later, completing cleanly.

## Why Are There No Tests?

The change is a declarative SCR Release target filter with no executable logic to unit test; component activation gating is OSGi framework behavior, and the upgrade-ordering race is not reproducible in a test. It follows the same pattern used by the existing upgrade step registrators across the codebase. The fix was verified at runtime by replaying the failing upgrade scenario locally.