### PR TITLE
[FIPS] LPD-94045 Enforce FIPS-approved PBKDF2/HMAC-SHA-256 password hashing

### DIFF
--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/DefaultPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/DefaultPasswordEncryptor.java
@@ -5,8 +5,13 @@
 
 package com.liferay.portal.security.password.encryptor.internal;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PwdEncryptorException;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.util.DigesterUtil;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -22,8 +27,21 @@ public class DefaultPasswordEncryptor implements PasswordEncryptor {
 
 	@Override
 	public String encrypt(
-		String algorithm, String plainTextPassword, String encryptedPassword,
-		boolean upgradeHashSecurity) {
+			String algorithm, String plainTextPassword,
+			String encryptedPassword, boolean upgradeHashSecurity)
+		throws PwdEncryptorException {
+
+		try {
+			MessageDigest.getInstance(algorithm);
+		}
+		catch (NoSuchAlgorithmException noSuchAlgorithmException) {
+			throw new PwdEncryptorException.UnavailableAlgorithm(
+				StringBundler.concat(
+					"The algorithm \"", algorithm,
+					"\" is not available from the configured security ",
+					"provider"),
+				noSuchAlgorithmException);
+		}
 
 		return DigesterUtil.digest(algorithm, plainTextPassword);
 	}

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/PBKDF2PasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/PBKDF2PasswordEncryptor.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.security.SecureRandomUtil;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.nio.BufferUnderflowException;
@@ -114,14 +115,18 @@ public class PBKDF2PasswordEncryptor implements PasswordEncryptor {
 		}
 	}
 
-	private static final int _KEY_SIZE = 160;
+	private static final int _KEY_SIZE = 256;
+
+	private static final int _KEY_SIZE_FLOOR = 112;
 
 	private static final int _ROUNDS = 1300000;
