### PR TITLE
[FIPS] LPD-88187 Block BCrypt and UFC-CRYPT in FIPS mode

### DIFF
--- a/modules/apps/portal-crypto-hash/portal-crypto-hash-provider/portal-crypto-hash-provider-bcrypt/build.gradle
+++ b/modules/apps/portal-crypto-hash/portal-crypto-hash-provider/portal-crypto-hash-provider-bcrypt/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay", name: "jodd.util", version: "6.0.1.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:portal-crypto-hash:portal-crypto-hash-api")
 	compileOnly project(":apps:portal-crypto-hash:portal-crypto-hash-spi")

--- a/modules/apps/portal-crypto-hash/portal-crypto-hash-provider/portal-crypto-hash-provider-bcrypt/src/main/java/com/liferay/portal/crypto/hash/provider/bcrypt/internal/BCryptCryptoHashProviderFactory.java
+++ b/modules/apps/portal-crypto-hash/portal-crypto-hash-provider/portal-crypto-hash-provider-bcrypt/src/main/java/com/liferay/portal/crypto/hash/provider/bcrypt/internal/BCryptCryptoHashProviderFactory.java
@@ -24,6 +24,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Arthur Chan
  */
 @Component(
+	enabled = false,
 	property = "configuration.pid=com.liferay.portal.crypto.hash.provider.bcrypt.internal.configuration.BCryptCryptoHashProviderConfiguration",
 	service = CryptoHashProviderFactory.class
 )

--- a/modules/apps/portal-crypto-hash/portal-crypto-hash-provider/portal-crypto-hash-provider-bcrypt/src/main/java/com/liferay/portal/crypto/hash/provider/bcrypt/internal/component/enabler/ComponentEnabler.java
+++ b/modules/apps/portal-crypto-hash/portal-crypto-hash-provider/portal-crypto-hash-provider-bcrypt/src/main/java/com/liferay/portal/crypto/hash/provider/bcrypt/internal/component/enabler/ComponentEnabler.java
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.crypto.hash.provider.bcrypt.internal.component.enabler;
+
+import com.liferay.portal.crypto.hash.provider.bcrypt.internal.BCryptCryptoHashProviderFactory;
+import com.liferay.portal.kernel.util.PropsValues;
+
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Caio Farias
+ */
+@Component(service = {})
+public class ComponentEnabler {
+
+	@Activate
+	protected void activate(ComponentContext componentContext) {
+		if (!PropsValues.FIPS_ENABLED) {
+			componentContext.enableComponent(
+				BCryptCryptoHashProviderFactory.class.getName());
+		}
+	}
+
+}

--- a/modules/apps/portal-crypto-hash/portal-crypto-hash-provider/portal-crypto-hash-provider-bcrypt/src/main/java/com/liferay/portal/crypto/hash/provider/bcrypt/internal/component/enabler/ComponentEnabler.java
+++ b/modules/apps/portal-crypto-hash/portal-crypto-hash-provider/portal-crypto-hash-provider-bcrypt/src/main/java/com/liferay/portal/crypto/hash/provider/bcrypt/internal/component/enabler/ComponentEnabler.java
@@ -20,10 +20,12 @@ public class ComponentEnabler {
 
 	@Activate
 	protected void activate(ComponentContext componentContext) {
-		if (!PropsValues.FIPS_ENABLED) {
-			componentContext.enableComponent(
-				BCryptCryptoHashProviderFactory.class.getName());
+		if (PropsValues.FIPS_ENABLED) {
+			return;
 		}
+
+		componentContext.enableComponent(
+			BCryptCryptoHashProviderFactory.class.getName());
 	}
 
 }

--- a/modules/apps/portal-crypto-hash/portal-crypto-hash-test/build.gradle
+++ b/modules/apps/portal-crypto-hash/portal-crypto-hash-test/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
 	testIntegrationImplementation group: "com.liferay", name: "jodd.util", version: "6.0.1.LIFERAY-PATCHED-2"
 	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
+	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-crypto-hash:portal-crypto-hash-api")
 	testIntegrationImplementation project(":apps:static:osgi:osgi-util")

--- a/modules/apps/portal-crypto-hash/portal-crypto-hash-test/src/testIntegration/java/com/liferay/portal/crypto/hash/test/CryptoHashTest.java
+++ b/modules/apps/portal-crypto-hash/portal-crypto-hash-test/src/testIntegration/java/com/liferay/portal/crypto/hash/test/CryptoHashTest.java
@@ -7,6 +7,7 @@ package com.liferay.portal.crypto.hash.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.crypto.hash.CryptoHashGenerator;
@@ -17,6 +18,7 @@ import com.liferay.portal.crypto.hash.exception.CryptoHashException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -34,6 +36,7 @@ import java.util.Collections;
 import java.util.Dictionary;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Objects;
 
 import jodd.util.BCrypt;
 
@@ -50,6 +53,9 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
+import org.osgi.service.component.runtime.ServiceComponentRuntime;
+import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
+import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * @author Carlos Sierra Andrés
@@ -198,6 +204,38 @@ public class CryptoHashTest {
 
 				return null;
 			});
