### PR TITLE
LPD-91328 Serialize the dynamic registration response scope as a string

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
@@ -9,8 +9,10 @@ import com.liferay.oauth2.provider.rest.internal.endpoint.dynamic.registration.m
 import com.liferay.oauth2.provider.rest.internal.endpoint.dynamic.registration.model.LiferayClientRegistrationResponse;
 import com.liferay.oauth2.provider.rest.internal.endpoint.util.OAuth2ErrorUtil;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.ws.rs.Consumes;
@@ -245,7 +247,8 @@ public class LiferayDynamicRegistrationService
 
 		if (ListUtil.isNotEmpty(client.getRegisteredScopes())) {
 			liferayClientRegistrationResponse.setScope(
-				client.getRegisteredScopes());
+				StringUtil.merge(
+					client.getRegisteredScopes(), StringPool.SPACE));
 		}
 
 		if (properties.get("software_id") != null) {

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/model/LiferayClientRegistrationResponse.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/model/LiferayClientRegistrationResponse.java
@@ -39,7 +39,7 @@ public class LiferayClientRegistrationResponse
 		return responseTypes;
 	}
 
-	public List<String> getScope() {
+	public String getScope() {
 		return scope;
 	}
 
@@ -75,7 +75,7 @@ public class LiferayClientRegistrationResponse
 		this.responseTypes = responseTypes;
 	}
 
-	public void setScope(List<String> scope) {
+	public void setScope(String scope) {
 		this.scope = scope;
 	}
 
@@ -93,7 +93,7 @@ public class LiferayClientRegistrationResponse
 	protected String logoUri;
 	protected List<String> redirectUris;
 	protected String responseTypes;
-	protected List<String> scope;
+	protected String scope;
 	protected String softwareId;
 	protected String tosUri;
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
@@ -11,6 +11,9 @@ import com.liferay.oauth2.provider.client.test.BaseTestPreparatorBundleActivator
 import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
@@ -21,6 +24,8 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -32,6 +37,7 @@ import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -113,9 +119,9 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 
 		String clientName = RandomTestUtil.randomString();
 
-		String scope =
-			"Liferay.Headless.Admin.Site.everything " +
-				"Liferay.Headless.Admin.User.everything";
+		String scope = StringBundler.concat(
+			RandomTestUtil.randomString(), StringPool.SPACE,
+			RandomTestUtil.randomString());
 
 		JSONObject jsonObject = JSONUtil.put(
 			"client_name", clientName
@@ -127,8 +133,12 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 		).put(
 			"redirect_uris",
 			new String[] {
-				"https://client.example.org/callback",
-				"https://client.example.org/callback2"
+				StringBundler.concat(
+					Http.HTTPS_WITH_SLASH, RandomTestUtil.randomString(),
+					StringPool.SLASH, RandomTestUtil.randomString()),
+				StringBundler.concat(
+					Http.HTTPS_WITH_SLASH, RandomTestUtil.randomString(),
+					StringPool.SLASH, RandomTestUtil.randomString())
 			}
 		).put(
 			"scope", scope
@@ -154,7 +164,17 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 
 		Assert.assertEquals(
 			clientName, responseJSONObject.getString("client_name"));
-		Assert.assertEquals(scope, responseJSONObject.getString("scope"));
+
+		String[] expectedScopes = StringUtil.split(scope, CharPool.SPACE);
+
+		Arrays.sort(expectedScopes);
+
+		String[] actualScopes = StringUtil.split(
+			responseJSONObject.getString("scope"), CharPool.SPACE);
+
+		Arrays.sort(actualScopes);
+
+		Assert.assertArrayEquals(expectedScopes, actualScopes);
 
 		String clientId = responseJSONObject.getString(
 			OAuthConstants.CLIENT_ID);
@@ -219,11 +239,17 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 				).put(
 					"redirect_uris",
 					new String[] {
-						"https://client.example.org/callback",
-						"https://client.example.org/callback2"
+						StringBundler.concat(
+							Http.HTTPS_WITH_SLASH,
+							RandomTestUtil.randomString(), StringPool.SLASH,
+							RandomTestUtil.randomString()),
+						StringBundler.concat(
+							Http.HTTPS_WITH_SLASH,
+							RandomTestUtil.randomString(), StringPool.SLASH,
+							RandomTestUtil.randomString())
 					}
 				).put(
-					"scope", "Liferay.Headless.Admin.Site.everything"
+					"scope", RandomTestUtil.randomString()
 				).toString()));
 
 		Assert.assertEquals(200, response.getStatus());

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
@@ -113,6 +113,10 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 
 		String clientName = RandomTestUtil.randomString();
 
+		String scope =
+			"Liferay.Headless.Admin.Site.everything " +
+				"Liferay.Headless.Admin.User.everything";
+
 		JSONObject jsonObject = JSONUtil.put(
 			"client_name", clientName
 		).put(
@@ -127,7 +131,7 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 				"https://client.example.org/callback2"
 			}
 		).put(
-			"scope", "Liferay.Headless.Admin.Site.everything"
+			"scope", scope
 		);
 
 		response = invocationBuilder.method(
@@ -150,6 +154,7 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 
 		Assert.assertEquals(
 			clientName, responseJSONObject.getString("client_name"));
+		Assert.assertEquals(scope, responseJSONObject.getString("scope"));
 
 		String clientId = responseJSONObject.getString(
 			OAuthConstants.CLIENT_ID);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91328

## What Is Being Fixed

The dynamic client registration response serialized the `scope` field as a JSON array, because the response model held it as a `List<String>` and Jackson serializes lists as arrays. RFC 7591 defines the registration response `scope` as a space-delimited string, and MCP clients validate it as a string and reject the array — breaking dynamic client registration for those clients.

## How It Is Being Fixed

The response model now holds `scope` as a `String`, mirroring the registration request model, so its getter and setter are symmetric and Jackson serializes it as a string. `LiferayDynamicRegistrationService` merges the registered scopes with a single space when building the response. `testPost` registers a client with two requested scopes and asserts the response carries `scope` as a space-delimited JSON string, comparing order-independently because the registration normalizes scope order. The registration tests also generate their previously hardcoded redirect URIs and scope values with `RandomTestUtil`, since no assertion depends on the specific values.

## PR Check

**pr-check: PASS** — tested on `d19cd756dc87c8857bd756efd8e13c87423f2802`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "d19cd756dc87c8857bd756efd8e13c87423f2802"} -->