### PR TITLE
LPD-91289 Add the OAuthClientPRLocalMetadata REST API

### DIFF
--- a/modules/apps/oauth-client/oauth-client-rest-api/bnd.bnd
+++ b/modules/apps/oauth-client/oauth-client-rest-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay OAuth Client REST API
 Bundle-SymbolicName: com.liferay.oauth.client.rest.api
-Bundle-Version: 1.0.3
+Bundle-Version: 1.1.0
 Export-Package:\
 	com.liferay.oauth.client.rest.dto.v1_0,\
 	com.liferay.oauth.client.rest.resource.v1_0

--- a/modules/apps/oauth-client/oauth-client-rest-api/src/main/java/com/liferay/oauth/client/rest/dto/v1_0/OAuthClientPRLocalMetadata.java
+++ b/modules/apps/oauth-client/oauth-client-rest-api/src/main/java/com/liferay/oauth/client/rest/dto/v1_0/OAuthClientPRLocalMetadata.java
@@ -1,0 +1,641 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.rest.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.headless.delivery.dto.v1_0.Creator;
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.validation.Valid;
+
+import jakarta.xml.bind.annotation.XmlRootElement;
+
+import java.io.Serializable;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Date;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+/**
+ * @author Manuele Castro
+ * @generated
+ */
+@Generated("")
+@GraphQLName("OAuthClientPRLocalMetadata")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "OAuthClientPRLocalMetadata")
+public class OAuthClientPRLocalMetadata implements Serializable {
+
+	public static OAuthClientPRLocalMetadata toDTO(String json) {
+		return ObjectMapperUtil.readValue(
+			OAuthClientPRLocalMetadata.class, json);
+	}
+
+	public static OAuthClientPRLocalMetadata unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(
+			OAuthClientPRLocalMetadata.class, json);
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	@Valid
+	public Creator getCreator() {
+		if (_creatorSupplier != null) {
+			creator = _creatorSupplier.get();
+
+			_creatorSupplier = null;
+		}
+
+		return creator;
+	}
+
+	public void setCreator(Creator creator) {
+		this.creator = creator;
+
+		_creatorSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setCreator(
+		UnsafeSupplier<Creator, Exception> creatorUnsafeSupplier) {
+
+		_creatorSupplier = () -> {
+			try {
+				return creatorUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Creator creator;
+
+	@JsonIgnore
+	private Supplier<Creator> _creatorSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Date getDateCreated() {
+		if (_dateCreatedSupplier != null) {
+			dateCreated = _dateCreatedSupplier.get();
+
+			_dateCreatedSupplier = null;
+		}
+
+		return dateCreated;
+	}
+
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+
+		_dateCreatedSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDateCreated(
+		UnsafeSupplier<Date, Exception> dateCreatedUnsafeSupplier) {
+
+		_dateCreatedSupplier = () -> {
+			try {
+				return dateCreatedUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Date dateCreated;
+
+	@JsonIgnore
+	private Supplier<Date> _dateCreatedSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Date getDateModified() {
+		if (_dateModifiedSupplier != null) {
+			dateModified = _dateModifiedSupplier.get();
+
+			_dateModifiedSupplier = null;
+		}
+
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+
+		_dateModifiedSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		_dateModifiedSupplier = () -> {
+			try {
+				return dateModifiedUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Date dateModified;
+
+	@JsonIgnore
+	private Supplier<Date> _dateModifiedSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCodeSupplier != null) {
+			externalReferenceCode = _externalReferenceCodeSupplier.get();
+
+			_externalReferenceCodeSupplier = null;
+		}
+
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+
+		_externalReferenceCodeSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		_externalReferenceCodeSupplier = () -> {
+			try {
+				return externalReferenceCodeUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String externalReferenceCode;
+
+	@JsonIgnore
+	private Supplier<String> _externalReferenceCodeSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public Boolean getLocalWellKnownEnabled() {
+		if (_localWellKnownEnabledSupplier != null) {
+			localWellKnownEnabled = _localWellKnownEnabledSupplier.get();
+
+			_localWellKnownEnabledSupplier = null;
+		}
+
+		return localWellKnownEnabled;
+	}
+
+	public void setLocalWellKnownEnabled(Boolean localWellKnownEnabled) {
+		this.localWellKnownEnabled = localWellKnownEnabled;
+
+		_localWellKnownEnabledSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setLocalWellKnownEnabled(
+		UnsafeSupplier<Boolean, Exception>
+			localWellKnownEnabledUnsafeSupplier) {
+
+		_localWellKnownEnabledSupplier = () -> {
+			try {
+				return localWellKnownEnabledUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Boolean localWellKnownEnabled;
+
+	@JsonIgnore
+	private Supplier<Boolean> _localWellKnownEnabledSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getLocalWellKnownURI() {
+		if (_localWellKnownURISupplier != null) {
+			localWellKnownURI = _localWellKnownURISupplier.get();
+
+			_localWellKnownURISupplier = null;
+		}
+
+		return localWellKnownURI;
+	}
+
+	public void setLocalWellKnownURI(String localWellKnownURI) {
+		this.localWellKnownURI = localWellKnownURI;
+
+		_localWellKnownURISupplier = null;
+	}
+
+	@JsonIgnore
+	public void setLocalWellKnownURI(
+		UnsafeSupplier<String, Exception> localWellKnownURIUnsafeSupplier) {
+
+		_localWellKnownURISupplier = () -> {
+			try {
+				return localWellKnownURIUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String localWellKnownURI;
+
+	@JsonIgnore
+	private Supplier<String> _localWellKnownURISupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getMetadataJSON() {
+		if (_metadataJSONSupplier != null) {
+			metadataJSON = _metadataJSONSupplier.get();
+
+			_metadataJSONSupplier = null;
+		}
+
+		return metadataJSON;
+	}
+
+	public void setMetadataJSON(String metadataJSON) {
+		this.metadataJSON = metadataJSON;
+
+		_metadataJSONSupplier = null;
+	}
+
+	@JsonIgnore
+	public void setMetadataJSON(
+		UnsafeSupplier<String, Exception> metadataJSONUnsafeSupplier) {
+
+		_metadataJSONSupplier = () -> {
+			try {
+				return metadataJSONUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String metadataJSON;
+
+	@JsonIgnore
+	private Supplier<String> _metadataJSONSupplier;
+
+	@io.swagger.v3.oas.annotations.media.Schema
+	public String getProtectedResourceURI() {
+		if (_protectedResourceURISupplier != null) {
+			protectedResourceURI = _protectedResourceURISupplier.get();
+
+			_protectedResourceURISupplier = null;
+		}
+
+		return protectedResourceURI;
+	}
+
+	public void setProtectedResourceURI(String protectedResourceURI) {
+		this.protectedResourceURI = protectedResourceURI;
+
+		_protectedResourceURISupplier = null;
+	}
+
+	@JsonIgnore
+	public void setProtectedResourceURI(
+		UnsafeSupplier<String, Exception> protectedResourceURIUnsafeSupplier) {
+
+		_protectedResourceURISupplier = () -> {
+			try {
+				return protectedResourceURIUnsafeSupplier.get();
+			}
+			catch (RuntimeException runtimeException) {
+				throw runtimeException;
+			}
+			catch (Exception exception) {
+				throw new RuntimeException(exception);
+			}
+		};
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String protectedResourceURI;
+
+	@JsonIgnore
+	private Supplier<String> _protectedResourceURISupplier;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof OAuthClientPRLocalMetadata)) {
+			return false;
+		}
+
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata =
+			(OAuthClientPRLocalMetadata)object;
+
+		return Objects.equals(
+			toString(), oAuthClientPRLocalMetadata.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+
+		Creator creator = getCreator();
+
+		if (creator != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"creator\": ");
+
+			sb.append(creator);
+		}
+
+		Date dateCreated = getDateCreated();
+
+		if (dateCreated != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateCreated\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateCreated));
+
+			sb.append("\"");
+		}
+
+		Date dateModified = getDateModified();
+
+		if (dateModified != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(liferayToJSONDateFormat.format(dateModified));
+
+			sb.append("\"");
+		}
+
+		String externalReferenceCode = getExternalReferenceCode();
+
+		if (externalReferenceCode != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(externalReferenceCode));
+
+			sb.append("\"");
+		}
+
+		Boolean localWellKnownEnabled = getLocalWellKnownEnabled();
+
+		if (localWellKnownEnabled != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"localWellKnownEnabled\": ");
+
+			sb.append(localWellKnownEnabled);
+		}
+
+		String localWellKnownURI = getLocalWellKnownURI();
+
+		if (localWellKnownURI != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"localWellKnownURI\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(localWellKnownURI));
+
+			sb.append("\"");
+		}
+
+		String metadataJSON = getMetadataJSON();
+
+		if (metadataJSON != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"metadataJSON\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(metadataJSON));
+
+			sb.append("\"");
+		}
+
+		String protectedResourceURI = getProtectedResourceURI();
+
+		if (protectedResourceURI != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"protectedResourceURI\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(protectedResourceURI));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@io.swagger.v3.oas.annotations.media.Schema(
+		accessMode = io.swagger.v3.oas.annotations.media.Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.oauth.client.rest.dto.v1_0.OAuthClientPRLocalMetadata",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof Map) {
+						sb.append(_toJSON((Map<String, ?>)valueArray[i]));
+					}
+					else if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}
+// LIFERAY-REST-BUILDER-HASH:1540184452

--- a/modules/apps/oauth-client/oauth-client-rest-api/src/main/java/com/liferay/oauth/client/rest/resource/v1_0/OAuthClientPRLocalMetadataResource.java
+++ b/modules/apps/oauth-client/oauth-client-rest-api/src/main/java/com/liferay/oauth/client/rest/resource/v1_0/OAuthClientPRLocalMetadataResource.java
@@ -1,0 +1,174 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.rest.resource.v1_0;
+
+import com.liferay.oauth.client.rest.dto.v1_0.OAuthClientPRLocalMetadata;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.osgi.annotation.versioning.ProviderType;
+
+/**
+ * To access this resource, run:
+ *
+ *     curl -u your@email.com:yourpassword -D - http://localhost:8080/o/oauth-client/v1.0
+ *
+ * @author Manuele Castro
+ * @generated
+ */
+@Generated("")
+@ProviderType
+public interface OAuthClientPRLocalMetadataResource {
+
+	public void deleteOAuthClientPRLocalMetadataByExternalReferenceCode(
+			String externalReferenceCode)
+		throws Exception;
+
+	public OAuthClientPRLocalMetadata
+			getOAuthClientPRLocalMetadataByExternalReferenceCode(
+				String externalReferenceCode)
+		throws Exception;
+
+	public Page<OAuthClientPRLocalMetadata> getOAuthClientPRLocalMetadatasPage()
+		throws Exception;
+
+	public OAuthClientPRLocalMetadata postOAuthClientPRLocalMetadata(
+			OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+		throws Exception;
+
+	public Response postOAuthClientPRLocalMetadataBatch(
+			String callbackURL, Object object)
+		throws Exception;
+
+	public Response postOAuthClientPRLocalMetadatasPageExportBatch(
+			String callbackURL, String contentType, String fieldNames)
+		throws Exception;
+
+	public OAuthClientPRLocalMetadata
+			putOAuthClientPRLocalMetadataByExternalReferenceCode(
+				String externalReferenceCode,
+				OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+		throws Exception;
+
+	public default void setContextAcceptLanguage(
+		AcceptLanguage contextAcceptLanguage) {
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany);
+
+	public default void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+	}
+
+	public default void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+	}
+
+	public default void setContextUriInfo(UriInfo contextUriInfo) {
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser);
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert);
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider);
+
+	public void setGroupLocalService(GroupLocalService groupLocalService);
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService);
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService);
+
+	public void setRoleLocalService(RoleLocalService roleLocalService);
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider);
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource);
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource);
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString) {
+
+		return toFilter(
+			filterString, Collections.<String, List<String>>emptyMap());
+	}
+
+	public default com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		return null;
+	}
+
+	public default com.liferay.portal.kernel.search.Sort[] toSorts(
+		String sortsString) {
+
+		return new com.liferay.portal.kernel.search.Sort[0];
+	}
+
+	@ProviderType
+	public interface Builder {
+
+		public OAuthClientPRLocalMetadataResource build();
+
+		public Builder checkPermissions(boolean checkPermissions);
+
+		public Builder httpServletRequest(
+			HttpServletRequest httpServletRequest);
+
+		public Builder httpServletResponse(
+			HttpServletResponse httpServletResponse);
+
+		public Builder preferredLocale(Locale preferredLocale);
+
+		public Builder uriInfo(UriInfo uriInfo);
+
+		public Builder user(com.liferay.portal.kernel.model.User user);
+
+	}
+
+	@ProviderType
+	public interface Factory {
+
+		public Builder create();
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1299704667

--- a/modules/apps/oauth-client/oauth-client-rest-api/src/main/resources/com/liferay/oauth/client/rest/dto/v1_0/packageinfo
+++ b/modules/apps/oauth-client/oauth-client-rest-api/src/main/resources/com/liferay/oauth/client/rest/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/oauth-client/oauth-client-rest-api/src/main/resources/com/liferay/oauth/client/rest/resource/v1_0/packageinfo
+++ b/modules/apps/oauth-client/oauth-client-rest-api/src/main/resources/com/liferay/oauth/client/rest/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/oauth-client/oauth-client-rest-client/src/main/java/com/liferay/oauth/client/rest/client/dto/v1_0/OAuthClientPRLocalMetadata.java
+++ b/modules/apps/oauth-client/oauth-client-rest-client/src/main/java/com/liferay/oauth/client/rest/client/dto/v1_0/OAuthClientPRLocalMetadata.java
@@ -1,0 +1,234 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.rest.client.dto.v1_0;
+
+import com.liferay.oauth.client.rest.client.function.UnsafeSupplier;
+import com.liferay.oauth.client.rest.client.serdes.v1_0.OAuthClientPRLocalMetadataSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.io.Serializable;
+
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * @author Manuele Castro
+ * @generated
+ */
+@Generated("")
+public class OAuthClientPRLocalMetadata implements Cloneable, Serializable {
+
+	public static OAuthClientPRLocalMetadata toDTO(String json) {
+		return OAuthClientPRLocalMetadataSerDes.toDTO(json);
+	}
+
+	public Creator getCreator() {
+		return creator;
+	}
+
+	public void setCreator(Creator creator) {
+		this.creator = creator;
+	}
+
+	public void setCreator(
+		UnsafeSupplier<Creator, Exception> creatorUnsafeSupplier) {
+
+		try {
+			creator = creatorUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Creator creator;
+
+	public Date getDateCreated() {
+		return dateCreated;
+	}
+
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+	}
+
+	public void setDateCreated(
+		UnsafeSupplier<Date, Exception> dateCreatedUnsafeSupplier) {
+
+		try {
+			dateCreated = dateCreatedUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateCreated;
+
+	public Date getDateModified() {
+		return dateModified;
+	}
+
+	public void setDateModified(Date dateModified) {
+		this.dateModified = dateModified;
+	}
+
+	public void setDateModified(
+		UnsafeSupplier<Date, Exception> dateModifiedUnsafeSupplier) {
+
+		try {
+			dateModified = dateModifiedUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Date dateModified;
+
+	public String getExternalReferenceCode() {
+		return externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		this.externalReferenceCode = externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(
+		UnsafeSupplier<String, Exception> externalReferenceCodeUnsafeSupplier) {
+
+		try {
+			externalReferenceCode = externalReferenceCodeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String externalReferenceCode;
+
+	public Boolean getLocalWellKnownEnabled() {
+		return localWellKnownEnabled;
+	}
+
+	public void setLocalWellKnownEnabled(Boolean localWellKnownEnabled) {
+		this.localWellKnownEnabled = localWellKnownEnabled;
+	}
+
+	public void setLocalWellKnownEnabled(
+		UnsafeSupplier<Boolean, Exception>
+			localWellKnownEnabledUnsafeSupplier) {
+
+		try {
+			localWellKnownEnabled = localWellKnownEnabledUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Boolean localWellKnownEnabled;
+
+	public String getLocalWellKnownURI() {
+		return localWellKnownURI;
+	}
+
+	public void setLocalWellKnownURI(String localWellKnownURI) {
+		this.localWellKnownURI = localWellKnownURI;
+	}
+
+	public void setLocalWellKnownURI(
+		UnsafeSupplier<String, Exception> localWellKnownURIUnsafeSupplier) {
+
+		try {
+			localWellKnownURI = localWellKnownURIUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String localWellKnownURI;
+
+	public String getMetadataJSON() {
+		return metadataJSON;
+	}
+
+	public void setMetadataJSON(String metadataJSON) {
+		this.metadataJSON = metadataJSON;
+	}
+
+	public void setMetadataJSON(
+		UnsafeSupplier<String, Exception> metadataJSONUnsafeSupplier) {
+
+		try {
+			metadataJSON = metadataJSONUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String metadataJSON;
+
+	public String getProtectedResourceURI() {
+		return protectedResourceURI;
+	}
+
+	public void setProtectedResourceURI(String protectedResourceURI) {
+		this.protectedResourceURI = protectedResourceURI;
+	}
+
+	public void setProtectedResourceURI(
+		UnsafeSupplier<String, Exception> protectedResourceURIUnsafeSupplier) {
+
+		try {
+			protectedResourceURI = protectedResourceURIUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String protectedResourceURI;
+
+	@Override
+	public OAuthClientPRLocalMetadata clone()
+		throws CloneNotSupportedException {
+
+		return (OAuthClientPRLocalMetadata)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof OAuthClientPRLocalMetadata)) {
+			return false;
+		}
+
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata =
+			(OAuthClientPRLocalMetadata)object;
+
+		return Objects.equals(
+			toString(), oAuthClientPRLocalMetadata.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return OAuthClientPRLocalMetadataSerDes.toJSON(this);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1444863950

--- a/modules/apps/oauth-client/oauth-client-rest-client/src/main/java/com/liferay/oauth/client/rest/client/resource/v1_0/OAuthClientPRLocalMetadataResource.java
+++ b/modules/apps/oauth-client/oauth-client-rest-client/src/main/java/com/liferay/oauth/client/rest/client/resource/v1_0/OAuthClientPRLocalMetadataResource.java
@@ -1,0 +1,979 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.rest.client.resource.v1_0;
+
+import com.liferay.oauth.client.rest.client.dto.v1_0.OAuthClientPRLocalMetadata;
+import com.liferay.oauth.client.rest.client.http.HttpInvoker;
+import com.liferay.oauth.client.rest.client.pagination.Page;
+import com.liferay.oauth.client.rest.client.problem.Problem;
+import com.liferay.oauth.client.rest.client.serdes.v1_0.OAuthClientPRLocalMetadataSerDes;
+
+import jakarta.annotation.Generated;
+
+import java.net.URL;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * @author Manuele Castro
+ * @generated
+ */
+@Generated("")
+public interface OAuthClientPRLocalMetadataResource {
+
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	public void deleteOAuthClientPRLocalMetadataByExternalReferenceCode(
+			String externalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			deleteOAuthClientPRLocalMetadataByExternalReferenceCodeHttpResponse(
+				String externalReferenceCode)
+		throws Exception;
+
+	public OAuthClientPRLocalMetadata
+			getOAuthClientPRLocalMetadataByExternalReferenceCode(
+				String externalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getOAuthClientPRLocalMetadataByExternalReferenceCodeHttpResponse(
+				String externalReferenceCode)
+		throws Exception;
+
+	public Page<OAuthClientPRLocalMetadata> getOAuthClientPRLocalMetadatasPage()
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			getOAuthClientPRLocalMetadatasPageHttpResponse()
+		throws Exception;
+
+	public OAuthClientPRLocalMetadata postOAuthClientPRLocalMetadata(
+			OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postOAuthClientPRLocalMetadataHttpResponse(
+			OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+		throws Exception;
+
+	public void postOAuthClientPRLocalMetadataBatch(
+			String callbackURL, Object object)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			postOAuthClientPRLocalMetadataBatchHttpResponse(
+				String callbackURL, Object object)
+		throws Exception;
+
+	public void postOAuthClientPRLocalMetadatasPageExportBatch(
+			String callbackURL, String contentType, String fieldNames)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			postOAuthClientPRLocalMetadatasPageExportBatchHttpResponse(
+				String callbackURL, String contentType, String fieldNames)
+		throws Exception;
+
+	public OAuthClientPRLocalMetadata
+			putOAuthClientPRLocalMetadataByExternalReferenceCode(
+				String externalReferenceCode,
+				OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse
+			putOAuthClientPRLocalMetadataByExternalReferenceCodeHttpResponse(
+				String externalReferenceCode,
+				OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+		throws Exception;
+
+	public static class Builder {
+
+		public Builder authentication(String login, String password) {
+			_login = login;
+			_password = password;
+
+			return this;
+		}
+
+		public Builder bearerToken(String token) {
+			return header("Authorization", "Bearer " + token);
+		}
+
+		public OAuthClientPRLocalMetadataResource build() {
+			return new OAuthClientPRLocalMetadataResourceImpl(this);
+		}
+
+		public Builder contextPath(String contextPath) {
+			_contextPath = contextPath;
+
+			return this;
+		}
+
+		public Builder endpoint(String address, String scheme) {
+			String[] addressParts = address.split(":");
+
+			String host = addressParts[0];
+
+			int port = 443;
+
+			if (addressParts.length > 1) {
+				String portString = addressParts[1];
+
+				try {
+					port = Integer.parseInt(portString);
+				}
+				catch (NumberFormatException numberFormatException) {
+					throw new IllegalArgumentException(
+						"Unable to parse port from " + portString);
+				}
+			}
+
+			return endpoint(host, port, scheme);
+		}
+
+		public Builder endpoint(String host, int port, String scheme) {
+			_host = host;
+			_port = port;
+			_scheme = scheme;
+
+			return this;
+		}
+
+		public Builder endpoint(URL url) {
+			return endpoint(url.getHost(), url.getPort(), url.getProtocol());
+		}
+
+		public Builder header(String key, String value) {
+			_headers.put(key, value);
+
+			return this;
+		}
+
+		public Builder locale(Locale locale) {
+			_locale = locale;
+
+			return this;
+		}
+
+		public Builder parameter(String key, String value) {
+			_parameters.put(key, value);
+
+			return this;
+		}
+
+		public Builder parameters(String... parameters) {
+			if ((parameters.length % 2) != 0) {
+				throw new IllegalArgumentException(
+					"Parameters length is not an even number");
+			}
+
+			for (int i = 0; i < parameters.length; i += 2) {
+				String parameterName = String.valueOf(parameters[i]);
+				String parameterValue = String.valueOf(parameters[i + 1]);
+
+				_parameters.put(parameterName, parameterValue);
+			}
+
+			return this;
+		}
+
+		private Builder() {
+		}
+
+		private String _contextPath = "";
+		private Map<String, String> _headers = new LinkedHashMap<>();
+		private String _host = "localhost";
+		private Locale _locale;
+		private String _login;
+		private String _password;
+		private Map<String, String> _parameters = new LinkedHashMap<>();
+		private int _port = 8080;
+		private String _scheme = "http";
+
+	}
+
+	public static class OAuthClientPRLocalMetadataResourceImpl
+		implements OAuthClientPRLocalMetadataResource {
+
+		public void deleteOAuthClientPRLocalMetadataByExternalReferenceCode(
+				String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				deleteOAuthClientPRLocalMetadataByExternalReferenceCodeHttpResponse(
+					externalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return;
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				deleteOAuthClientPRLocalMetadataByExternalReferenceCodeHttpResponse(
+					String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.DELETE);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/oauth-client/v1.0/oauth-client-pr-local-metadata/by-external-reference-code/{externalReferenceCode}");
+
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public OAuthClientPRLocalMetadata
+				getOAuthClientPRLocalMetadataByExternalReferenceCode(
+					String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getOAuthClientPRLocalMetadataByExternalReferenceCodeHttpResponse(
+					externalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return OAuthClientPRLocalMetadataSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getOAuthClientPRLocalMetadataByExternalReferenceCodeHttpResponse(
+					String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/oauth-client/v1.0/oauth-client-pr-local-metadata/by-external-reference-code/{externalReferenceCode}");
+
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public Page<OAuthClientPRLocalMetadata>
+				getOAuthClientPRLocalMetadatasPage()
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getOAuthClientPRLocalMetadatasPageHttpResponse();
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(
+					content, OAuthClientPRLocalMetadataSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getOAuthClientPRLocalMetadatasPageHttpResponse()
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/oauth-client/v1.0/oauth-client-pr-local-metadatas");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public OAuthClientPRLocalMetadata postOAuthClientPRLocalMetadata(
+				OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postOAuthClientPRLocalMetadataHttpResponse(
+					oAuthClientPRLocalMetadata);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return OAuthClientPRLocalMetadataSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postOAuthClientPRLocalMetadataHttpResponse(
+					OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(
+				oAuthClientPRLocalMetadata.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/oauth-client/v1.0/oauth-client-pr-local-metadatas");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postOAuthClientPRLocalMetadataBatch(
+				String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postOAuthClientPRLocalMetadataBatchHttpResponse(
+					callbackURL, object);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postOAuthClientPRLocalMetadataBatchHttpResponse(
+					String callbackURL, Object object)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(object.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/oauth-client/v1.0/oauth-client-pr-local-metadatas/batch");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public void postOAuthClientPRLocalMetadatasPageExportBatch(
+				String callbackURL, String contentType, String fieldNames)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postOAuthClientPRLocalMetadatasPageExportBatchHttpResponse(
+					callbackURL, contentType, fieldNames);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				postOAuthClientPRLocalMetadatasPageExportBatchHttpResponse(
+					String callbackURL, String contentType, String fieldNames)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body("[]", "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			if (callbackURL != null) {
+				httpInvoker.parameter(
+					"callbackURL", String.valueOf(callbackURL));
+			}
+
+			if (contentType != null) {
+				httpInvoker.parameter(
+					"contentType", String.valueOf(contentType));
+			}
+
+			if (fieldNames != null) {
+				httpInvoker.parameter("fieldNames", String.valueOf(fieldNames));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/oauth-client/v1.0/oauth-client-pr-local-metadatas/export-batch");
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		public OAuthClientPRLocalMetadata
+				putOAuthClientPRLocalMetadataByExternalReferenceCode(
+					String externalReferenceCode,
+					OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				putOAuthClientPRLocalMetadataByExternalReferenceCodeHttpResponse(
+					externalReferenceCode, oAuthClientPRLocalMetadata);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return OAuthClientPRLocalMetadataSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				putOAuthClientPRLocalMetadataByExternalReferenceCodeHttpResponse(
+					String externalReferenceCode,
+					OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.body(
+				oAuthClientPRLocalMetadata.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.PUT);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/oauth-client/v1.0/oauth-client-pr-local-metadata/by-external-reference-code/{externalReferenceCode}");
+
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			if ((_builder._login != null) && (_builder._password != null)) {
+				httpInvoker.userNameAndPassword(
+					_builder._login + ":" + _builder._password);
+			}
+
+			return httpInvoker.invoke();
+		}
+
+		private OAuthClientPRLocalMetadataResourceImpl(Builder builder) {
+			_builder = builder;
+		}
+
+		private static final Logger _logger = Logger.getLogger(
+			OAuthClientPRLocalMetadataResource.class.getName());
+
+		private Builder _builder;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-2022268235

--- a/modules/apps/oauth-client/oauth-client-rest-client/src/main/java/com/liferay/oauth/client/rest/client/serdes/v1_0/OAuthClientPRLocalMetadataSerDes.java
+++ b/modules/apps/oauth-client/oauth-client-rest-client/src/main/java/com/liferay/oauth/client/rest/client/serdes/v1_0/OAuthClientPRLocalMetadataSerDes.java
@@ -1,0 +1,465 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.rest.client.serdes.v1_0;
+
+import com.liferay.oauth.client.rest.client.dto.v1_0.OAuthClientPRLocalMetadata;
+import com.liferay.oauth.client.rest.client.json.BaseJSONParser;
+
+import jakarta.annotation.Generated;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * @author Manuele Castro
+ * @generated
+ */
+@Generated("")
+public class OAuthClientPRLocalMetadataSerDes {
+
+	public static OAuthClientPRLocalMetadata toDTO(String json) {
+		OAuthClientPRLocalMetadataJSONParser
+			oAuthClientPRLocalMetadataJSONParser =
+				new OAuthClientPRLocalMetadataJSONParser();
+
+		return oAuthClientPRLocalMetadataJSONParser.parseToDTO(json);
+	}
+
+	public static OAuthClientPRLocalMetadata[] toDTOs(String json) {
+		OAuthClientPRLocalMetadataJSONParser
+			oAuthClientPRLocalMetadataJSONParser =
+				new OAuthClientPRLocalMetadataJSONParser();
+
+		return oAuthClientPRLocalMetadataJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata) {
+
+		if (oAuthClientPRLocalMetadata == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (oAuthClientPRLocalMetadata.getCreator() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"creator\": ");
+
+			sb.append(oAuthClientPRLocalMetadata.getCreator());
+		}
+
+		if (oAuthClientPRLocalMetadata.getDateCreated() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateCreated\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(
+					oAuthClientPRLocalMetadata.getDateCreated()));
+
+			sb.append("\"");
+		}
+
+		if (oAuthClientPRLocalMetadata.getDateModified() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"dateModified\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				liferayToJSONDateFormat.format(
+					oAuthClientPRLocalMetadata.getDateModified()));
+
+			sb.append("\"");
+		}
+
+		if (oAuthClientPRLocalMetadata.getExternalReferenceCode() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"externalReferenceCode\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				_escape(oAuthClientPRLocalMetadata.getExternalReferenceCode()));
+
+			sb.append("\"");
+		}
+
+		if (oAuthClientPRLocalMetadata.getLocalWellKnownEnabled() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"localWellKnownEnabled\": ");
+
+			sb.append(oAuthClientPRLocalMetadata.getLocalWellKnownEnabled());
+		}
+
+		if (oAuthClientPRLocalMetadata.getLocalWellKnownURI() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"localWellKnownURI\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				_escape(oAuthClientPRLocalMetadata.getLocalWellKnownURI()));
+
+			sb.append("\"");
+		}
+
+		if (oAuthClientPRLocalMetadata.getMetadataJSON() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"metadataJSON\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(oAuthClientPRLocalMetadata.getMetadataJSON()));
+
+			sb.append("\"");
+		}
+
+		if (oAuthClientPRLocalMetadata.getProtectedResourceURI() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"protectedResourceURI\": ");
+
+			sb.append("\"");
+
+			sb.append(
+				_escape(oAuthClientPRLocalMetadata.getProtectedResourceURI()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		OAuthClientPRLocalMetadataJSONParser
+			oAuthClientPRLocalMetadataJSONParser =
+				new OAuthClientPRLocalMetadataJSONParser();
+
+		return oAuthClientPRLocalMetadataJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata) {
+
+		if (oAuthClientPRLocalMetadata == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		DateFormat liferayToJSONDateFormat = new SimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ssXX");
+
+		if (oAuthClientPRLocalMetadata.getCreator() == null) {
+			map.put("creator", null);
+		}
+		else {
+			map.put(
+				"creator",
+				String.valueOf(oAuthClientPRLocalMetadata.getCreator()));
+		}
+
+		if (oAuthClientPRLocalMetadata.getDateCreated() == null) {
+			map.put("dateCreated", null);
+		}
+		else {
+			map.put(
+				"dateCreated",
+				liferayToJSONDateFormat.format(
+					oAuthClientPRLocalMetadata.getDateCreated()));
+		}
+
+		if (oAuthClientPRLocalMetadata.getDateModified() == null) {
+			map.put("dateModified", null);
+		}
+		else {
+			map.put(
+				"dateModified",
+				liferayToJSONDateFormat.format(
+					oAuthClientPRLocalMetadata.getDateModified()));
+		}
+
+		if (oAuthClientPRLocalMetadata.getExternalReferenceCode() == null) {
+			map.put("externalReferenceCode", null);
+		}
+		else {
+			map.put(
+				"externalReferenceCode",
+				String.valueOf(
+					oAuthClientPRLocalMetadata.getExternalReferenceCode()));
+		}
+
+		if (oAuthClientPRLocalMetadata.getLocalWellKnownEnabled() == null) {
+			map.put("localWellKnownEnabled", null);
+		}
+		else {
+			map.put(
+				"localWellKnownEnabled",
+				String.valueOf(
+					oAuthClientPRLocalMetadata.getLocalWellKnownEnabled()));
+		}
+
+		if (oAuthClientPRLocalMetadata.getLocalWellKnownURI() == null) {
+			map.put("localWellKnownURI", null);
+		}
+		else {
+			map.put(
+				"localWellKnownURI",
+				String.valueOf(
+					oAuthClientPRLocalMetadata.getLocalWellKnownURI()));
+		}
+
+		if (oAuthClientPRLocalMetadata.getMetadataJSON() == null) {
+			map.put("metadataJSON", null);
+		}
+		else {
+			map.put(
+				"metadataJSON",
+				String.valueOf(oAuthClientPRLocalMetadata.getMetadataJSON()));
+		}
+
+		if (oAuthClientPRLocalMetadata.getProtectedResourceURI() == null) {
+			map.put("protectedResourceURI", null);
+		}
+		else {
+			map.put(
+				"protectedResourceURI",
+				String.valueOf(
+					oAuthClientPRLocalMetadata.getProtectedResourceURI()));
+		}
+
+		return map;
+	}
+
+	public static class OAuthClientPRLocalMetadataJSONParser
+		extends BaseJSONParser<OAuthClientPRLocalMetadata> {
+
+		@Override
+		protected OAuthClientPRLocalMetadata createDTO() {
+			return new OAuthClientPRLocalMetadata();
+		}
+
+		@Override
+		protected OAuthClientPRLocalMetadata[] createDTOArray(int size) {
+			return new OAuthClientPRLocalMetadata[size];
+		}
+
+		@Override
+		protected boolean parseMaps(String jsonParserFieldName) {
+			if (Objects.equals(jsonParserFieldName, "creator")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateCreated")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "localWellKnownEnabled")) {
+
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "localWellKnownURI")) {
+				return false;
+			}
+			else if (Objects.equals(jsonParserFieldName, "metadataJSON")) {
+				return false;
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "protectedResourceURI")) {
+
+				return false;
+			}
+
+			return false;
+		}
+
+		@Override
+		protected void setField(
+			OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata,
+			String jsonParserFieldName, Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "creator")) {
+				if (jsonParserFieldValue != null) {
+					oAuthClientPRLocalMetadata.setCreator(
+						CreatorSerDes.toDTO((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateCreated")) {
+				if (jsonParserFieldValue != null) {
+					oAuthClientPRLocalMetadata.setDateCreated(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "dateModified")) {
+				if (jsonParserFieldValue != null) {
+					oAuthClientPRLocalMetadata.setDateModified(
+						toDate((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
+				if (jsonParserFieldValue != null) {
+					oAuthClientPRLocalMetadata.setExternalReferenceCode(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "localWellKnownEnabled")) {
+
+				if (jsonParserFieldValue != null) {
+					oAuthClientPRLocalMetadata.setLocalWellKnownEnabled(
+						(Boolean)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "localWellKnownURI")) {
+				if (jsonParserFieldValue != null) {
+					oAuthClientPRLocalMetadata.setLocalWellKnownURI(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "metadataJSON")) {
+				if (jsonParserFieldValue != null) {
+					oAuthClientPRLocalMetadata.setMetadataJSON(
+						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "protectedResourceURI")) {
+
+				if (jsonParserFieldValue != null) {
+					oAuthClientPRLocalMetadata.setProtectedResourceURI(
+						(String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			sb.append(_toJSON(value));
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static String _toJSON(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Map) {
+			return _toJSON((Map)value);
+		}
+
+		Class<?> clazz = value.getClass();
+
+		if (clazz.isArray()) {
+			StringBuilder sb = new StringBuilder("[");
+
+			Object[] values = (Object[])value;
+
+			for (int i = 0; i < values.length; i++) {
+				sb.append(_toJSON(values[i]));
+
+				if ((i + 1) < values.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+
+			return sb.toString();
+		}
+
+		if (value instanceof String) {
+			return "\"" + _escape(value) + "\"";
+		}
+
+		return String.valueOf(value);
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:-244555007

--- a/modules/apps/oauth-client/oauth-client-rest-impl/rest-openapi.yaml
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/rest-openapi.yaml
@@ -62,6 +62,27 @@ components:
                 tokenRequestParametersJSON:
                     type: string
             type: object
+        OAuthClientPRLocalMetadata:
+            properties:
+                creator:
+                    $ref: ../../headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml#Creator
+                    readOnly: true
+                dateCreated:
+                    format: date
+                    type: string
+                dateModified:
+                    format: date
+                    type: string
+                externalReferenceCode:
+                    type: string
+                localWellKnownEnabled:
+                    type: boolean
+                localWellKnownURI:
+                    type: string
+                metadataJSON:
+                    type: string
+                protectedResourceURI:
+                    type: string
 info:
     license:
         name: Apache 2.0
@@ -262,3 +283,99 @@ paths:
                             schema:
                                 $ref: "#/components/schemas/OAuthClientEntry"
             tags: ["OAuthClientEntry"]
+    "/oauth-client-pr-local-metadata/by-external-reference-code/{externalReferenceCode}":
+        delete:
+            operationId: deleteOAuthClientPRLocalMetadataByExternalReferenceCode
+            parameters:
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+            responses:
+                204:
+                    content:
+                        application/json: {}
+                        application/xml: {}
+            tags: ["OAuthClientPRLocalMetadata"]
+        get:
+            operationId: getOAuthClientPRLocalMetadataByExternalReferenceCode
+            parameters:
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/OAuthClientPRLocalMetadata"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/OAuthClientPRLocalMetadata"
+            tags: ["OAuthClientPRLocalMetadata"]
+        put:
+            operationId: putOAuthClientPRLocalMetadataByExternalReferenceCode
+            parameters:
+                -   in: path
+                    name: externalReferenceCode
+                    required: true
+                    schema:
+                        type: string
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/OAuthClientPRLocalMetadata"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/OAuthClientPRLocalMetadata"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/OAuthClientPRLocalMetadata"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/OAuthClientPRLocalMetadata"
+            tags: ["OAuthClientPRLocalMetadata"]
+    "/oauth-client-pr-local-metadatas":
+        get:
+            operationId: getOAuthClientPRLocalMetadatasPage
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/OAuthClientPRLocalMetadata"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/OAuthClientPRLocalMetadata"
+                                type: array
+            tags: ["OAuthClientPRLocalMetadata"]
+        post:
+            operationId: postOAuthClientPRLocalMetadata
+            requestBody:
+                content:
+                    application/json:
+                        schema:
+                            $ref: "#/components/schemas/OAuthClientPRLocalMetadata"
+                    application/xml:
+                        schema:
+                            $ref: "#/components/schemas/OAuthClientPRLocalMetadata"
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/OAuthClientPRLocalMetadata"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/OAuthClientPRLocalMetadata"
+            tags: ["OAuthClientPRLocalMetadata"]

--- a/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/dto/v1_0/util/OAuthClientPRLocalMetadataUtil.java
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/dto/v1_0/util/OAuthClientPRLocalMetadataUtil.java
@@ -8,7 +8,7 @@ package com.liferay.oauth.client.rest.internal.dto.v1_0.util;
 import com.liferay.headless.delivery.dto.v1_0.util.CreatorUtil;
 import com.liferay.oauth.client.persistence.service.OAuthClientPRLocalMetadataService;
 import com.liferay.oauth.client.rest.dto.v1_0.OAuthClientPRLocalMetadata;
-import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
@@ -24,7 +24,6 @@ public class OAuthClientPRLocalMetadataUtil {
 	public static
 		com.liferay.oauth.client.persistence.model.OAuthClientPRLocalMetadata
 				addOAuthClientPRLocalMetadata(
-					JSONFactory jsonFactory,
 					OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata,
 					OAuthClientPRLocalMetadataService
 						oAuthClientPRLocalMetadataService)
@@ -36,7 +35,7 @@ public class OAuthClientPRLocalMetadataUtil {
 			throw new IllegalArgumentException("Metadata JSON is required");
 		}
 
-		JSONObject metadataJSONObject = jsonFactory.createJSONObject(
+		JSONObject metadataJSONObject = JSONFactoryUtil.createJSONObject(
 			metadataJSON);
 
 		return oAuthClientPRLocalMetadataService.addOAuthClientPRLocalMetadata(

--- a/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/dto/v1_0/util/OAuthClientPRLocalMetadataUtil.java
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/dto/v1_0/util/OAuthClientPRLocalMetadataUtil.java
@@ -1,0 +1,78 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.rest.internal.dto.v1_0.util;
+
+import com.liferay.headless.delivery.dto.v1_0.util.CreatorUtil;
+import com.liferay.oauth.client.persistence.service.OAuthClientPRLocalMetadataService;
+import com.liferay.oauth.client.rest.dto.v1_0.OAuthClientPRLocalMetadata;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.util.Portal;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class OAuthClientPRLocalMetadataUtil {
+
+	public static
+		com.liferay.oauth.client.persistence.model.OAuthClientPRLocalMetadata
+				addOAuthClientPRLocalMetadata(
+					JSONFactory jsonFactory,
+					OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata,
+					OAuthClientPRLocalMetadataService
+						oAuthClientPRLocalMetadataService)
+			throws Exception {
+
+		JSONObject metadataJSONObject = jsonFactory.createJSONObject(
+			oAuthClientPRLocalMetadata.getMetadataJSON());
+
+		return oAuthClientPRLocalMetadataService.addOAuthClientPRLocalMetadata(
+			oAuthClientPRLocalMetadata.getExternalReferenceCode(),
+			JSONUtil.toStringArray(
+				metadataJSONObject.getJSONArray("authorization_servers")),
+			JSONUtil.toStringArray(
+				metadataJSONObject.getJSONArray("bearer_methods_supported")),
+			oAuthClientPRLocalMetadata.getLocalWellKnownEnabled(),
+			oAuthClientPRLocalMetadata.getProtectedResourceURI(),
+			metadataJSONObject.getString("resource_name"),
+			JSONUtil.toStringArray(
+				metadataJSONObject.getJSONArray("scopes_supported")));
+	}
+
+	public static OAuthClientPRLocalMetadata toOAuthClientPRLocalMetadata(
+		Portal portal,
+		com.liferay.oauth.client.persistence.model.OAuthClientPRLocalMetadata
+			serviceBuilderOAuthClientPRLocalMetadata,
+		User user) {
+
+		return new OAuthClientPRLocalMetadata() {
+			{
+				setCreator(() -> CreatorUtil.toCreator(null, portal, user));
+				setDateCreated(
+					serviceBuilderOAuthClientPRLocalMetadata::getCreateDate);
+				setDateModified(
+					serviceBuilderOAuthClientPRLocalMetadata::getModifiedDate);
+				setExternalReferenceCode(
+					serviceBuilderOAuthClientPRLocalMetadata::
+						getExternalReferenceCode);
+				setLocalWellKnownEnabled(
+					serviceBuilderOAuthClientPRLocalMetadata::
+						getLocalWellKnownEnabled);
+				setLocalWellKnownURI(
+					serviceBuilderOAuthClientPRLocalMetadata::
+						getLocalWellKnownURI);
+				setMetadataJSON(
+					serviceBuilderOAuthClientPRLocalMetadata::getMetadataJSON);
+				setProtectedResourceURI(
+					serviceBuilderOAuthClientPRLocalMetadata::
+						getProtectedResourceURI);
+			}
+		};
+	}
+
+}

--- a/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/dto/v1_0/util/OAuthClientPRLocalMetadataUtil.java
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/dto/v1_0/util/OAuthClientPRLocalMetadataUtil.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -44,7 +45,8 @@ public class OAuthClientPRLocalMetadataUtil {
 				metadataJSONObject.getJSONArray("authorization_servers")),
 			JSONUtil.toStringArray(
 				metadataJSONObject.getJSONArray("bearer_methods_supported")),
-			oAuthClientPRLocalMetadata.getLocalWellKnownEnabled(),
+			GetterUtil.getBoolean(
+				oAuthClientPRLocalMetadata.getLocalWellKnownEnabled()),
 			oAuthClientPRLocalMetadata.getProtectedResourceURI(),
 			metadataJSONObject.getString("resource_name"),
 			JSONUtil.toStringArray(

--- a/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/dto/v1_0/util/OAuthClientPRLocalMetadataUtil.java
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/dto/v1_0/util/OAuthClientPRLocalMetadataUtil.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 
 /**
  * @author Jorge García Jiménez
@@ -28,8 +29,14 @@ public class OAuthClientPRLocalMetadataUtil {
 						oAuthClientPRLocalMetadataService)
 			throws Exception {
 
+		String metadataJSON = oAuthClientPRLocalMetadata.getMetadataJSON();
+
+		if (Validator.isNull(metadataJSON)) {
+			throw new IllegalArgumentException("Metadata JSON is required");
+		}
+
 		JSONObject metadataJSONObject = jsonFactory.createJSONObject(
-			oAuthClientPRLocalMetadata.getMetadataJSON());
+			metadataJSON);
 
 		return oAuthClientPRLocalMetadataService.addOAuthClientPRLocalMetadata(
 			oAuthClientPRLocalMetadata.getExternalReferenceCode(),

--- a/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/BaseOAuthClientPRLocalMetadataResourceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/BaseOAuthClientPRLocalMetadataResourceImpl.java
@@ -1,0 +1,1086 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.rest.internal.resource.v1_0;
+
+import com.liferay.oauth.client.rest.dto.v1_0.OAuthClientPRLocalMetadata;
+import com.liferay.oauth.client.rest.resource.v1_0.OAuthClientPRLocalMetadataResource;
+import com.liferay.petra.function.UnsafeBiConsumer;
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeFunction;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParser;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortField;
+import com.liferay.portal.odata.sort.SortParser;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+import com.liferay.portal.vulcan.batch.engine.VulcanBatchEngineTaskItemDelegate;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineExportTaskResource;
+import com.liferay.portal.vulcan.batch.engine.resource.VulcanBatchEngineImportTaskResource;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+import com.liferay.portal.vulcan.util.ActionUtil;
+import com.liferay.portal.vulcan.util.UriInfoUtil;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.NotSupportedException;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+
+import java.io.Serializable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Manuele Castro
+ * @generated
+ */
+@Generated("")
+@jakarta.ws.rs.Path("/v1.0")
+public abstract class BaseOAuthClientPRLocalMetadataResourceImpl
+	implements EntityModelResource, OAuthClientPRLocalMetadataResource,
+			   VulcanBatchEngineTaskItemDelegate<OAuthClientPRLocalMetadata> {
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'DELETE' 'http://localhost:8080/o/oauth-client/v1.0/oauth-client-pr-local-metadata/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "OAuthClientPRLocalMetadata"
+			)
+		}
+	)
+	@jakarta.ws.rs.DELETE
+	@jakarta.ws.rs.Path(
+		"/oauth-client-pr-local-metadata/by-external-reference-code/{externalReferenceCode}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public void deleteOAuthClientPRLocalMetadataByExternalReferenceCode(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.validation.constraints.NotNull
+			@jakarta.ws.rs.PathParam("externalReferenceCode")
+			String externalReferenceCode)
+		throws Exception {
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/oauth-client/v1.0/oauth-client-pr-local-metadata/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "OAuthClientPRLocalMetadata"
+			)
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path(
+		"/oauth-client-pr-local-metadata/by-external-reference-code/{externalReferenceCode}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public OAuthClientPRLocalMetadata
+			getOAuthClientPRLocalMetadataByExternalReferenceCode(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode)
+		throws Exception {
+
+		return new OAuthClientPRLocalMetadata();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/oauth-client/v1.0/oauth-client-pr-local-metadatas'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "OAuthClientPRLocalMetadata"
+			)
+		}
+	)
+	@jakarta.ws.rs.GET
+	@jakarta.ws.rs.Path("/oauth-client-pr-local-metadatas")
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<OAuthClientPRLocalMetadata> getOAuthClientPRLocalMetadatasPage()
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/oauth-client/v1.0/oauth-client-pr-local-metadatas' -d $'{"dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "localWellKnownEnabled": ___, "localWellKnownURI": ___, "metadataJSON": ___, "protectedResourceURI": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "OAuthClientPRLocalMetadata"
+			)
+		}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path("/oauth-client-pr-local-metadatas")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public OAuthClientPRLocalMetadata postOAuthClientPRLocalMetadata(
+			OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+		throws Exception {
+
+		return new OAuthClientPRLocalMetadata();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/oauth-client/v1.0/oauth-client-pr-local-metadatas/batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "OAuthClientPRLocalMetadata"
+			)
+		}
+	)
+	@jakarta.ws.rs.Consumes("application/json")
+	@jakarta.ws.rs.Path("/oauth-client-pr-local-metadatas/batch")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces("application/json")
+	@Override
+	public Response postOAuthClientPRLocalMetadataBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			Object object)
+		throws Exception {
+
+		vulcanBatchEngineImportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineImportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineImportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineImportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineImportTaskResource.setContextUser(contextUser);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineImportTaskResource.postImportTask(
+				OAuthClientPRLocalMetadata.class.getName(), callbackURL, null,
+				object)
+		).build();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/oauth-client/v1.0/oauth-client-pr-local-metadatas/export-batch'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "callbackURL"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "contentType"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "fieldNames"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "OAuthClientPRLocalMetadata"
+			)
+		}
+	)
+	@jakarta.ws.rs.Consumes("application/json")
+	@jakarta.ws.rs.Path("/oauth-client-pr-local-metadatas/export-batch")
+	@jakarta.ws.rs.POST
+	@jakarta.ws.rs.Produces("application/json")
+	@Override
+	public Response postOAuthClientPRLocalMetadatasPageExportBatch(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("callbackURL")
+			String callbackURL,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.DefaultValue("JSON")
+			@jakarta.ws.rs.QueryParam("contentType")
+			String contentType,
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@jakarta.ws.rs.QueryParam("fieldNames")
+			String fieldNames)
+		throws Exception {
+
+		vulcanBatchEngineExportTaskResource.setContextAcceptLanguage(
+			contextAcceptLanguage);
+		vulcanBatchEngineExportTaskResource.setContextCompany(contextCompany);
+		vulcanBatchEngineExportTaskResource.setContextHttpServletRequest(
+			contextHttpServletRequest);
+		vulcanBatchEngineExportTaskResource.setContextUriInfo(contextUriInfo);
+		vulcanBatchEngineExportTaskResource.setContextUser(contextUser);
+		vulcanBatchEngineExportTaskResource.setGroupLocalService(
+			groupLocalService);
+
+		Response.ResponseBuilder responseBuilder = Response.accepted();
+
+		return responseBuilder.entity(
+			vulcanBatchEngineExportTaskResource.postExportTask(
+				OAuthClientPRLocalMetadata.class.getName(), callbackURL,
+				contentType, fieldNames)
+		).build();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'PUT' 'http://localhost:8080/o/oauth-client/v1.0/oauth-client-pr-local-metadata/by-external-reference-code/{externalReferenceCode}' -d $'{"dateCreated": ___, "dateModified": ___, "externalReferenceCode": ___, "localWellKnownEnabled": ___, "localWellKnownURI": ___, "metadataJSON": ___, "protectedResourceURI": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {
+			@io.swagger.v3.oas.annotations.tags.Tag(
+				name = "OAuthClientPRLocalMetadata"
+			)
+		}
+	)
+	@jakarta.ws.rs.Consumes({"application/json", "application/xml"})
+	@jakarta.ws.rs.Path(
+		"/oauth-client-pr-local-metadata/by-external-reference-code/{externalReferenceCode}"
+	)
+	@jakarta.ws.rs.Produces({"application/json", "application/xml"})
+	@jakarta.ws.rs.PUT
+	@Override
+	public OAuthClientPRLocalMetadata
+			putOAuthClientPRLocalMetadataByExternalReferenceCode(
+				@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+				@jakarta.validation.constraints.NotNull
+				@jakarta.ws.rs.PathParam("externalReferenceCode")
+				String externalReferenceCode,
+				OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+		throws Exception {
+
+		return new OAuthClientPRLocalMetadata();
+	}
+
+	@Override
+	@SuppressWarnings("PMD.UnusedLocalVariable")
+	public void create(
+			Collection<OAuthClientPRLocalMetadata> oAuthClientPRLocalMetadatas,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		UnsafeFunction
+			<OAuthClientPRLocalMetadata, OAuthClientPRLocalMetadata, Exception>
+				oAuthClientPRLocalMetadataUnsafeFunction = null;
+
+		String createStrategy = (String)parameters.getOrDefault(
+			"createStrategy", "INSERT");
+
+		if (StringUtil.equalsIgnoreCase(createStrategy, "INSERT")) {
+			oAuthClientPRLocalMetadataUnsafeFunction =
+				oAuthClientPRLocalMetadata -> postOAuthClientPRLocalMetadata(
+					oAuthClientPRLocalMetadata);
+		}
+
+		if (StringUtil.equalsIgnoreCase(createStrategy, "UPSERT")) {
+			String updateStrategy = (String)parameters.getOrDefault(
+				"updateStrategy", "UPDATE");
+
+			if (StringUtil.equalsIgnoreCase(updateStrategy, "UPDATE")) {
+				oAuthClientPRLocalMetadataUnsafeFunction =
+					oAuthClientPRLocalMetadata -> {
+						OAuthClientPRLocalMetadata
+							persistedOAuthClientPRLocalMetadata = null;
+
+						persistedOAuthClientPRLocalMetadata =
+							putOAuthClientPRLocalMetadataByExternalReferenceCode(
+								oAuthClientPRLocalMetadata.
+									getExternalReferenceCode(),
+								oAuthClientPRLocalMetadata);
+
+						return persistedOAuthClientPRLocalMetadata;
+					};
+			}
+		}
+
+		if (oAuthClientPRLocalMetadataUnsafeFunction == null) {
+			throw new NotSupportedException(
+				"Create strategy \"" + createStrategy +
+					"\" is not supported for OAuthClientPRLocalMetadata");
+		}
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(
+				oAuthClientPRLocalMetadatas,
+				oAuthClientPRLocalMetadataUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				oAuthClientPRLocalMetadatas,
+				oAuthClientPRLocalMetadataUnsafeFunction::apply);
+		}
+		else {
+			for (OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata :
+					oAuthClientPRLocalMetadatas) {
+
+				oAuthClientPRLocalMetadataUnsafeFunction.apply(
+					oAuthClientPRLocalMetadata);
+			}
+		}
+	}
+
+	@Override
+	public void delete(
+			Collection<OAuthClientPRLocalMetadata> oAuthClientPRLocalMetadatas,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		UnsafeFunction
+			<OAuthClientPRLocalMetadata, OAuthClientPRLocalMetadata, Exception>
+				oAuthClientPRLocalMetadataUnsafeFunction =
+					oAuthClientPRLocalMetadata -> {
+						if (oAuthClientPRLocalMetadata.
+								getExternalReferenceCode() != null) {
+
+							deleteOAuthClientPRLocalMetadataByExternalReferenceCode(
+								oAuthClientPRLocalMetadata.
+									getExternalReferenceCode());
+
+							return oAuthClientPRLocalMetadata;
+						}
+
+						throw new UnsupportedOperationException(
+							"Unable to delete by external reference code or ID");
+					};
+
+		if (contextBatchUnsafeBiConsumer != null) {
+			contextBatchUnsafeBiConsumer.accept(
+				oAuthClientPRLocalMetadatas,
+				oAuthClientPRLocalMetadataUnsafeFunction);
+		}
+		else if (contextBatchUnsafeConsumer != null) {
+			contextBatchUnsafeConsumer.accept(
+				oAuthClientPRLocalMetadatas,
+				oAuthClientPRLocalMetadataUnsafeFunction::apply);
+		}
+		else {
+			for (OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata :
+					oAuthClientPRLocalMetadatas) {
+
+				oAuthClientPRLocalMetadataUnsafeFunction.apply(
+					oAuthClientPRLocalMetadata);
+			}
+		}
+	}
+
+	public Set<String> getAvailableCreateStrategies() {
+		return SetUtil.fromArray("INSERT", "UPSERT");
+	}
+
+	public Set<String> getAvailableUpdateStrategies() {
+		return SetUtil.fromArray();
+	}
+
+	@Override
+	public EntityModel getEntityModel(Map<String, List<String>> multivaluedMap)
+		throws Exception {
+
+		return getEntityModel(
+			new MultivaluedHashMap<String, Object>(multivaluedMap));
+	}
+
+	public String getResourceName() {
+		return "OAuthClientPRLocalMetadata";
+	}
+
+	public String getVersion() {
+		return "v1.0";
+	}
+
+	@Override
+	public Page<OAuthClientPRLocalMetadata> read(
+			com.liferay.portal.kernel.search.filter.Filter filter,
+			Pagination pagination,
+			com.liferay.portal.kernel.search.Sort[] sorts,
+			Map<String, Serializable> parameters, String search)
+		throws Exception {
+
+		return getOAuthClientPRLocalMetadatasPage();
+	}
+
+	@Override
+	public void setLanguageId(String languageId) {
+		this.contextAcceptLanguage = new AcceptLanguage() {
+
+			@Override
+			public List<Locale> getLocales() {
+				return null;
+			}
+
+			@Override
+			public String getPreferredLanguageId() {
+				return languageId;
+			}
+
+			@Override
+			public Locale getPreferredLocale() {
+				return LocaleUtil.fromLanguageId(languageId);
+			}
+
+		};
+	}
+
+	@Override
+	public void update(
+			Collection<OAuthClientPRLocalMetadata> oAuthClientPRLocalMetadatas,
+			Map<String, Serializable> parameters)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Override
+	public EntityModel getEntityModel(MultivaluedMap multivaluedMap)
+		throws Exception {
+
+		return null;
+	}
+
+	public void setContextAcceptLanguage(AcceptLanguage contextAcceptLanguage) {
+		this.contextAcceptLanguage = contextAcceptLanguage;
+	}
+
+	public void setContextBatchUnsafeBiConsumer(
+		UnsafeBiConsumer
+			<Collection<OAuthClientPRLocalMetadata>,
+			 UnsafeFunction
+				 <OAuthClientPRLocalMetadata, OAuthClientPRLocalMetadata,
+				  Exception>,
+			 Exception> contextBatchUnsafeBiConsumer) {
+
+		this.contextBatchUnsafeBiConsumer = contextBatchUnsafeBiConsumer;
+	}
+
+	public void setContextBatchUnsafeConsumer(
+		UnsafeBiConsumer
+			<Collection<OAuthClientPRLocalMetadata>,
+			 UnsafeConsumer<OAuthClientPRLocalMetadata, Exception>, Exception>
+				contextBatchUnsafeConsumer) {
+
+		this.contextBatchUnsafeConsumer = contextBatchUnsafeConsumer;
+	}
+
+	public void setContextCompany(
+		com.liferay.portal.kernel.model.Company contextCompany) {
+
+		this.contextCompany = contextCompany;
+	}
+
+	public void setContextHttpServletRequest(
+		HttpServletRequest contextHttpServletRequest) {
+
+		this.contextHttpServletRequest = contextHttpServletRequest;
+	}
+
+	public void setContextHttpServletResponse(
+		HttpServletResponse contextHttpServletResponse) {
+
+		this.contextHttpServletResponse = contextHttpServletResponse;
+	}
+
+	public void setContextUriInfo(UriInfo contextUriInfo) {
+		this.contextUriInfo = UriInfoUtil.getVulcanUriInfo(
+			getApplicationPath(), contextUriInfo);
+	}
+
+	public void setContextUser(
+		com.liferay.portal.kernel.model.User contextUser) {
+
+		this.contextUser = contextUser;
+	}
+
+	public void setExpressionConvert(
+		ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+			expressionConvert) {
+
+		this.expressionConvert = expressionConvert;
+	}
+
+	public void setFilterParserProvider(
+		FilterParserProvider filterParserProvider) {
+
+		this.filterParserProvider = filterParserProvider;
+	}
+
+	public void setGroupLocalService(GroupLocalService groupLocalService) {
+		this.groupLocalService = groupLocalService;
+	}
+
+	public void setResourceActionLocalService(
+		ResourceActionLocalService resourceActionLocalService) {
+
+		this.resourceActionLocalService = resourceActionLocalService;
+	}
+
+	public void setResourcePermissionLocalService(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		this.resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	public void setRoleLocalService(RoleLocalService roleLocalService) {
+		this.roleLocalService = roleLocalService;
+	}
+
+	public void setSortParserProvider(SortParserProvider sortParserProvider) {
+		this.sortParserProvider = sortParserProvider;
+	}
+
+	protected String getApplicationPath() {
+		return "oauth-client";
+	}
+
+	public void setVulcanBatchEngineExportTaskResource(
+		VulcanBatchEngineExportTaskResource
+			vulcanBatchEngineExportTaskResource) {
+
+		this.vulcanBatchEngineExportTaskResource =
+			vulcanBatchEngineExportTaskResource;
+	}
+
+	public void setVulcanBatchEngineImportTaskResource(
+		VulcanBatchEngineImportTaskResource
+			vulcanBatchEngineImportTaskResource) {
+
+		this.vulcanBatchEngineImportTaskResource =
+			vulcanBatchEngineImportTaskResource;
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.filter.Filter toFilter(
+		String filterString, Map<String, List<String>> multivaluedMap) {
+
+		try {
+			EntityModel entityModel = getEntityModel(multivaluedMap);
+
+			FilterParser filterParser = filterParserProvider.provide(
+				entityModel);
+
+			com.liferay.portal.odata.filter.Filter oDataFilter =
+				new com.liferay.portal.odata.filter.Filter(
+					filterParser.parse(filterString));
+
+			return expressionConvert.convert(
+				oDataFilter.getExpression(),
+				contextAcceptLanguage.getPreferredLocale(), entityModel);
+		}
+		catch (Exception exception) {
+			_log.error("Invalid filter " + filterString, exception);
+
+			return null;
+		}
+	}
+
+	@Override
+	public com.liferay.portal.kernel.search.Sort[] toSorts(String sortString) {
+		if (Validator.isNull(sortString)) {
+			return null;
+		}
+
+		try {
+			SortParser sortParser = sortParserProvider.provide(
+				getEntityModel(Collections.emptyMap()));
+
+			if (sortParser == null) {
+				return null;
+			}
+
+			com.liferay.portal.odata.sort.Sort oDataSort =
+				new com.liferay.portal.odata.sort.Sort(
+					sortParser.parse(sortString));
+
+			List<SortField> sortFields = oDataSort.getSortFields();
+			com.liferay.portal.kernel.search.Sort[] sorts =
+				new com.liferay.portal.kernel.search.Sort[sortFields.size()];
+
+			for (int i = 0; i < sortFields.size(); i++) {
+				SortField sortField = sortFields.get(i);
+
+				sorts[i] = new com.liferay.portal.kernel.search.Sort(
+					sortField.getSortableFieldName(
+						contextAcceptLanguage.getPreferredLocale()),
+					!sortField.isAscending());
+			}
+
+			return sorts;
+		}
+		catch (Exception exception) {
+			_log.error("Invalid sort " + sortString, exception);
+
+			return new com.liferay.portal.kernel.search.Sort[0];
+		}
+	}
+
+	protected Map<String, String> addAction(
+		String actionName,
+		com.liferay.portal.kernel.model.GroupedModel groupedModel,
+		String methodName) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), groupedModel, methodName,
+			contextScopeChecker, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName, Long ownerId,
+		String permissionName, Long siteId) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			ownerId, permissionName, siteId, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, Long id, String methodName,
+		ModelResourcePermission modelResourcePermission) {
+
+		return ActionUtil.addAction(
+			actionName, getClass(), id, methodName, contextScopeChecker,
+			modelResourcePermission, contextUriInfo);
+	}
+
+	protected Map<String, String> addAction(
+		String actionName, String methodName, String permissionName,
+		Long siteId) {
+
+		return addAction(
+			actionName, siteId, methodName, null, permissionName, siteId);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transform(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] transform(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transform(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] transformToArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+		Class<? extends R> clazz) {
+
+		return TransformUtil.transformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		Collection<T> collection,
+		UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[] transformToBooleanArray(
+		T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction) {
+
+		return TransformUtil.transformToBooleanArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] transformToByteArray(
+		T[] array, UnsafeFunction<T, Byte, E> unsafeFunction) {
+
+		return TransformUtil.transformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		Collection<T> collection, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[] transformToDoubleArray(
+		T[] array, UnsafeFunction<T, Double, E> unsafeFunction) {
+
+		return TransformUtil.transformToDoubleArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		Collection<T> collection, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] transformToFloatArray(
+		T[] array, UnsafeFunction<T, Float, E> unsafeFunction) {
+
+		return TransformUtil.transformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] transformToIntArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] transformToIntArray(
+		T[] array, UnsafeFunction<T, Integer, E> unsafeFunction) {
+
+		return TransformUtil.transformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		int[] array, UnsafeFunction<Integer, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> transformToList(
+		long[] array, UnsafeFunction<Long, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> transformToList(
+		T[] array, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] transformToLongArray(
+		Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] transformToLongArray(
+		T[] array, UnsafeFunction<T, Long, E> unsafeFunction) {
+
+		return TransformUtil.transformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		Collection<T> collection, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] transformToShortArray(
+		T[] array, UnsafeFunction<T, Short, E> unsafeFunction) {
+
+		return TransformUtil.transformToShortArray(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransform(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransform(collection, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	public static <R, E extends Throwable> R[] unsafeTransform(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransform(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransform(array, unsafeFunction, clazz);
+	}
+
+	protected <T, R, E extends Throwable> R[] unsafeTransformToArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction,
+			Class<? extends R> clazz)
+		throws E {
+
+		return TransformUtil.unsafeTransformToArray(
+			collection, unsafeFunction, clazz);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> boolean[]
+			unsafeTransformToBooleanArray(
+				T[] array, UnsafeFunction<T, Boolean, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToBooleanArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			Collection<T> collection, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> byte[] unsafeTransformToByteArray(
+			T[] array, UnsafeFunction<T, Byte, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToByteArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				Collection<T> collection,
+				UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> double[]
+			unsafeTransformToDoubleArray(
+				T[] array, UnsafeFunction<T, Double, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToDoubleArray(
+			array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> float[] unsafeTransformToFloatArray(
+			T[] array, UnsafeFunction<T, Float, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToFloatArray(array, unsafeFunction);
+	}
+
+	public static <T, R, E extends Throwable> int[] unsafeTransformToIntArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> int[] unsafeTransformToIntArray(
+			T[] array, UnsafeFunction<T, Integer, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToIntArray(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			int[] array, UnsafeFunction<Integer, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	public static <R, E extends Throwable> List<R> unsafeTransformToList(
+			long[] array, UnsafeFunction<Long, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> List<R> unsafeTransformToList(
+			T[] array, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToList(array, unsafeFunction);
+	}
+
+	protected <T, R, E extends Throwable> long[] unsafeTransformToLongArray(
+			Collection<T> collection, UnsafeFunction<T, R, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> long[] unsafeTransformToLongArray(
+			T[] array, UnsafeFunction<T, Long, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToLongArray(array, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			Collection<T> collection,
+			UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(
+			collection, unsafeFunction);
+	}
+
+	public static <T, E extends Throwable> short[] unsafeTransformToShortArray(
+			T[] array, UnsafeFunction<T, Short, E> unsafeFunction)
+		throws E {
+
+		return TransformUtil.unsafeTransformToShortArray(array, unsafeFunction);
+	}
+
+	protected AcceptLanguage contextAcceptLanguage;
+	protected UnsafeBiConsumer
+		<Collection<OAuthClientPRLocalMetadata>,
+		 UnsafeFunction
+			 <OAuthClientPRLocalMetadata, OAuthClientPRLocalMetadata,
+			  Exception>,
+		 Exception> contextBatchUnsafeBiConsumer;
+	protected UnsafeBiConsumer
+		<Collection<OAuthClientPRLocalMetadata>,
+		 UnsafeConsumer<OAuthClientPRLocalMetadata, Exception>, Exception>
+			contextBatchUnsafeConsumer;
+	protected com.liferay.portal.kernel.model.Company contextCompany;
+	protected HttpServletRequest contextHttpServletRequest;
+	protected HttpServletResponse contextHttpServletResponse;
+	protected Object contextScopeChecker;
+	protected UriInfo contextUriInfo;
+	protected com.liferay.portal.kernel.model.User contextUser;
+	protected ExpressionConvert<com.liferay.portal.kernel.search.filter.Filter>
+		expressionConvert;
+	protected FilterParserProvider filterParserProvider;
+	protected GroupLocalService groupLocalService;
+	protected ResourceActionLocalService resourceActionLocalService;
+	protected ResourcePermissionLocalService resourcePermissionLocalService;
+	protected RoleLocalService roleLocalService;
+	protected SortParserProvider sortParserProvider;
+	protected VulcanBatchEngineExportTaskResource
+		vulcanBatchEngineExportTaskResource;
+	protected VulcanBatchEngineImportTaskResource
+		vulcanBatchEngineImportTaskResource;
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(BaseOAuthClientPRLocalMetadataResourceImpl.class);
+
+}
+// LIFERAY-REST-BUILDER-HASH:1209371799

--- a/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/OAuthClientPRLocalMetadataResourceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/OAuthClientPRLocalMetadataResourceImpl.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.pagination.Page;
@@ -170,7 +171,9 @@ public class OAuthClientPRLocalMetadataResourceImpl
 						JSONUtil.toStringArray(
 							metadataJSONObject.getJSONArray(
 								"bearer_methods_supported")),
-						oAuthClientPRLocalMetadata.getLocalWellKnownEnabled(),
+						GetterUtil.getBoolean(
+							oAuthClientPRLocalMetadata.
+								getLocalWellKnownEnabled()),
 						oAuthClientPRLocalMetadata.getProtectedResourceURI(),
 						metadataJSONObject.getString("resource_name"),
 						JSONUtil.toStringArray(

--- a/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/OAuthClientPRLocalMetadataResourceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/OAuthClientPRLocalMetadataResourceImpl.java
@@ -118,7 +118,7 @@ public class OAuthClientPRLocalMetadataResourceImpl
 		com.liferay.oauth.client.persistence.model.OAuthClientPRLocalMetadata
 			serviceBuilderOAuthClientPRLocalMetadata =
 				OAuthClientPRLocalMetadataUtil.addOAuthClientPRLocalMetadata(
-					_jsonFactory, oAuthClientPRLocalMetadata,
+					oAuthClientPRLocalMetadata,
 					_oAuthClientPRLocalMetadataService);
 
 		return OAuthClientPRLocalMetadataUtil.toOAuthClientPRLocalMetadata(

--- a/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/OAuthClientPRLocalMetadataResourceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/OAuthClientPRLocalMetadataResourceImpl.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.pagination.Page;
 
 import org.osgi.service.component.annotations.Component;
@@ -149,8 +150,14 @@ public class OAuthClientPRLocalMetadataResourceImpl
 						contextCompany.getCompanyId());
 
 		if (serviceBuilderOAuthClientPRLocalMetadata != null) {
+			String metadataJSON = oAuthClientPRLocalMetadata.getMetadataJSON();
+
+			if (Validator.isNull(metadataJSON)) {
+				throw new IllegalArgumentException("Metadata JSON is required");
+			}
+
 			JSONObject metadataJSONObject = _jsonFactory.createJSONObject(
-				oAuthClientPRLocalMetadata.getMetadataJSON());
+				metadataJSON);
 
 			serviceBuilderOAuthClientPRLocalMetadata =
 				_oAuthClientPRLocalMetadataService.

--- a/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/OAuthClientPRLocalMetadataResourceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/OAuthClientPRLocalMetadataResourceImpl.java
@@ -1,0 +1,195 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.rest.internal.resource.v1_0;
+
+import com.liferay.oauth.client.persistence.service.OAuthClientPRLocalMetadataService;
+import com.liferay.oauth.client.rest.dto.v1_0.OAuthClientPRLocalMetadata;
+import com.liferay.oauth.client.rest.internal.dto.v1_0.util.OAuthClientPRLocalMetadataUtil;
+import com.liferay.oauth.client.rest.resource.v1_0.OAuthClientPRLocalMetadataResource;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.vulcan.pagination.Page;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ServiceScope;
+
+/**
+ * @author Jorge García Jiménez
+ */
+@Component(
+	properties = "OSGI-INF/liferay/rest/v1_0/o-auth-client-pr-local-metadata.properties",
+	scope = ServiceScope.PROTOTYPE,
+	service = OAuthClientPRLocalMetadataResource.class
+)
+public class OAuthClientPRLocalMetadataResourceImpl
+	extends BaseOAuthClientPRLocalMetadataResourceImpl {
+
+	@Override
+	public void deleteOAuthClientPRLocalMetadataByExternalReferenceCode(
+			String oAuthClientPRLocalMetadataExternalReferenceCode)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-63415")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		com.liferay.oauth.client.persistence.model.OAuthClientPRLocalMetadata
+			oAuthClientPRLocalMetadata =
+				_oAuthClientPRLocalMetadataService.
+					getOAuthClientPRLocalMetadataByExternalReferenceCode(
+						oAuthClientPRLocalMetadataExternalReferenceCode,
+						contextCompany.getCompanyId());
+
+		_oAuthClientPRLocalMetadataService.deleteOAuthClientPRLocalMetadata(
+			oAuthClientPRLocalMetadata.getOAuthClientPRLocalMetadataId());
+	}
+
+	@Override
+	public OAuthClientPRLocalMetadata
+			getOAuthClientPRLocalMetadataByExternalReferenceCode(
+				String oAuthClientPRLocalMetadataExternalReferenceCode)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-63415")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		com.liferay.oauth.client.persistence.model.OAuthClientPRLocalMetadata
+			serviceBuilderOAuthClientPRLocalMetadata =
+				_oAuthClientPRLocalMetadataService.
+					getOAuthClientPRLocalMetadataByExternalReferenceCode(
+						oAuthClientPRLocalMetadataExternalReferenceCode,
+						contextCompany.getCompanyId());
+
+		return OAuthClientPRLocalMetadataUtil.toOAuthClientPRLocalMetadata(
+			_portal, serviceBuilderOAuthClientPRLocalMetadata,
+			_userLocalService.fetchUser(
+				serviceBuilderOAuthClientPRLocalMetadata.getUserId()));
+	}
+
+	@Override
+	public Page<OAuthClientPRLocalMetadata> getOAuthClientPRLocalMetadatasPage()
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-63415")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		return Page.of(
+			transform(
+				_oAuthClientPRLocalMetadataService.
+					getCompanyOAuthClientPRLocalMetadata(
+						contextCompany.getCompanyId()),
+				serviceBuilderOAuthClientPRLocalMetadata ->
+					OAuthClientPRLocalMetadataUtil.toOAuthClientPRLocalMetadata(
+						_portal, serviceBuilderOAuthClientPRLocalMetadata,
+						_userLocalService.fetchUser(
+							serviceBuilderOAuthClientPRLocalMetadata.
+								getUserId()))));
+	}
+
+	@Override
+	public OAuthClientPRLocalMetadata postOAuthClientPRLocalMetadata(
+			OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-63415")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		com.liferay.oauth.client.persistence.model.OAuthClientPRLocalMetadata
+			serviceBuilderOAuthClientPRLocalMetadata =
+				OAuthClientPRLocalMetadataUtil.addOAuthClientPRLocalMetadata(
+					_jsonFactory, oAuthClientPRLocalMetadata,
+					_oAuthClientPRLocalMetadataService);
+
+		return OAuthClientPRLocalMetadataUtil.toOAuthClientPRLocalMetadata(
+			_portal, serviceBuilderOAuthClientPRLocalMetadata,
+			_userLocalService.fetchUser(
+				serviceBuilderOAuthClientPRLocalMetadata.getUserId()));
+	}
+
+	@Override
+	public OAuthClientPRLocalMetadata
+			putOAuthClientPRLocalMetadataByExternalReferenceCode(
+				String oAuthClientPRLocalMetadataExternalReferenceCode,
+				OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled(
+				contextCompany.getCompanyId(), "LPD-63415")) {
+
+			throw new UnsupportedOperationException();
+		}
+
+		oAuthClientPRLocalMetadata.setExternalReferenceCode(
+			() -> oAuthClientPRLocalMetadataExternalReferenceCode);
+
+		com.liferay.oauth.client.persistence.model.OAuthClientPRLocalMetadata
+			serviceBuilderOAuthClientPRLocalMetadata =
+				_oAuthClientPRLocalMetadataService.
+					fetchOAuthClientPRLocalMetadataByExternalReferenceCode(
+						oAuthClientPRLocalMetadataExternalReferenceCode,
+						contextCompany.getCompanyId());
+
+		if (serviceBuilderOAuthClientPRLocalMetadata != null) {
+			JSONObject metadataJSONObject = _jsonFactory.createJSONObject(
+				oAuthClientPRLocalMetadata.getMetadataJSON());
+
+			serviceBuilderOAuthClientPRLocalMetadata =
+				_oAuthClientPRLocalMetadataService.
+					updateOAuthClientPRLocalMetadata(
+						serviceBuilderOAuthClientPRLocalMetadata.
+							getOAuthClientPRLocalMetadataId(),
+						JSONUtil.toStringArray(
+							metadataJSONObject.getJSONArray(
+								"authorization_servers")),
+						JSONUtil.toStringArray(
+							metadataJSONObject.getJSONArray(
+								"bearer_methods_supported")),
+						oAuthClientPRLocalMetadata.getLocalWellKnownEnabled(),
+						oAuthClientPRLocalMetadata.getProtectedResourceURI(),
+						metadataJSONObject.getString("resource_name"),
+						JSONUtil.toStringArray(
+							metadataJSONObject.getJSONArray(
+								"scopes_supported")));
+
+			return OAuthClientPRLocalMetadataUtil.toOAuthClientPRLocalMetadata(
+				_portal, serviceBuilderOAuthClientPRLocalMetadata,
+				_userLocalService.fetchUser(
+					serviceBuilderOAuthClientPRLocalMetadata.getUserId()));
+		}
+
+		return postOAuthClientPRLocalMetadata(oAuthClientPRLocalMetadata);
+	}
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private OAuthClientPRLocalMetadataService
+		_oAuthClientPRLocalMetadataService;
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -89,9 +89,11 @@ public class OpenAPIResourceImpl {
 
 			add(OAuthClientEntryResourceImpl.class);
 
+			add(OAuthClientPRLocalMetadataResourceImpl.class);
+
 			add(OpenAPIResourceImpl.class);
 		}
 	};
 
 }
-// LIFERAY-REST-BUILDER-HASH:-1720401828
+// LIFERAY-REST-BUILDER-HASH:79070554

--- a/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/factory/OAuthClientPRLocalMetadataResourceFactoryImpl.java
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/src/main/java/com/liferay/oauth/client/rest/internal/resource/v1_0/factory/OAuthClientPRLocalMetadataResourceFactoryImpl.java
@@ -1,0 +1,345 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.rest.internal.resource.v1_0.factory;
+
+import com.liferay.oauth.client.rest.internal.security.permission.LiberalPermissionChecker;
+import com.liferay.oauth.client.rest.resource.v1_0.OAuthClientPRLocalMetadataResource;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.filter.Filter;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactory;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.odata.filter.ExpressionConvert;
+import com.liferay.portal.odata.filter.FilterParserProvider;
+import com.liferay.portal.odata.sort.SortParserProvider;
+import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
+
+import jakarta.annotation.Generated;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import jakarta.ws.rs.core.UriInfo;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Function;
+
+import org.osgi.service.component.ComponentServiceObjects;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferenceScope;
+
+/**
+ * @author Manuele Castro
+ * @generated
+ */
+@Component(
+	property = "resource.locator.key=/oauth-client/v1.0/OAuthClientPRLocalMetadata",
+	service = OAuthClientPRLocalMetadataResource.Factory.class
+)
+@Generated("")
+public class OAuthClientPRLocalMetadataResourceFactoryImpl
+	implements OAuthClientPRLocalMetadataResource.Factory {
+
+	@Override
+	public OAuthClientPRLocalMetadataResource.Builder create() {
+		return new OAuthClientPRLocalMetadataResource.Builder() {
+
+			@Override
+			public OAuthClientPRLocalMetadataResource build() {
+				if (_user == null) {
+					throw new IllegalArgumentException("User is not set");
+				}
+
+				Function<InvocationHandler, OAuthClientPRLocalMetadataResource>
+					oAuthClientPRLocalMetadataResourceProxyProviderFunction =
+						ResourceProxyProviderFunctionHolder.
+							_oAuthClientPRLocalMetadataResourceProxyProviderFunction;
+
+				return oAuthClientPRLocalMetadataResourceProxyProviderFunction.
+					apply(
+						(proxy, method, arguments) -> _invoke(
+							method, arguments, _checkPermissions,
+							_httpServletRequest, _httpServletResponse,
+							_preferredLocale, _uriInfo, _user));
+			}
+
+			@Override
+			public OAuthClientPRLocalMetadataResource.Builder checkPermissions(
+				boolean checkPermissions) {
+
+				_checkPermissions = checkPermissions;
+
+				return this;
+			}
+
+			@Override
+			public OAuthClientPRLocalMetadataResource.Builder
+				httpServletRequest(HttpServletRequest httpServletRequest) {
+
+				_httpServletRequest = httpServletRequest;
+
+				return this;
+			}
+
+			@Override
+			public OAuthClientPRLocalMetadataResource.Builder
+				httpServletResponse(HttpServletResponse httpServletResponse) {
+
+				_httpServletResponse = httpServletResponse;
+
+				return this;
+			}
+
+			@Override
+			public OAuthClientPRLocalMetadataResource.Builder preferredLocale(
+				Locale preferredLocale) {
+
+				_preferredLocale = preferredLocale;
+
+				return this;
+			}
+
+			@Override
+			public OAuthClientPRLocalMetadataResource.Builder uriInfo(
+				UriInfo uriInfo) {
+
+				_uriInfo = uriInfo;
+
+				return this;
+			}
+
+			@Override
+			public OAuthClientPRLocalMetadataResource.Builder user(User user) {
+				_user = user;
+
+				return this;
+			}
+
+			private boolean _checkPermissions = true;
+			private HttpServletRequest _httpServletRequest;
+			private HttpServletResponse _httpServletResponse;
+			private Locale _preferredLocale;
+			private UriInfo _uriInfo;
+			private User _user;
+
+		};
+	}
+
+	private static Function
+		<InvocationHandler, OAuthClientPRLocalMetadataResource>
+			_getProxyProviderFunction() {
+
+		Class<?> proxyClass = ProxyUtil.getProxyClass(
+			OAuthClientPRLocalMetadataResource.class.getClassLoader(),
+			OAuthClientPRLocalMetadataResource.class);
+
+		try {
+			Constructor<OAuthClientPRLocalMetadataResource> constructor =
+				(Constructor<OAuthClientPRLocalMetadataResource>)
+					proxyClass.getConstructor(InvocationHandler.class);
+
+			return invocationHandler -> {
+				try {
+					return constructor.newInstance(invocationHandler);
+				}
+				catch (ReflectiveOperationException
+							reflectiveOperationException) {
+
+					throw new InternalError(reflectiveOperationException);
+				}
+			};
+		}
+		catch (NoSuchMethodException noSuchMethodException) {
+			throw new InternalError(noSuchMethodException);
+		}
+	}
+
+	private Object _invoke(
+			Method method, Object[] arguments, boolean checkPermissions,
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Locale preferredLocale,
+			UriInfo uriInfo, User user)
+		throws Throwable {
+
+		String name = PrincipalThreadLocal.getName();
+
+		PrincipalThreadLocal.setName(user.getUserId());
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+
+		if (checkPermissions) {
+			PermissionThreadLocal.setPermissionChecker(
+				_defaultPermissionCheckerFactory.create(user));
+		}
+		else {
+			PermissionThreadLocal.setPermissionChecker(
+				new LiberalPermissionChecker(user));
+		}
+
+		OAuthClientPRLocalMetadataResource oAuthClientPRLocalMetadataResource =
+			_componentServiceObjects.getService();
+
+		oAuthClientPRLocalMetadataResource.setContextAcceptLanguage(
+			new AcceptLanguageImpl(httpServletRequest, preferredLocale, user));
+
+		Company company = _companyLocalService.getCompany(user.getCompanyId());
+
+		oAuthClientPRLocalMetadataResource.setContextCompany(company);
+
+		oAuthClientPRLocalMetadataResource.setContextHttpServletRequest(
+			httpServletRequest);
+		oAuthClientPRLocalMetadataResource.setContextHttpServletResponse(
+			httpServletResponse);
+		oAuthClientPRLocalMetadataResource.setContextUriInfo(uriInfo);
+		oAuthClientPRLocalMetadataResource.setContextUser(user);
+		oAuthClientPRLocalMetadataResource.setExpressionConvert(
+			_expressionConvert);
+		oAuthClientPRLocalMetadataResource.setFilterParserProvider(
+			_filterParserProvider);
+		oAuthClientPRLocalMetadataResource.setGroupLocalService(
+			_groupLocalService);
+		oAuthClientPRLocalMetadataResource.setResourceActionLocalService(
+			_resourceActionLocalService);
+		oAuthClientPRLocalMetadataResource.setResourcePermissionLocalService(
+			_resourcePermissionLocalService);
+		oAuthClientPRLocalMetadataResource.setRoleLocalService(
+			_roleLocalService);
+		oAuthClientPRLocalMetadataResource.setSortParserProvider(
+			_sortParserProvider);
+
+		try {
+			return method.invoke(oAuthClientPRLocalMetadataResource, arguments);
+		}
+		catch (InvocationTargetException invocationTargetException) {
+			throw invocationTargetException.getTargetException();
+		}
+		finally {
+			_componentServiceObjects.ungetService(
+				oAuthClientPRLocalMetadataResource);
+
+			PrincipalThreadLocal.setName(name);
+
+			PermissionThreadLocal.setPermissionChecker(permissionChecker);
+		}
+	}
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference(scope = ReferenceScope.PROTOTYPE_REQUIRED)
+	private ComponentServiceObjects<OAuthClientPRLocalMetadataResource>
+		_componentServiceObjects;
+
+	@Reference
+	private PermissionCheckerFactory _defaultPermissionCheckerFactory;
+
+	@Reference(
+		target = "(result.class.name=com.liferay.portal.kernel.search.filter.Filter)"
+	)
+	private ExpressionConvert<Filter> _expressionConvert;
+
+	@Reference
+	private FilterParserProvider _filterParserProvider;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SortParserProvider _sortParserProvider;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+	private static class ResourceProxyProviderFunctionHolder {
+
+		private static final Function
+			<InvocationHandler, OAuthClientPRLocalMetadataResource>
+				_oAuthClientPRLocalMetadataResourceProxyProviderFunction =
+					_getProxyProviderFunction();
+
+	}
+
+	private class AcceptLanguageImpl implements AcceptLanguage {
+
+		public AcceptLanguageImpl(
+			HttpServletRequest httpServletRequest, Locale preferredLocale,
+			User user) {
+
+			_httpServletRequest = httpServletRequest;
+			_preferredLocale = preferredLocale;
+			_user = user;
+		}
+
+		@Override
+		public List<Locale> getLocales() {
+			return Arrays.asList(getPreferredLocale());
+		}
+
+		@Override
+		public String getPreferredLanguageId() {
+			return LocaleUtil.toLanguageId(getPreferredLocale());
+		}
+
+		@Override
+		public Locale getPreferredLocale() {
+			if (_preferredLocale != null) {
+				return _preferredLocale;
+			}
+
+			if (_httpServletRequest != null) {
+				Locale locale = (Locale)_httpServletRequest.getAttribute(
+					WebKeys.LOCALE);
+
+				if (locale != null) {
+					return locale;
+				}
+			}
+
+			return _user.getLocale();
+		}
+
+		@Override
+		public boolean isAcceptAllLanguages() {
+			return false;
+		}
+
+		private final HttpServletRequest _httpServletRequest;
+		private final Locale _preferredLocale;
+		private final User _user;
+
+	}
+
+}
+// LIFERAY-REST-BUILDER-HASH:1265424319

--- a/modules/apps/oauth-client/oauth-client-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/o-auth-client-pr-local-metadata.properties
+++ b/modules/apps/oauth-client/oauth-client-rest-impl/src/main/resources/OSGI-INF/liferay/rest/v1_0/o-auth-client-pr-local-metadata.properties
@@ -1,0 +1,12 @@
+#
+# This is a generated file.
+#
+
+api.version=v1.0
+batch.engine.entity.class.name=com.liferay.oauth.client.rest.dto.v1_0.OAuthClientPRLocalMetadata
+batch.engine.task.item.delegate=true
+batch.planner.export.enabled=true
+batch.planner.import.enabled=true
+entity.class.name=com.liferay.oauth.client.rest.dto.v1_0.OAuthClientPRLocalMetadata
+osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.OAuth.Client.REST)
+osgi.jaxrs.resource=true

--- a/modules/apps/oauth-client/oauth-client-rest-test/src/testIntegration/java/com/liferay/oauth/client/rest/resource/v1_0/test/BaseOAuthClientPRLocalMetadataResourceTestCase.java
+++ b/modules/apps/oauth-client/oauth-client-rest-test/src/testIntegration/java/com/liferay/oauth/client/rest/resource/v1_0/test/BaseOAuthClientPRLocalMetadataResourceTestCase.java
@@ -1,0 +1,1544 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.rest.resource.v1_0.test;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
+
+import com.liferay.headless.batch.engine.client.dto.v1_0.ImportTask;
+import com.liferay.headless.batch.engine.client.http.HttpInvoker.HttpResponse;
+import com.liferay.headless.batch.engine.client.resource.v1_0.ImportTaskResource;
+import com.liferay.oauth.client.rest.client.dto.v1_0.OAuthClientPRLocalMetadata;
+import com.liferay.oauth.client.rest.client.http.HttpInvoker;
+import com.liferay.oauth.client.rest.client.pagination.Page;
+import com.liferay.oauth.client.rest.client.resource.v1_0.OAuthClientPRLocalMetadataResource;
+import com.liferay.oauth.client.rest.client.serdes.v1_0.OAuthClientPRLocalMetadataSerDes;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.odata.entity.EntityModel;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.vulcan.resource.EntityModelResource;
+
+import jakarta.annotation.Generated;
+
+import jakarta.ws.rs.core.MultivaluedHashMap;
+
+import java.lang.reflect.Method;
+
+import java.text.Format;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Manuele Castro
+ * @generated
+ */
+@Generated("")
+public abstract class BaseOAuthClientPRLocalMetadataResourceTestCase {
+
+	@ClassRule
+	@Rule
+	public static final LiferayIntegrationTestRule liferayIntegrationTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_format = FastDateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyy-MM-dd'T'HH:mm:ss'Z'");
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		irrelevantGroup = GroupTestUtil.addGroup();
+		testGroup = GroupTestUtil.addGroup();
+
+		testCompany = CompanyLocalServiceUtil.getCompany(
+			testGroup.getCompanyId());
+
+		_oAuthClientPRLocalMetadataResource.setContextCompany(testCompany);
+
+		_testCompanyAdminUser = UserTestUtil.getAdminUser(
+			testCompany.getCompanyId());
+
+		oAuthClientPRLocalMetadataResource =
+			OAuthClientPRLocalMetadataResource.builder(
+			).authentication(
+				_testCompanyAdminUser.getEmailAddress(),
+				PropsValues.DEFAULT_ADMIN_PASSWORD
+			).endpoint(
+				testCompany.getVirtualHostname(),
+				PortalUtil.getPortalServerPort(false), "http"
+			).locale(
+				LocaleUtil.getDefault()
+			).build();
+
+		importTaskResource = ImportTaskResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).locale(
+			LocaleUtil.getDefault()
+		).build();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		GroupTestUtil.deleteGroup(irrelevantGroup);
+		GroupTestUtil.deleteGroup(testGroup);
+	}
+
+	@Test
+	public void testClientSerDesToDTO() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata1 =
+			randomOAuthClientPRLocalMetadata();
+
+		String json = objectMapper.writeValueAsString(
+			oAuthClientPRLocalMetadata1);
+
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata2 =
+			OAuthClientPRLocalMetadataSerDes.toDTO(json);
+
+		Assert.assertTrue(
+			equals(oAuthClientPRLocalMetadata1, oAuthClientPRLocalMetadata2));
+	}
+
+	@Test
+	public void testClientSerDesToJSON() throws Exception {
+		ObjectMapper objectMapper = getClientSerDesObjectMapper();
+
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata =
+			randomOAuthClientPRLocalMetadata();
+
+		String json1 = objectMapper.writeValueAsString(
+			oAuthClientPRLocalMetadata);
+		String json2 = OAuthClientPRLocalMetadataSerDes.toJSON(
+			oAuthClientPRLocalMetadata);
+
+		Assert.assertEquals(
+			objectMapper.readTree(json1), objectMapper.readTree(json2));
+	}
+
+	protected ObjectMapper getClientSerDesObjectMapper() {
+		return new ObjectMapper() {
+			{
+				configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+				configure(
+					SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
+				enable(SerializationFeature.INDENT_OUTPUT);
+				setDateFormat(new ISO8601DateFormat());
+				setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+				setSerializationInclusion(JsonInclude.Include.NON_NULL);
+				setVisibility(
+					PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+				setVisibility(
+					PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+			}
+		};
+	}
+
+	@Test
+	public void testEscapeRegexInStringFields() throws Exception {
+		String regex = "^[0-9]+(\\.[0-9]{1,2})\"?";
+
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata =
+			randomOAuthClientPRLocalMetadata();
+
+		oAuthClientPRLocalMetadata.setExternalReferenceCode(regex);
+		oAuthClientPRLocalMetadata.setLocalWellKnownURI(regex);
+		oAuthClientPRLocalMetadata.setMetadataJSON(regex);
+		oAuthClientPRLocalMetadata.setProtectedResourceURI(regex);
+
+		String json = OAuthClientPRLocalMetadataSerDes.toJSON(
+			oAuthClientPRLocalMetadata);
+
+		Assert.assertFalse(json.contains(regex));
+
+		oAuthClientPRLocalMetadata = OAuthClientPRLocalMetadataSerDes.toDTO(
+			json);
+
+		Assert.assertEquals(
+			regex, oAuthClientPRLocalMetadata.getExternalReferenceCode());
+		Assert.assertEquals(
+			regex, oAuthClientPRLocalMetadata.getLocalWellKnownURI());
+		Assert.assertEquals(
+			regex, oAuthClientPRLocalMetadata.getMetadataJSON());
+		Assert.assertEquals(
+			regex, oAuthClientPRLocalMetadata.getProtectedResourceURI());
+	}
+
+	@Test
+	public void testDeleteOAuthClientPRLocalMetadataByExternalReferenceCode()
+		throws Exception {
+
+		@SuppressWarnings("PMD.UnusedLocalVariable")
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata =
+			testDeleteOAuthClientPRLocalMetadataByExternalReferenceCode_addOAuthClientPRLocalMetadata();
+
+		assertHttpResponseStatusCode(
+			204,
+			oAuthClientPRLocalMetadataResource.
+				deleteOAuthClientPRLocalMetadataByExternalReferenceCodeHttpResponse(
+					oAuthClientPRLocalMetadata.getExternalReferenceCode()));
+
+		assertHttpResponseStatusCode(
+			404,
+			oAuthClientPRLocalMetadataResource.
+				getOAuthClientPRLocalMetadataByExternalReferenceCodeHttpResponse(
+					oAuthClientPRLocalMetadata.getExternalReferenceCode()));
+		assertHttpResponseStatusCode(
+			404,
+			oAuthClientPRLocalMetadataResource.
+				getOAuthClientPRLocalMetadataByExternalReferenceCodeHttpResponse(
+					"-"));
+	}
+
+	protected OAuthClientPRLocalMetadata
+			testDeleteOAuthClientPRLocalMetadataByExternalReferenceCode_addOAuthClientPRLocalMetadata()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGetOAuthClientPRLocalMetadataByExternalReferenceCode()
+		throws Exception {
+
+		OAuthClientPRLocalMetadata postOAuthClientPRLocalMetadata =
+			testGetOAuthClientPRLocalMetadataByExternalReferenceCode_addOAuthClientPRLocalMetadata();
+
+		OAuthClientPRLocalMetadata getOAuthClientPRLocalMetadata =
+			oAuthClientPRLocalMetadataResource.
+				getOAuthClientPRLocalMetadataByExternalReferenceCode(
+					postOAuthClientPRLocalMetadata.getExternalReferenceCode());
+
+		assertEquals(
+			postOAuthClientPRLocalMetadata, getOAuthClientPRLocalMetadata);
+		assertValid(getOAuthClientPRLocalMetadata);
+	}
+
+	protected OAuthClientPRLocalMetadata
+			testGetOAuthClientPRLocalMetadataByExternalReferenceCode_addOAuthClientPRLocalMetadata()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGetOAuthClientPRLocalMetadatasPage() throws Exception {
+		Page<OAuthClientPRLocalMetadata> page =
+			oAuthClientPRLocalMetadataResource.
+				getOAuthClientPRLocalMetadatasPage();
+
+		long totalCount = page.getTotalCount();
+
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata1 =
+			testGetOAuthClientPRLocalMetadatasPage_addOAuthClientPRLocalMetadata(
+				randomOAuthClientPRLocalMetadata());
+
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata2 =
+			testGetOAuthClientPRLocalMetadatasPage_addOAuthClientPRLocalMetadata(
+				randomOAuthClientPRLocalMetadata());
+
+		page =
+			oAuthClientPRLocalMetadataResource.
+				getOAuthClientPRLocalMetadatasPage();
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(
+			oAuthClientPRLocalMetadata1,
+			(List<OAuthClientPRLocalMetadata>)page.getItems());
+		assertContains(
+			oAuthClientPRLocalMetadata2,
+			(List<OAuthClientPRLocalMetadata>)page.getItems());
+		assertValid(
+			page, testGetOAuthClientPRLocalMetadatasPage_getExpectedActions());
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetOAuthClientPRLocalMetadatasPage_getExpectedActions()
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	protected OAuthClientPRLocalMetadata
+			testGetOAuthClientPRLocalMetadatasPage_addOAuthClientPRLocalMetadata(
+				OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testPostOAuthClientPRLocalMetadata() throws Exception {
+		OAuthClientPRLocalMetadata randomOAuthClientPRLocalMetadata =
+			randomOAuthClientPRLocalMetadata();
+
+		OAuthClientPRLocalMetadata postOAuthClientPRLocalMetadata =
+			testPostOAuthClientPRLocalMetadata_addOAuthClientPRLocalMetadata(
+				randomOAuthClientPRLocalMetadata);
+
+		assertEquals(
+			randomOAuthClientPRLocalMetadata, postOAuthClientPRLocalMetadata);
+		assertValid(postOAuthClientPRLocalMetadata);
+	}
+
+	protected OAuthClientPRLocalMetadata
+			testPostOAuthClientPRLocalMetadata_addOAuthClientPRLocalMetadata(
+				OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testPutOAuthClientPRLocalMetadataByExternalReferenceCode()
+		throws Exception {
+
+		OAuthClientPRLocalMetadata postOAuthClientPRLocalMetadata =
+			testPutOAuthClientPRLocalMetadataByExternalReferenceCode_addOAuthClientPRLocalMetadata();
+
+		OAuthClientPRLocalMetadata randomOAuthClientPRLocalMetadata =
+			randomOAuthClientPRLocalMetadata();
+
+		OAuthClientPRLocalMetadata putOAuthClientPRLocalMetadata =
+			oAuthClientPRLocalMetadataResource.
+				putOAuthClientPRLocalMetadataByExternalReferenceCode(
+					postOAuthClientPRLocalMetadata.getExternalReferenceCode(),
+					randomOAuthClientPRLocalMetadata);
+
+		assertEquals(
+			randomOAuthClientPRLocalMetadata, putOAuthClientPRLocalMetadata);
+		assertValid(putOAuthClientPRLocalMetadata);
+
+		OAuthClientPRLocalMetadata getOAuthClientPRLocalMetadata =
+			oAuthClientPRLocalMetadataResource.
+				getOAuthClientPRLocalMetadataByExternalReferenceCode(
+					putOAuthClientPRLocalMetadata.getExternalReferenceCode());
+
+		assertEquals(
+			randomOAuthClientPRLocalMetadata, getOAuthClientPRLocalMetadata);
+		assertValid(getOAuthClientPRLocalMetadata);
+
+		OAuthClientPRLocalMetadata newOAuthClientPRLocalMetadata =
+			testPutOAuthClientPRLocalMetadataByExternalReferenceCode_createOAuthClientPRLocalMetadata();
+
+		putOAuthClientPRLocalMetadata =
+			oAuthClientPRLocalMetadataResource.
+				putOAuthClientPRLocalMetadataByExternalReferenceCode(
+					newOAuthClientPRLocalMetadata.getExternalReferenceCode(),
+					newOAuthClientPRLocalMetadata);
+
+		assertEquals(
+			newOAuthClientPRLocalMetadata, putOAuthClientPRLocalMetadata);
+		assertValid(putOAuthClientPRLocalMetadata);
+
+		getOAuthClientPRLocalMetadata =
+			oAuthClientPRLocalMetadataResource.
+				getOAuthClientPRLocalMetadataByExternalReferenceCode(
+					putOAuthClientPRLocalMetadata.getExternalReferenceCode());
+
+		assertEquals(
+			newOAuthClientPRLocalMetadata, getOAuthClientPRLocalMetadata);
+
+		Assert.assertEquals(
+			newOAuthClientPRLocalMetadata.getExternalReferenceCode(),
+			putOAuthClientPRLocalMetadata.getExternalReferenceCode());
+	}
+
+	protected OAuthClientPRLocalMetadata
+			testPutOAuthClientPRLocalMetadataByExternalReferenceCode_addOAuthClientPRLocalMetadata()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected OAuthClientPRLocalMetadata
+			testPutOAuthClientPRLocalMetadataByExternalReferenceCode_createOAuthClientPRLocalMetadata()
+		throws Exception {
+
+		return randomOAuthClientPRLocalMetadata();
+	}
+
+	@Test
+	public void testBatchEngineDeleteImportTask() throws Exception {
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata1 =
+			testBatchEngineDeleteImportTask_addOAuthClientPRLocalMetadata();
+
+		testBatchEngineDeleteImportTask_deleteOAuthClientPRLocalMetadata(
+			200, oAuthClientPRLocalMetadata1.getExternalReferenceCode());
+	}
+
+	protected OAuthClientPRLocalMetadata
+			testBatchEngineDeleteImportTask_addOAuthClientPRLocalMetadata()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	protected void
+			testBatchEngineDeleteImportTask_deleteOAuthClientPRLocalMetadata(
+				int expectedStatusCode, String externalReferenceCode,
+				String... parameters)
+		throws Exception {
+
+		ImportTaskResource importTaskResource = ImportTaskResource.builder(
+		).authentication(
+			_testCompanyAdminUser.getEmailAddress(),
+			PropsValues.DEFAULT_ADMIN_PASSWORD
+		).endpoint(
+			testCompany.getVirtualHostname(),
+			PortalUtil.getPortalServerPort(false), "http"
+		).parameters(
+			parameters
+		).build();
+
+		HttpResponse httpResponse =
+			importTaskResource.deleteImportTaskHttpResponse(
+				"com.liferay.oauth.client.rest.dto.v1_0.OAuthClientPRLocalMetadata",
+				null, null, null, null,
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"externalReferenceCode", () -> externalReferenceCode)));
+
+		Assert.assertEquals(expectedStatusCode, httpResponse.getStatusCode());
+
+		if (expectedStatusCode == 200) {
+			waitForFinish(
+				"COMPLETED",
+				JSONFactoryUtil.createJSONObject(httpResponse.getContent()));
+		}
+	}
+
+	protected void assertContains(
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata,
+		List<OAuthClientPRLocalMetadata> oAuthClientPRLocalMetadatas) {
+
+		boolean contains = false;
+
+		for (OAuthClientPRLocalMetadata item : oAuthClientPRLocalMetadatas) {
+			if (equals(oAuthClientPRLocalMetadata, item)) {
+				contains = true;
+
+				break;
+			}
+		}
+
+		Assert.assertTrue(
+			oAuthClientPRLocalMetadatas + " does not contain " +
+				oAuthClientPRLocalMetadata,
+			contains);
+	}
+
+	protected void assertHttpResponseStatusCode(
+		int expectedHttpResponseStatusCode,
+		HttpInvoker.HttpResponse actualHttpResponse) {
+
+		Assert.assertEquals(
+			expectedHttpResponseStatusCode, actualHttpResponse.getStatusCode());
+	}
+
+	protected void assertEquals(
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata1,
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata2) {
+
+		Assert.assertTrue(
+			oAuthClientPRLocalMetadata1 + " does not equal " +
+				oAuthClientPRLocalMetadata2,
+			equals(oAuthClientPRLocalMetadata1, oAuthClientPRLocalMetadata2));
+	}
+
+	protected void assertEquals(
+		List<OAuthClientPRLocalMetadata> oAuthClientPRLocalMetadatas1,
+		List<OAuthClientPRLocalMetadata> oAuthClientPRLocalMetadatas2) {
+
+		Assert.assertEquals(
+			oAuthClientPRLocalMetadatas1.size(),
+			oAuthClientPRLocalMetadatas2.size());
+
+		for (int i = 0; i < oAuthClientPRLocalMetadatas1.size(); i++) {
+			OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata1 =
+				oAuthClientPRLocalMetadatas1.get(i);
+			OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata2 =
+				oAuthClientPRLocalMetadatas2.get(i);
+
+			assertEquals(
+				oAuthClientPRLocalMetadata1, oAuthClientPRLocalMetadata2);
+		}
+	}
+
+	protected void assertEqualsIgnoringOrder(
+		List<OAuthClientPRLocalMetadata> oAuthClientPRLocalMetadatas1,
+		List<OAuthClientPRLocalMetadata> oAuthClientPRLocalMetadatas2) {
+
+		Assert.assertEquals(
+			oAuthClientPRLocalMetadatas1.size(),
+			oAuthClientPRLocalMetadatas2.size());
+
+		for (OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata1 :
+				oAuthClientPRLocalMetadatas1) {
+
+			boolean contains = false;
+
+			for (OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata2 :
+					oAuthClientPRLocalMetadatas2) {
+
+				if (equals(
+						oAuthClientPRLocalMetadata1,
+						oAuthClientPRLocalMetadata2)) {
+
+					contains = true;
+
+					break;
+				}
+			}
+
+			Assert.assertTrue(
+				oAuthClientPRLocalMetadatas2 + " does not contain " +
+					oAuthClientPRLocalMetadata1,
+				contains);
+		}
+	}
+
+	protected void assertValid(
+			OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+		throws Exception {
+
+		boolean valid = true;
+
+		if (oAuthClientPRLocalMetadata.getDateCreated() == null) {
+			valid = false;
+		}
+
+		if (oAuthClientPRLocalMetadata.getDateModified() == null) {
+			valid = false;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("creator", additionalAssertFieldName)) {
+				if (oAuthClientPRLocalMetadata.getCreator() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (oAuthClientPRLocalMetadata.getExternalReferenceCode() ==
+						null) {
+
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"localWellKnownEnabled", additionalAssertFieldName)) {
+
+				if (oAuthClientPRLocalMetadata.getLocalWellKnownEnabled() ==
+						null) {
+
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"localWellKnownURI", additionalAssertFieldName)) {
+
+				if (oAuthClientPRLocalMetadata.getLocalWellKnownURI() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("metadataJSON", additionalAssertFieldName)) {
+				if (oAuthClientPRLocalMetadata.getMetadataJSON() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"protectedResourceURI", additionalAssertFieldName)) {
+
+				if (oAuthClientPRLocalMetadata.getProtectedResourceURI() ==
+						null) {
+
+					valid = false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		Assert.assertTrue(valid);
+	}
+
+	protected void assertValid(Page<OAuthClientPRLocalMetadata> page) {
+		assertValid(page, Collections.emptyMap());
+	}
+
+	protected void assertValid(
+		Page<OAuthClientPRLocalMetadata> page,
+		Map<String, Map<String, String>> expectedActions) {
+
+		boolean valid = false;
+
+		java.util.Collection<OAuthClientPRLocalMetadata>
+			oAuthClientPRLocalMetadatas = page.getItems();
+
+		int size = oAuthClientPRLocalMetadatas.size();
+
+		if ((page.getLastPage() > 0) && (page.getPage() > 0) &&
+			(page.getPageSize() > 0) && (page.getTotalCount() > 0) &&
+			(size > 0)) {
+
+			valid = true;
+		}
+
+		Assert.assertTrue(valid);
+
+		assertValid(page.getActions(), expectedActions);
+	}
+
+	protected void assertValid(
+		Map<String, Map<String, String>> actions1,
+		Map<String, Map<String, String>> actions2) {
+
+		for (String key : actions2.keySet()) {
+			Map action = actions1.get(key);
+
+			Assert.assertNotNull(key + " does not contain an action", action);
+
+			Map<String, String> expectedAction = actions2.get(key);
+
+			Assert.assertEquals(
+				expectedAction.get("method"), action.get("method"));
+			Assert.assertEquals(expectedAction.get("href"), action.get("href"));
+		}
+	}
+
+	protected String[] getAdditionalAssertFieldNames() {
+		return new String[0];
+	}
+
+	protected List<GraphQLField> getGraphQLFields() throws Exception {
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		graphQLFields.add(new GraphQLField("externalReferenceCode"));
+
+		for (java.lang.reflect.Field field :
+				getDeclaredFields(
+					com.liferay.oauth.client.rest.dto.v1_0.
+						OAuthClientPRLocalMetadata.class)) {
+
+			if (!ArrayUtil.contains(
+					getAdditionalAssertFieldNames(), field.getName())) {
+
+				continue;
+			}
+
+			graphQLFields.addAll(getGraphQLFields(field));
+		}
+
+		return graphQLFields;
+	}
+
+	protected List<GraphQLField> getGraphQLFields(
+			java.lang.reflect.Field... fields)
+		throws Exception {
+
+		List<GraphQLField> graphQLFields = new ArrayList<>();
+
+		for (java.lang.reflect.Field field : fields) {
+			com.liferay.portal.vulcan.graphql.annotation.GraphQLField
+				vulcanGraphQLField = field.getAnnotation(
+					com.liferay.portal.vulcan.graphql.annotation.GraphQLField.
+						class);
+
+			if (vulcanGraphQLField != null) {
+				Class<?> clazz = field.getType();
+
+				if (clazz.isArray()) {
+					clazz = clazz.getComponentType();
+				}
+
+				List<GraphQLField> childrenGraphQLFields = getGraphQLFields(
+					getDeclaredFields(clazz));
+
+				graphQLFields.add(
+					new GraphQLField(field.getName(), childrenGraphQLFields));
+			}
+		}
+
+		return graphQLFields;
+	}
+
+	protected String[] getIgnoredEntityFieldNames() {
+		return new String[0];
+	}
+
+	protected boolean equals(
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata1,
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata2) {
+
+		if (oAuthClientPRLocalMetadata1 == oAuthClientPRLocalMetadata2) {
+			return true;
+		}
+
+		for (String additionalAssertFieldName :
+				getAdditionalAssertFieldNames()) {
+
+			if (Objects.equals("creator", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						oAuthClientPRLocalMetadata1.getCreator(),
+						oAuthClientPRLocalMetadata2.getCreator())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("dateCreated", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						oAuthClientPRLocalMetadata1.getDateCreated(),
+						oAuthClientPRLocalMetadata2.getDateCreated())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("dateModified", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						oAuthClientPRLocalMetadata1.getDateModified(),
+						oAuthClientPRLocalMetadata2.getDateModified())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"externalReferenceCode", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						oAuthClientPRLocalMetadata1.getExternalReferenceCode(),
+						oAuthClientPRLocalMetadata2.
+							getExternalReferenceCode())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"localWellKnownEnabled", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						oAuthClientPRLocalMetadata1.getLocalWellKnownEnabled(),
+						oAuthClientPRLocalMetadata2.
+							getLocalWellKnownEnabled())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"localWellKnownURI", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						oAuthClientPRLocalMetadata1.getLocalWellKnownURI(),
+						oAuthClientPRLocalMetadata2.getLocalWellKnownURI())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("metadataJSON", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						oAuthClientPRLocalMetadata1.getMetadataJSON(),
+						oAuthClientPRLocalMetadata2.getMetadataJSON())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"protectedResourceURI", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						oAuthClientPRLocalMetadata1.getProtectedResourceURI(),
+						oAuthClientPRLocalMetadata2.
+							getProtectedResourceURI())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			throw new IllegalArgumentException(
+				"Invalid additional assert field name " +
+					additionalAssertFieldName);
+		}
+
+		return true;
+	}
+
+	protected boolean equals(
+		Map<String, Object> map1, Map<String, Object> map2) {
+
+		if (Objects.equals(map1.keySet(), map2.keySet())) {
+			for (Map.Entry<String, Object> entry : map1.entrySet()) {
+				if (entry.getValue() instanceof Map) {
+					if (!equals(
+							(Map)entry.getValue(),
+							(Map)map2.get(entry.getKey()))) {
+
+						return false;
+					}
+				}
+				else if (!Objects.deepEquals(
+							entry.getValue(), map2.get(entry.getKey()))) {
+
+					return false;
+				}
+			}
+
+			return true;
+		}
+
+		return false;
+	}
+
+	protected java.lang.reflect.Field[] getDeclaredFields(Class clazz)
+		throws Exception {
+
+		if (clazz.getClassLoader() == null) {
+			return new java.lang.reflect.Field[0];
+		}
+
+		return TransformUtil.transform(
+			ReflectionUtil.getDeclaredFields(clazz),
+			field -> {
+				if (field.isSynthetic()) {
+					return null;
+				}
+
+				return field;
+			},
+			java.lang.reflect.Field.class);
+	}
+
+	protected java.util.Collection<EntityField> getEntityFields()
+		throws Exception {
+
+		if (!(_oAuthClientPRLocalMetadataResource instanceof
+				EntityModelResource)) {
+
+			throw new UnsupportedOperationException(
+				"Resource is not an instance of EntityModelResource");
+		}
+
+		EntityModelResource entityModelResource =
+			(EntityModelResource)_oAuthClientPRLocalMetadataResource;
+
+		EntityModel entityModel = entityModelResource.getEntityModel(
+			new MultivaluedHashMap());
+
+		if (entityModel == null) {
+			return Collections.emptyList();
+		}
+
+		Map<String, EntityField> entityFieldsMap =
+			entityModel.getEntityFieldsMap();
+
+		return entityFieldsMap.values();
+	}
+
+	protected List<EntityField> getEntityFields(EntityField.Type type)
+		throws Exception {
+
+		return TransformUtil.transform(
+			getEntityFields(),
+			entityField -> {
+				if (!Objects.equals(entityField.getType(), type) ||
+					ArrayUtil.contains(
+						getIgnoredEntityFieldNames(), entityField.getName())) {
+
+					return null;
+				}
+
+				return entityField;
+			});
+	}
+
+	protected String getFilterString(
+		EntityField entityField, String operator,
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata) {
+
+		StringBundler sb = new StringBundler();
+
+		String entityFieldName = entityField.getName();
+
+		sb.append(entityFieldName);
+
+		sb.append(" ");
+		sb.append(operator);
+		sb.append(" ");
+
+		if (entityFieldName.equals("creator")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("dateCreated")) {
+			if (operator.equals("between")) {
+				Date date = oAuthClientPRLocalMetadata.getDateCreated();
+
+				sb = new StringBundler();
+
+				sb.append("(");
+				sb.append(entityFieldName);
+				sb.append(" gt ");
+				sb.append(_format.format(date.getTime() - (2 * Time.SECOND)));
+				sb.append(" and ");
+				sb.append(entityFieldName);
+				sb.append(" lt ");
+				sb.append(_format.format(date.getTime() + (2 * Time.SECOND)));
+				sb.append(")");
+			}
+			else {
+				sb.append(entityFieldName);
+
+				sb.append(" ");
+				sb.append(operator);
+				sb.append(" ");
+
+				sb.append(
+					_format.format(
+						oAuthClientPRLocalMetadata.getDateCreated()));
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("dateModified")) {
+			if (operator.equals("between")) {
+				Date date = oAuthClientPRLocalMetadata.getDateModified();
+
+				sb = new StringBundler();
+
+				sb.append("(");
+				sb.append(entityFieldName);
+				sb.append(" gt ");
+				sb.append(_format.format(date.getTime() - (2 * Time.SECOND)));
+				sb.append(" and ");
+				sb.append(entityFieldName);
+				sb.append(" lt ");
+				sb.append(_format.format(date.getTime() + (2 * Time.SECOND)));
+				sb.append(")");
+			}
+			else {
+				sb.append(entityFieldName);
+
+				sb.append(" ");
+				sb.append(operator);
+				sb.append(" ");
+
+				sb.append(
+					_format.format(
+						oAuthClientPRLocalMetadata.getDateModified()));
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("externalReferenceCode")) {
+			Object object =
+				oAuthClientPRLocalMetadata.getExternalReferenceCode();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("localWellKnownEnabled")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("localWellKnownURI")) {
+			Object object = oAuthClientPRLocalMetadata.getLocalWellKnownURI();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("metadataJSON")) {
+			Object object = oAuthClientPRLocalMetadata.getMetadataJSON();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("protectedResourceURI")) {
+			Object object =
+				oAuthClientPRLocalMetadata.getProtectedResourceURI();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		throw new IllegalArgumentException(
+			"Invalid entity field " + entityFieldName);
+	}
+
+	protected String invoke(String query) throws Exception {
+		HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+		httpInvoker.body(
+			JSONUtil.put(
+				"query", query
+			).toString(),
+			"application/json");
+		httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+		httpInvoker.path(
+			"http://localhost:" + PortalUtil.getPortalServerPort(false) +
+				"/o/graphql");
+		httpInvoker.userNameAndPassword(
+			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD);
+
+		HttpInvoker.HttpResponse httpResponse = httpInvoker.invoke();
+
+		return httpResponse.getContent();
+	}
+
+	protected JSONObject invokeGraphQLMutation(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField mutationGraphQLField = new GraphQLField(
+			"mutation", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(mutationGraphQLField.toString()));
+	}
+
+	protected JSONObject invokeGraphQLQuery(GraphQLField graphQLField)
+		throws Exception {
+
+		GraphQLField queryGraphQLField = new GraphQLField(
+			"query", graphQLField);
+
+		return JSONFactoryUtil.createJSONObject(
+			invoke(queryGraphQLField.toString()));
+	}
+
+	protected OAuthClientPRLocalMetadata randomOAuthClientPRLocalMetadata()
+		throws Exception {
+
+		return new OAuthClientPRLocalMetadata() {
+			{
+				dateCreated = RandomTestUtil.nextDate();
+				dateModified = RandomTestUtil.nextDate();
+				externalReferenceCode = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				localWellKnownEnabled = RandomTestUtil.randomBoolean();
+				localWellKnownURI = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				metadataJSON = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				protectedResourceURI = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+			}
+		};
+	}
+
+	protected OAuthClientPRLocalMetadata
+			randomIrrelevantOAuthClientPRLocalMetadata()
+		throws Exception {
+
+		OAuthClientPRLocalMetadata randomIrrelevantOAuthClientPRLocalMetadata =
+			randomOAuthClientPRLocalMetadata();
+
+		return randomIrrelevantOAuthClientPRLocalMetadata;
+	}
+
+	protected OAuthClientPRLocalMetadata randomPatchOAuthClientPRLocalMetadata()
+		throws Exception {
+
+		return randomOAuthClientPRLocalMetadata();
+	}
+
+	protected final JSONObject waitForFinish(
+			String expectedExecuteStatus, JSONObject jsonObject)
+		throws Exception {
+
+		while (true) {
+			ImportTask importTask = importTaskResource.getImportTask(
+				jsonObject.getLong("id"));
+
+			ImportTask.ExecuteStatus executeStatus =
+				importTask.getExecuteStatus();
+
+			if (StringUtil.equals(executeStatus.getValue(), "COMPLETED") ||
+				StringUtil.equals(executeStatus.getValue(), "FAILED")) {
+
+				Assert.assertEquals(
+					expectedExecuteStatus, executeStatus.getValue());
+
+				return jsonObject;
+			}
+		}
+	}
+
+	protected OAuthClientPRLocalMetadataResource
+		oAuthClientPRLocalMetadataResource;
+	protected ImportTaskResource importTaskResource;
+	protected com.liferay.portal.kernel.model.Group irrelevantGroup;
+	protected com.liferay.portal.kernel.model.Company testCompany;
+	protected com.liferay.portal.kernel.model.Group testGroup;
+
+	protected static class BeanTestUtil {
+
+		public static void copyProperties(Object source, Object target)
+			throws Exception {
+
+			Class<?> sourceClass = source.getClass();
+
+			Class<?> targetClass = target.getClass();
+
+			for (java.lang.reflect.Field field :
+					_getAllDeclaredFields(sourceClass)) {
+
+				if (field.isSynthetic()) {
+					continue;
+				}
+
+				Method getMethod = _getMethod(
+					sourceClass, field.getName(), "get");
+
+				try {
+					Method setMethod = _getMethod(
+						targetClass, field.getName(), "set",
+						getMethod.getReturnType());
+
+					setMethod.invoke(target, getMethod.invoke(source));
+				}
+				catch (Exception e) {
+					continue;
+				}
+			}
+		}
+
+		public static boolean hasProperty(Object bean, String name) {
+			Method setMethod = _getMethod(
+				bean.getClass(), "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod != null) {
+				return true;
+			}
+
+			return false;
+		}
+
+		public static void setProperty(Object bean, String name, Object value)
+			throws Exception {
+
+			Class<?> clazz = bean.getClass();
+
+			Method setMethod = _getMethod(
+				clazz, "set" + StringUtil.upperCaseFirstLetter(name));
+
+			if (setMethod == null) {
+				throw new NoSuchMethodException();
+			}
+
+			Class<?>[] parameterTypes = setMethod.getParameterTypes();
+
+			setMethod.invoke(bean, _translateValue(parameterTypes[0], value));
+		}
+
+		private static List<java.lang.reflect.Field> _getAllDeclaredFields(
+			Class<?> clazz) {
+
+			List<java.lang.reflect.Field> fields = new ArrayList<>();
+
+			while ((clazz != null) && (clazz != Object.class)) {
+				for (java.lang.reflect.Field field :
+						clazz.getDeclaredFields()) {
+
+					fields.add(field);
+				}
+
+				clazz = clazz.getSuperclass();
+			}
+
+			return fields;
+		}
+
+		private static Method _getMethod(Class<?> clazz, String name) {
+			for (Method method : clazz.getMethods()) {
+				if (name.equals(method.getName()) &&
+					(method.getParameterCount() == 1) &&
+					_parameterTypes.contains(method.getParameterTypes()[0])) {
+
+					return method;
+				}
+			}
+
+			return null;
+		}
+
+		private static Method _getMethod(
+				Class<?> clazz, String fieldName, String prefix,
+				Class<?>... parameterTypes)
+			throws Exception {
+
+			return clazz.getMethod(
+				prefix + StringUtil.upperCaseFirstLetter(fieldName),
+				parameterTypes);
+		}
+
+		private static Object _translateValue(
+			Class<?> parameterType, Object value) {
+
+			if ((value instanceof Integer) &&
+				parameterType.equals(Long.class)) {
+
+				Integer intValue = (Integer)value;
+
+				return intValue.longValue();
+			}
+
+			return value;
+		}
+
+		private static final Set<Class<?>> _parameterTypes = new HashSet<>(
+			Arrays.asList(
+				Boolean.class, Date.class, Double.class, Integer.class,
+				Long.class, Map.class, String.class));
+
+	}
+
+	protected class GraphQLField {
+
+		public GraphQLField(String key, GraphQLField... graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(String key, List<GraphQLField> graphQLFields) {
+			this(key, new HashMap<>(), graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			GraphQLField... graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = Arrays.asList(graphQLFields);
+		}
+
+		public GraphQLField(
+			String key, Map<String, Object> parameterMap,
+			List<GraphQLField> graphQLFields) {
+
+			_key = key;
+			_parameterMap = parameterMap;
+			_graphQLFields = graphQLFields;
+		}
+
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder(_key);
+
+			if (!_parameterMap.isEmpty()) {
+				sb.append("(");
+
+				for (Map.Entry<String, Object> entry :
+						_parameterMap.entrySet()) {
+
+					sb.append(entry.getKey());
+					sb.append(": ");
+					sb.append(entry.getValue());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append(")");
+			}
+
+			if (!_graphQLFields.isEmpty()) {
+				sb.append("{");
+
+				for (GraphQLField graphQLField : _graphQLFields) {
+					sb.append(graphQLField.toString());
+					sb.append(", ");
+				}
+
+				sb.setLength(sb.length() - 2);
+
+				sb.append("}");
+			}
+
+			return sb.toString();
+		}
+
+		private final List<GraphQLField> _graphQLFields;
+		private final String _key;
+		private final Map<String, Object> _parameterMap;
+
+	}
+
+	private static final com.liferay.portal.kernel.log.Log _log =
+		LogFactoryUtil.getLog(
+			BaseOAuthClientPRLocalMetadataResourceTestCase.class);
+
+	private static Format _format;
+
+	private com.liferay.portal.kernel.model.User _testCompanyAdminUser;
+
+	@Inject
+	private com.liferay.oauth.client.rest.resource.v1_0.
+		OAuthClientPRLocalMetadataResource _oAuthClientPRLocalMetadataResource;
+
+}
+// LIFERAY-REST-BUILDER-HASH:-1892611457

--- a/modules/apps/oauth-client/oauth-client-rest-test/src/testIntegration/java/com/liferay/oauth/client/rest/resource/v1_0/test/OAuthClientPRLocalMetadataResourceTest.java
+++ b/modules/apps/oauth-client/oauth-client-rest-test/src/testIntegration/java/com/liferay/oauth/client/rest/resource/v1_0/test/OAuthClientPRLocalMetadataResourceTest.java
@@ -37,11 +37,12 @@ public class OAuthClientPRLocalMetadataResourceTest
 					"https://" +
 						StringUtil.toLowerCase(RandomTestUtil.randomString()))
 			).put(
-				"bearer_methods_supported", JSONUtil.put("header")
+				"bearer_methods_supported",
+				JSONUtil.put(RandomTestUtil.randomString())
 			).put(
 				"resource_name", RandomTestUtil.randomString()
 			).put(
-				"scopes_supported", JSONUtil.put("read")
+				"scopes_supported", JSONUtil.put(RandomTestUtil.randomString())
 			).toString());
 		oAuthClientPRLocalMetadata.setProtectedResourceURI(
 			"https://" + StringUtil.toLowerCase(RandomTestUtil.randomString()));

--- a/modules/apps/oauth-client/oauth-client-rest-test/src/testIntegration/java/com/liferay/oauth/client/rest/resource/v1_0/test/OAuthClientPRLocalMetadataResourceTest.java
+++ b/modules/apps/oauth-client/oauth-client-rest-test/src/testIntegration/java/com/liferay/oauth/client/rest/resource/v1_0/test/OAuthClientPRLocalMetadataResourceTest.java
@@ -1,0 +1,108 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.rest.resource.v1_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth.client.rest.client.dto.v1_0.OAuthClientPRLocalMetadata;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+
+import org.junit.runner.RunWith;
+
+/**
+ * @author Manuele Castro
+ */
+@FeatureFlags(featureFlags = @FeatureFlag(value = "LPD-63415"))
+@RunWith(Arquillian.class)
+public class OAuthClientPRLocalMetadataResourceTest
+	extends BaseOAuthClientPRLocalMetadataResourceTestCase {
+
+	@Override
+	protected OAuthClientPRLocalMetadata randomOAuthClientPRLocalMetadata()
+		throws Exception {
+
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata =
+			super.randomOAuthClientPRLocalMetadata();
+
+		oAuthClientPRLocalMetadata.setMetadataJSON(
+			JSONUtil.put(
+				"authorization_servers",
+				JSONUtil.put(
+					"https://" +
+						StringUtil.toLowerCase(RandomTestUtil.randomString()))
+			).put(
+				"bearer_methods_supported", JSONUtil.put("header")
+			).put(
+				"resource_name", RandomTestUtil.randomString()
+			).put(
+				"scopes_supported", JSONUtil.put("read")
+			).toString());
+		oAuthClientPRLocalMetadata.setProtectedResourceURI(
+			"https://" + StringUtil.toLowerCase(RandomTestUtil.randomString()));
+
+		return oAuthClientPRLocalMetadata;
+	}
+
+	@Override
+	protected OAuthClientPRLocalMetadata
+			testBatchEngineDeleteImportTask_addOAuthClientPRLocalMetadata()
+		throws Exception {
+
+		return oAuthClientPRLocalMetadataResource.
+			postOAuthClientPRLocalMetadata(randomOAuthClientPRLocalMetadata());
+	}
+
+	@Override
+	protected OAuthClientPRLocalMetadata
+			testDeleteOAuthClientPRLocalMetadataByExternalReferenceCode_addOAuthClientPRLocalMetadata()
+		throws Exception {
+
+		return oAuthClientPRLocalMetadataResource.
+			postOAuthClientPRLocalMetadata(randomOAuthClientPRLocalMetadata());
+	}
+
+	@Override
+	protected OAuthClientPRLocalMetadata
+			testGetOAuthClientPRLocalMetadataByExternalReferenceCode_addOAuthClientPRLocalMetadata()
+		throws Exception {
+
+		return oAuthClientPRLocalMetadataResource.
+			postOAuthClientPRLocalMetadata(randomOAuthClientPRLocalMetadata());
+	}
+
+	@Override
+	protected OAuthClientPRLocalMetadata
+			testGetOAuthClientPRLocalMetadatasPage_addOAuthClientPRLocalMetadata(
+				OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+		throws Exception {
+
+		return oAuthClientPRLocalMetadataResource.
+			postOAuthClientPRLocalMetadata(oAuthClientPRLocalMetadata);
+	}
+
+	@Override
+	protected OAuthClientPRLocalMetadata
+			testPostOAuthClientPRLocalMetadata_addOAuthClientPRLocalMetadata(
+				OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata)
+		throws Exception {
+
+		return oAuthClientPRLocalMetadataResource.
+			postOAuthClientPRLocalMetadata(oAuthClientPRLocalMetadata);
+	}
+
+	@Override
+	protected OAuthClientPRLocalMetadata
+			testPutOAuthClientPRLocalMetadataByExternalReferenceCode_addOAuthClientPRLocalMetadata()
+		throws Exception {
+
+		return oAuthClientPRLocalMetadataResource.
+			postOAuthClientPRLocalMetadata(randomOAuthClientPRLocalMetadata());
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91289

## What Is Being Fixed

LPD-91289 adds RFC 9728 OAuth protected-resource metadata. The persistence and service layers for OAuthClientPRLocalMetadata are already in master, but the public REST API for managing those entries was missing.

## How It Is Being Fixed

Adds the OAuthClientPRLocalMetadata REST resource — the REST Builder generated DTO, resource interface, and client; the resource implementation backed by OAuthClientPRLocalMetadataLocalService and gated behind the LPD-63415 feature flag; and an integration test. The implementation follows the established OAuthClientASLocalMetadata sibling conventions: the metadata JSON is parsed with JSONFactoryUtil, and the test randomizes the values it does not assert on.

## PR Check

**pr-check: PASS** — tested on `5ec9fc66c6b82acf0d2652d305b829743b6af0f3`

| Validation | Result |
| --- | --- |
| REST Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5ec9fc66c6b82acf0d2652d305b829743b6af0f3"} -->
