### PR TITLE
LPD-94502 Render the cookies banner with its card background and shadow

### DIFF
--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner/css/main.scss
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner/css/main.scss
@@ -1,8 +1,9 @@
-@import 'cadmin-variables';
+@import 'atlas-variables';
 
 .cookies-banner {
-	background-color: $cadmin-white;
-	box-shadow: $cadmin-box-shadow-lg;
+	background-color: var(--white);
+	box-shadow: $box-shadow-lg;
+	color: var(--gray-900);
 	display: none;
 	left: 0;
 	right: 0;

--- a/modules/test/playwright/tests/cookies-banner-web/main/cookiesBannerCadmin.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/main/cookiesBannerCadmin.spec.ts
@@ -21,6 +21,13 @@ export const test = mergeTests(
 );
 
 test.afterEach(async ({systemSettingsPage}) => {
+	await test.step('Deactivate Consent Manager', async () => {
+		await updateConsentManagerConfiguration(systemSettingsPage.page, {
+			active: false,
+			forceReload: true,
+		});
+	});
+
 	await test.step('Reset Consent Manager Configuration', async () => {
 		await resetConsentManagerConfiguration(systemSettingsPage);
 	});
@@ -60,3 +67,42 @@ test('LPD-25440 Cookie Banner Cadmin', async ({page}) => {
 		await expect(modalBody).not.toHaveClass(/cadmin/);
 	});
 });
+
+test(
+	'Cookie Banner renders with a solid background and drop shadow',
+	{tag: '@LPD-94502'},
+	async ({page}) => {
+		await test.step('Enable Third Party Cookies', async () => {
+			await updateConsentManagerConfiguration(page, {
+				enabled: true,
+				forceReload: true,
+			});
+		});
+
+		await test.step('Render the banner on the configuration page', async () => {
+			await page.reload();
+
+			await page.locator('.cookies-banner').waitFor({state: 'visible'});
+		});
+
+		await test.step('Verify the banner card is not transparent and has a shadow', async () => {
+			const banner = page.locator('.cookies-banner');
+
+			await expect(banner).not.toHaveCSS(
+				'background-color',
+				'rgba(0, 0, 0, 0)'
+			);
+
+			await expect(banner).not.toHaveCSS('box-shadow', 'none');
+		});
+
+		await test.step('Verify the banner card adapts to dark mode', async () => {
+			await page.emulateMedia({colorScheme: 'dark'});
+
+			await expect(page.locator('.cookies-banner')).not.toHaveCSS(
+				'background-color',
+				'rgb(255, 255, 255)'
+			);
+		});
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94502

## What Is Being Fixed

Since ~2026-06-01 the cookies consent banner renders on end-user site pages with no white background and no drop shadow — its text and buttons float over the page instead of appearing as a card. LPD-85958 redefined `$cadmin-white` and `$cadmin-box-shadow-lg` as `.cadmin`-scoped CSS custom properties with no global `:root` fallback, and the banner renders at the theme bottom (`bottom.jsp#post`) outside any `.cadmin` element, so those tokens resolved to a transparent background and no shadow. On dark-mode-capable surfaces the banner additionally showed unreadable light text on the white card, because it set no text color of its own and inherited the page's light dark-mode text.

## How It Is Being Fixed

The banner stylesheet now uses the globally-resolvable Atlas custom properties `var(--white)` for the card background and `var(--gray-900)` for the text color, keeping the base `$box-shadow-lg` for the drop shadow. Both are `light-dark()` tokens defined at the global `:root`, so the card surface and its text resolve everywhere the banner renders and adapt together: on dark-capable surfaces the card goes dark with light text, and on end-user themes (which ship no dark mode) it stays a readable white card with dark text. A Playwright regression test asserts the banner has a non-transparent background and a shadow, and that it adapts to dark mode on the configuration page (a dark-capable surface, since end-user themes have no `prefers-color-scheme` dark mode). The spec's `afterEach` now deactivates the consent manager so tests leave the portal clean and the suite is order-independent.

## PR Check

**pr-check: PASS** — tested on `86be9886417691870ecab4326b9387ca6be0b572`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "86be9886417691870ecab4326b9387ca6be0b572"} -->