### PR TITLE
LPD-91328 Serialize the dynamic registration response scope as a string

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/model/LiferayClientRegistrationResponse.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/model/LiferayClientRegistrationResponse.java
@@ -5,6 +5,12 @@
 
 package com.liferay.oauth2.provider.rest.internal.endpoint.dynamic.registration.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.ListUtil;
+
 import java.util.List;
 
 import org.apache.cxf.rs.security.oauth2.services.ClientRegistrationResponse;
@@ -39,8 +45,18 @@ public class LiferayClientRegistrationResponse
 		return responseTypes;
 	}
 
+	@JsonIgnore
 	public List<String> getScope() {
 		return scope;
+	}
+
+	@JsonProperty("scope")
+	public String getScopeString() {
+		if (ListUtil.isEmpty(scope)) {
+			return null;
+		}
+
+		return String.join(StringPool.SPACE, scope);
 	}
 
 	public String getSoftwareId() {

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
@@ -187,6 +187,42 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 
 	@FeatureFlag("LPD-63416")
 	@Test
+	public void testPostSerializesScopeAsString() throws Exception {
+		WebTarget registerWebTarget = getRegisterWebTarget();
+
+		Invocation.Builder invocationBuilder = authorize(
+			registerWebTarget.request(),
+			_getToken(_getDynamicRegistratorOAuth2Application()));
+
+		String scope =
+			"Liferay.Headless.Admin.Site.everything " +
+				"Liferay.Headless.Admin.User.everything";
+
+		Response response = invocationBuilder.method(
+			"post",
+			Entity.json(
+				JSONUtil.put(
+					"client_name", RandomTestUtil.randomString()
+				).put(
+					"grant_types",
+					new String[] {OAuthConstants.CLIENT_CREDENTIALS_GRANT}
+				).put(
+					"redirect_uris",
+					new String[] {"https://client.example.org/callback"}
+				).put(
+					"scope", scope
+				).toString()));
+
+		Assert.assertEquals(201, response.getStatus());
+
+		String json = response.readEntity(String.class);
+
+		Assert.assertTrue(json, json.contains("\"scope\":\"" + scope + "\""));
+		Assert.assertFalse(json, json.contains("\"scope\":["));
+	}
+
+	@FeatureFlag("LPD-63416")
+	@Test
 	public void testPut() throws Exception {
 		OAuth2Application oAuth2Application =
 			_oAuth2ApplicationLocalService.fetchOAuth2Application(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91328

## What Is Being Fixed

The dynamic client registration response serialized the `scope` field as a JSON array, because the underlying CXF model holds it as a `List<String>` and Jackson serializes lists as arrays. RFC 7591 defines the registration response `scope` as a space-delimited string, and MCP clients validate it as a string and reject the array — breaking dynamic client registration for those clients.

## How It Is Being Fixed

`LiferayClientRegistrationResponse` now excludes the list getter from serialization with `@JsonIgnore` and exposes a dedicated getter annotated `@JsonProperty("scope")` that joins the registered scopes with a single space (via `StringPool.SPACE`). The list getter stays available for any Java caller, so only the wire format changes. An integration test registers a client with two requested scopes and asserts the response carries `scope` as a single space-delimited JSON string rather than an array, locking the RFC 7591 contract that MCP clients depend on.

## PR Check

**pr-check: PASS** — tested on `ac105b791ecea6486c2a85336cc395ddb9778942`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "ac105b791ecea6486c2a85336cc395ddb9778942"} -->