### PR TITLE
LPD-91289 Allow the MCP-Protocol-Version header on discovery preflights

### DIFF
--- a/modules/apps/oauth-client/oauth-client-admin-web-test/src/testIntegration/java/com/liferay/oauth/client/admin/web/internal/servlet/filter/test/OAuth2WellKnownAuthorizationServerMetadataFilterTest.java
+++ b/modules/apps/oauth-client/oauth-client-admin-web-test/src/testIntegration/java/com/liferay/oauth/client/admin/web/internal/servlet/filter/test/OAuth2WellKnownAuthorizationServerMetadataFilterTest.java
@@ -130,8 +130,8 @@ public class OAuth2WellKnownAuthorizationServerMetadataFilterTest {
 		httpResponse = _send(urlString, "OPTIONS");
 
 		_assertHeader(
-			"Authorization, Content-Type", "Access-Control-Allow-Headers",
-			httpResponse.headers());
+			"Authorization, Content-Type, MCP-Protocol-Version",
+			"Access-Control-Allow-Headers", httpResponse.headers());
 		_assertHeader(
 			"GET, HEAD, OPTIONS", "Access-Control-Allow-Methods",
 			httpResponse.headers());

--- a/modules/apps/oauth-client/oauth-client-admin-web-test/src/testIntegration/java/com/liferay/oauth/client/admin/web/internal/servlet/filter/test/OAuth2WellKnownProtectedResourceMetadataFilterTest.java
+++ b/modules/apps/oauth-client/oauth-client-admin-web-test/src/testIntegration/java/com/liferay/oauth/client/admin/web/internal/servlet/filter/test/OAuth2WellKnownProtectedResourceMetadataFilterTest.java
@@ -145,8 +145,8 @@ public class OAuth2WellKnownProtectedResourceMetadataFilterTest {
 		httpResponse = _send(urlString, "OPTIONS");
 
 		_assertHeader(
-			"Authorization, Content-Type", "Access-Control-Allow-Headers",
-			httpResponse.headers());
+			"Authorization, Content-Type, MCP-Protocol-Version",
+			"Access-Control-Allow-Headers", httpResponse.headers());
 		_assertHeader(
 			"GET, HEAD, OPTIONS", "Access-Control-Allow-Methods",
 			httpResponse.headers());

--- a/modules/apps/oauth-client/oauth-client-admin-web/src/main/java/com/liferay/oauth/client/admin/web/internal/servlet/filter/OAuth2WellKnownAuthorizationServerMetadataFilter.java
+++ b/modules/apps/oauth-client/oauth-client-admin-web/src/main/java/com/liferay/oauth/client/admin/web/internal/servlet/filter/OAuth2WellKnownAuthorizationServerMetadataFilter.java
@@ -65,7 +65,8 @@ public class OAuth2WellKnownAuthorizationServerMetadataFilter
 		throws Exception {
 
 		httpServletResponse.setHeader(
-			"Access-Control-Allow-Headers", "Authorization, Content-Type");
+			"Access-Control-Allow-Headers",
+			"Authorization, Content-Type, MCP-Protocol-Version");
 		httpServletResponse.setHeader(
 			"Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");
 		httpServletResponse.setHeader("Access-Control-Allow-Origin", "*");

--- a/modules/apps/oauth-client/oauth-client-admin-web/src/main/java/com/liferay/oauth/client/admin/web/internal/servlet/filter/OAuth2WellKnownProtectedResourceMetadataFilter.java
+++ b/modules/apps/oauth-client/oauth-client-admin-web/src/main/java/com/liferay/oauth/client/admin/web/internal/servlet/filter/OAuth2WellKnownProtectedResourceMetadataFilter.java
@@ -65,7 +65,8 @@ public class OAuth2WellKnownProtectedResourceMetadataFilter extends BaseFilter {
 		throws Exception {
 
 		httpServletResponse.setHeader(
-			"Access-Control-Allow-Headers", "Authorization, Content-Type");
+			"Access-Control-Allow-Headers",
+			"Authorization, Content-Type, MCP-Protocol-Version");
 		httpServletResponse.setHeader(
 			"Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");
 		httpServletResponse.setHeader("Access-Control-Allow-Origin", "*");


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91289

## What Is Being Fixed

The MCP SDK sends an `MCP-Protocol-Version` header on its OAuth discovery requests. The well-known discovery filters (`/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource`) emit their own CORS headers and only allowed `Authorization` and `Content-Type`, so the browser preflight to these endpoints was rejected and OAuth discovery never reached the metadata.

## How It Is Being Fixed

`MCP-Protocol-Version` is added to `Access-Control-Allow-Headers` on both well-known filters, so the discovery preflight is accepted. The change is scoped to the well-known discovery preflight pattern alone, which is why it lives in these two filters rather than as a portal-wide CORS change. The existing OPTIONS-preflight assertions in both filter integration tests are updated to expect the new allowed header.

## PR Check

**pr-check: PASS** — tested on `15bbeb5f51374c90bf16d4e75ce79610380e241b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "15bbeb5f51374c90bf16d4e75ce79610380e241b"} -->
