### PR TITLE
LPD-94383 Add forcePredictable flags to cookies-rest-impl and regen

### DIFF
--- a/modules/apps/cookies/cookies-rest-api/src/main/java/com/liferay/cookies/rest/resource/v1_0/CookiesConsentPreferenceResource.java
+++ b/modules/apps/cookies/cookies-rest-api/src/main/java/com/liferay/cookies/rest/resource/v1_0/CookiesConsentPreferenceResource.java
@@ -14,15 +14,12 @@ import com.liferay.portal.odata.filter.ExpressionConvert;
 import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 
 import jakarta.annotation.Generated;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.Collections;
@@ -44,10 +41,10 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface CookiesConsentPreferenceResource {
 
+	public void deleteCookiesConsentPreference() throws Exception;
+
 	public void deleteCookiesConsentPreferenceByName(String name)
 		throws Exception;
-
-	public void deleteCookiesConsentPreferences() throws Exception;
 
 	public CookiesConsentPreference getCookiesConsentPreferenceByName(
 			String name)
@@ -55,10 +52,6 @@ public interface CookiesConsentPreferenceResource {
 
 	public CookiesConsentPreference putCookiesConsentPreference(
 			CookiesConsentPreference cookiesConsentPreference)
-		throws Exception;
-
-	public Response putCookiesConsentPreferenceBatch(
-			String callbackURL, Object object)
 		throws Exception;
 
 	public default void setContextAcceptLanguage(
@@ -100,14 +93,6 @@ public interface CookiesConsentPreferenceResource {
 	public void setRoleLocalService(RoleLocalService roleLocalService);
 
 	public void setSortParserProvider(SortParserProvider sortParserProvider);
-
-	public void setVulcanBatchEngineExportTaskResource(
-		VulcanBatchEngineExportTaskResource
-			vulcanBatchEngineExportTaskResource);
-
-	public void setVulcanBatchEngineImportTaskResource(
-		VulcanBatchEngineImportTaskResource
-			vulcanBatchEngineImportTaskResource);
 
 	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
 		String filterString) {
@@ -157,4 +142,4 @@ public interface CookiesConsentPreferenceResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-390898972
+// LIFERAY-REST-BUILDER-HASH:-636529269

--- a/modules/apps/cookies/cookies-rest-client/src/main/java/com/liferay/cookies/rest/client/resource/v1_0/CookiesConsentPreferenceResource.java
+++ b/modules/apps/cookies/cookies-rest-client/src/main/java/com/liferay/cookies/rest/client/resource/v1_0/CookiesConsentPreferenceResource.java
@@ -32,17 +32,16 @@ public interface CookiesConsentPreferenceResource {
 		return new Builder();
 	}
 
+	public void deleteCookiesConsentPreference() throws Exception;
+
+	public HttpInvoker.HttpResponse deleteCookiesConsentPreferenceHttpResponse()
+		throws Exception;
+
 	public void deleteCookiesConsentPreferenceByName(String name)
 		throws Exception;
 
 	public HttpInvoker.HttpResponse
 			deleteCookiesConsentPreferenceByNameHttpResponse(String name)
-		throws Exception;
-
-	public void deleteCookiesConsentPreferences() throws Exception;
-
-	public HttpInvoker.HttpResponse
-			deleteCookiesConsentPreferencesHttpResponse()
 		throws Exception;
 
 	public CookiesConsentPreference getCookiesConsentPreferenceByName(
@@ -59,15 +58,6 @@ public interface CookiesConsentPreferenceResource {
 
 	public HttpInvoker.HttpResponse putCookiesConsentPreferenceHttpResponse(
 			CookiesConsentPreference cookiesConsentPreference)
-		throws Exception;
-
-	public void putCookiesConsentPreferenceBatch(
-			String callbackURL, Object object)
-		throws Exception;
-
-	public HttpInvoker.HttpResponse
-			putCookiesConsentPreferenceBatchHttpResponse(
-				String callbackURL, Object object)
 		throws Exception;
 
 	public static class Builder {
@@ -179,6 +169,107 @@ public interface CookiesConsentPreferenceResource {
 	public static class CookiesConsentPreferenceResourceImpl
 		implements CookiesConsentPreferenceResource {
 
+		public void deleteCookiesConsentPreference() throws Exception {
+			HttpInvoker.HttpResponse httpResponse =
+				deleteCookiesConsentPreferenceHttpResponse();
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteCookiesConsentPreferenceHttpResponse()
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/cookies/v1.0/cookies-consent-preferences");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
 		public void deleteCookiesConsentPreferenceByName(String name)
 			throws Exception {
 
@@ -275,107 +366,6 @@ public interface CookiesConsentPreferenceResource {
 						"/o/cookies/v1.0/cookies-consent-preferences/by-name/{name}");
 
 			httpInvoker.path("name", name);
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
-		public void deleteCookiesConsentPreferences() throws Exception {
-			HttpInvoker.HttpResponse httpResponse =
-				deleteCookiesConsentPreferencesHttpResponse();
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-
-			try {
-				return;
-			}
-			catch (Exception e) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response: " + content, e);
-
-				throw new Problem.ProblemException(Problem.toDTO(content));
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				deleteCookiesConsentPreferencesHttpResponse()
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/cookies/v1.0/cookies-consent-preferences");
 
 			if ((_builder._login != null) && (_builder._password != null)) {
 				httpInvoker.userNameAndPassword(
@@ -599,108 +589,6 @@ public interface CookiesConsentPreferenceResource {
 			return httpInvoker.invoke();
 		}
 
-		public void putCookiesConsentPreferenceBatch(
-				String callbackURL, Object object)
-			throws Exception {
-
-			HttpInvoker.HttpResponse httpResponse =
-				putCookiesConsentPreferenceBatchHttpResponse(
-					callbackURL, object);
-
-			String content = httpResponse.getContent();
-
-			if ((httpResponse.getStatusCode() / 100) != 2) {
-				_logger.log(
-					Level.WARNING,
-					"Unable to process HTTP response content: " + content);
-				_logger.log(
-					Level.WARNING,
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.log(
-					Level.WARNING,
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-
-				Problem.ProblemException problemException = null;
-
-				if (Objects.equals(
-						httpResponse.getContentType(), "application/json")) {
-
-					problemException = new Problem.ProblemException(
-						Problem.toDTO(content));
-				}
-				else {
-					_logger.log(
-						Level.WARNING,
-						"Unable to process content type: " +
-							httpResponse.getContentType());
-
-					Problem problem = new Problem();
-
-					problem.setStatus(
-						String.valueOf(httpResponse.getStatusCode()));
-
-					problemException = new Problem.ProblemException(problem);
-				}
-
-				throw problemException;
-			}
-			else {
-				_logger.fine("HTTP response content: " + content);
-				_logger.fine(
-					"HTTP response message: " + httpResponse.getMessage());
-				_logger.fine(
-					"HTTP response status code: " +
-						httpResponse.getStatusCode());
-			}
-		}
-
-		public HttpInvoker.HttpResponse
-				putCookiesConsentPreferenceBatchHttpResponse(
-					String callbackURL, Object object)
-			throws Exception {
-
-			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
-
-			httpInvoker.body(object.toString(), "application/json");
-
-			if (_builder._locale != null) {
-				httpInvoker.header(
-					"Accept-Language", _builder._locale.toLanguageTag());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._headers.entrySet()) {
-
-				httpInvoker.header(entry.getKey(), entry.getValue());
-			}
-
-			for (Map.Entry<String, String> entry :
-					_builder._parameters.entrySet()) {
-
-				httpInvoker.parameter(entry.getKey(), entry.getValue());
-			}
-
-			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
-
-			if (callbackURL != null) {
-				httpInvoker.parameter(
-					"callbackURL", String.valueOf(callbackURL));
-			}
-
-			httpInvoker.path(
-				_builder._scheme + "://" + _builder._host + ":" +
-					_builder._port + _builder._contextPath +
-						"/o/cookies/v1.0/cookies-consent-preferences/batch");
-
-			if ((_builder._login != null) && (_builder._password != null)) {
-				httpInvoker.userNameAndPassword(
-					_builder._login + ":" + _builder._password);
-			}
-
-			return httpInvoker.invoke();
-		}
-
 		private CookiesConsentPreferenceResourceImpl(Builder builder) {
 			_builder = builder;
 		}
@@ -713,4 +601,4 @@ public interface CookiesConsentPreferenceResource {
 	}
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1577574750
+// LIFERAY-REST-BUILDER-HASH:1994306772

--- a/modules/apps/cookies/cookies-rest-impl/rest-config.yaml
+++ b/modules/apps/cookies/cookies-rest-impl/rest-config.yaml
@@ -7,5 +7,7 @@ application:
 author: Christopher Kian
 clientDir: ../cookies-rest-client/src/main/java
 compatibilityVersion: 14
+forcePredictableOperationId: true
+forcePredictableSchemaPropertyName: true
 javaEEPackage: jakarta
 testDir: ../cookies-rest-test/src/testIntegration/java

--- a/modules/apps/cookies/cookies-rest-impl/rest-config.yaml
+++ b/modules/apps/cookies/cookies-rest-impl/rest-config.yaml
@@ -9,5 +9,6 @@ clientDir: ../cookies-rest-client/src/main/java
 compatibilityVersion: 14
 forcePredictableOperationId: true
 forcePredictableSchemaPropertyName: true
+generateBatch: false
 javaEEPackage: jakarta
 testDir: ../cookies-rest-test/src/testIntegration/java

--- a/modules/apps/cookies/cookies-rest-impl/rest-openapi.yaml
+++ b/modules/apps/cookies/cookies-rest-impl/rest-openapi.yaml
@@ -51,7 +51,7 @@ paths:
         delete:
             description:
                 Deletes all cookies consent preference entries of the user who made the request.
-            operationId: deleteCookiesConsentPreferences
+            operationId: deleteCookiesConsentPreference
             responses:
                 204:
                     content:

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/graphql/mutation/v1_0/Mutation.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/graphql/mutation/v1_0/Mutation.java
@@ -12,8 +12,6 @@ import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
 import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
 
@@ -22,7 +20,6 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
 import java.util.function.BiFunction;
@@ -46,6 +43,20 @@ public class Mutation {
 	}
 
 	@GraphQLField(
+		description = "Deletes all cookies consent preference entries of the user who made the request."
+	)
+	public boolean deleteCookiesConsentPreference() throws Exception {
+		_applyVoidComponentServiceObjects(
+			_cookiesConsentPreferenceResourceComponentServiceObjects,
+			this::_populateResourceContext,
+			cookiesConsentPreferenceResource ->
+				cookiesConsentPreferenceResource.
+					deleteCookiesConsentPreference());
+
+		return true;
+	}
+
+	@GraphQLField(
 		description = "Deletes the specified cookies consent preference of the user who made the request."
 	)
 	public boolean deleteCookiesConsentPreferenceByName(
@@ -58,20 +69,6 @@ public class Mutation {
 			cookiesConsentPreferenceResource ->
 				cookiesConsentPreferenceResource.
 					deleteCookiesConsentPreferenceByName(name));
-
-		return true;
-	}
-
-	@GraphQLField(
-		description = "Deletes all cookies consent preference entries of the user who made the request."
-	)
-	public boolean deleteCookiesConsentPreferences() throws Exception {
-		_applyVoidComponentServiceObjects(
-			_cookiesConsentPreferenceResourceComponentServiceObjects,
-			this::_populateResourceContext,
-			cookiesConsentPreferenceResource ->
-				cookiesConsentPreferenceResource.
-					deleteCookiesConsentPreferences());
 
 		return true;
 	}
@@ -90,20 +87,6 @@ public class Mutation {
 			cookiesConsentPreferenceResource ->
 				cookiesConsentPreferenceResource.putCookiesConsentPreference(
 					cookiesConsentPreference));
-	}
-
-	@GraphQLField
-	public Response updateCookiesConsentPreferenceBatch(
-			@GraphQLName("callbackURL") String callbackURL,
-			@GraphQLName("object") Object object)
-		throws Exception {
-
-		return _applyComponentServiceObjects(
-			_cookiesConsentPreferenceResourceComponentServiceObjects,
-			this::_populateResourceContext,
-			cookiesConsentPreferenceResource ->
-				cookiesConsentPreferenceResource.
-					putCookiesConsentPreferenceBatch(callbackURL, object));
 	}
 
 	private <T, R, E1 extends Throwable, E2 extends Throwable> R
@@ -160,12 +143,6 @@ public class Mutation {
 		cookiesConsentPreferenceResource.setGroupLocalService(
 			_groupLocalService);
 		cookiesConsentPreferenceResource.setRoleLocalService(_roleLocalService);
-
-		cookiesConsentPreferenceResource.setVulcanBatchEngineExportTaskResource(
-			_vulcanBatchEngineExportTaskResource);
-
-		cookiesConsentPreferenceResource.setVulcanBatchEngineImportTaskResource(
-			_vulcanBatchEngineImportTaskResource);
 	}
 
 	private static ComponentServiceObjects<CookiesConsentPreferenceResource>
@@ -181,10 +158,6 @@ public class Mutation {
 		_sortsBiFunction;
 	private UriInfo _uriInfo;
 	private com.liferay.portal.kernel.model.User _user;
-	private VulcanBatchEngineExportTaskResource
-		_vulcanBatchEngineExportTaskResource;
-	private VulcanBatchEngineImportTaskResource
-		_vulcanBatchEngineImportTaskResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:-936149283
+// LIFERAY-REST-BUILDER-HASH:1721433606

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/graphql/servlet/v1_0/ServletDataImpl.java
@@ -76,25 +76,20 @@ public class ServletDataImpl implements ServletData {
 			new HashMap<String, ObjectValuePair<Class<?>, String>>() {
 				{
 					put(
+						"mutation#deleteCookiesConsentPreference",
+						new ObjectValuePair<>(
+							CookiesConsentPreferenceResourceImpl.class,
+							"deleteCookiesConsentPreference"));
+					put(
 						"mutation#deleteCookiesConsentPreferenceByName",
 						new ObjectValuePair<>(
 							CookiesConsentPreferenceResourceImpl.class,
 							"deleteCookiesConsentPreferenceByName"));
 					put(
-						"mutation#deleteCookiesConsentPreferences",
-						new ObjectValuePair<>(
-							CookiesConsentPreferenceResourceImpl.class,
-							"deleteCookiesConsentPreferences"));
-					put(
 						"mutation#updateCookiesConsentPreference",
 						new ObjectValuePair<>(
 							CookiesConsentPreferenceResourceImpl.class,
 							"putCookiesConsentPreference"));
-					put(
-						"mutation#updateCookiesConsentPreferenceBatch",
-						new ObjectValuePair<>(
-							CookiesConsentPreferenceResourceImpl.class,
-							"putCookiesConsentPreferenceBatch"));
 
 					put(
 						"query#cookiesConsentPreferenceByName",
@@ -109,4 +104,4 @@ public class ServletDataImpl implements ServletData {
 		_cookiesConsentPreferenceResourceComponentServiceObjects;
 
 }
-// LIFERAY-REST-BUILDER-HASH:256119608
+// LIFERAY-REST-BUILDER-HASH:-2090217516

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/BaseCookiesConsentPreferenceResourceImpl.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/BaseCookiesConsentPreferenceResourceImpl.java
@@ -7,8 +7,6 @@ package com.liferay.cookies.rest.internal.resource.v1_0;
 
 import com.liferay.cookies.rest.dto.v1_0.CookiesConsentPreference;
 import com.liferay.cookies.rest.resource.v1_0.CookiesConsentPreferenceResource;
-import com.liferay.petra.function.UnsafeBiConsumer;
-import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.function.UnsafeFunction;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -17,24 +15,10 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceActionLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
-import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.SetUtil;
-import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.ExpressionConvert;
-import com.liferay.portal.odata.filter.FilterParser;
 import com.liferay.portal.odata.filter.FilterParserProvider;
-import com.liferay.portal.odata.sort.SortField;
-import com.liferay.portal.odata.sort.SortParser;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
-import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
-import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
-import com.liferay.portal.vulcan.pagination.Page;
-import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.ActionUtil;
 import com.liferay.portal.vulcan.util.UriInfoUtil;
 
@@ -43,20 +27,11 @@ import jakarta.annotation.Generated;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
-import jakarta.ws.rs.NotSupportedException;
-import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
-import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
 
-import java.io.Serializable;
-
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * @author Christopher Kian
@@ -65,8 +40,29 @@ import java.util.Set;
 @Generated("")
 @jakarta.ws.rs.Path("/v1.0")
 public abstract class BaseCookiesConsentPreferenceResourceImpl
-	implements CookiesConsentPreferenceResource, EntityModelResource,
-			   VulcanBatchEngineTaskItemDelegate<CookiesConsentPreference> {
+	implements CookiesConsentPreferenceResource {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/cookies/v1.0/cookies-consent-preferences'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Deletes all cookies consent preference entries of the user who made the request."
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "CookiesConsentPreference"
+			)
+		}
+	)
+	@jakarta.ws.rs.DELETE
+	@jakarta.ws.rs.Path("/cookies-consent-preferences")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void deleteCookiesConsentPreference() throws Exception {
+	}
 
 	/**
 	 * Invoke this method with the command line:
@@ -101,28 +97,6 @@ public abstract class BaseCookiesConsentPreferenceResourceImpl
 			@jakarta.ws.rs.PathParam("name")
 			String name)
 		throws Exception {
-	}
-
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'DELETE' 'http://localhost:8080/o/cookies/v1.0/cookies-consent-preferences'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Operation(
-		description = "Deletes all cookies consent preference entries of the user who made the request."
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(
-				name = "CookiesConsentPreference"
-			)
-		}
-	)
-	@jakarta.ws.rs.DELETE
-	@jakarta.ws.rs.Path("/cookies-consent-preferences")
-	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
-	@Override
-	public void deleteCookiesConsentPreferences() throws Exception {
 	}
 
 	/**
@@ -189,207 +163,8 @@ public abstract class BaseCookiesConsentPreferenceResourceImpl
 		return new CookiesConsentPreference();
 	}
 
-	/**
-	 * Invoke this method with the command line:
-	 *
-	 * curl -X 'PUT' 'http://localhost:8080/o/cookies/v1.0/cookies-consent-preferences/batch'  -u 'test@liferay.com:test'
-	 */
-	@io.swagger.v3.oas.annotations.Parameters(
-		value = {
-			@io.swagger.v3.oas.annotations.Parameter(
-				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
-				name = "callbackURL"
-			)
-		}
-	)
-	@io.swagger.v3.oas.annotations.tags.Tags(
-		value = {
-			@io.swagger.v3.oas.annotations.tags.Tag(
-				name = "CookiesConsentPreference"
-			)
-		}
-	)
-	@jakarta.ws.rs.Consumes("application/json")
-	@jakarta.ws.rs.Path("/cookies-consent-preferences/batch")
-	@jakarta.ws.rs.Produces("application/json")
-	@jakarta.ws.rs.PUT
-	@Override
-	public Response putCookiesConsentPreferenceBatch(
-			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
-			@jakarta.ws.rs.QueryParam("callbackURL")
-			String callbackURL,
-			Object object)
-		throws Exception {
-
-		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
-			contextAcceptLanguage);
-		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
-		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
-			contextHttpServletRequest);
-		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
-		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
-
-		Response.ResponseBuilder responseBuilder = Response.accepted();
-
-		return responseBuilder.entity(
-			vulcanBatchEngineImportTaskResource.putImportTask(
-				CookiesConsentPreference.class.getName(), callbackURL, object)
-		).build();
-	}
-
-	@Override
-	@SuppressWarnings("PMD.UnusedLocalVariable")
-	public void create(
-			Collection<CookiesConsentPreference> cookiesConsentPreferences,
-			Map<String, Serializable> parameters)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Override
-	public void delete(
-			Collection<CookiesConsentPreference> cookiesConsentPreferences,
-			Map<String, Serializable> parameters)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	public Set<String> getAvailableCreateStrategies() {
-		return SetUtil.fromArray();
-	}
-
-	public Set<String> getAvailableUpdateStrategies() {
-		return SetUtil.fromArray("UPDATE");
-	}
-
-	@Override
-	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
-		throws Exception {
-
-		return getEntityModel(
-			new MultivaluedHashMap<String, Object>(multivaluedMap));
-	}
-
-	public String getResourceName() {
-		return "CookiesConsentPreference";
-	}
-
-	public String getVersion() {
-		return "v1.0";
-	}
-
-	@Override
-	public Page<CookiesConsentPreference> read(
-			com.liferay.portal.kernel.search.filter.Filter filter,
-			Pagination pagination,
-			com.liferay.portal.kernel.search.Sort[] sorts,
-			Map<String, Serializable> parameters, String search)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Override
-	public void setLanguageId(String languageId) {
-		this.contextAcceptLanguage = new AcceptLanguage() {
-
-			@Override
-			public List<Locale> getLocales() {
-				return null;
-			}
-
-			@Override
-			public String getPreferredLanguageId() {
-				return languageId;
-			}
-
-			@Override
-			public Locale getPreferredLocale() {
-				return LocaleUtil.fromLanguageId(languageId);
-			}
-
-		};
-	}
-
-	@Override
-	public void update(
-			Collection<CookiesConsentPreference> cookiesConsentPreferences,
-			Map<String, Serializable> parameters)
-		throws Exception {
-
-		UnsafeFunction
-			<CookiesConsentPreference, CookiesConsentPreference, Exception>
-				cookiesConsentPreferenceUnsafeFunction = null;
-
-		String updateStrategy = (String)parameters.getOrDefault(
-			"updateStrategy", "UPDATE");
-
-		if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
-			cookiesConsentPreferenceUnsafeFunction =
-				cookiesConsentPreference -> putCookiesConsentPreference(
-					cookiesConsentPreference);
-		}
-
-		if (cookiesConsentPreferenceUnsafeFunction == null) {
-			throw new NotSupportedException(
-				"Update strategy \"" + updateStrategy +
-					"\" is not supported for CookiesConsentPreference");
-		}
-
-		if (contextBatchUnsafeBiConsumer != null) {
-			contextBatchUnsafeBiConsumer.accept(
-				cookiesConsentPreferences,
-				cookiesConsentPreferenceUnsafeFunction);
-		}
-		else if (contextBatchUnsafeConsumer != null) {
-			contextBatchUnsafeConsumer.accept(
-				cookiesConsentPreferences,
-				cookiesConsentPreferenceUnsafeFunction::apply);
-		}
-		else {
-			for (CookiesConsentPreference cookiesConsentPreference :
-					cookiesConsentPreferences) {
-
-				cookiesConsentPreferenceUnsafeFunction.apply(
-					cookiesConsentPreference);
-			}
-		}
-	}
-
-	@Override
-	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
-		throws Exception {
-
-		return null;
-	}
-
 	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
 		this.contextAcceptLanguage = contextAcceptLanguage;
-	}
-
-	public void setContextBatchUnsafeBiConsumer(
-		UnsafeBiConsumer
-			<Collection<CookiesConsentPreference>,
-			 UnsafeFunction
-				 <CookiesConsentPreference, CookiesConsentPreference,
-				  Exception>,
-			 Exception> contextBatchUnsafeBiConsumer) {
-
-		this.contextBatchUnsafeBiConsumer = contextBatchUnsafeBiConsumer;
-	}
-
-	public void setContextBatchUnsafeConsumer(
-		UnsafeBiConsumer
-			<Collection<CookiesConsentPreference>,
-			 UnsafeConsumer<CookiesConsentPreference, Exception>, Exception>
-				contextBatchUnsafeConsumer) {
-
-		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
 	}
 
 	public void setContextCompany(
@@ -460,87 +235,6 @@ public abstract class BaseCookiesConsentPreferenceResourceImpl
 
 	protected String getApplicationPath() {
 		return "cookies";
-	}
-
-	public void setVulcanBatchEngineExportTaskResource(
-		VulcanBatchEngineExportTaskResource
-			vulcanBatchEngineExportTaskResource) {
-
-		this.vulcanBatchEngineExportTaskResource =
-			vulcanBatchEngineExportTaskResource;
-	}
-
-	public void setVulcanBatchEngineImportTaskResource(
-		VulcanBatchEngineImportTaskResource
-			vulcanBatchEngineImportTaskResource) {
-
-		this.vulcanBatchEngineImportTaskResource =
-			vulcanBatchEngineImportTaskResource;
-	}
-
-	@Override
-	public com.liferay.portal.kernel.search.filter.Filter toFilter(
-		String filterString, Map<String, List<String>> multivaluedMap) {
-
-		try {
-			EntityModel entityModel = getEntityModel(multivaluedMap);
-
-			FilterParser filterParser = filterParserProvider.provide(
-				entityModel);
-
-			com.liferay.portal.odata.filter.Filter oDataFilter =
-				new com.liferay.portal.odata.filter.Filter(
-					filterParser.parse(filterString));
-
-			return expressionConvert.convert(
-				oDataFilter.getExpression(),
-				contextAcceptLanguage.getPreferredLocale(), entityModel);
-		}
-		catch (Exception exception) {
-			_log.error("Invalid filter " + filterString, exception);
-
-			return null;
-		}
-	}
-
-	@Override
-	public com.liferay.portal.kernel.search.Sort[] toSorts(String sortString) {
-		if (Validator.isNull(sortString)) {
-			return null;
-		}
-
-		try {
-			SortParser sortParser = sortParserProvider.provide(
-				getEntityModel(Collections.emptyMap()));
-
-			if (sortParser == null) {
-				return null;
-			}
-
-			com.liferay.portal.odata.sort.Sort oDataSort =
-				new com.liferay.portal.odata.sort.Sort(
-					sortParser.parse(sortString));
-
-			List<SortField> sortFields = oDataSort.getSortFields();
-			com.liferay.portal.kernel.search.Sort[] sorts =
-				new com.liferay.portal.kernel.search.Sort[sortFields.size()];
-
-			for (int i = 0; i < sortFields.size(); i++) {
-				SortField sortField = sortFields.get(i);
-
-				sorts[i] = new com.liferay.portal.kernel.search.Sort(
-					sortField.getSortableFieldName(
-						contextAcceptLanguage.getPreferredLocale()),
-					!sortField.isAscending());
-			}
-
-			return sorts;
-		}
-		catch (Exception exception) {
-			_log.error("Invalid sort " + sortString, exception);
-
-			return new com.liferay.portal.kernel.search.Sort[0];
-		}
 	}
 
 	protected Map<String, String> addAction(
@@ -895,15 +589,6 @@ public abstract class BaseCookiesConsentPreferenceResourceImpl
 	}
 
 	protected AcceptLanguage contextAcceptLanguage;
-	protected UnsafeBiConsumer
-		<Collection<CookiesConsentPreference>,
-		 UnsafeFunction
-			 <CookiesConsentPreference, CookiesConsentPreference, Exception>,
-		 Exception> contextBatchUnsafeBiConsumer;
-	protected UnsafeBiConsumer
-		<Collection<CookiesConsentPreference>,
-		 UnsafeConsumer<CookiesConsentPreference, Exception>, Exception>
-			contextBatchUnsafeConsumer;
 	protected com.liferay.portal.kernel.model.Company contextCompany;
 	protected HttpServletRequest contextHttpServletRequest;
 	protected HttpServletResponse contextHttpServletResponse;
@@ -918,13 +603,9 @@ public abstract class BaseCookiesConsentPreferenceResourceImpl
 	protected ResourcePermissionLocalService resourcePermissionLocalService;
 	protected RoleLocalService roleLocalService;
 	protected SortParserProvider sortParserProvider;
-	protected VulcanBatchEngineExportTaskResource
-		vulcanBatchEngineExportTaskResource;
-	protected VulcanBatchEngineImportTaskResource
-		vulcanBatchEngineImportTaskResource;
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseCookiesConsentPreferenceResourceImpl.class);
 
 }
-// LIFERAY-REST-BUILDER-HASH:112616867
+// LIFERAY-REST-BUILDER-HASH:-1824720156

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
@@ -38,7 +38,7 @@ public class CookiesConsentPreferenceResourceImpl
 	}
 
 	@Override
-	public void deleteCookiesConsentPreferences() throws Exception {
+	public void deleteCookiesConsentPreference() throws Exception {
 		_cookiesConsentPreferenceLocalService.deleteCookiesConsentPreferences(
 			contextUser.getUserId(), _getDomain());
 	}

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
@@ -30,17 +30,17 @@ public class CookiesConsentPreferenceResourceImpl
 	extends BaseCookiesConsentPreferenceResourceImpl {
 
 	@Override
+	public void deleteCookiesConsentPreference() throws Exception {
+		_cookiesConsentPreferenceLocalService.deleteCookiesConsentPreferences(
+			contextUser.getUserId(), _getDomain());
+	}
+
+	@Override
 	public void deleteCookiesConsentPreferenceByName(String name)
 		throws Exception {
 
 		_cookiesConsentPreferenceLocalService.deleteCookiesConsentPreference(
 			contextUser.getUserId(), _getDomain(), name);
-	}
-
-	@Override
-	public void deleteCookiesConsentPreference() throws Exception {
-		_cookiesConsentPreferenceLocalService.deleteCookiesConsentPreferences(
-			contextUser.getUserId(), _getDomain());
 	}
 
 	@Override
@@ -101,12 +101,11 @@ public class CookiesConsentPreferenceResourceImpl
 	}
 
 	private String _getDomain() {
-		StringBuilder sb = new StringBuilder(3);
-
 		URI uri = contextUriInfo.getRequestUri();
 
-		sb.append(uri.getScheme());
+		StringBuilder sb = new StringBuilder(3);
 
+		sb.append(uri.getScheme());
 		sb.append("://");
 		sb.append(uri.getAuthority());
 

--- a/modules/apps/cookies/cookies-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cookies-consent-preference.properties
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/cookies-consent-preference.properties
@@ -3,10 +3,6 @@
 #
 
 api.version=v1.0
-batch.engine.entity.class.name=com.liferay.cookies.rest.dto.v1_0.CookiesConsentPreference
-batch.engine.task.item.delegate=true
-batch.planner.export.enabled=false
-batch.planner.import.enabled=false
 entity.class.name=com.liferay.cookies.rest.dto.v1_0.CookiesConsentPreference
 osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Cookies.REST)
 osgi.jaxrs.resource=true

--- a/modules/apps/cookies/cookies-rest-test/src/testIntegration/java/com/liferay/cookies/rest/resource/v1_0/test/BaseCookiesConsentPreferenceResourceTestCase.java
+++ b/modules/apps/cookies/cookies-rest-test/src/testIntegration/java/com/liferay/cookies/rest/resource/v1_0/test/BaseCookiesConsentPreferenceResourceTestCase.java
@@ -195,6 +195,31 @@ public abstract class BaseCookiesConsentPreferenceResourceTestCase {
 	}
 
 	@Test
+	public void testDeleteCookiesConsentPreference() throws Exception {
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		CookiesConsentPreference cookiesConsentPreference =
+			testDeleteCookiesConsentPreference_addCookiesConsentPreference();
+
+		assertHttpResponseStatusCode(
+			204,
+			cookiesConsentPreferenceResource.
+				deleteCookiesConsentPreferenceHttpResponse());
+	}
+
+	protected CookiesConsentPreference
+			testDeleteCookiesConsentPreference_addCookiesConsentPreference()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGraphQLDeleteCookiesConsentPreference() throws Exception {
+		Assert.assertTrue(false);
+	}
+
+	@Test
 	public void testDeleteCookiesConsentPreferenceByName() throws Exception {
 		@SuppressWarnings("PMD.UnusedLocalVariable")
 		CookiesConsentPreference cookiesConsentPreference =
@@ -319,31 +344,6 @@ public abstract class BaseCookiesConsentPreferenceResourceTestCase {
 		throws Exception {
 
 		return testGraphQLCookiesConsentPreference_addCookiesConsentPreference();
-	}
-
-	@Test
-	public void testDeleteCookiesConsentPreferences() throws Exception {
-		@SuppressWarnings("PMD.UnusedLocalVariable")
-		CookiesConsentPreference cookiesConsentPreference =
-			testDeleteCookiesConsentPreferences_addCookiesConsentPreference();
-
-		assertHttpResponseStatusCode(
-			204,
-			cookiesConsentPreferenceResource.
-				deleteCookiesConsentPreferencesHttpResponse());
-	}
-
-	protected CookiesConsentPreference
-			testDeleteCookiesConsentPreferences_addCookiesConsentPreference()
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
-
-	@Test
-	public void testGraphQLDeleteCookiesConsentPreferences() throws Exception {
-		Assert.assertTrue(false);
 	}
 
 	@Test
@@ -510,11 +510,6 @@ public abstract class BaseCookiesConsentPreferenceResourceTestCase {
 
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
-	}
-
-	@Test
-	public void testBatchEngineDeleteImportTask() throws Exception {
-		Assert.assertTrue(true);
 	}
 
 	protected CookiesConsentPreference
@@ -1431,4 +1426,4 @@ public abstract class BaseCookiesConsentPreferenceResourceTestCase {
 			_cookiesConsentPreferenceResource;
 
 }
-// LIFERAY-REST-BUILDER-HASH:811696207
+// LIFERAY-REST-BUILDER-HASH:138682693


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94383

## What Is Being Fixed

The cookies-rest-impl REST Builder module did not set forcePredictableOperationId or forcePredictableSchemaPropertyName, leaving its generated operation IDs out of step with the predictable naming convention used elsewhere (for example, headless-dsr-impl).

## How It Is Being Fixed

Added forcePredictableOperationId: true and forcePredictableSchemaPropertyName: true to cookies-rest-impl/rest-config.yaml. forcePredictableOperationId renames the collection-level "delete all" endpoint from deleteCookiesConsentPreferences to deleteCookiesConsentPreference. That rename makes the operation match REST Builder's batch-delete trigger, which then auto-generates a batch DELETE endpoint whose body assumes a delete-by-id method this API does not have, breaking compilation. Adding generateBatch: false (matching the headless-dsr-impl reference) suppresses batch generation; this also drops the previously auto-generated PUT batch endpoint, which was never explicitly authored. After regenerating with buildREST, the hand-written CookiesConsentPreferenceResourceImpl override was renamed from deleteCookiesConsentPreferences to deleteCookiesConsentPreference to match the new base signature.

## Why Are There No Tests?

This PR only adds rest-config.yaml flags and regenerates REST Builder artifacts; behavior is unchanged, so no new tests are warranted. The regenerated base test case stays in sync automatically.

## PR Check

**pr-check: PASS** — tested on `5c2db90f051da4d116872bd17d156e22eb34b4b0`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Deploy | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5c2db90f051da4d116872bd17d156e22eb34b4b0"} -->