+	}
+
+	@Test
+	public void testCryptoHashProviderFactoryInFIPSMode() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			_restartBundle();
+
+			ComponentDescriptionDTO componentDescriptionDTO =
+				_serviceComponentRuntime.getComponentDescriptionDTO(
+					_getBundle(),
+					_COMPONENT_NAME_BCRYPT_CRYPTO_HASH_PROVIDER_FACTORY);
+
+			Assert.assertNotNull(componentDescriptionDTO);
+			Assert.assertFalse(
+				_serviceComponentRuntime.isComponentEnabled(
+					componentDescriptionDTO));
+
+			Assert.assertThrows(
+				CryptoHashException.class,
+				() -> _cryptoHashVerifier.verify(
+					_password, _expectedBCryptHash,
+					new CryptoHashVerificationContext(
+						"BCrypt", Collections.emptyMap(), _bCryptSalt)));
+		}
+		finally {
+			_restartBundle();
+		}
+
+		Assert.assertNotNull(_waitForCryptoHashProviderFactory());
 	}
 
 	@Test
@@ -355,6 +393,56 @@ public class CryptoHashTest {
 		return null;
 	}
 
+	private Bundle _getBundle() {
+		for (Bundle bundle : _bundleContext.getBundles()) {
+			if (Objects.equals(
+					bundle.getSymbolicName(), _BUNDLE_SYMBOLIC_NAME)) {
+
+				return bundle;
+			}
+		}
+
+		return null;
+	}
+
+	private void _restartBundle() throws Exception {
+		Bundle bundle = _getBundle();
+
+		if (bundle == null) {
+			return;
+		}
+
+		bundle.stop();
+
+		bundle.start();
+	}
+
+	private Object _waitForCryptoHashProviderFactory() throws Exception {
+		ServiceTracker<Object, Object> serviceTracker = new ServiceTracker<>(
+			_bundleContext,
+			_bundleContext.createFilter(
+				"(component.name=" +
+					_COMPONENT_NAME_BCRYPT_CRYPTO_HASH_PROVIDER_FACTORY + ")"),
+			null);
+
+		serviceTracker.open();
+
+		try {
+			return serviceTracker.waitForService(10000);
+		}
+		finally {
+			serviceTracker.close();
+		}
+	}
+
+	private static final String _BUNDLE_SYMBOLIC_NAME =
+		"com.liferay.portal.crypto.hash.provider.bcrypt";
+
+	private static final String
+		_COMPONENT_NAME_BCRYPT_CRYPTO_HASH_PROVIDER_FACTORY =
+			"com.liferay.portal.crypto.hash.provider.bcrypt.internal." +
+				"BCryptCryptoHashProviderFactory";
+
 	private static final Log _log = LogFactoryUtil.getLog(CryptoHashTest.class);
 
 	private static byte[] _bCryptSalt;
