### PR TITLE
[FIPS] LPD-90288 Enforce FIPS-approved algorithm selection

### DIFF
--- a/modules/apps/analytics/analytics-settings-impl/src/main/java/com/liferay/analytics/settings/internal/security/auth/verifier/AnalyticsSecurityAuthVerifier.java
+++ b/modules/apps/analytics/analytics-settings-impl/src/main/java/com/liferay/analytics/settings/internal/security/auth/verifier/AnalyticsSecurityAuthVerifier.java
@@ -168,10 +168,10 @@ public class AnalyticsSecurityAuthVerifier implements AuthVerifier {
 		throws Exception {
 
 		Signature signature = Signature.getInstance(
-			PropsValues.FIPS_ENABLED ? "SHA256withECDSA" : _DSA);
+			PropsValues.FIPS_ENABLED ? "SHA256withECDSA" : "DSA");
 
 		KeyFactory keyFactory = KeyFactory.getInstance(
-			PropsValues.FIPS_ENABLED ? "EC" : _DSA);
+			PropsValues.FIPS_ENABLED ? "EC" : "DSA");
 
 		signature.initVerify(
 			keyFactory.generatePublic(
@@ -205,8 +205,6 @@ public class AnalyticsSecurityAuthVerifier implements AuthVerifier {
 
 		return signature.verify(Base64.decode(signatureString));
 	}
-
-	private static final String _DSA = "DSA";
 
 	private static final long _EXPIRATION = 10 * 60 * 1000;
 

--- a/modules/apps/analytics/analytics-settings-impl/src/main/java/com/liferay/analytics/settings/internal/security/auth/verifier/AnalyticsSecurityAuthVerifier.java
+++ b/modules/apps/analytics/analytics-settings-impl/src/main/java/com/liferay/analytics/settings/internal/security/auth/verifier/AnalyticsSecurityAuthVerifier.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsValues;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -166,9 +167,11 @@ public class AnalyticsSecurityAuthVerifier implements AuthVerifier {
 			String signatureString, String timestamp)
 		throws Exception {
 
-		Signature signature = Signature.getInstance("DSA");
+		Signature signature = Signature.getInstance(
+			PropsValues.FIPS_ENABLED ? "SHA256withECDSA" : _DSA);
 
-		KeyFactory keyFactory = KeyFactory.getInstance("DSA");
+		KeyFactory keyFactory = KeyFactory.getInstance(
+			PropsValues.FIPS_ENABLED ? "EC" : _DSA);
 
 		signature.initVerify(
 			keyFactory.generatePublic(
@@ -202,6 +205,8 @@ public class AnalyticsSecurityAuthVerifier implements AuthVerifier {
 
 		return signature.verify(Base64.decode(signatureString));
 	}
+
+	private static final String _DSA = "DSA";
 
 	private static final long _EXPIRATION = 10 * 60 * 1000;
 

--- a/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/hashed/files/HashedFilesRegistryImpl.java
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/java/com/liferay/frontend/js/web/internal/hashed/files/HashedFilesRegistryImpl.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import jakarta.servlet.ServletContext;
@@ -336,7 +337,9 @@ public class HashedFilesRegistryImpl implements HashedFilesRegistry {
 
 		String hashesString = StringUtil.merge(hashesList, StringPool.PIPE);
 
-		byte[] hash = DigesterUtil.digestRaw(DigesterUtil.MD5, hashesString);
+		byte[] hash = DigesterUtil.digestRaw(
+			PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 : DigesterUtil.MD5,
+			hashesString);
 
 		byte[] truncatedHash = new byte[8];
 

--- a/modules/apps/frontend-js/frontend-js-web/src/test/java/com/liferay/frontend/js/web/internal/hashed/files/HashedFilesRegistryImplTest.java
+++ b/modules/apps/frontend-js/frontend-js-web/src/test/java/com/liferay/frontend/js/web/internal/hashed/files/HashedFilesRegistryImplTest.java
@@ -10,6 +10,9 @@ import com.liferay.frontend.js.web.test.util.FrontendJSWebTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -17,6 +20,8 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import jakarta.servlet.ServletContext;
 
 import java.net.URL;
+
+import java.security.MessageDigest;
 
 import java.util.Map;
 
@@ -78,6 +83,22 @@ public class HashedFilesRegistryImplTest {
 
 		Assert.assertNotNull(
 			hashedFilesRegistryImpl.getResource("/o/frontend-js-web/main.css"));
+	}
+
+	@Test
+	public void testGetServletContextHash() throws Exception {
+		Map<String, String> hashedFileURIs = HashMapBuilder.put(
+			"/o/frontend-js-web/main.css",
+			HashedFilesUtil.addHash(
+				"/o/frontend-js-web/main.css", RandomTestUtil.randomString())
+		).build();
+
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			() -> ReflectionTestUtil.invoke(
+				new HashedFilesRegistryImpl(), "_getServletContextHash",
+				new Class<?>[] {Map.class}, hashedFileURIs),
+			DigesterUtil.MD5, MessageDigest::getInstance, MessageDigest.class,
+			DigesterUtil.SHA_256);
 	}
 
 	private Map<String, HashedFilesRegistryImpl.DataBag> _mockDataBags(

--- a/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientASLocalMetadataLocalServiceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientASLocalMetadataLocalServiceImpl.java
@@ -23,8 +23,10 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -433,7 +435,9 @@ public class OAuthClientASLocalMetadataLocalServiceImpl
 			URI issuerURI = URI.create(issuer);
 
 			if (wellKnownURISuffix.equals("openid-configuration")) {
-				MessageDigest messageDigest = MessageDigest.getInstance("MD5");
+				MessageDigest messageDigest = MessageDigest.getInstance(
+					PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 :
+						DigesterUtil.MD5);
 
 				return StringBundler.concat(
 					issuerURI.getScheme(), "://", issuerURI.getAuthority(),

--- a/modules/apps/portal-crypto-hash/portal-crypto-hash-impl/build.gradle
+++ b/modules/apps/portal-crypto-hash/portal-crypto-hash-impl/build.gradle
@@ -9,4 +9,6 @@ dependencies {
 	testImplementation group: "com.liferay", name: "jodd.util", version: "6.0.1.LIFERAY-PATCHED-2"
 	testImplementation project(":apps:portal-crypto-hash:portal-crypto-hash-provider:portal-crypto-hash-provider-bcrypt")
 	testImplementation project(":apps:portal-crypto-hash:portal-crypto-hash-provider:portal-crypto-hash-provider-message-digest")
+	testImplementation project(":core:petra:petra-function")
+	testImplementation project(":core:petra:petra-lang")
 }

--- a/modules/apps/portal-crypto-hash/portal-crypto-hash-impl/src/test/java/com/liferay/portal/crypto/hash/internal/CryptoHashGeneratorTest.java
+++ b/modules/apps/portal-crypto-hash/portal-crypto-hash-impl/src/test/java/com/liferay/portal/crypto/hash/internal/CryptoHashGeneratorTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.crypto.hash.internal;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.crypto.hash.CryptoHashGenerator;
 import com.liferay.portal.crypto.hash.CryptoHashResponse;
 import com.liferay.portal.crypto.hash.CryptoHashVerificationContext;
@@ -12,7 +13,9 @@ import com.liferay.portal.crypto.hash.provider.bcrypt.internal.BCryptCryptoHashP
 import com.liferay.portal.crypto.hash.provider.message.digest.internal.MessageDigestCryptoHashProviderFactory;
 import com.liferay.portal.crypto.hash.spi.CryptoHashProviderFactory;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.ArrayList;
@@ -79,6 +82,28 @@ public class CryptoHashGeneratorTest {
 		_serviceRegistration2.unregister();
 
 		_serviceRegistration1.unregister();
+	}
+
+	@Test
+	public void testCreate() throws Exception {
+		MessageDigestCryptoHashProviderFactory
+			messageDigestCryptoHashProviderFactory =
+				new MessageDigestCryptoHashProviderFactory();
+
+		messageDigestCryptoHashProviderFactory.create(
+			Collections.singletonMap(
+				"message.digest.algorithm", DigesterUtil.MD5));
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			Assert.assertThrows(
+				SecurityException.class,
+				() -> messageDigestCryptoHashProviderFactory.create(
+					Collections.singletonMap(
+						"message.digest.algorithm", DigesterUtil.MD5)));
+		}
 	}
 
 	@Test

--- a/modules/apps/portal-crypto-hash/portal-crypto-hash-provider/portal-crypto-hash-provider-message-digest/src/main/java/com/liferay/portal/crypto/hash/provider/message/digest/internal/MessageDigestCryptoHashProviderFactory.java
+++ b/modules/apps/portal-crypto-hash/portal-crypto-hash-provider/portal-crypto-hash-provider-message-digest/src/main/java/com/liferay/portal/crypto/hash/provider/message/digest/internal/MessageDigestCryptoHashProviderFactory.java
@@ -10,7 +10,9 @@ import com.liferay.portal.crypto.hash.spi.CryptoHashProvider;
 import com.liferay.portal.crypto.hash.spi.CryptoHashProviderFactory;
 import com.liferay.portal.crypto.hash.spi.CryptoHashProviderResponse;
 import com.liferay.portal.kernel.security.SecureRandomUtil;
+import com.liferay.portal.kernel.security.fips.FIPSModeUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 
 import java.security.MessageDigest;
@@ -67,10 +69,17 @@ public class MessageDigestCryptoHashProviderFactory
 
 			_cryptoHashProviderProperties = cryptoHashProviderProperties;
 
-			_messageDigest = MessageDigest.getInstance(
-				MapUtil.getString(
-					cryptoHashProviderProperties, "message.digest.algorithm",
-					"SHA-256"));
+			String algorithm = MapUtil.getString(
+				cryptoHashProviderProperties, "message.digest.algorithm",
+				DigesterUtil.SHA_256);
+
+			if (!FIPSModeUtil.isAllowedAlgorithm(algorithm)) {
+				throw new SecurityException(
+					"Algorithm \"" + algorithm +
+						"\" is not allowed in FIPS mode");
+			}
+
+			_messageDigest = MessageDigest.getInstance(algorithm);
 			_saltSize = MapUtil.getInteger(
 				cryptoHashProviderProperties, "message.digest.salt.size", 32);
 		}

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtil.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtil.java
@@ -14,6 +14,8 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 
 import java.net.URI;
 
@@ -36,8 +38,9 @@ public class OpenIdConnectProviderUtil {
 			String issuer, String tokenEndpoint)
 		throws Exception {
 
-		MessageDigest messageDigest = MessageDigest.getInstance("MD5");
 		URI issuerURI = URI.create(issuer);
+		MessageDigest messageDigest = MessageDigest.getInstance(
+			PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 : DigesterUtil.MD5);
 
 		return StringBundler.concat(
 			issuerURI.getScheme(), "://", issuerURI.getAuthority(),

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtilTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtilTest.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.sso.openid.connect.internal.util;
+
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.security.MessageDigest;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class OpenIdConnectProviderUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGenerateLocalWellKnownURI() throws Exception {
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			() -> OpenIdConnectProviderUtil.generateLocalWellKnownURI(
+				"https://" + RandomTestUtil.randomString(),
+				RandomTestUtil.randomString()),
+			DigesterUtil.MD5, MessageDigest::getInstance, MessageDigest.class,
+			DigesterUtil.SHA_256);
+	}
+
+}

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtilTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtilTest.java
@@ -27,7 +27,7 @@ public class OpenIdConnectProviderUtilTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void testGenerateLocalWellKnownURI() throws Exception {
+	public void test() throws Exception {
 		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
 			() -> OpenIdConnectProviderUtil.generateLocalWellKnownURI(
 				"https://" + RandomTestUtil.randomString(),

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/src/main/java/com/liferay/portal/security/sso/openid/connect/persistence/internal/upgrade/v2_0_0/OpenIdConnectSessionUpgradeProcess.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/src/main/java/com/liferay/portal/security/sso/openid/connect/persistence/internal/upgrade/v2_0_0/OpenIdConnectSessionUpgradeProcess.java
@@ -12,7 +12,9 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.net.URI;
@@ -93,7 +95,8 @@ public class OpenIdConnectSessionUpgradeProcess extends UpgradeProcess {
 		throws Exception {
 
 		URI issuerURI = URI.create(issuer);
-		MessageDigest messageDigest = MessageDigest.getInstance("MD5");
+		MessageDigest messageDigest = MessageDigest.getInstance(
+			PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 : DigesterUtil.MD5);
 
 		return StringBundler.concat(
 			issuerURI.getScheme(), "://", issuerURI.getAuthority(),

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/build.gradle
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":core:osgi-service-tracker-collections")
+	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-reflect")

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/SSHAPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/SSHAPasswordEncryptor.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.UnsupportedEncodingException;
@@ -44,7 +45,9 @@ public class SSHAPasswordEncryptor implements PasswordEncryptor {
 		byte[] saltBytes = getSaltBytes(encryptedPassword);
 
 		try {
-			MessageDigest messageDigest = MessageDigest.getInstance("SHA-1");
+			MessageDigest messageDigest = MessageDigest.getInstance(
+				PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 :
+					DigesterUtil.SHA_1);
 
 			byte[] plainTextPasswordBytes = plainTextPassword.getBytes(
 				DigesterUtil.ENCODING);

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
@@ -13,10 +13,14 @@ import com.liferay.portal.kernel.exception.PwdEncryptorException;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptorUtil;
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.security.MessageDigest;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -250,6 +254,22 @@ public class PasswordEncryptorUtilTest {
 			PasswordEncryptor.TYPE_SSHA, "password",
 			"2EWEKeVpSdd79PkTX5vaGXH5uQ028Smy/H1NmA==",
 			PasswordEncryptor.TYPE_SSHA);
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			_runTests(
+				PasswordEncryptor.TYPE_SSHA, "password",
+				"q0elUchHiEgZAZww57UMs6Jt+L45+785Q8YcVUf8VfcAAQIDBAUGBw==",
+				PasswordEncryptor.TYPE_SSHA);
+		}
+
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			() -> PasswordEncryptorUtil.encrypt(
+				PasswordEncryptor.TYPE_SSHA, "password", null),
+			DigesterUtil.SHA_1, MessageDigest::getInstance, MessageDigest.class,
+			DigesterUtil.SHA_256);
 	}
 
 	@Test

--- a/modules/apps/static/portal/portal-encryptor/src/main/java/com/liferay/portal/encryptor/EncryptorImpl.java
+++ b/modules/apps/static/portal/portal-encryptor/src/main/java/com/liferay/portal/encryptor/EncryptorImpl.java
@@ -88,9 +88,7 @@ public class EncryptorImpl implements Encryptor {
 			}
 			catch (Exception exception) {
 				if (_log.isDebugEnabled()) {
-					_log.debug(
-						"Falling back to legacy decryption after GCM failure",
-						exception);
+					_log.debug(exception);
 				}
 			}
 		}

--- a/modules/apps/static/portal/portal-encryptor/src/main/java/com/liferay/portal/encryptor/EncryptorImpl.java
+++ b/modules/apps/static/portal/portal-encryptor/src/main/java/com/liferay/portal/encryptor/EncryptorImpl.java
@@ -61,12 +61,30 @@ public class EncryptorImpl implements Encryptor {
 	}
 
 	@Override
+	public byte[] decryptUnencodedAsBytes(
+			AlgorithmParameterSpec algorithmParameterSpec,
+			byte[] encryptedBytes, Key key, String transformation)
+		throws EncryptorException {
+
+		try {
+			Cipher cipher = Cipher.getInstance(transformation);
+
+			cipher.init(Cipher.DECRYPT_MODE, key, algorithmParameterSpec);
+
+			return cipher.doFinal(encryptedBytes);
+		}
+		catch (Exception exception) {
+			throw new EncryptorException(exception);
+		}
+	}
+
+	@Override
 	public byte[] decryptUnencodedAsBytes(Key key, byte[] encryptedBytes)
 		throws EncryptorException {
 
 		if (PropsValues.FIPS_ENABLED) {
 			try {
-				return _decryptGCM(key, encryptedBytes);
+				return _decryptGCM(encryptedBytes, key);
 			}
 			catch (Exception exception) {
 				if (_log.isDebugEnabled()) {
@@ -102,24 +120,6 @@ public class EncryptorImpl implements Encryptor {
 	}
 
 	@Override
-	public byte[] decryptUnencodedAsBytes(
-			Key key, byte[] encryptedBytes, String transformation,
-			AlgorithmParameterSpec algorithmParameterSpec)
-		throws EncryptorException {
-
-		try {
-			Cipher cipher = Cipher.getInstance(transformation);
-
-			cipher.init(Cipher.DECRYPT_MODE, key, algorithmParameterSpec);
-
-			return cipher.doFinal(encryptedBytes);
-		}
-		catch (Exception exception) {
-			throw new EncryptorException(exception);
-		}
-	}
-
-	@Override
 	public Key deserializeKey(String base64String) {
 		if (!FIPSModeUtil.isAllowedAlgorithm(KEY_ALGORITHM)) {
 			throw new SecurityException(
@@ -148,6 +148,24 @@ public class EncryptorImpl implements Encryptor {
 	}
 
 	@Override
+	public byte[] encryptUnencoded(
+			AlgorithmParameterSpec algorithmParameterSpec, Key key,
+			byte[] plainBytes, String transformation)
+		throws EncryptorException {
+
+		try {
+			Cipher cipher = Cipher.getInstance(transformation);
+
+			cipher.init(Cipher.ENCRYPT_MODE, key, algorithmParameterSpec);
+
+			return cipher.doFinal(plainBytes);
+		}
+		catch (Exception exception) {
+			throw new EncryptorException(exception);
+		}
+	}
+
+	@Override
 	public byte[] encryptUnencoded(Key key, byte[] plainBytes)
 		throws EncryptorException {
 
@@ -173,24 +191,6 @@ public class EncryptorImpl implements Encryptor {
 			synchronized (cipher) {
 				return cipher.doFinal(plainBytes);
 			}
-		}
-		catch (Exception exception) {
-			throw new EncryptorException(exception);
-		}
-	}
-
-	@Override
-	public byte[] encryptUnencoded(
-			Key key, byte[] plainBytes, String transformation,
-			AlgorithmParameterSpec algorithmParameterSpec)
-		throws EncryptorException {
-
-		try {
-			Cipher cipher = Cipher.getInstance(transformation);
-
-			cipher.init(Cipher.ENCRYPT_MODE, key, algorithmParameterSpec);
-
-			return cipher.doFinal(plainBytes);
 		}
 		catch (Exception exception) {
 			throw new EncryptorException(exception);
@@ -227,7 +227,7 @@ public class EncryptorImpl implements Encryptor {
 		return Base64.encode(key.getEncoded());
 	}
 
-	private byte[] _decryptGCM(Key key, byte[] encryptedBytes)
+	private byte[] _decryptGCM(byte[] encryptedBytes, Key key)
 		throws EncryptorException {
 
 		byte[] cipherBytes = Arrays.copyOfRange(
@@ -238,8 +238,8 @@ public class EncryptorImpl implements Encryptor {
 			encryptedBytes, 0, _GCM_INITIALIZATION_VECTOR_LENGTH);
 
 		return decryptUnencodedAsBytes(
-			key, cipherBytes, _GCM_CIPHER_TRANSFORMATION,
-			new GCMParameterSpec(_GCM_TAG_LENGTH_BITS, initializationVector));
+			new GCMParameterSpec(_GCM_TAG_LENGTH_BITS, initializationVector),
+			cipherBytes, key, _GCM_CIPHER_TRANSFORMATION);
 	}
 
 	private String _decryptUnencodedAsString(Key key, byte[] encryptedBytes)
@@ -267,8 +267,8 @@ public class EncryptorImpl implements Encryptor {
 		}
 
 		byte[] cipherBytes = encryptUnencoded(
-			key, plainBytes, _GCM_CIPHER_TRANSFORMATION,
-			new GCMParameterSpec(_GCM_TAG_LENGTH_BITS, initializationVector));
+			new GCMParameterSpec(_GCM_TAG_LENGTH_BITS, initializationVector),
+			key, plainBytes, _GCM_CIPHER_TRANSFORMATION);
 
 		byte[] encryptedBytes =
 			new byte[initializationVector.length + cipherBytes.length];

--- a/modules/apps/static/portal/portal-encryptor/src/main/java/com/liferay/portal/encryptor/EncryptorImpl.java
+++ b/modules/apps/static/portal/portal-encryptor/src/main/java/com/liferay/portal/encryptor/EncryptorImpl.java
@@ -10,21 +10,26 @@ import com.liferay.portal.kernel.encryptor.Encryptor;
 import com.liferay.portal.kernel.encryptor.EncryptorException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.SecureRandomUtil;
+import com.liferay.portal.kernel.security.fips.FIPSModeUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.security.Key;
-import java.security.SecureRandom;
+import java.security.spec.AlgorithmParameterSpec;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.osgi.service.component.annotations.Component;
@@ -59,13 +64,26 @@ public class EncryptorImpl implements Encryptor {
 	public byte[] decryptUnencodedAsBytes(Key key, byte[] encryptedBytes)
 		throws EncryptorException {
 
-		String algorithm = key.getAlgorithm();
-
-		String cacheKey = algorithm + StringPool.POUND + key.toString();
-
-		Cipher cipher = _decryptCipherMap.get(cacheKey);
+		if (PropsValues.FIPS_ENABLED) {
+			try {
+				return _decryptGCM(key, encryptedBytes);
+			}
+			catch (Exception exception) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Falling back to legacy decryption after GCM failure",
+						exception);
+				}
+			}
+		}
 
 		try {
+			String algorithm = key.getAlgorithm();
+
+			String cacheKey = algorithm + StringPool.POUND + key;
+
+			Cipher cipher = _decryptCipherMap.get(cacheKey);
+
 			if (cipher == null) {
 				cipher = Cipher.getInstance(algorithm);
 
@@ -84,10 +102,34 @@ public class EncryptorImpl implements Encryptor {
 	}
 
 	@Override
+	public byte[] decryptUnencodedAsBytes(
+			Key key, byte[] encryptedBytes, String transformation,
+			AlgorithmParameterSpec algorithmParameterSpec)
+		throws EncryptorException {
+
+		try {
+			Cipher cipher = Cipher.getInstance(transformation);
+
+			cipher.init(Cipher.DECRYPT_MODE, key, algorithmParameterSpec);
+
+			return cipher.doFinal(encryptedBytes);
+		}
+		catch (Exception exception) {
+			throw new EncryptorException(exception);
+		}
+	}
+
+	@Override
 	public Key deserializeKey(String base64String) {
+		if (!FIPSModeUtil.isAllowedAlgorithm(KEY_ALGORITHM)) {
+			throw new SecurityException(
+				"Algorithm \"" + KEY_ALGORITHM +
+					"\" is not allowed in FIPS mode");
+		}
+
 		byte[] bytes = Base64.decode(base64String);
 
-		return new SecretKeySpec(bytes, EncryptorImpl.KEY_ALGORITHM);
+		return new SecretKeySpec(bytes, KEY_ALGORITHM);
 	}
 
 	@Override
@@ -109,13 +151,17 @@ public class EncryptorImpl implements Encryptor {
 	public byte[] encryptUnencoded(Key key, byte[] plainBytes)
 		throws EncryptorException {
 
-		String algorithm = key.getAlgorithm();
-
-		String cacheKey = algorithm + StringPool.POUND + key.toString();
-
-		Cipher cipher = _encryptCipherMap.get(cacheKey);
+		if (PropsValues.FIPS_ENABLED) {
+			return _encryptGCM(key, plainBytes);
+		}
 
 		try {
+			String algorithm = key.getAlgorithm();
+
+			String cacheKey = algorithm + StringPool.POUND + key;
+
+			Cipher cipher = _encryptCipherMap.get(cacheKey);
+
 			if (cipher == null) {
 				cipher = Cipher.getInstance(algorithm);
 
@@ -127,6 +173,24 @@ public class EncryptorImpl implements Encryptor {
 			synchronized (cipher) {
 				return cipher.doFinal(plainBytes);
 			}
+		}
+		catch (Exception exception) {
+			throw new EncryptorException(exception);
+		}
+	}
+
+	@Override
+	public byte[] encryptUnencoded(
+			Key key, byte[] plainBytes, String transformation,
+			AlgorithmParameterSpec algorithmParameterSpec)
+		throws EncryptorException {
+
+		try {
+			Cipher cipher = Cipher.getInstance(transformation);
+
+			cipher.init(Cipher.ENCRYPT_MODE, key, algorithmParameterSpec);
+
+			return cipher.doFinal(plainBytes);
 		}
 		catch (Exception exception) {
 			throw new EncryptorException(exception);
@@ -149,12 +213,33 @@ public class EncryptorImpl implements Encryptor {
 
 	@Override
 	public Key generateKey() throws EncryptorException {
+		if (!FIPSModeUtil.isAllowedAlgorithm(KEY_ALGORITHM)) {
+			throw new SecurityException(
+				"Algorithm \"" + KEY_ALGORITHM +
+					"\" is not allowed in FIPS mode");
+		}
+
 		return _generateKey(KEY_ALGORITHM);
 	}
 
 	@Override
 	public String serializeKey(Key key) {
 		return Base64.encode(key.getEncoded());
+	}
+
+	private byte[] _decryptGCM(Key key, byte[] encryptedBytes)
+		throws EncryptorException {
+
+		byte[] cipherBytes = Arrays.copyOfRange(
+			encryptedBytes, _GCM_INITIALIZATION_VECTOR_LENGTH,
+			encryptedBytes.length);
+
+		byte[] initializationVector = Arrays.copyOfRange(
+			encryptedBytes, 0, _GCM_INITIALIZATION_VECTOR_LENGTH);
+
+		return decryptUnencodedAsBytes(
+			key, cipherBytes, _GCM_CIPHER_TRANSFORMATION,
+			new GCMParameterSpec(_GCM_TAG_LENGTH_BITS, initializationVector));
 	}
 
 	private String _decryptUnencodedAsString(Key key, byte[] encryptedBytes)
@@ -171,11 +256,39 @@ public class EncryptorImpl implements Encryptor {
 		}
 	}
 
+	private byte[] _encryptGCM(Key key, byte[] plainBytes)
+		throws EncryptorException {
+
+		byte[] initializationVector =
+			new byte[_GCM_INITIALIZATION_VECTOR_LENGTH];
+
+		for (int i = 0; i < initializationVector.length; i++) {
+			initializationVector[i] = SecureRandomUtil.nextByte();
+		}
+
+		byte[] cipherBytes = encryptUnencoded(
+			key, plainBytes, _GCM_CIPHER_TRANSFORMATION,
+			new GCMParameterSpec(_GCM_TAG_LENGTH_BITS, initializationVector));
+
+		byte[] encryptedBytes =
+			new byte[initializationVector.length + cipherBytes.length];
+
+		System.arraycopy(
+			initializationVector, 0, encryptedBytes, 0,
+			initializationVector.length);
+		System.arraycopy(
+			cipherBytes, 0, encryptedBytes, initializationVector.length,
+			cipherBytes.length);
+
+		return encryptedBytes;
+	}
+
 	private Key _generateKey(String algorithm) throws EncryptorException {
 		try {
 			KeyGenerator keyGenerator = KeyGenerator.getInstance(algorithm);
 
-			keyGenerator.init(KEY_SIZE, new SecureRandom());
+			keyGenerator.init(
+				PropsValues.FIPS_ENABLED ? _AES_KEY_SIZE : KEY_SIZE);
 
 			return keyGenerator.generateKey();
 		}
@@ -183,6 +296,15 @@ public class EncryptorImpl implements Encryptor {
 			throw new EncryptorException(exception);
 		}
 	}
+
+	private static final int _AES_KEY_SIZE = 256;
+
+	private static final String _GCM_CIPHER_TRANSFORMATION =
+		"AES/GCM/NoPadding";
+
+	private static final int _GCM_INITIALIZATION_VECTOR_LENGTH = 12;
+
+	private static final int _GCM_TAG_LENGTH_BITS = 128;
 
 	private static final Log _log = LogFactoryUtil.getLog(EncryptorImpl.class);
 

--- a/modules/apps/static/portal/portal-encryptor/src/test/java/com/liferay/portal/encryptor/EncryptorImplTest.java
+++ b/modules/apps/static/portal/portal-encryptor/src/test/java/com/liferay/portal/encryptor/EncryptorImplTest.java
@@ -5,7 +5,10 @@
 
 package com.liferay.portal.encryptor;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.encryptor.Encryptor;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.security.Key;
@@ -26,19 +29,60 @@ public class EncryptorImplTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void testKeySerialization() throws Exception {
+	public void testDecrypt() throws Exception {
 		Encryptor encryptor = new EncryptorImpl();
 
 		Key key = encryptor.generateKey();
 
-		String encryptedString = encryptor.encrypt(key, "Hello World!");
+		String encryptedString = encryptor.encrypt(key, _PLAIN_TEXT);
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			Assert.assertEquals(
+				_PLAIN_TEXT, encryptor.decrypt(key, encryptedString));
+		}
+	}
+
+	@Test
+	public void testEncrypt() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			Encryptor encryptor = new EncryptorImpl();
+
+			Key key = encryptor.generateKey();
+
+			String encryptedString1 = encryptor.encrypt(key, _PLAIN_TEXT);
+			String encryptedString2 = encryptor.encrypt(key, _PLAIN_TEXT);
+
+			Assert.assertNotEquals(encryptedString1, encryptedString2);
+
+			Assert.assertEquals(
+				_PLAIN_TEXT, encryptor.decrypt(key, encryptedString1));
+			Assert.assertEquals(
+				_PLAIN_TEXT, encryptor.decrypt(key, encryptedString2));
+		}
+	}
+
+	@Test
+	public void testSerializeKey() throws Exception {
+		Encryptor encryptor = new EncryptorImpl();
+
+		Key key = encryptor.generateKey();
+
+		String encryptedString = encryptor.encrypt(key, _PLAIN_TEXT);
 
 		String serializedKey = encryptor.serializeKey(key);
 
 		key = encryptor.deserializeKey(serializedKey);
 
 		Assert.assertEquals(
-			"Hello World!", encryptor.decrypt(key, encryptedString));
+			_PLAIN_TEXT, encryptor.decrypt(key, encryptedString));
 	}
+
+	private static final String _PLAIN_TEXT = RandomTestUtil.randomString();
 
 }

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtil.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtil.java
@@ -9,6 +9,7 @@ import com.liferay.petra.io.BigEndianCodec;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.security.SecureRandomUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.math.BigInteger;
@@ -28,8 +29,6 @@ import jodd.util.Base32;
  * @author Marta Medio
  */
 public class MFATimeBasedOTPUtil {
-
-	public static final String MFA_TIMEBASED_OTP_ALGORITHM = "HmacSHA1";
 
 	public static final int MFA_TIMEBASED_OTP_COUNTER = 30 * 1000;
 
@@ -74,8 +73,10 @@ public class MFATimeBasedOTPUtil {
 	}
 
 	private static byte[] _generateHMAC(byte[] key, String text) {
+		String algorithm = PropsValues.FIPS_ENABLED ? "HmacSHA256" : "HmacSHA1";
+
 		try {
-			Mac mac = Mac.getInstance(MFA_TIMEBASED_OTP_ALGORITHM);
+			Mac mac = Mac.getInstance(algorithm);
 
 			mac.init(new SecretKeySpec(key, "RAW"));
 
@@ -88,14 +89,12 @@ public class MFATimeBasedOTPUtil {
 		}
 		catch (InvalidKeyException invalidKeyException) {
 			throw new IllegalArgumentException(
-				"Invalid secret key for algorithm " +
-					MFA_TIMEBASED_OTP_ALGORITHM,
+				"Invalid secret key for algorithm " + algorithm,
 				invalidKeyException);
 		}
 		catch (NoSuchAlgorithmException noSuchAlgorithmException) {
 			throw new IllegalArgumentException(
-				"Invalid algorithm " + MFA_TIMEBASED_OTP_ALGORITHM,
-				noSuchAlgorithmException);
+				"Invalid algorithm " + algorithm, noSuchAlgorithmException);
 		}
 	}
 

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/test/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtilTest.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/test/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtilTest.java
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.multi.factor.authentication.timebased.otp.web.internal.util;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import javax.crypto.Mac;
+
+import jodd.util.Base32;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class MFATimeBasedOTPUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testVerifyTimeBasedOTP() throws Exception {
+		String sharedSecret = MFATimeBasedOTPUtil.generateSharedSecret(20);
+
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			() -> _generateCurrentOTP(sharedSecret), "HmacSHA1",
+			Mac::getInstance, Mac.class, "HmacSHA256");
+	}
+
+	private String _generateCurrentOTP(String sharedSecret) {
+		String timeCountHex = ReflectionTestUtil.invoke(
+			MFATimeBasedOTPUtil.class, "_getTimeCountHex",
+			new Class<?>[] {long.class},
+			System.currentTimeMillis() /
+				MFATimeBasedOTPUtil.MFA_TIMEBASED_OTP_COUNTER);
+
+		return ReflectionTestUtil.invoke(
+			MFATimeBasedOTPUtil.class, "_generateTimeBasedOTP",
+			new Class<?>[] {byte[].class, String.class},
+			Base32.decode(sharedSecret), timeCountHex);
+	}
+
+}

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/test/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtilTest.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/test/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtilTest.java
@@ -28,7 +28,7 @@ public class MFATimeBasedOTPUtilTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void testVerifyTimeBasedOTP() throws Exception {
+	public void test() throws Exception {
 		String sharedSecret = MFATimeBasedOTPUtil.generateSharedSecret(20);
 
 		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(

--- a/portal-impl/src/com/liferay/portal/events/CryptoStartupAction.java
+++ b/portal-impl/src/com/liferay/portal/events/CryptoStartupAction.java
@@ -8,6 +8,7 @@ package com.liferay.portal.events;
 import com.liferay.portal.kernel.events.SimpleAction;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 
 import java.security.NoSuchAlgorithmException;
 
@@ -20,12 +21,14 @@ public class CryptoStartupAction extends SimpleAction {
 
 	@Override
 	public void run(String[] ids) {
+		String algorithm = PropsValues.FIPS_ENABLED ? "HmacSHA256" : "HmacSHA1";
+
 		try {
-			Mac.getInstance("HmacSHA1");
+			Mac.getInstance(algorithm);
 		}
 		catch (NoSuchAlgorithmException noSuchAlgorithmException) {
 			_log.error(
-				"Unable to get Mac instance for algorithm HmacSHA1",
+				"Unable to get Mac instance for algorithm " + algorithm,
 				noSuchAlgorithmException);
 		}
 	}

--- a/portal-impl/src/com/liferay/portal/security/auth/tunnel/TunnelAuthenticationManagerImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/tunnel/TunnelAuthenticationManagerImpl.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.security.auth.AuthException;
 import com.liferay.portal.kernel.security.auth.RemoteAuthException;
 import com.liferay.portal.kernel.security.auth.http.HttpAuthorizationHeader;
 import com.liferay.portal.kernel.security.auth.tunnel.TunnelAuthenticationManager;
+import com.liferay.portal.kernel.security.fips.FIPSModeUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -206,8 +207,14 @@ public class TunnelAuthenticationManagerImpl
 			throw authException;
 		}
 
-		if (StringUtil.equalsIgnoreCase(
-				PropsValues.TUNNELING_SERVLET_ENCRYPTION_ALGORITHM, "AES") &&
+		String algorithm = PropsValues.TUNNELING_SERVLET_ENCRYPTION_ALGORITHM;
+
+		if (!FIPSModeUtil.isAllowedAlgorithm(algorithm)) {
+			throw new SecurityException(
+				"Algorithm \"" + algorithm + "\" is not allowed in FIPS mode");
+		}
+
+		if (StringUtil.equalsIgnoreCase(algorithm, "AES") &&
 			(key.length != 16) && (key.length != 32)) {
 
 			String message =
@@ -225,8 +232,7 @@ public class TunnelAuthenticationManagerImpl
 			throw authException;
 		}
 
-		return new SecretKeySpec(
-			key, PropsValues.TUNNELING_SERVLET_ENCRYPTION_ALGORITHM);
+		return new SecretKeySpec(key, algorithm);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portal/security/pwd/PwdAuthenticator.java
+++ b/portal-impl/src/com/liferay/portal/security/pwd/PwdAuthenticator.java
@@ -51,9 +51,10 @@ public class PwdAuthenticator {
 			}
 
 			try {
-				MessageDigest digester = MessageDigest.getInstance(algorithm);
+				MessageDigest messageDigest = MessageDigest.getInstance(
+					algorithm);
 
-				digester.update(login.getBytes(StringPool.UTF8));
+				messageDigest.update(login.getBytes(StringPool.UTF8));
 
 				String shardKey = PropsUtil.get(PropsKeys.AUTH_MAC_SHARED_KEY);
 
@@ -68,7 +69,7 @@ public class PwdAuthenticator {
 				}
 
 				encryptedPassword = Base64.encode(
-					digester.digest(shardKey.getBytes(StringPool.UTF8)));
+					messageDigest.digest(shardKey.getBytes(StringPool.UTF8)));
 
 				return clearTextPassword.equals(encryptedPassword);
 			}

--- a/portal-impl/src/com/liferay/portal/security/pwd/PwdAuthenticator.java
+++ b/portal-impl/src/com/liferay/portal/security/pwd/PwdAuthenticator.java
@@ -10,6 +10,7 @@ import com.liferay.portal.kernel.exception.PwdEncryptorException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.fips.FIPSModeUtil;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptorUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -41,9 +42,16 @@ public class PwdAuthenticator {
 		else if (GetterUtil.getBoolean(
 					PropsUtil.get(PropsKeys.AUTH_MAC_ALLOW))) {
 
+			String algorithm = PropsUtil.get(PropsKeys.AUTH_MAC_ALGORITHM);
+
+			if (!FIPSModeUtil.isAllowedAlgorithm(algorithm)) {
+				throw new SecurityException(
+					"Algorithm \"" + algorithm +
+						"\" is not allowed in FIPS mode");
+			}
+
 			try {
-				MessageDigest digester = MessageDigest.getInstance(
-					PropsUtil.get(PropsKeys.AUTH_MAC_ALGORITHM));
+				MessageDigest digester = MessageDigest.getInstance(algorithm);
 
 				digester.update(login.getBytes(StringPool.UTF8));
 

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeCompany.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeCompany.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.upgrade.v6_2_0;
 
 import com.liferay.portal.kernel.encryptor.EncryptorUtil;
+import com.liferay.portal.kernel.security.fips.FIPSModeUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -27,9 +28,13 @@ public class UpgradeCompany extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
-		String keyAlgorithm = _KEY_ALGORITHM;
+		if (!FIPSModeUtil.isAllowedAlgorithm(_KEY_ALGORITHM)) {
+			throw new SecurityException(
+				"Algorithm \"" + _KEY_ALGORITHM +
+					"\" is not allowed in FIPS mode");
+		}
 
-		if (keyAlgorithm.equals("DES")) {
+		if (_KEY_ALGORITHM.equals("DES")) {
 			return;
 		}
 

--- a/portal-impl/test/unit/com/liferay/portal/security/auth/tunnel/TunnelAuthenticationManagerImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/security/auth/tunnel/TunnelAuthenticationManagerImplTest.java
@@ -1,0 +1,86 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.auth.tunnel;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.security.Key;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class TunnelAuthenticationManagerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetSharedSecretKey() throws Exception {
+		try (SafeCloseable safeCloseable1 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"TUNNELING_SERVLET_SHARED_SECRET", _SHARED_SECRET);
+			SafeCloseable safeCloseable2 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"TUNNELING_SERVLET_SHARED_SECRET_HEX", false)) {
+
+			try (SafeCloseable safeCloseable3 =
+					PropsValuesTestUtil.swapWithSafeCloseable(
+						"TUNNELING_SERVLET_ENCRYPTION_ALGORITHM", "Blowfish");
+				SafeCloseable safeCloseable4 =
+					PropsValuesTestUtil.swapWithSafeCloseable(
+						"FIPS_ENABLED", false)) {
+
+				Key key = _getSharedSecretKey();
+
+				Assert.assertEquals("Blowfish", key.getAlgorithm());
+			}
+
+			try (SafeCloseable safeCloseable3 =
+					PropsValuesTestUtil.swapWithSafeCloseable(
+						"TUNNELING_SERVLET_ENCRYPTION_ALGORITHM", "Blowfish");
+				SafeCloseable safeCloseable4 =
+					PropsValuesTestUtil.swapWithSafeCloseable(
+						"FIPS_ENABLED", true)) {
+
+				Assert.assertThrows(
+					SecurityException.class, () -> _getSharedSecretKey());
+			}
+
+			try (SafeCloseable safeCloseable3 =
+					PropsValuesTestUtil.swapWithSafeCloseable(
+						"TUNNELING_SERVLET_ENCRYPTION_ALGORITHM", "AES");
+				SafeCloseable safeCloseable4 =
+					PropsValuesTestUtil.swapWithSafeCloseable(
+						"FIPS_ENABLED", true)) {
+
+				Key key = _getSharedSecretKey();
+
+				Assert.assertEquals("AES", key.getAlgorithm());
+			}
+		}
+	}
+
+	private Key _getSharedSecretKey() {
+		return ReflectionTestUtil.invoke(
+			new TunnelAuthenticationManagerImpl(), "getSharedSecretKey",
+			new Class<?>[0]);
+	}
+
+	private static final String _SHARED_SECRET = RandomTestUtil.randomString(
+		16);
+
+}

--- a/portal-impl/test/unit/com/liferay/portal/security/auth/tunnel/TunnelAuthenticationManagerImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/security/auth/tunnel/TunnelAuthenticationManagerImplTest.java
@@ -29,7 +29,7 @@ public class TunnelAuthenticationManagerImplTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void testGetSharedSecretKey() throws Exception {
+	public void test() throws Exception {
 		try (SafeCloseable safeCloseable1 =
 				PropsValuesTestUtil.swapWithSafeCloseable(
 					"TUNNELING_SERVLET_SHARED_SECRET", _SHARED_SECRET);

--- a/portal-kernel/src/com/liferay/portal/kernel/encryptor/Encryptor.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/encryptor/Encryptor.java
@@ -18,24 +18,24 @@ public interface Encryptor {
 	public String decrypt(Key key, String encryptedString)
 		throws EncryptorException;
 
-	public byte[] decryptUnencodedAsBytes(Key key, byte[] encryptedBytes)
+	public byte[] decryptUnencodedAsBytes(
+			AlgorithmParameterSpec algorithmParameterSpec,
+			byte[] encryptedBytes, Key key, String transformation)
 		throws EncryptorException;
 
-	public byte[] decryptUnencodedAsBytes(
-			Key key, byte[] encryptedBytes, String transformation,
-			AlgorithmParameterSpec algorithmParameterSpec)
+	public byte[] decryptUnencodedAsBytes(Key key, byte[] encryptedBytes)
 		throws EncryptorException;
 
 	public Key deserializeKey(String base64String);
 
 	public String encrypt(Key key, String plainText) throws EncryptorException;
 
-	public byte[] encryptUnencoded(Key key, byte[] plainBytes)
+	public byte[] encryptUnencoded(
+			AlgorithmParameterSpec algorithmParameterSpec, Key key,
+			byte[] plainBytes, String transformation)
 		throws EncryptorException;
 
-	public byte[] encryptUnencoded(
-			Key key, byte[] plainBytes, String transformation,
-			AlgorithmParameterSpec algorithmParameterSpec)
+	public byte[] encryptUnencoded(Key key, byte[] plainBytes)
 		throws EncryptorException;
 
 	public byte[] encryptUnencoded(Key key, String plainText)

--- a/portal-kernel/src/com/liferay/portal/kernel/encryptor/Encryptor.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/encryptor/Encryptor.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.kernel.encryptor;
 
 import java.security.Key;
+import java.security.spec.AlgorithmParameterSpec;
 
 /**
  * @author Brian Wing Shun Chan
@@ -20,11 +21,21 @@ public interface Encryptor {
 	public byte[] decryptUnencodedAsBytes(Key key, byte[] encryptedBytes)
 		throws EncryptorException;
 
+	public byte[] decryptUnencodedAsBytes(
+			Key key, byte[] encryptedBytes, String transformation,
+			AlgorithmParameterSpec algorithmParameterSpec)
+		throws EncryptorException;
+
 	public Key deserializeKey(String base64String);
 
 	public String encrypt(Key key, String plainText) throws EncryptorException;
 
 	public byte[] encryptUnencoded(Key key, byte[] plainBytes)
+		throws EncryptorException;
+
+	public byte[] encryptUnencoded(
+			Key key, byte[] plainBytes, String transformation,
+			AlgorithmParameterSpec algorithmParameterSpec)
 		throws EncryptorException;
 
 	public byte[] encryptUnencoded(Key key, String plainText)

--- a/portal-kernel/src/com/liferay/portal/kernel/encryptor/EncryptorUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/encryptor/EncryptorUtil.java
@@ -8,6 +8,7 @@ package com.liferay.portal.kernel.encryptor;
 import com.liferay.portal.kernel.module.service.Snapshot;
 
 import java.security.Key;
+import java.security.spec.AlgorithmParameterSpec;
 
 /**
  * @author Julius Lee
@@ -30,6 +31,17 @@ public class EncryptorUtil {
 		return encryptor.decryptUnencodedAsBytes(key, encryptedBytes);
 	}
 
+	public static byte[] decryptUnencodedAsBytes(
+			Key key, byte[] encryptedBytes, String transformation,
+			AlgorithmParameterSpec algorithmParameterSpec)
+		throws EncryptorException {
+
+		Encryptor encryptor = _encryptorSnapshot.get();
+
+		return encryptor.decryptUnencodedAsBytes(
+			key, encryptedBytes, transformation, algorithmParameterSpec);
+	}
+
 	public static Key deserializeKey(String base64String) {
 		Encryptor encryptor = _encryptorSnapshot.get();
 
@@ -50,6 +62,17 @@ public class EncryptorUtil {
 		Encryptor encryptor = _encryptorSnapshot.get();
 
 		return encryptor.encryptUnencoded(key, plainBytes);
+	}
+
+	public static byte[] encryptUnencoded(
+			Key key, byte[] plainBytes, String transformation,
+			AlgorithmParameterSpec algorithmParameterSpec)
+		throws EncryptorException {
+
+		Encryptor encryptor = _encryptorSnapshot.get();
+
+		return encryptor.encryptUnencoded(
+			key, plainBytes, transformation, algorithmParameterSpec);
 	}
 
 	public static byte[] encryptUnencoded(Key key, String plainText)

--- a/portal-kernel/src/com/liferay/portal/kernel/encryptor/EncryptorUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/encryptor/EncryptorUtil.java
@@ -23,23 +23,23 @@ public class EncryptorUtil {
 		return encryptor.decrypt(key, encryptedString);
 	}
 
+	public static byte[] decryptUnencodedAsBytes(
+			AlgorithmParameterSpec algorithmParameterSpec,
+			byte[] encryptedBytes, Key key, String transformation)
+		throws EncryptorException {
+
+		Encryptor encryptor = _encryptorSnapshot.get();
+
+		return encryptor.decryptUnencodedAsBytes(
+			algorithmParameterSpec, encryptedBytes, key, transformation);
+	}
+
 	public static byte[] decryptUnencodedAsBytes(Key key, byte[] encryptedBytes)
 		throws EncryptorException {
 
 		Encryptor encryptor = _encryptorSnapshot.get();
 
 		return encryptor.decryptUnencodedAsBytes(key, encryptedBytes);
-	}
-
-	public static byte[] decryptUnencodedAsBytes(
-			Key key, byte[] encryptedBytes, String transformation,
-			AlgorithmParameterSpec algorithmParameterSpec)
-		throws EncryptorException {
-
-		Encryptor encryptor = _encryptorSnapshot.get();
-
-		return encryptor.decryptUnencodedAsBytes(
-			key, encryptedBytes, transformation, algorithmParameterSpec);
 	}
 
 	public static Key deserializeKey(String base64String) {
@@ -56,23 +56,23 @@ public class EncryptorUtil {
 		return encryptor.encrypt(key, plainText);
 	}
 
+	public static byte[] encryptUnencoded(
+			AlgorithmParameterSpec algorithmParameterSpec, Key key,
+			byte[] plainBytes, String transformation)
+		throws EncryptorException {
+
+		Encryptor encryptor = _encryptorSnapshot.get();
+
+		return encryptor.encryptUnencoded(
+			algorithmParameterSpec, key, plainBytes, transformation);
+	}
+
 	public static byte[] encryptUnencoded(Key key, byte[] plainBytes)
 		throws EncryptorException {
 
 		Encryptor encryptor = _encryptorSnapshot.get();
 
 		return encryptor.encryptUnencoded(key, plainBytes);
-	}
-
-	public static byte[] encryptUnencoded(
-			Key key, byte[] plainBytes, String transformation,
-			AlgorithmParameterSpec algorithmParameterSpec)
-		throws EncryptorException {
-
-		Encryptor encryptor = _encryptorSnapshot.get();
-
-		return encryptor.encryptUnencoded(
-			key, plainBytes, transformation, algorithmParameterSpec);
 	}
 
 	public static byte[] encryptUnencoded(Key key, String plainText)

--- a/portal-kernel/src/com/liferay/portal/kernel/encryptor/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/encryptor/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeUtil.java
@@ -1,0 +1,40 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+/**
+ * @author Lucas Miranda
+ */
+public class FIPSModeUtil {
+
+	public static boolean isAllowedAlgorithm(String algorithm) {
+		if (!PropsValues.FIPS_ENABLED) {
+			return true;
+		}
+
+		if (Validator.isNull(algorithm)) {
+			return false;
+		}
+
+		String normalizedString = StringUtil.toUpperCase(algorithm);
+
+		if (normalizedString.equals("AES") ||
+			normalizedString.startsWith("PBKDF2") ||
+			normalizedString.equals("SHA-256") ||
+			normalizedString.equals("SHA-384") ||
+			normalizedString.equals("SHA-512")) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeUtil.java
@@ -23,13 +23,11 @@ public class FIPSModeUtil {
 			return false;
 		}
 
-		String normalizedString = StringUtil.toUpperCase(algorithm);
+		algorithm = StringUtil.toUpperCase(algorithm);
 
-		if (normalizedString.equals("AES") ||
-			normalizedString.startsWith("PBKDF2") ||
-			normalizedString.equals("SHA-256") ||
-			normalizedString.equals("SHA-384") ||
-			normalizedString.equals("SHA-512")) {
+		if (algorithm.equals("AES") || algorithm.startsWith("AES/") ||
+			algorithm.startsWith("PBKDF2") || algorithm.equals("SHA-256") ||
+			algorithm.equals("SHA-384") || algorithm.equals("SHA-512")) {
 
 			return true;
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/DigesterUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/DigesterUtil.java
@@ -29,8 +29,6 @@ import java.util.Objects;
  */
 public class DigesterUtil {
 
-	public static final String DEFAULT_ALGORITHM = "SHA";
-
 	public static final String ENCODING = StringPool.UTF8;
 
 	public static final String MD5 = "MD5";
@@ -42,15 +40,15 @@ public class DigesterUtil {
 	public static final String SHA_256 = "SHA-256";
 
 	public static String digest(ByteBuffer byteBuffer) {
-		return digest(DEFAULT_ALGORITHM, byteBuffer);
+		return digest(_getDefaultAlgorithm(), byteBuffer);
 	}
 
 	public static String digest(InputStream inputStream) {
-		return digest(DEFAULT_ALGORITHM, inputStream);
+		return digest(_getDefaultAlgorithm(), inputStream);
 	}
 
 	public static String digest(String text) {
-		return digest(DEFAULT_ALGORITHM, text);
+		return digest(_getDefaultAlgorithm(), text);
 	}
 
 	public static String digest(String algorithm, ByteBuffer byteBuffer) {
@@ -78,15 +76,15 @@ public class DigesterUtil {
 	}
 
 	public static String digestBase64(ByteBuffer byteBuffer) {
-		return digestBase64(DEFAULT_ALGORITHM, byteBuffer);
+		return digestBase64(_getDefaultAlgorithm(), byteBuffer);
 	}
 
 	public static String digestBase64(InputStream inputStream) {
-		return digestBase64(DEFAULT_ALGORITHM, inputStream);
+		return digestBase64(_getDefaultAlgorithm(), inputStream);
 	}
 
 	public static String digestBase64(String text) {
-		return digestBase64(DEFAULT_ALGORITHM, text);
+		return digestBase64(_getDefaultAlgorithm(), text);
 	}
 
 	public static String digestBase64(String algorithm, ByteBuffer byteBuffer) {
@@ -110,15 +108,15 @@ public class DigesterUtil {
 	}
 
 	public static String digestHex(ByteBuffer byteBuffer) {
-		return digestHex(DEFAULT_ALGORITHM, byteBuffer);
+		return digestHex(_getDefaultAlgorithm(), byteBuffer);
 	}
 
 	public static String digestHex(InputStream inputStream) {
-		return digestHex(DEFAULT_ALGORITHM, inputStream);
+		return digestHex(_getDefaultAlgorithm(), inputStream);
 	}
 
 	public static String digestHex(String text) {
-		return digestHex(DEFAULT_ALGORITHM, text);
+		return digestHex(_getDefaultAlgorithm(), text);
 	}
 
 	public static String digestHex(String algorithm, ByteBuffer byteBuffer) {
@@ -140,11 +138,11 @@ public class DigesterUtil {
 	}
 
 	public static byte[] digestRaw(ByteBuffer byteBuffer) {
-		return digestRaw(DEFAULT_ALGORITHM, byteBuffer);
+		return digestRaw(_getDefaultAlgorithm(), byteBuffer);
 	}
 
 	public static byte[] digestRaw(String text) {
-		return digestRaw(DEFAULT_ALGORITHM, text);
+		return digestRaw(_getDefaultAlgorithm(), text);
 	}
 
 	public static byte[] digestRaw(String algorithm, ByteBuffer byteBuffer) {
@@ -216,6 +214,14 @@ public class DigesterUtil {
 		}
 
 		return messageDigest.digest();
+	}
+
+	private static String _getDefaultAlgorithm() {
+		if (PropsValues.FIPS_ENABLED) {
+			return SHA_256;
+		}
+
+		return SHA;
 	}
 
 	private static final boolean _BASE_64 = Objects.equals(

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 98.1.0
+version 99.0.0

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/DigesterUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/DigesterUtilTest.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.util;
+
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+
+import java.security.MessageDigest;
+
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class DigesterUtilTest {
+
+	@Test
+	public void testDigestHex() throws Exception {
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			() -> DigesterUtil.digestHex(RandomTestUtil.randomString()),
+			DigesterUtil.SHA, MessageDigest::getInstance, MessageDigest.class,
+			DigesterUtil.SHA_256);
+	}
+
+}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/DigesterUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/DigesterUtilTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 public class DigesterUtilTest {
 
 	@Test
-	public void testDigestHex() throws Exception {
+	public void test() throws Exception {
 		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
 			() -> DigesterUtil.digestHex(RandomTestUtil.randomString()),
 			DigesterUtil.SHA, MessageDigest::getInstance, MessageDigest.class,

--- a/portal-test/bnd.bnd
+++ b/portal-test/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 32.6.2
+Bundle-Version: 32.7.0
 Export-Package:\
 	com.liferay.portal.kernel.dao.db.test,\
 	com.liferay.portal.kernel.test,\

--- a/portal-test/src/com/liferay/portal/kernel/test/util/FIPSAlgorithmTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/FIPSAlgorithmTestUtil.java
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.test.util;
+
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.lang.SafeCloseable;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Lucas Miranda
+ */
+public class FIPSAlgorithmTestUtil {
+
+	public static <T> void assertAlgorithmSwitch(
+			UnsafeRunnable<Exception> action, String algorithm,
+			UnsafeConsumer<String, Exception> algorithmCall,
+			Class<T> classToMock, String fipsAlgorithm)
+		throws Exception {
+
+		try (MockedStatic<T> mockedStatic = Mockito.mockStatic(
+				classToMock, Mockito.CALLS_REAL_METHODS)) {
+
+			action.run();
+
+			mockedStatic.verify(
+				() -> algorithmCall.accept(algorithm), Mockito.atLeastOnce());
+			mockedStatic.verify(
+				() -> algorithmCall.accept(fipsAlgorithm), Mockito.never());
+		}
+
+		try (MockedStatic<T> mockedStatic = Mockito.mockStatic(
+				classToMock, Mockito.CALLS_REAL_METHODS);
+			SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			action.run();
+
+			mockedStatic.verify(
+				() -> algorithmCall.accept(algorithm), Mockito.never());
+			mockedStatic.verify(
+				() -> algorithmCall.accept(fipsAlgorithm),
+				Mockito.atLeastOnce());
+		}
+	}
+
+}

--- a/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 10.7.0
+version 10.8.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90288

## What Is Being Fixed

Under FIPS 140-3, the portal must neither use non-approved cryptographic algorithms (MD5, SHA-1, DES, DSA, plain-AES/ECB) nor silently accept a non-approved algorithm chosen through a configuration property. Several code paths did exactly that — hashing with MD5/SHA-1, encrypting with AES/ECB, and reading algorithm names from properties such as company.encryption.algorithm, tunneling.servlet.encryption.algorithm, auth.mac.algorithm, and message.digest.algorithm without any FIPS gate.

## How It Is Being Fixed

Where the algorithm is an internal, hardcoded choice, MD5/SHA-1 were replaced with SHA-2 (LPD-90290). Where the algorithm comes from a user-configurable property, the configured value is kept and validated under the FIPS flag, failing fast with a SecurityException when it is not FIPS-approved rather than silently substituting one (LPD-90288): TunnelAuthenticationManagerImpl, UpgradeCompany, PwdAuthenticator, MessageDigestCryptoHashProviderFactory, and EncryptorImpl key handling. A new portal-kernel FIPSModeUtil centralizes the FIPS-on check and the approved-algorithm sets (isApprovedCipherAlgorithm, isApprovedPasswordAlgorithm), so call sites read as a single guard. EncryptorImpl additionally routes encryption through AES/GCM (random per-message IV, 256-bit keys) under FIPS while falling back to the legacy cipher on decrypt so data written before FIPS was enabled stays readable.

## PR Check

**pr-check: PASS** — tested on `fb563adf728070d91f89cf5fbfef70c7d1450dcf`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "fb563adf728070d91f89cf5fbfef70c7d1450dcf"} -->
