### PR TITLE
LPD-95283 Clear the maximum attempts warning after the retry timeout

### DIFF
--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
@@ -12,7 +12,7 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 %>
 
 <c:if test="<%= mfaEmailOTPFailedAttemptsRetryTimeout > 0 %>">
-	<div class="alert alert-danger">
+	<div class="alert alert-danger" id="<portlet:namespace />maximumAllowedAttemptsError">
 		<liferay-ui:message arguments="<%= mfaEmailOTPFailedAttemptsRetryTimeout %>" key="maximum-allowed-attempts-error" translateArguments="<%= false %>" />
 	</div>
 </c:if>
@@ -47,6 +47,8 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 
 	var countdown;
 
+	var failedAttemptsRetryCountdown;
+
 	var messageContainer = A.one('#<portlet:namespace />messageContainer');
 
 	var sendEmailButton = A.one('#<portlet:namespace />sendEmailButton');
@@ -54,6 +56,8 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 	var submitEmailButton = A.one('#<portlet:namespace />submitEmailButton');
 
 	var originalButtonText = sendEmailButton.text();
+
+	var originalSubmitButtonText = submitEmailButton.text();
 
 	var previousSetTime =
 		<%= GetterUtil.getLong(request.getAttribute(MFAEmailOTPWebKeys.MFA_EMAIL_OTP_SET_AT_TIME)) %>;
@@ -100,29 +104,40 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 		);
 	}
 