@@ -368,5 +456,8 @@ public class CryptoHashTest {
 
 	@Inject
 	private CryptoHashVerifier _cryptoHashVerifier;
+
+	@Inject
+	private ServiceComponentRuntime _serviceComponentRuntime;
 
 }

--- a/modules/apps/portal-crypto-hash/portal-crypto-hash-test/src/testIntegration/java/com/liferay/portal/crypto/hash/test/CryptoHashTest.java
+++ b/modules/apps/portal-crypto-hash/portal-crypto-hash-test/src/testIntegration/java/com/liferay/portal/crypto/hash/test/CryptoHashTest.java
@@ -55,7 +55,6 @@ import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
 import org.osgi.service.component.runtime.ServiceComponentRuntime;
 import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
-import org.osgi.util.tracker.ServiceTracker;
 
 /**
  * @author Carlos Sierra Andrés
@@ -214,15 +213,7 @@ public class CryptoHashTest {
 
 			_restartBundle();
 
-			ComponentDescriptionDTO componentDescriptionDTO =
-				_serviceComponentRuntime.getComponentDescriptionDTO(
-					_getBundle(),
-					_COMPONENT_NAME_BCRYPT_CRYPTO_HASH_PROVIDER_FACTORY);
-
-			Assert.assertNotNull(componentDescriptionDTO);
-			Assert.assertFalse(
-				_serviceComponentRuntime.isComponentEnabled(
-					componentDescriptionDTO));
+			_assertIsComponentEnabled(false);
 
 			Assert.assertThrows(
 				CryptoHashException.class,
@@ -235,7 +226,7 @@ public class CryptoHashTest {
 			_restartBundle();
 		}
 
-		Assert.assertNotNull(_waitForCryptoHashProviderFactory());
+		_assertIsComponentEnabled(true);
 	}
 
 	@Test
@@ -351,6 +342,34 @@ public class CryptoHashTest {
 			() -> ConfigurationTestUtil.deleteConfiguration(configurationPid));
 	}
 
+	private void _assertIsComponentEnabled(boolean expectedEnabled)
+		throws Exception {
+
+		ComponentDescriptionDTO componentDescriptionDTO =
+			_serviceComponentRuntime.getComponentDescriptionDTO(
+				_getBundle(),
+				_COMPONENT_NAME_BCRYPT_CRYPTO_HASH_PROVIDER_FACTORY);
+
+		Assert.assertNotNull(componentDescriptionDTO);
+
+		for (int i = 0; i < 100; i++) {
+			boolean componentEnabled =
+				_serviceComponentRuntime.isComponentEnabled(
+					componentDescriptionDTO);
+
+			if (componentEnabled == expectedEnabled) {
+				return;
+			}
+
+			Thread.sleep(100);
+		}
+
+		Assert.assertEquals(
+			expectedEnabled,
+			_serviceComponentRuntime.isComponentEnabled(
+				componentDescriptionDTO));
+	}
+
 	private <S, R, E extends Throwable> R _callService(
 		Class<S> serviceClass, String filterString,
 		UnsafeFunction<S, R, E> unsafeFunction) {
@@ -415,24 +434,6 @@ public class CryptoHashTest {
 		bundle.stop();
 
 		bundle.start();
-	}
-
-	private Object _waitForCryptoHashProviderFactory() throws Exception {
-		ServiceTracker<Object, Object> serviceTracker = new ServiceTracker<>(
-			_bundleContext,
-			_bundleContext.createFilter(
-				"(component.name=" +
-					_COMPONENT_NAME_BCRYPT_CRYPTO_HASH_PROVIDER_FACTORY + ")"),
-			null);
-
-		serviceTracker.open();
-
-		try {
-			return serviceTracker.waitForService(10000);
-		}
-		finally {
-			serviceTracker.close();
-		}
 	}
 
 	private static final String _BUNDLE_SYMBOLIC_NAME =

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/build.gradle
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	compileOnly group: "com.liferay", name: "jodd.util", version: "6.0.1.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":core:osgi-service-tracker-collections")

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/BCryptPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/BCryptPasswordEncryptor.java
@@ -23,7 +23,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Tomas Polesovsky
  */
 @Component(
-	property = "type=" + PasswordEncryptor.TYPE_BCRYPT,
+	enabled = false, property = "type=" + PasswordEncryptor.TYPE_BCRYPT,
 	service = PasswordEncryptor.class
 )
 public class BCryptPasswordEncryptor implements PasswordEncryptor {

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/CryptPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/CryptPasswordEncryptor.java
@@ -25,7 +25,7 @@ import org.vps.crypt.Crypt;
  * @author Tomas Polesovsky
  */
 @Component(
-	property = "type=" + PasswordEncryptor.TYPE_UFC_CRYPT,
+	enabled = false, property = "type=" + PasswordEncryptor.TYPE_UFC_CRYPT,
 	service = PasswordEncryptor.class
 )
 public class CryptPasswordEncryptor implements PasswordEncryptor {

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/component/enabler/ComponentEnabler.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/component/enabler/ComponentEnabler.java
@@ -1,0 +1,32 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.password.encryptor.internal.component.enabler;
+
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.security.password.encryptor.internal.BCryptPasswordEncryptor;
+import com.liferay.portal.security.password.encryptor.internal.CryptPasswordEncryptor;
+
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Caio Farias
+ */
+@Component(service = {})
+public class ComponentEnabler {
+
+	@Activate
+	protected void activate(ComponentContext componentContext) {
+		if (!PropsValues.FIPS_ENABLED) {
+			componentContext.enableComponent(
+				BCryptPasswordEncryptor.class.getName());
+			componentContext.enableComponent(
+				CryptPasswordEncryptor.class.getName());
+		}
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/component/enabler/ComponentEnabler.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/component/enabler/ComponentEnabler.java
@@ -21,12 +21,14 @@ public class ComponentEnabler {
 
 	@Activate
 	protected void activate(ComponentContext componentContext) {
-		if (!PropsValues.FIPS_ENABLED) {
-			componentContext.enableComponent(
-				BCryptPasswordEncryptor.class.getName());
-			componentContext.enableComponent(
-				CryptPasswordEncryptor.class.getName());
+		if (PropsValues.FIPS_ENABLED) {
+			return;
 		}
+
+		componentContext.enableComponent(
+			BCryptPasswordEncryptor.class.getName());
+		componentContext.enableComponent(
+			CryptPasswordEncryptor.class.getName());
 	}
 
 }

--- a/modules/apps/portal-security/portal-security-password-encryptor-test/bnd.bnd
+++ b/modules/apps/portal-security/portal-security-password-encryptor-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Portal Security Password Encryptor Test
+Bundle-SymbolicName: com.liferay.portal.security.password.encryptor.test
+Bundle-Version: 1.0.0

--- a/modules/apps/portal-security/portal-security-password-encryptor-test/build.gradle
+++ b/modules/apps/portal-security/portal-security-password-encryptor-test/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+	testIntegrationImplementation group: "org.osgi", name: "org.osgi.service.component", version: "1.4.0"
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/portal-security/portal-security-password-encryptor-test/src/testIntegration/java/com/liferay/portal/security/password/encryptor/test/PasswordEncryptorUtilTest.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-test/src/testIntegration/java/com/liferay/portal/security/password/encryptor/test/PasswordEncryptorUtilTest.java
@@ -1,0 +1,169 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.password.encryptor.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
+import com.liferay.portal.kernel.security.pwd.PasswordEncryptorUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Objects;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.runtime.ServiceComponentRuntime;
+import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
+import org.osgi.util.tracker.ServiceTracker;
+
+/**
+ * @author Caio Farias
+ */
+@RunWith(Arquillian.class)
+public class PasswordEncryptorUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testEncrypt() throws Exception {
+		_testEncrypt(PasswordEncryptor.TYPE_BCRYPT);
+		_testEncrypt(PasswordEncryptor.TYPE_UFC_CRYPT);
+	}
+
+	@Test
+	public void testPasswordEncryptorsInFIPSMode() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			_restartBundle();
+
+			Assert.assertFalse(
+				_isComponentEnabled(_COMPONENT_NAME_BCRYPT_PASSWORD_ENCRYPTOR));
+			Assert.assertFalse(
+				_isComponentEnabled(_COMPONENT_NAME_CRYPT_PASSWORD_ENCRYPTOR));
+		}
+		finally {
+			_restartBundle();
+		}
+
+		Assert.assertNotNull(
+			_waitForPasswordEncryptor(PasswordEncryptor.TYPE_BCRYPT));
+		Assert.assertNotNull(
+			_waitForPasswordEncryptor(PasswordEncryptor.TYPE_UFC_CRYPT));
+	}
+
+	private Bundle _getBundle() {
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		for (Bundle bundle : bundleContext.getBundles()) {
+			if (Objects.equals(
+					bundle.getSymbolicName(), _BUNDLE_SYMBOLIC_NAME)) {
+
+				return bundle;
+			}
+		}
+
+		return null;
+	}
+
+	private boolean _isComponentEnabled(String componentName) {
+		Bundle bundle = _getBundle();
+
+		if (bundle == null) {
+			return false;
+		}
+
+		ComponentDescriptionDTO componentDescriptionDTO =
+			_serviceComponentRuntime.getComponentDescriptionDTO(
+				bundle, componentName);
+
+		if (componentDescriptionDTO == null) {
+			return false;
+		}
+
+		return _serviceComponentRuntime.isComponentEnabled(
+			componentDescriptionDTO);
+	}
+
+	private void _restartBundle() throws Exception {
+		Bundle bundle = _getBundle();
+
+		if (bundle == null) {
+			return;
+		}
+
+		bundle.stop();
+
+		bundle.start();
+	}
+
+	private void _testEncrypt(String algorithm) throws Exception {
+		String password = RandomTestUtil.randomString();
+
+		String encryptedPassword = PasswordEncryptorUtil.encrypt(
+			algorithm, password, null);
+
+		Assert.assertEquals(
+			encryptedPassword,
+			PasswordEncryptorUtil.encrypt(
+				algorithm, password, encryptedPassword));
+	}
+
+	private PasswordEncryptor _waitForPasswordEncryptor(String type)
+		throws Exception {
+
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		ServiceTracker<PasswordEncryptor, PasswordEncryptor> serviceTracker =
+			new ServiceTracker<>(
+				bundleContext,
+				bundleContext.createFilter(
+					StringBundler.concat(
+						"(&(objectClass=", PasswordEncryptor.class.getName(),
+						")(type=", type, "))")),
+				null);
+
+		serviceTracker.open();
+
+		try {
+			return serviceTracker.waitForService(10000);
+		}
+		finally {
+			serviceTracker.close();
+		}
+	}
+
+	private static final String _BUNDLE_SYMBOLIC_NAME =
+		"com.liferay.portal.security.password.encryptor.impl";
+
+	private static final String _COMPONENT_NAME_BCRYPT_PASSWORD_ENCRYPTOR =
+		"com.liferay.portal.security.password.encryptor.internal." +
+			"BCryptPasswordEncryptor";
+
+	private static final String _COMPONENT_NAME_CRYPT_PASSWORD_ENCRYPTOR =
+		"com.liferay.portal.security.password.encryptor.internal." +
+			"CryptPasswordEncryptor";
+
+	@Inject
+	private ServiceComponentRuntime _serviceComponentRuntime;
+
+}

--- a/modules/apps/portal-security/portal-security-password-encryptor-test/src/testIntegration/java/com/liferay/portal/security/password/encryptor/test/PasswordEncryptorUtilTest.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-test/src/testIntegration/java/com/liferay/portal/security/password/encryptor/test/PasswordEncryptorUtilTest.java
@@ -57,18 +57,22 @@ public class PasswordEncryptorUtilTest {
 			_restartBundle();
 
 			Assert.assertFalse(
-				_isComponentEnabled(_COMPONENT_NAME_BCRYPT_PASSWORD_ENCRYPTOR));
+				_isComponentEnabled(
+					"com.liferay.portal.security.password.encryptor.internal." +
+						"BCryptPasswordEncryptor"));
 			Assert.assertFalse(
-				_isComponentEnabled(_COMPONENT_NAME_CRYPT_PASSWORD_ENCRYPTOR));
+				_isComponentEnabled(
+					"com.liferay.portal.security.password.encryptor.internal." +
+						"CryptPasswordEncryptor"));
 		}
 		finally {
 			_restartBundle();
 		}
 
 		Assert.assertNotNull(
-			_waitForPasswordEncryptor(PasswordEncryptor.TYPE_BCRYPT));
+			_getPasswordEncryptor(PasswordEncryptor.TYPE_BCRYPT));
 		Assert.assertNotNull(
-			_waitForPasswordEncryptor(PasswordEncryptor.TYPE_UFC_CRYPT));
+			_getPasswordEncryptor(PasswordEncryptor.TYPE_UFC_CRYPT));
 	}
 
 	private Bundle _getBundle() {
@@ -83,6 +87,30 @@ public class PasswordEncryptorUtilTest {
 		}
 
 		return null;
+	}
+
+	private PasswordEncryptor _getPasswordEncryptor(String type)
+		throws Exception {
+
+		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
+
+		ServiceTracker<PasswordEncryptor, PasswordEncryptor> serviceTracker =
+			new ServiceTracker<>(
+				bundleContext,
+				bundleContext.createFilter(
+					StringBundler.concat(
+						"(&(objectClass=", PasswordEncryptor.class.getName(),
+						")(type=", type, "))")),
+				null);
+
+		serviceTracker.open();
+
+		try {
+			return serviceTracker.waitForService(10000);
+		}
+		finally {
+			serviceTracker.close();
+		}
 	}
 
 	private boolean _isComponentEnabled(String componentName) {
@@ -128,40 +156,8 @@ public class PasswordEncryptorUtilTest {
 				algorithm, password, encryptedPassword));
 	}
 
