### PR TITLE
[FIPS] LPD-90288 Enforce FIPS-approved algorithm selection

### DIFF
--- a/modules/apps/analytics/analytics-settings-impl/src/main/java/com/liferay/analytics/settings/internal/security/auth/verifier/AnalyticsSecurityAuthVerifier.java
+++ b/modules/apps/analytics/analytics-settings-impl/src/main/java/com/liferay/analytics/settings/internal/security/auth/verifier/AnalyticsSecurityAuthVerifier.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsValues;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -166,9 +167,11 @@ public class AnalyticsSecurityAuthVerifier implements AuthVerifier {
 			String signatureString, String timestamp)
 		throws Exception {
 
-		Signature signature = Signature.getInstance("DSA");
+		Signature signature = Signature.getInstance(
+			PropsValues.FIPS_ENABLED ? _SHA_256_WITH_ECDSA : _DSA);
 
-		KeyFactory keyFactory = KeyFactory.getInstance("DSA");
+		KeyFactory keyFactory = KeyFactory.getInstance(
+			PropsValues.FIPS_ENABLED ? _EC : _DSA);
 
 		signature.initVerify(
 			keyFactory.generatePublic(
@@ -203,7 +206,13 @@ public class AnalyticsSecurityAuthVerifier implements AuthVerifier {
 		return signature.verify(Base64.decode(signatureString));
 	}
 
+	private static final String _DSA = "DSA";
+
+	private static final String _EC = "EC";
+
 	private static final long _EXPIRATION = 10 * 60 * 1000;
+
+	private static final String _SHA_256_WITH_ECDSA = "SHA256withECDSA";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AnalyticsSecurityAuthVerifier.class);

--- a/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/hashed/files/HashedFilesRegistryImpl.java
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/hashed/files/HashedFilesRegistryImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import jakarta.servlet.ServletContext;
@@ -336,7 +337,9 @@ public class HashedFilesRegistryImpl implements HashedFilesRegistry {
 
 		String hashesString = StringUtil.merge(hashesList, StringPool.PIPE);
 
-		byte[] hash = DigesterUtil.digestRaw(DigesterUtil.MD5, hashesString);
+		byte[] hash = DigesterUtil.digestRaw(
+			PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 : DigesterUtil.MD5,
+			hashesString);
 
 		byte[] truncatedHash = new byte[8];
 

--- a/modules/apps/frontend-js/frontend-js-web/src/test/java/com/liferay/frontend/js/web/internal/hashed/files/HashedFilesRegistryImplTest.java
+++ b/modules/apps/frontend-js/frontend-js-web/src/test/java/com/liferay/frontend/js/web/internal/hashed/files/HashedFilesRegistryImplTest.java
@@ -10,6 +10,9 @@ import com.liferay.frontend.js.web.test.util.FrontendJSWebTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -17,6 +20,8 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import jakarta.servlet.ServletContext;
 
 import java.net.URL;
+
+import java.security.MessageDigest;
 
 import java.util.Map;
 
@@ -78,6 +83,22 @@ public class HashedFilesRegistryImplTest {
 
 		Assert.assertNotNull(
 			hashedFilesRegistryImpl.getResource("/o/frontend-js-web/main.css"));
+	}
+
+	@Test
+	public void testGetServletContextHash() throws Exception {
+		Map<String, String> hashedFileURIs = HashMapBuilder.put(
+			"/o/frontend-js-web/main.css",
+			HashedFilesUtil.addHash(
+				"/o/frontend-js-web/main.css", RandomTestUtil.randomString())
+		).build();
+
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			() -> ReflectionTestUtil.invoke(
+				new HashedFilesRegistryImpl(), "_getServletContextHash",
+				new Class<?>[] {Map.class}, hashedFileURIs),
+			DigesterUtil.MD5, MessageDigest::getInstance, MessageDigest.class,
+			DigesterUtil.SHA_256);
 	}
 
 	private Map<String, HashedFilesRegistryImpl.DataBag> _mockDataBags(

--- a/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientASLocalMetadataLocalServiceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientASLocalMetadataLocalServiceImpl.java
@@ -23,8 +23,10 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -433,7 +435,9 @@ public class OAuthClientASLocalMetadataLocalServiceImpl
 			URI issuerURI = URI.create(issuer);
 
 			if (wellKnownURISuffix.equals("openid-configuration")) {
-				MessageDigest messageDigest = MessageDigest.getInstance("MD5");
+				MessageDigest messageDigest = MessageDigest.getInstance(
+					PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 :
+						DigesterUtil.MD5);
 
 				return StringBundler.concat(
 					issuerURI.getScheme(), "://", issuerURI.getAuthority(),

--- a/modules/apps/portal-crypto-hash/portal-crypto-hash-impl/build.gradle
+++ b/modules/apps/portal-crypto-hash/portal-crypto-hash-impl/build.gradle
@@ -9,4 +9,6 @@ dependencies {
 	testImplementation group: "com.liferay", name: "jodd.util", version: "6.0.1.LIFERAY-PATCHED-2"
 	testImplementation project(":apps:portal-crypto-hash:portal-crypto-hash-provider:portal-crypto-hash-provider-bcrypt")
 	testImplementation project(":apps:portal-crypto-hash:portal-crypto-hash-provider:portal-crypto-hash-provider-message-digest")
+	testImplementation project(":core:petra:petra-function")
+	testImplementation project(":core:petra:petra-lang")
 }

--- a/modules/apps/portal-crypto-hash/portal-crypto-hash-impl/src/test/java/com/liferay/portal/crypto/hash/internal/CryptoHashGeneratorTest.java
+++ b/modules/apps/portal-crypto-hash/portal-crypto-hash-impl/src/test/java/com/liferay/portal/crypto/hash/internal/CryptoHashGeneratorTest.java
@@ -12,8 +12,12 @@ import com.liferay.portal.crypto.hash.provider.bcrypt.internal.BCryptCryptoHashP
 import com.liferay.portal.crypto.hash.provider.message.digest.internal.MessageDigestCryptoHashProviderFactory;
 import com.liferay.portal.crypto.hash.spi.CryptoHashProviderFactory;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.security.MessageDigest;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -79,6 +83,20 @@ public class CryptoHashGeneratorTest {
 		_serviceRegistration2.unregister();
 
 		_serviceRegistration1.unregister();
+	}
+
+	@Test
+	public void testCreate() throws Exception {
+		MessageDigestCryptoHashProviderFactory
+			messageDigestCryptoHashProviderFactory =
+				new MessageDigestCryptoHashProviderFactory();
+
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			() -> messageDigestCryptoHashProviderFactory.create(
+				Collections.singletonMap(
+					"message.digest.algorithm", DigesterUtil.MD5)),
+			DigesterUtil.MD5, MessageDigest::getInstance, MessageDigest.class,
+			DigesterUtil.SHA_256);
 	}
 
 	@Test

--- a/modules/apps/portal-crypto-hash/portal-crypto-hash-provider/portal-crypto-hash-provider-message-digest/src/main/java/com/liferay/portal/crypto/hash/provider/message/digest/internal/MessageDigestCryptoHashProviderFactory.java
+++ b/modules/apps/portal-crypto-hash/portal-crypto-hash-provider/portal-crypto-hash-provider-message-digest/src/main/java/com/liferay/portal/crypto/hash/provider/message/digest/internal/MessageDigestCryptoHashProviderFactory.java
@@ -11,7 +11,9 @@ import com.liferay.portal.crypto.hash.spi.CryptoHashProviderFactory;
 import com.liferay.portal.crypto.hash.spi.CryptoHashProviderResponse;
 import com.liferay.portal.kernel.security.SecureRandomUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -67,10 +69,15 @@ public class MessageDigestCryptoHashProviderFactory
 
 			_cryptoHashProviderProperties = cryptoHashProviderProperties;
 
-			_messageDigest = MessageDigest.getInstance(
-				MapUtil.getString(
+			String algorithm = DigesterUtil.SHA_256;
+
+			if (!PropsValues.FIPS_ENABLED) {
+				algorithm = MapUtil.getString(
 					cryptoHashProviderProperties, "message.digest.algorithm",
-					"SHA-256"));
+					DigesterUtil.SHA_256);
+			}
+
+			_messageDigest = MessageDigest.getInstance(algorithm);
 			_saltSize = MapUtil.getInteger(
 				cryptoHashProviderProperties, "message.digest.salt.size", 32);
 		}

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtil.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtil.java
@@ -14,6 +14,8 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 
 import java.net.URI;
 
@@ -36,8 +38,9 @@ public class OpenIdConnectProviderUtil {
 			String issuer, String tokenEndpoint)
 		throws Exception {
 
-		MessageDigest messageDigest = MessageDigest.getInstance("MD5");
 		URI issuerURI = URI.create(issuer);
+		MessageDigest messageDigest = MessageDigest.getInstance(
+			PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 : DigesterUtil.MD5);
 
 		return StringBundler.concat(
 			issuerURI.getScheme(), "://", issuerURI.getAuthority(),

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtilTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtilTest.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.sso.openid.connect.internal.util;
+
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.security.MessageDigest;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class OpenIdConnectProviderUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGenerateLocalWellKnownURI() throws Exception {
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			() -> OpenIdConnectProviderUtil.generateLocalWellKnownURI(
+				"https://" + RandomTestUtil.randomString(),
+				RandomTestUtil.randomString()),
+			DigesterUtil.MD5, MessageDigest::getInstance, MessageDigest.class,
+			DigesterUtil.SHA_256);
+	}
+
+}

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/src/main/java/com/liferay/portal/security/sso/openid/connect/persistence/internal/upgrade/v2_0_0/OpenIdConnectSessionUpgradeProcess.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/src/main/java/com/liferay/portal/security/sso/openid/connect/persistence/internal/upgrade/v2_0_0/OpenIdConnectSessionUpgradeProcess.java
@@ -12,7 +12,9 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.net.URI;
@@ -93,7 +95,8 @@ public class OpenIdConnectSessionUpgradeProcess extends UpgradeProcess {
 		throws Exception {
 
 		URI issuerURI = URI.create(issuer);
-		MessageDigest messageDigest = MessageDigest.getInstance("MD5");
+		MessageDigest messageDigest = MessageDigest.getInstance(
+			PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 : DigesterUtil.MD5);
 
 		return StringBundler.concat(
 			issuerURI.getScheme(), "://", issuerURI.getAuthority(),

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/build.gradle
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":core:osgi-service-tracker-collections")
+	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-reflect")

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/SSHAPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/SSHAPasswordEncryptor.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.UnsupportedEncodingException;
@@ -44,7 +45,9 @@ public class SSHAPasswordEncryptor implements PasswordEncryptor {
 		byte[] saltBytes = getSaltBytes(encryptedPassword);
 
 		try {
-			MessageDigest messageDigest = MessageDigest.getInstance("SHA-1");
+			MessageDigest messageDigest = MessageDigest.getInstance(
+				PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 :
+					DigesterUtil.SHA_1);
 
 			byte[] plainTextPasswordBytes = plainTextPassword.getBytes(
 				DigesterUtil.ENCODING);

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
@@ -13,10 +13,14 @@ import com.liferay.portal.kernel.exception.PwdEncryptorException;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptorUtil;
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.security.MessageDigest;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -250,6 +254,22 @@ public class PasswordEncryptorUtilTest {
 			PasswordEncryptor.TYPE_SSHA, "password",
 			"2EWEKeVpSdd79PkTX5vaGXH5uQ028Smy/H1NmA==",
 			PasswordEncryptor.TYPE_SSHA);
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			_runTests(
+				PasswordEncryptor.TYPE_SSHA, "password",
+				"q0elUchHiEgZAZww57UMs6Jt+L45+785Q8YcVUf8VfcAAQIDBAUGBw==",
+				PasswordEncryptor.TYPE_SSHA);
+		}
+
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			() -> PasswordEncryptorUtil.encrypt(
+				PasswordEncryptor.TYPE_SSHA, "password", null),
+			DigesterUtil.SHA_1, MessageDigest::getInstance, MessageDigest.class,
+			DigesterUtil.SHA_256);
 	}
 
 	@Test

--- a/modules/apps/static/portal/portal-encryptor/src/main/java/com/liferay/portal/encryptor/EncryptorImpl.java
+++ b/modules/apps/static/portal/portal-encryptor/src/main/java/com/liferay/portal/encryptor/EncryptorImpl.java
@@ -15,16 +15,19 @@ import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.security.Key;
 import java.security.SecureRandom;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.osgi.service.component.annotations.Component;
@@ -59,13 +62,40 @@ public class EncryptorImpl implements Encryptor {
 	public byte[] decryptUnencodedAsBytes(Key key, byte[] encryptedBytes)
 		throws EncryptorException {
 
-		String algorithm = key.getAlgorithm();
+		if (PropsValues.FIPS_ENABLED) {
+			try {
+				Cipher cipher = Cipher.getInstance(_FIPS_CIPHER_TRANSFORMATION);
 
-		String cacheKey = algorithm + StringPool.POUND + key.toString();
+				byte[] cipherBytes = Arrays.copyOfRange(
+					encryptedBytes, _FIPS_GCM_INITIALIZATION_VECTOR_LENGTH,
+					encryptedBytes.length);
 
-		Cipher cipher = _decryptCipherMap.get(cacheKey);
+				byte[] initializationVector = Arrays.copyOfRange(
+					encryptedBytes, 0, _FIPS_GCM_INITIALIZATION_VECTOR_LENGTH);
+
+				cipher.init(
+					Cipher.DECRYPT_MODE, key,
+					new GCMParameterSpec(
+						_FIPS_GCM_TAG_LENGTH_BITS, initializationVector));
+
+				return cipher.doFinal(cipherBytes);
+			}
+			catch (Exception exception) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Falling back to legacy decryption after GCM failure",
+						exception);
+				}
+			}
+		}
 
 		try {
+			String algorithm = key.getAlgorithm();
+
+			String cacheKey = algorithm + StringPool.POUND + key;
+
+			Cipher cipher = _decryptCipherMap.get(cacheKey);
+
 			if (cipher == null) {
 				cipher = Cipher.getInstance(algorithm);
 
@@ -87,7 +117,9 @@ public class EncryptorImpl implements Encryptor {
 	public Key deserializeKey(String base64String) {
 		byte[] bytes = Base64.decode(base64String);
 
-		return new SecretKeySpec(bytes, EncryptorImpl.KEY_ALGORITHM);
+		return new SecretKeySpec(
+			bytes,
+			PropsValues.FIPS_ENABLED ? _AES : EncryptorImpl.KEY_ALGORITHM);
 	}
 
 	@Override
@@ -109,13 +141,41 @@ public class EncryptorImpl implements Encryptor {
 	public byte[] encryptUnencoded(Key key, byte[] plainBytes)
 		throws EncryptorException {
 
-		String algorithm = key.getAlgorithm();
-
-		String cacheKey = algorithm + StringPool.POUND + key.toString();
-
-		Cipher cipher = _encryptCipherMap.get(cacheKey);
-
 		try {
+			if (PropsValues.FIPS_ENABLED) {
+				byte[] initializationVector =
+					new byte[_FIPS_GCM_INITIALIZATION_VECTOR_LENGTH];
+
+				_secureRandom.nextBytes(initializationVector);
+
+				Cipher cipher = Cipher.getInstance(_FIPS_CIPHER_TRANSFORMATION);
+
+				cipher.init(
+					Cipher.ENCRYPT_MODE, key,
+					new GCMParameterSpec(
+						_FIPS_GCM_TAG_LENGTH_BITS, initializationVector));
+
+				byte[] cipherBytes = cipher.doFinal(plainBytes);
+
+				byte[] encryptedBytes =
+					new byte[initializationVector.length + cipherBytes.length];
+
+				System.arraycopy(
+					initializationVector, 0, encryptedBytes, 0,
+					initializationVector.length);
+				System.arraycopy(
+					cipherBytes, 0, encryptedBytes, initializationVector.length,
+					cipherBytes.length);
+
+				return encryptedBytes;
+			}
+
+			String algorithm = key.getAlgorithm();
+
+			String cacheKey = algorithm + StringPool.POUND + key;
+
+			Cipher cipher = _encryptCipherMap.get(cacheKey);
+
 			if (cipher == null) {
 				cipher = Cipher.getInstance(algorithm);
 
@@ -149,7 +209,7 @@ public class EncryptorImpl implements Encryptor {
 
 	@Override
 	public Key generateKey() throws EncryptorException {
-		return _generateKey(KEY_ALGORITHM);
+		return _generateKey(PropsValues.FIPS_ENABLED ? _AES : KEY_ALGORITHM);
 	}
 
 	@Override
@@ -175,7 +235,9 @@ public class EncryptorImpl implements Encryptor {
 		try {
 			KeyGenerator keyGenerator = KeyGenerator.getInstance(algorithm);
 
-			keyGenerator.init(KEY_SIZE, new SecureRandom());
+			keyGenerator.init(
+				PropsValues.FIPS_ENABLED ? _FIPS_KEY_SIZE : KEY_SIZE,
+				_secureRandom);
 
 			return keyGenerator.generateKey();
 		}
@@ -184,7 +246,20 @@ public class EncryptorImpl implements Encryptor {
 		}
 	}
 
+	private static final String _AES = "AES";
+
+	private static final String _FIPS_CIPHER_TRANSFORMATION =
+		"AES/GCM/NoPadding";
+
+	private static final int _FIPS_GCM_INITIALIZATION_VECTOR_LENGTH = 12;
+
+	private static final int _FIPS_GCM_TAG_LENGTH_BITS = 128;
+
+	private static final int _FIPS_KEY_SIZE = 256;
+
 	private static final Log _log = LogFactoryUtil.getLog(EncryptorImpl.class);
+
+	private static final SecureRandom _secureRandom = new SecureRandom();
 
 	private final Map<String, Cipher> _decryptCipherMap =
 		new ConcurrentHashMap<>(1, 1F, 1);

--- a/modules/apps/static/portal/portal-encryptor/src/test/java/com/liferay/portal/encryptor/EncryptorImplTest.java
+++ b/modules/apps/static/portal/portal-encryptor/src/test/java/com/liferay/portal/encryptor/EncryptorImplTest.java
@@ -5,7 +5,10 @@
 
 package com.liferay.portal.encryptor;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.encryptor.Encryptor;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.security.Key;
@@ -26,19 +29,60 @@ public class EncryptorImplTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void testKeySerialization() throws Exception {
+	public void testDecrypt() throws Exception {
 		Encryptor encryptor = new EncryptorImpl();
 
 		Key key = encryptor.generateKey();
 
-		String encryptedString = encryptor.encrypt(key, "Hello World!");
+		String encryptedString = encryptor.encrypt(key, _PLAIN_TEXT);
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			Assert.assertEquals(
+				_PLAIN_TEXT, encryptor.decrypt(key, encryptedString));
+		}
+	}
+
+	@Test
+	public void testEncrypt() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			Encryptor encryptor = new EncryptorImpl();
+
+			Key key = encryptor.generateKey();
+
+			String encryptedString1 = encryptor.encrypt(key, _PLAIN_TEXT);
+			String encryptedString2 = encryptor.encrypt(key, _PLAIN_TEXT);
+
+			Assert.assertNotEquals(encryptedString1, encryptedString2);
+
+			Assert.assertEquals(
+				_PLAIN_TEXT, encryptor.decrypt(key, encryptedString1));
+			Assert.assertEquals(
+				_PLAIN_TEXT, encryptor.decrypt(key, encryptedString2));
+		}
+	}
+
+	@Test
+	public void testSerializeKey() throws Exception {
+		Encryptor encryptor = new EncryptorImpl();
+
+		Key key = encryptor.generateKey();
+
+		String encryptedString = encryptor.encrypt(key, _PLAIN_TEXT);
 
 		String serializedKey = encryptor.serializeKey(key);
 
 		key = encryptor.deserializeKey(serializedKey);
 
 		Assert.assertEquals(
-			"Hello World!", encryptor.decrypt(key, encryptedString));
+			_PLAIN_TEXT, encryptor.decrypt(key, encryptedString));
 	}
+
+	private static final String _PLAIN_TEXT = RandomTestUtil.randomString();
 
 }

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtil.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtil.java
@@ -9,6 +9,7 @@ import com.liferay.petra.io.BigEndianCodec;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.security.SecureRandomUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.math.BigInteger;
@@ -28,8 +29,6 @@ import jodd.util.Base32;
  * @author Marta Medio
  */
 public class MFATimeBasedOTPUtil {
-
-	public static final String MFA_TIMEBASED_OTP_ALGORITHM = "HmacSHA1";
 
 	public static final int MFA_TIMEBASED_OTP_COUNTER = 30 * 1000;
 
@@ -74,8 +73,10 @@ public class MFATimeBasedOTPUtil {
 	}
 
 	private static byte[] _generateHMAC(byte[] key, String text) {
+		String algorithm = PropsValues.FIPS_ENABLED ? "HmacSHA256" : "HmacSHA1";
+
 		try {
-			Mac mac = Mac.getInstance(MFA_TIMEBASED_OTP_ALGORITHM);
+			Mac mac = Mac.getInstance(algorithm);
 
 			mac.init(new SecretKeySpec(key, "RAW"));
 
@@ -88,14 +89,12 @@ public class MFATimeBasedOTPUtil {
 		}
 		catch (InvalidKeyException invalidKeyException) {
 			throw new IllegalArgumentException(
-				"Invalid secret key for algorithm " +
-					MFA_TIMEBASED_OTP_ALGORITHM,
+				"Invalid secret key for algorithm " + algorithm,
 				invalidKeyException);
 		}
 		catch (NoSuchAlgorithmException noSuchAlgorithmException) {
 			throw new IllegalArgumentException(
-				"Invalid algorithm " + MFA_TIMEBASED_OTP_ALGORITHM,
-				noSuchAlgorithmException);
+				"Invalid algorithm " + algorithm, noSuchAlgorithmException);
 		}
 	}
 

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/test/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtilTest.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/test/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtilTest.java
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.multi.factor.authentication.timebased.otp.web.internal.util;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import javax.crypto.Mac;
+
+import jodd.util.Base32;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class MFATimeBasedOTPUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testVerifyTimeBasedOTP() throws Exception {
+		String sharedSecret = MFATimeBasedOTPUtil.generateSharedSecret(20);
+
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			() -> _generateCurrentOTP(sharedSecret), "HmacSHA1",
+			Mac::getInstance, Mac.class, "HmacSHA256");
+	}
+
+	private String _generateCurrentOTP(String sharedSecret) {
+		String timeCountHex = ReflectionTestUtil.invoke(
+			MFATimeBasedOTPUtil.class, "_getTimeCountHex",
+			new Class<?>[] {long.class},
+			System.currentTimeMillis() /
+				MFATimeBasedOTPUtil.MFA_TIMEBASED_OTP_COUNTER);
+
+		return ReflectionTestUtil.invoke(
+			MFATimeBasedOTPUtil.class, "_generateTimeBasedOTP",
+			new Class<?>[] {byte[].class, String.class},
+			Base32.decode(sharedSecret), timeCountHex);
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/events/CryptoStartupAction.java
+++ b/portal-impl/src/com/liferay/portal/events/CryptoStartupAction.java
@@ -8,6 +8,7 @@ package com.liferay.portal.events;
 import com.liferay.portal.kernel.events.SimpleAction;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 
 import java.security.NoSuchAlgorithmException;
 
@@ -20,12 +21,14 @@ public class CryptoStartupAction extends SimpleAction {
 
 	@Override
 	public void run(String[] ids) {
+		String algorithm = PropsValues.FIPS_ENABLED ? "HmacSHA256" : "HmacSHA1";
+
 		try {
-			Mac.getInstance("HmacSHA1");
+			Mac.getInstance(algorithm);
 		}
 		catch (NoSuchAlgorithmException noSuchAlgorithmException) {
 			_log.error(
-				"Unable to get Mac instance for algorithm HmacSHA1",
+				"Unable to get Mac instance for algorithm " + algorithm,
 				noSuchAlgorithmException);
 		}
 	}

--- a/portal-impl/src/com/liferay/portal/security/auth/tunnel/TunnelAuthenticationManagerImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/tunnel/TunnelAuthenticationManagerImpl.java
@@ -206,8 +206,10 @@ public class TunnelAuthenticationManagerImpl
 			throw authException;
 		}
 
-		if (StringUtil.equalsIgnoreCase(
-				PropsValues.TUNNELING_SERVLET_ENCRYPTION_ALGORITHM, "AES") &&
+		String algorithm = PropsValues.FIPS_ENABLED ? _AES :
+			PropsValues.TUNNELING_SERVLET_ENCRYPTION_ALGORITHM;
+
+		if (StringUtil.equalsIgnoreCase(algorithm, _AES) &&
 			(key.length != 16) && (key.length != 32)) {
 
 			String message =
@@ -225,9 +227,10 @@ public class TunnelAuthenticationManagerImpl
 			throw authException;
 		}
 
-		return new SecretKeySpec(
-			key, PropsValues.TUNNELING_SERVLET_ENCRYPTION_ALGORITHM);
+		return new SecretKeySpec(key, algorithm);
 	}
+
+	private static final String _AES = "AES";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		TunnelAuthenticationManagerImpl.class);

--- a/portal-impl/src/com/liferay/portal/security/pwd/PwdAuthenticator.java
+++ b/portal-impl/src/com/liferay/portal/security/pwd/PwdAuthenticator.java
@@ -12,9 +12,11 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptorUtil;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.UnsupportedEncodingException;
@@ -43,7 +45,8 @@ public class PwdAuthenticator {
 
 			try {
 				MessageDigest digester = MessageDigest.getInstance(
-					PropsUtil.get(PropsKeys.AUTH_MAC_ALGORITHM));
+					PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 :
+						PropsUtil.get(PropsKeys.AUTH_MAC_ALGORITHM));
 
 				digester.update(login.getBytes(StringPool.UTF8));
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeCompany.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeCompany.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -27,7 +28,7 @@ public class UpgradeCompany extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		String keyAlgorithm = _KEY_ALGORITHM;
+		String keyAlgorithm = PropsValues.FIPS_ENABLED ? "AES" : _KEY_ALGORITHM;
 
 		if (keyAlgorithm.equals("DES")) {
 			return;

--- a/portal-impl/test/unit/com/liferay/portal/security/auth/tunnel/TunnelAuthenticationManagerImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/security/auth/tunnel/TunnelAuthenticationManagerImplTest.java
@@ -1,0 +1,72 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.auth.tunnel;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.security.Key;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class TunnelAuthenticationManagerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetSharedSecretKey() throws Exception {
+		try (SafeCloseable safeCloseable1 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"TUNNELING_SERVLET_SHARED_SECRET", _SHARED_SECRET);
+			SafeCloseable safeCloseable2 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"TUNNELING_SERVLET_SHARED_SECRET_HEX", false);
+			SafeCloseable safeCloseable3 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"TUNNELING_SERVLET_ENCRYPTION_ALGORITHM", "Blowfish")) {
+
+			try (SafeCloseable safeCloseable =
+					PropsValuesTestUtil.swapWithSafeCloseable(
+						"FIPS_ENABLED", false)) {
+
+				Key key = _getSharedSecretKey();
+
+				Assert.assertEquals("Blowfish", key.getAlgorithm());
+			}
+
+			try (SafeCloseable safeCloseable =
+					PropsValuesTestUtil.swapWithSafeCloseable(
+						"FIPS_ENABLED", true)) {
+
+				Key key = _getSharedSecretKey();
+
+				Assert.assertEquals("AES", key.getAlgorithm());
+			}
+		}
+	}
+
+	private Key _getSharedSecretKey() {
+		return ReflectionTestUtil.invoke(
+			new TunnelAuthenticationManagerImpl(), "getSharedSecretKey",
+			new Class<?>[0]);
+	}
+
+	private static final String _SHARED_SECRET = RandomTestUtil.randomString(
+		16);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/DigesterUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/DigesterUtil.java
@@ -29,8 +29,6 @@ import java.util.Objects;
  */
 public class DigesterUtil {
 
-	public static final String DEFAULT_ALGORITHM = "SHA";
-
 	public static final String ENCODING = StringPool.UTF8;
 
 	public static final String MD5 = "MD5";
@@ -42,15 +40,15 @@ public class DigesterUtil {
 	public static final String SHA_256 = "SHA-256";
 
 	public static String digest(ByteBuffer byteBuffer) {
-		return digest(DEFAULT_ALGORITHM, byteBuffer);
+		return digest(_getDefaultAlgorithm(), byteBuffer);
 	}
 
 	public static String digest(InputStream inputStream) {
-		return digest(DEFAULT_ALGORITHM, inputStream);
+		return digest(_getDefaultAlgorithm(), inputStream);
 	}
 
 	public static String digest(String text) {
-		return digest(DEFAULT_ALGORITHM, text);
+		return digest(_getDefaultAlgorithm(), text);
 	}
 
 	public static String digest(String algorithm, ByteBuffer byteBuffer) {
@@ -78,15 +76,15 @@ public class DigesterUtil {
 	}
 
 	public static String digestBase64(ByteBuffer byteBuffer) {
-		return digestBase64(DEFAULT_ALGORITHM, byteBuffer);
+		return digestBase64(_getDefaultAlgorithm(), byteBuffer);
 	}
 
 	public static String digestBase64(InputStream inputStream) {
-		return digestBase64(DEFAULT_ALGORITHM, inputStream);
+		return digestBase64(_getDefaultAlgorithm(), inputStream);
 	}
 
 	public static String digestBase64(String text) {
-		return digestBase64(DEFAULT_ALGORITHM, text);
+		return digestBase64(_getDefaultAlgorithm(), text);
 	}
 
 	public static String digestBase64(String algorithm, ByteBuffer byteBuffer) {
@@ -110,15 +108,15 @@ public class DigesterUtil {
 	}
 
 	public static String digestHex(ByteBuffer byteBuffer) {
-		return digestHex(DEFAULT_ALGORITHM, byteBuffer);
+		return digestHex(_getDefaultAlgorithm(), byteBuffer);
 	}
 
 	public static String digestHex(InputStream inputStream) {
-		return digestHex(DEFAULT_ALGORITHM, inputStream);
+		return digestHex(_getDefaultAlgorithm(), inputStream);
 	}
 
 	public static String digestHex(String text) {
-		return digestHex(DEFAULT_ALGORITHM, text);
+		return digestHex(_getDefaultAlgorithm(), text);
 	}
 
 	public static String digestHex(String algorithm, ByteBuffer byteBuffer) {
@@ -140,11 +138,11 @@ public class DigesterUtil {
 	}
 
 	public static byte[] digestRaw(ByteBuffer byteBuffer) {
-		return digestRaw(DEFAULT_ALGORITHM, byteBuffer);
+		return digestRaw(_getDefaultAlgorithm(), byteBuffer);
 	}
 
 	public static byte[] digestRaw(String text) {
-		return digestRaw(DEFAULT_ALGORITHM, text);
+		return digestRaw(_getDefaultAlgorithm(), text);
 	}
 
 	public static byte[] digestRaw(String algorithm, ByteBuffer byteBuffer) {
@@ -216,6 +214,14 @@ public class DigesterUtil {
 		}
 
 		return messageDigest.digest();
+	}
+
+	private static String _getDefaultAlgorithm() {
+		if (PropsValues.FIPS_ENABLED) {
+			return SHA_256;
+		}
+
+		return SHA;
 	}
 
 	private static final boolean _BASE_64 = Objects.equals(

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 98.0.0
+version 99.0.0

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/DigesterUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/DigesterUtilTest.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.util;
+
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+
+import java.security.MessageDigest;
+
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class DigesterUtilTest {
+
+	@Test
+	public void testDigestHex() throws Exception {
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			() -> DigesterUtil.digestHex(RandomTestUtil.randomString()),
+			DigesterUtil.SHA, MessageDigest::getInstance, MessageDigest.class,
+			DigesterUtil.SHA_256);
+	}
+
+}

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 32.6.1
+Bundle-Version: 32.7.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/kernel/test/util/FIPSAlgorithmTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/FIPSAlgorithmTestUtil.java
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.test.util;
+
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.lang.SafeCloseable;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Lucas Miranda
+ */
+public class FIPSAlgorithmTestUtil {
+
+	public static <T> void assertAlgorithmSwitch(
+			UnsafeRunnable<Exception> action, String algorithm,
+			UnsafeConsumer<String, Exception> algorithmCall,
+			Class<T> classToMock, String fipsAlgorithm)
+		throws Exception {
+
+		try (MockedStatic<T> mockedStatic = Mockito.mockStatic(
+				classToMock, Mockito.CALLS_REAL_METHODS)) {
+
+			action.run();
+
+			mockedStatic.verify(
+				() -> algorithmCall.accept(algorithm), Mockito.atLeastOnce());
+			mockedStatic.verify(
+				() -> algorithmCall.accept(fipsAlgorithm), Mockito.never());
+		}
+
+		try (MockedStatic<T> mockedStatic = Mockito.mockStatic(
+				classToMock, Mockito.CALLS_REAL_METHODS);
+			SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			action.run();
+
+			mockedStatic.verify(
+				() -> algorithmCall.accept(algorithm), Mockito.never());
+			mockedStatic.verify(
+				() -> algorithmCall.accept(fipsAlgorithm),
+				Mockito.atLeastOnce());
+		}
+	}
+
+}

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 10.7.0
+version 10.8.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90288
https://liferay.atlassian.net/browse/LPD-90290

## What Is Being Fixed

Several portal classes selected their cryptographic algorithm, cipher mode, or key size from configuration or relied on weak defaults, allowing non-FIPS-approved algorithms to be used at runtime. EncryptorImpl used the implicit ECB cipher mode, and TunnelAuthenticationManagerImpl, PwdAuthenticator, UpgradeCompany, and MessageDigestCryptoHashProviderFactory derived their algorithm from properties that could resolve to non-approved values.

## How It Is Being Fixed

Each affected class uses a hardcoded FIPS-approved value when FIPS mode is enabled instead of the configured one, while non-FIPS deployments keep their existing behavior. EncryptorImpl switches from the implicit ECB cipher to AES/GCM/NoPadding with a random 96-bit IV and generates AES-256 keys under FIPS; decryption attempts the GCM format first and falls back to the legacy format so values encrypted before FIPS was enabled remain readable.

The LPD-90290 commits in this branch are included only as a dependency: LPD-90288 reuses the FIPSAlgorithmTestUtil test helper and the DigesterUtil constants introduced there. That work is reviewed under LPD-90290, not this ticket.

## PR Check

**pr-check: PASS** — tested on `074482e715de5ea532b77bf13ad6b527180b7bdb`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "074482e715de5ea532b77bf13ad6b527180b7bdb"} -->