+	function <portlet:namespace />setFailedAttemptsRetryCountdown(
+		failedAttemptsRetryTimeout
+	) {
+		if (failedAttemptsRetryTimeout < 1) {
+			var maximumAllowedAttemptsError = A.one(
+				'#<portlet:namespace />maximumAllowedAttemptsError'
+			);
+
+			if (maximumAllowedAttemptsError) {
+				maximumAllowedAttemptsError.remove();
+			}
+
+			sendEmailButton.removeAttribute('disabled');
+
+			submitEmailButton.text(originalSubmitButtonText);
+
+			submitEmailButton.removeAttribute('disabled');
+
+			clearInterval(failedAttemptsRetryCountdown);
+		}
+		else {
+			submitEmailButton.text(failedAttemptsRetryTimeout);
+		}
+	}
+
 	if (failedAttemptsRetryTimeout > 0) {
 		sendEmailButton.setAttribute('disabled', 'disabled');
 		submitEmailButton.setAttribute('disabled', 'disabled');
 
-		var originalSubmitButtonText = submitEmailButton.text();
-
-		setInterval(() => {
-			--failedAttemptsRetryTimeout;
-			{
-				if (failedAttemptsRetryTimeout < 1) {
-					sendEmailButton.removeAttribute('disabled');
-
-					submitEmailButton.text(originalSubmitButtonText);
-
-					submitEmailButton.removeAttribute('disabled');
-
-					clearInterval(failedAttemptsRetryTimeout);
-				}
-				else {
-					submitEmailButton.text(failedAttemptsRetryTimeout);
-				}
-			}
-		}, 1000);
+		failedAttemptsRetryCountdown = <portlet:namespace />createCountdown(
+			<portlet:namespace />setFailedAttemptsRetryCountdown,
+			failedAttemptsRetryTimeout,
+			1000
+		);
 	}
 
 	A.one('#<portlet:namespace />sendEmailButton').on('click', (event) => {

--- a/modules/test/playwright/pages/multi-factor-authentication/MultiFactorAuthenticationConfigurationPage.ts
+++ b/modules/test/playwright/pages/multi-factor-authentication/MultiFactorAuthenticationConfigurationPage.ts
@@ -11,22 +11,28 @@ import {InstanceSettingsPage} from '../configuration-admin-web/InstanceSettingsP
 export class MultiFactorAuthenticationConfigurationPage {
 	readonly actions: Locator;
 	readonly enabledCheckBox: Locator;
+	readonly failedAttemptsAllowed: Locator;
 	readonly instanceSettingsPage: InstanceSettingsPage;
 	readonly oneTimePasswordLength: Locator;
 	readonly page: Page;
 	readonly resetDefaultValues: Locator;
+	readonly retryTimeout: Locator;
 	readonly saveButton: Locator;
 	readonly updateButton: Locator;
 
 	constructor(page: Page) {
 		this.actions = page.getByRole('button', {name: 'Actions'});
 		this.enabledCheckBox = page.getByLabel('Enabled');
+		this.failedAttemptsAllowed = page.getByLabel(
+			'Set the number of allowed failed attempts'
+		);
 		this.instanceSettingsPage = new InstanceSettingsPage(page);
 		this.oneTimePasswordLength = page.getByLabel(
 			'One-Time Password Length'
 		);
 		this.page = page;
 		this.resetDefaultValues = page.getByText('Reset Default Values');
+		this.retryTimeout = page.getByLabel('Retry Timeout');
 		this.saveButton = page.getByRole('button', {name: 'Save'});
 		this.updateButton = page.getByRole('button', {name: 'Update'});
 	}
@@ -39,6 +45,25 @@ export class MultiFactorAuthenticationConfigurationPage {
 
 			await expect(this.enabledCheckBox).toBeChecked();
 		}).toPass();
+
+		await this.instanceSettingsPage.saveAndWaitForAlert();
+	}
+
+	async enableWithFailedAttempts(
+		failedAttemptsAllowed: number,
+		retryTimeout: number
+	) {
+		await expect(this.enabledCheckBox).toBeVisible();
+
+		await expect(async () => {
+			await this.enabledCheckBox.check();
+
+			await expect(this.enabledCheckBox).toBeChecked();
+		}).toPass();
+
+		await this.failedAttemptsAllowed.fill(String(failedAttemptsAllowed));
+
+		await this.retryTimeout.fill(String(retryTimeout));
 
 		await this.instanceSettingsPage.saveAndWaitForAlert();
 	}

--- a/modules/test/playwright/tests/multi-factor-authentication-web/main/emailOneTimePassword.spec.ts
+++ b/modules/test/playwright/tests/multi-factor-authentication-web/main/emailOneTimePassword.spec.ts
@@ -1,0 +1,90 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {multiFactorAuthenticationPagesTest} from '../../../fixtures/multiFactorAuthenticationPagesTest';
+import {UserLoginPage} from '../../../pages/users-admin-web/UserLoginPage';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+
+export const test = mergeTests(
+	dataApiHelpersTest,
+	loginTest(),
+	multiFactorAuthenticationPagesTest
+);
+
+test(
+	'maximum attempts warning is removed once the retry timeout expires',
+	{tag: '@LPD-95283'},
+	async ({
+		apiHelpers,
+		browser,
+		multiFactorAuthenticationConfigurationPage,
+	}) => {
+		await multiFactorAuthenticationConfigurationPage.goto();
+
+		try {
+			await multiFactorAuthenticationConfigurationPage.enableWithFailedAttempts(
+				1,
+				10
+			);
+
+			const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+			const userContext = await browser.newContext();
+			const userPage = await userContext.newPage();
+
+			const userLoginPage = new UserLoginPage(userPage);
+
+			const maximumAllowedAttemptsError = userPage.getByText(
+				'You have reached the maximum allowed failed attempts'
+			);
+			const otpInput = userPage.getByLabel(
+				'Enter the one-time password from the email'
+			);
+			const submitButton = userPage.getByRole('button', {name: 'Submit'});
+
+			try {
+				await userPage.goto('/');
+
+				await clickAndExpectToBeVisible({
+					target: userLoginPage.emailAddressInput,
+					trigger: userLoginPage.signInNavButton,
+				});
+
+				await userLoginPage.emailAddressInput.fill(user.emailAddress);
+				await userLoginPage.passwordInput.fill('test');
+
+				await userLoginPage.signInButton.click();
+
+				await expect(otpInput).toBeVisible({timeout: 10000});
+
+				await otpInput.fill('000000');
+
+				await submitButton.click();
+
+				await expect(maximumAllowedAttemptsError).toBeVisible({
+					timeout: 10000,
+				});
+
+				await expect(maximumAllowedAttemptsError).toBeHidden({
+					timeout: 20000,
+				});
+
+				await expect(submitButton).toBeEnabled();
+			}
+			finally {
+				await userContext.close();
+			}
+		}
+		finally {
+			await multiFactorAuthenticationConfigurationPage.goto();
+
+			await multiFactorAuthenticationConfigurationPage.resetConfiguration();
+		}
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95283

## What Is Being Fixed

In the email OTP Multi-Factor Authentication flow, once a user exhausts the allowed number of failed attempts, a warning ("You have reached the maximum allowed failed attempts. Please retry again in {0} seconds.") is shown together with a retry countdown on the Submit button. When the countdown finished, the buttons were re-enabled but the warning stayed on screen, falsely telling the user they were still locked out.

## How It Is Being Fixed

The retry countdown now mirrors the existing resend-email countdown in the same JSP: it runs through the `createCountdown` helper, stores the interval id, and on completion removes the warning element and clears the correct interval. Previously the countdown counter value was passed to `clearInterval` instead of the interval id, so the timer never stopped, and no code ever removed the server-rendered warning.

The behavior is hidden purely in client-side JavaScript, so the regression is only observable through the browser. A Playwright test enables email OTP with a single allowed attempt and a short retry timeout, signs in as a fresh user to reach the verification screen, submits a wrong code to trigger the warning, and asserts the warning disappears once the timeout elapses.

## PR Check

**pr-check: PASS** — tested on `632cf9a216d441f7bd25f4dcad170efb67d7bcb1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |
| JavaScript Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "632cf9a216d441f7bd25f4dcad170efb67d7bcb1"} -->