+
+	private static final int _ROUNDS_FLOOR = 1300000;
 
 	private static final int _SALT_BYTES_LENGTH = 16;
 
 	private static final Pattern _pattern = Pattern.compile(
-		"^.*/?([0-9]+)?/([0-9]+)$");
+		"^[^/]*(?:/([0-9]+))?/([0-9]+)$");
 
 	private static class PBKDF2EncryptionConfiguration {
 
@@ -140,8 +145,30 @@ public class PBKDF2PasswordEncryptor implements PasswordEncryptor {
 					_rounds = GetterUtil.getInteger(matcher.group(2), _ROUNDS);
 				}
 
-				BigEndianCodec.putLong(
-					_saltBytes, 0, SecureRandomUtil.nextLong());
+				if (PropsValues.FIPS_ENABLED) {
+					if (_rounds < _ROUNDS_FLOOR) {
+						throw new PwdEncryptorException.InvalidAlgorithm(
+							StringBundler.concat(
+								"PBKDF2 iteration count ", _rounds,
+								" is below the minimum allowed value of ",
+								_ROUNDS_FLOOR),
+							null);
+					}
+
+					if (_keySize < _KEY_SIZE_FLOOR) {
+						throw new PwdEncryptorException.InvalidAlgorithm(
+							StringBundler.concat(
+								"PBKDF2 output length ", _keySize,
+								" bits is below the minimum allowed value of ",
+								_KEY_SIZE_FLOOR, " bits"),
+							null);
+					}
+				}
+
+				for (int i = 0; i < _SALT_BYTES_LENGTH; i += 8) {
+					BigEndianCodec.putLong(
+						_saltBytes, i, SecureRandomUtil.nextLong());
+				}
 			}
 			else {
 				ByteBuffer byteBuffer = ByteBuffer.wrap(

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
@@ -259,10 +259,49 @@ public class PasswordEncryptorUtilTest {
 			PasswordEncryptor.TYPE_UFC_CRYPT);
 	}
 
+	@Test
+	public void testEncryptUnavailableAlgorithm() throws Exception {
+		DefaultPasswordEncryptor defaultPasswordEncryptor =
+			new DefaultPasswordEncryptor();
+
+		try {
+			defaultPasswordEncryptor.encrypt(
+				"Some Nonexistent Algorithm", "password", null, false);
+
+			Assert.fail();
+		}
+		catch (PwdEncryptorException.UnavailableAlgorithm
+					pwdEncryptorException) {
+		}
+	}
+
 	@Test(expected = PwdEncryptorException.MustSetLegacyAlgorithmProperty.class)
 	public void testEncryptWithLegacyAlgorithm() throws Exception {
 		_testEncryptWithLegacyAlgorithm(
 			null, RandomTestUtil.randomString(), RandomTestUtil.randomString());
+	}
+
+	@Test
+	public void testFIPSModeEnforcesPBKDF2WithHmacSHA256() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			_testEncryptGenerationFailure(
+				PasswordEncryptor.TYPE_BCRYPT + "/10");
+
+			_testEncryptGenerationFailure(
+				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA1/160/1300000");
+
+			_testEncryptGenerationFailure(
+				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA256/256/600000");
+
+			_testEncryptGenerationFailure(
+				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA256/64/1300000");
+
+			_testEncrypt(
+				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA256/256/1300000");
+		}
 	}
 
 	private void _runTests(
@@ -309,6 +348,16 @@ public class PasswordEncryptorUtilTest {
 			Assert.fail();
 		}
 		catch (Exception exception) {
+		}
+	}
+
+	private void _testEncryptGenerationFailure(String algorithm) {
+		try {
+			PasswordEncryptorUtil.encrypt(algorithm, "password", null);
+
+			Assert.fail();
+		}
+		catch (PwdEncryptorException pwdEncryptorException) {
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/security/pwd/PwdAuthenticator.java
+++ b/portal-impl/src/com/liferay/portal/security/pwd/PwdAuthenticator.java
@@ -32,8 +32,35 @@ public class PwdAuthenticator {
 			String currentEncryptedPassword)
 		throws PwdEncryptorException {
 
-		String encryptedPassword = PasswordEncryptorUtil.encrypt(
-			clearTextPassword, currentEncryptedPassword);
+		String encryptedPassword = null;
+
+		try {
+			encryptedPassword = PasswordEncryptorUtil.encrypt(
+				clearTextPassword, currentEncryptedPassword);
+		}
+		catch (PwdEncryptorException.UnavailableAlgorithm
+					pwdEncryptorException1) {
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to verify a password hashed with an unavailable " +
+						"algorithm",
+					pwdEncryptorException1);
+			}
+
+			try {
+				PasswordEncryptorUtil.encrypt(
+					clearTextPassword, _PRETENDED_CURRENT_ENCRYPTED_PASSWORD);
+			}
+			catch (PwdEncryptorException pwdEncryptorException2) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Unable to perform decoy hash", pwdEncryptorException2);
+				}
+			}
+
+			return false;
+		}
 
 		if (currentEncryptedPassword.equals(encryptedPassword)) {
 			return true;

--- a/portal-kernel/src/com/liferay/portal/kernel/exception/PwdEncryptorException.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/exception/PwdEncryptorException.java
@@ -48,6 +48,14 @@ public class PwdEncryptorException extends PortalException {
 
 	}
 
+	public static class UnavailableAlgorithm extends PwdEncryptorException {
+
+		public UnavailableAlgorithm(String msg, Throwable throwable) {
+			super(msg, throwable);
+		}
+
+	}
+
 	public static class UnsupportedEncoding extends PwdEncryptorException {
 
 		public UnsupportedEncoding(String msg, Throwable throwable) {

--- a/portal-kernel/src/com/liferay/portal/kernel/exception/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/exception/packageinfo
@@ -1,1 +1,1 @@
-version 16.7.0
+version 16.8.0

--- a/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptorUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptorUtil.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.util.ClassUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -142,6 +143,19 @@ public class PasswordEncryptorUtil {
 			if (Validator.isNull(algorithm)) {
 				algorithm = _PASSWORDS_ENCRYPTION_ALGORITHM;
 			}
+		}
+
+		if (PropsValues.FIPS_ENABLED && Validator.isNull(encryptedPassword) &&
+			!_isFIPSApprovedAlgorithm(algorithm)) {
+
+			throw new PwdEncryptorException.InvalidAlgorithm(
+				StringBundler.concat(
+					"FIPS mode requires the property \"",
+					PropsKeys.PASSWORDS_ENCRYPTION_ALGORITHM,
+					"\" to use PBKDF2 with HMAC-SHA-256 (for example, ",
+					"PBKDF2WithHmacSHA256/256/600000), but was \"", algorithm,
+					"\""),
+				null);
 		}
 
 		PasswordEncryptor passwordEncryptor = _getPasswordEncryptor(algorithm);
@@ -281,6 +295,22 @@ public class PasswordEncryptorUtil {
 		}
 
 		return passwordEncryptor;
+	}
+
+	private static boolean _isFIPSApprovedAlgorithm(String algorithm) {
+		if (Validator.isNull(algorithm)) {
+			return false;
+		}
+
+		String upperCaseAlgorithm = StringUtil.toUpperCase(algorithm);
+
+		if (upperCaseAlgorithm.startsWith(PasswordEncryptor.TYPE_PBKDF2) &&
+			upperCaseAlgorithm.contains("SHA256")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static final String _PASSWORDS_ENCRYPTION_ALGORITHM =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94045

## What Is Being Fixed

In FIPS mode the validated security provider rejects bcrypt and other non-approved algorithms, so password storage must use PBKDF2 with HMAC-SHA-256. The existing PBKDF2 encryptor also had defects that undermined this: it filled only the first 8 of its 16 salt bytes (64 bits of entropy instead of 128) and silently ignored the configured key size, so the output length could never be validated. And when a stored hash uses an algorithm the validated provider rejects (e.g. MD5), the password cannot be verified — that failure must not reveal which accounts still hold legacy hashes.

## How It Is Being Fixed

The PBKDF2 encryptor now fills the full 16-byte salt and honors the configured key size. When FIPS mode is enabled it enforces a 1,300,000-iteration floor and a 112-bit output-length floor, and PasswordEncryptorUtil rejects any configured algorithm other than PBKDF2/HMAC-SHA-256 for new hashes, so a misconfigured FIPS deployment fails fast. Verification of existing hashes is left untouched so bcrypt and other still-supported hashes keep migrating transparently on the next login. When a stored hash uses a provider-rejected algorithm, the default encryptor throws a typed exception that authentication treats as an ordinary failure after an equivalent decoy hash, so neither the error message nor the response time distinguishes those accounts.

## PR Check

**pr-check: PASS** — tested on `bb2511b36c969e24bdc6b4bf44f4546e4d99dff5`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "bb2511b36c969e24bdc6b4bf44f4546e4d99dff5"} -->