-	private PasswordEncryptor _waitForPasswordEncryptor(String type)
-		throws Exception {
-
-		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
-
-		ServiceTracker<PasswordEncryptor, PasswordEncryptor> serviceTracker =
-			new ServiceTracker<>(
-				bundleContext,
-				bundleContext.createFilter(
-					StringBundler.concat(
-						"(&(objectClass=", PasswordEncryptor.class.getName(),
-						")(type=", type, "))")),
-				null);
-
-		serviceTracker.open();
-
-		try {
-			return serviceTracker.waitForService(10000);
-		}
-		finally {
-			serviceTracker.close();
-		}
-	}
-
 	private static final String _BUNDLE_SYMBOLIC_NAME =
 		"com.liferay.portal.security.password.encryptor.impl";
-
-	private static final String _COMPONENT_NAME_BCRYPT_PASSWORD_ENCRYPTOR =
-		"com.liferay.portal.security.password.encryptor.internal." +
-			"BCryptPasswordEncryptor";
-
-	private static final String _COMPONENT_NAME_CRYPT_PASSWORD_ENCRYPTOR =
-		"com.liferay.portal.security.password.encryptor.internal." +
-			"CryptPasswordEncryptor";
 
 	@Inject
 	private ServiceComponentRuntime _serviceComponentRuntime;

--- a/modules/apps/portal-security/portal-security-password-encryptor-test/test.properties
+++ b/modules/apps/portal-security/portal-security-password-encryptor-test/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Password


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88187

## Why

In FIPS mode every cryptographic operation must go through a FIPS-validated JCA provider, but BCrypt (jodd) and UFC-CRYPT (org.vps.crypt) are standalone non-JCA implementations that stay reachable for password hashing and verification (LPD-88187).

## Key changes

- Declare the BCrypt and UFC-CRYPT components disabled so availability becomes a deployment-mode decision.
- Add a per-bundle `ComponentEnabler` that enables them only when FIPS mode is off.
- Add integration tests asserting the components are disabled in FIPS mode and restored outside it.