### PR TITLE
LPD-93632 Wait for scoped configuration deletion in tearDown

### DIFF
--- a/modules/apps/portal-security/portal-security-iframe-sanitizer-test/src/testIntegration/java/com/liferay/portal/security/iframe/sanitizer/internal/test/IFrameSanitizerImplTest.java
+++ b/modules/apps/portal-security/portal-security-iframe-sanitizer-test/src/testIntegration/java/com/liferay/portal/security/iframe/sanitizer/internal/test/IFrameSanitizerImplTest.java
@@ -66,7 +66,7 @@ public class IFrameSanitizerImplTest {
 			Configuration configuration = configurations[0];
 
 			if (configuration != null) {
-				configuration.delete();
+				ConfigurationTestUtil.deleteConfiguration(configuration);
 			}
 		}
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93632

## Failing Test

`com.liferay.portal.security.iframe.sanitizer.internal.test.IFrameSanitizerImplTest`

`modules/apps/portal-security/portal-security-iframe-sanitizer-test/src/testIntegration/java/com/liferay/portal/security/iframe/sanitizer/internal/test/IFrameSanitizerImplTest.java`

```
testSanitizeHTMLWithIFrameJournalArticleClassNameWhitelistedByDefault: org.junit.ComparisonFailure: expected:<...1><iframe src="test"[]></iframe>> but was:<...1><iframe src="test"[ sandbox=""]></iframe>>  at org.junit.Assert.assertEquals(Assert.java:117)
```

## Root Cause

Commit `6fce7b5464a31` ("LPD-28893 New test to check that the changed configuration works with company scope now...") added a tearDown that deletes the company-scoped configuration with a raw `Configuration.delete()`, which returns before ConfigurationAdmin delivers the deleted event to `IFrameConfigurationHelper`. When the next test starts before the event is processed, the sanitizer still sees the stale company whitelist (empty), so the test asserting the default whitelist (`com.liferay.journal.model.JournalArticle`) intermittently sees `sandbox=""` added. This matches the flip-flopping Testray history (FAILED/PASSED alternating with no code changes to the module).

## Fix

Replace the raw `Configuration.delete()` in tearDown with `ConfigurationTestUtil.deleteConfiguration(configuration)`, which blocks until the deletion has propagated through the ConfigurationAdmin event queue, so each test starts from the default configuration.

- `modules/apps/portal-security/portal-security-iframe-sanitizer-test/src/testIntegration/java/com/liferay/portal/security/iframe/sanitizer/internal/test/IFrameSanitizerImplTest.java`

## PR Check

**pr-check: SKIPPED** — Structural Smoke failure is pre-existing on master (Log4jConfigUtil coverage gap, LPD-70455), unrelated to this test-only diff. Source Format and Integration Test Compile passed on `c7104ebbb2695`.

<!-- pr-check {"reason": "Structural Smoke failure is pre-existing on master (Log4jConfigUtil coverage gap, LPD-70455), unrelated to this test-only diff", "result": "skipped", "sha": "c7104ebbb2695cee1b0ae07fe6b79013cadcb457"} -->
