### PR TITLE
LPD-91328 Serialize the dynamic registration response scope as a string

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
@@ -9,8 +9,10 @@ import com.liferay.oauth2.provider.rest.internal.endpoint.dynamic.registration.m
 import com.liferay.oauth2.provider.rest.internal.endpoint.dynamic.registration.model.LiferayClientRegistrationResponse;
 import com.liferay.oauth2.provider.rest.internal.endpoint.util.OAuth2ErrorUtil;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.ws.rs.Consumes;
@@ -245,7 +247,8 @@ public class LiferayDynamicRegistrationService
 
 		if (ListUtil.isNotEmpty(client.getRegisteredScopes())) {
 			liferayClientRegistrationResponse.setScope(
-				client.getRegisteredScopes());
+				StringUtil.merge(
+					client.getRegisteredScopes(), StringPool.SPACE));
 		}
 
 		if (properties.get("software_id") != null) {

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/model/LiferayClientRegistrationResponse.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/model/LiferayClientRegistrationResponse.java
@@ -39,7 +39,7 @@ public class LiferayClientRegistrationResponse
 		return responseTypes;
 	}
 
-	public List<String> getScope() {
+	public String getScope() {
 		return scope;
 	}
 
@@ -75,7 +75,7 @@ public class LiferayClientRegistrationResponse
 		this.responseTypes = responseTypes;
 	}
 
-	public void setScope(List<String> scope) {
+	public void setScope(String scope) {
 		this.scope = scope;
 	}
 
@@ -93,7 +93,7 @@ public class LiferayClientRegistrationResponse
 	protected String logoUri;
 	protected List<String> redirectUris;
 	protected String responseTypes;
-	protected List<String> scope;
+	protected String scope;
 	protected String softwareId;
 	protected String tosUri;
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
@@ -113,6 +113,10 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 
 		String clientName = RandomTestUtil.randomString();
 
+		String scope =
+			"Liferay.Headless.Admin.Site.everything " +
+				"Liferay.Headless.Admin.User.everything";
+
 		JSONObject jsonObject = JSONUtil.put(
 			"client_name", clientName
 		).put(
@@ -127,7 +131,7 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 				"https://client.example.org/callback2"
 			}
 		).put(
-			"scope", "Liferay.Headless.Admin.Site.everything"
+			"scope", scope
 		);
 
 		response = invocationBuilder.method(
@@ -150,6 +154,7 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 
 		Assert.assertEquals(
 			clientName, responseJSONObject.getString("client_name"));
+		Assert.assertEquals(scope, responseJSONObject.getString("scope"));
 
 		String clientId = responseJSONObject.getString(
 			OAuthConstants.CLIENT_ID);

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
@@ -11,6 +11,8 @@ import com.liferay.oauth2.provider.client.test.BaseTestPreparatorBundleActivator
 import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
@@ -21,6 +23,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -127,8 +130,12 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 		).put(
 			"redirect_uris",
 			new String[] {
-				"https://client.example.org/callback",
-				"https://client.example.org/callback2"
+				StringBundler.concat(
+					Http.HTTPS_WITH_SLASH, RandomTestUtil.randomString(),
+					StringPool.SLASH, RandomTestUtil.randomString()),
+				StringBundler.concat(
+					Http.HTTPS_WITH_SLASH, RandomTestUtil.randomString(),
+					StringPool.SLASH, RandomTestUtil.randomString())
 			}
 		).put(
 			"scope", scope
@@ -219,8 +226,14 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 				).put(
 					"redirect_uris",
 					new String[] {
-						"https://client.example.org/callback",
-						"https://client.example.org/callback2"
+						StringBundler.concat(
+							Http.HTTPS_WITH_SLASH,
+							RandomTestUtil.randomString(), StringPool.SLASH,
+							RandomTestUtil.randomString()),
+						StringBundler.concat(
+							Http.HTTPS_WITH_SLASH,
+							RandomTestUtil.randomString(), StringPool.SLASH,
+							RandomTestUtil.randomString())
 					}
 				).put(
 					"scope", "Liferay.Headless.Admin.Site.everything"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91328

## What Is Being Fixed

The dynamic client registration response serialized the `scope` field as a JSON array, because the response model held it as a `List<String>` and Jackson serializes lists as arrays. RFC 7591 defines the registration response `scope` as a space-delimited string, and MCP clients validate it as a string and reject the array — breaking dynamic client registration for those clients.

## How It Is Being Fixed

The response model now holds `scope` as a `String`, mirroring the registration request model, so its getter and setter are symmetric and Jackson serializes it as a string. `LiferayDynamicRegistrationService` merges the registered scopes with a single space when building the response. `testPost` registers a client with two requested scopes and asserts the response carries `scope` as a single space-delimited JSON string, locking the RFC 7591 contract. The registration tests also generate their previously hardcoded redirect URIs with `RandomTestUtil`, since no assertion depends on those values.

## PR Check

**pr-check: PASS** — tested on `c40fa9c306de887f2dfc8c7ea6075ae0771f2f1d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c40fa9c306de887f2dfc8c7ea6075ae0771f2f1d"} -->