### PR TITLE
LPD-95283 Clear the maximum attempts warning after the retry timeout

### DIFF
--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
@@ -45,9 +45,9 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 
 	var failedAttemptsRetryTimeout = <%= mfaEmailOTPFailedAttemptsRetryTimeout %>;
 
-	var resendCountdown;
-
 	var failedAttemptsRetryCountdown;
+
+	var resendCountdown;
 
 	var messageContainer = A.one('#<portlet:namespace />messageContainer');
 
@@ -71,7 +71,9 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 		}, interval);
 	}
 
-	function <portlet:namespace />setFailedAttemptsRetryCountdown(failedAttemptsRetryTimeout) {
+	function <portlet:namespace />setFailedAttemptsRetryCountdown(
+		failedAttemptsRetryTimeout
+	) {
 		if (failedAttemptsRetryTimeout < 1) {
 			var maximumAllowedAttemptsError = A.one(
 				'#<portlet:namespace />maximumAllowedAttemptsError'

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
@@ -12,7 +12,7 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 %>
 
 <c:if test="<%= mfaEmailOTPFailedAttemptsRetryTimeout > 0 %>">
-	<div class="alert alert-danger">
+	<div class="alert alert-danger" id="<portlet:namespace />maximumAllowedAttemptsError">
 		<liferay-ui:message arguments="<%= mfaEmailOTPFailedAttemptsRetryTimeout %>" key="maximum-allowed-attempts-error" translateArguments="<%= false %>" />
 	</div>
 </c:if>
@@ -47,6 +47,8 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 
 	var countdown;
 
+	var failedAttemptsRetryCountdown;
+
 	var messageContainer = A.one('#<portlet:namespace />messageContainer');
 
 	var sendEmailButton = A.one('#<portlet:namespace />sendEmailButton');
@@ -54,6 +56,8 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 	var submitEmailButton = A.one('#<portlet:namespace />submitEmailButton');
 
 	var originalButtonText = sendEmailButton.text();
+
+	var originalSubmitButtonText = submitEmailButton.text();
 
 	var previousSetTime =
 		<%= GetterUtil.getLong(request.getAttribute(MFAEmailOTPWebKeys.MFA_EMAIL_OTP_SET_AT_TIME)) %>;
@@ -67,8 +71,8 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 		}, interval);
 	}
 
-	function <portlet:namespace />setResendCountdown(resendDuration) {
-		if (resendDuration < 1) {
+	function <portlet:namespace />setResendCountdown(remainingTime) {
+		if (remainingTime < 1) {
 			sendEmailButton.text(originalButtonText);
 
 			sendEmailButton.removeAttribute('disabled');
@@ -80,7 +84,7 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 			);
 		}
 		else {
-			sendEmailButton.text(resendDuration);
+			sendEmailButton.text(remainingTime);
 		}
 	}
 
@@ -100,29 +104,38 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 		);
 	}
 
+	function <portlet:namespace />setFailedAttemptsRetryCountdown(remainingTime) {
+		if (remainingTime < 1) {
+			var maximumAllowedAttemptsError = A.one(
+				'#<portlet:namespace />maximumAllowedAttemptsError'
+			);
+
+			if (maximumAllowedAttemptsError) {
+				maximumAllowedAttemptsError.remove();
+			}
+
+			sendEmailButton.removeAttribute('disabled');
+
+			submitEmailButton.text(originalSubmitButtonText);
+
+			submitEmailButton.removeAttribute('disabled');
+
+			clearInterval(failedAttemptsRetryCountdown);
+		}
+		else {
+			submitEmailButton.text(remainingTime);
+		}
+	}
+
 	if (failedAttemptsRetryTimeout > 0) {
 		sendEmailButton.setAttribute('disabled', 'disabled');
 		submitEmailButton.setAttribute('disabled', 'disabled');
 
-		var originalSubmitButtonText = submitEmailButton.text();
-
-		setInterval(() => {
-			--failedAttemptsRetryTimeout;
-			{
-				if (failedAttemptsRetryTimeout < 1) {
-					sendEmailButton.removeAttribute('disabled');
-
-					submitEmailButton.text(originalSubmitButtonText);
-
-					submitEmailButton.removeAttribute('disabled');
-
-					clearInterval(failedAttemptsRetryTimeout);
-				}
-				else {
-					submitEmailButton.text(failedAttemptsRetryTimeout);
-				}
-			}
-		}, 1000);
+		failedAttemptsRetryCountdown = <portlet:namespace />createCountdown(
+			<portlet:namespace />setFailedAttemptsRetryCountdown,
+			failedAttemptsRetryTimeout,
+			1000
+		);
 	}
 
 	A.one('#<portlet:namespace />sendEmailButton').on('click', (event) => {

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
@@ -45,7 +45,7 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 
 	var failedAttemptsRetryTimeout = <%= mfaEmailOTPFailedAttemptsRetryTimeout %>;
 
-	var countdown;
+	var resendCountdown;
 
 	var failedAttemptsRetryCountdown;
 
@@ -55,7 +55,7 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 
 	var submitEmailButton = A.one('#<portlet:namespace />submitEmailButton');
 
-	var originalButtonText = sendEmailButton.text();
+	var originalSendButtonText = sendEmailButton.text();
 
 	var originalSubmitButtonText = submitEmailButton.text();
 
@@ -71,41 +71,8 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 		}, interval);
 	}
 
-	function <portlet:namespace />setResendCountdown(remainingTime) {
-		if (remainingTime < 1) {
-			sendEmailButton.text(originalButtonText);
-
-			sendEmailButton.removeAttribute('disabled');
-
-			clearInterval(countdown);
-
-			messageContainer.html(
-				'<span class="alert alert-success"><liferay-ui:message key="your-otp-has-been-sent-by-email" /></span>'
-			);
-		}
-		else {
-			sendEmailButton.text(remainingTime);
-		}
-	}
-
-	if (
-		elapsedTime > 0 &&
-		elapsedTime < configuredResendDuration &&
-		previousSetTime > 0
-	) {
-		sendEmailButton.setAttribute('disabled', 'disabled');
-
-		var resendDuration = configuredResendDuration - elapsedTime;
-
-		countdown = <portlet:namespace />createCountdown(
-			<portlet:namespace />setResendCountdown,
-			resendDuration,
-			1000
-		);
-	}
-
-	function <portlet:namespace />setFailedAttemptsRetryCountdown(remainingTime) {
-		if (remainingTime < 1) {
+	function <portlet:namespace />setFailedAttemptsRetryCountdown(failedAttemptsRetryTimeout) {
+		if (failedAttemptsRetryTimeout < 1) {
 			var maximumAllowedAttemptsError = A.one(
 				'#<portlet:namespace />maximumAllowedAttemptsError'
 			);
@@ -123,8 +90,41 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 			clearInterval(failedAttemptsRetryCountdown);
 		}
 		else {
-			submitEmailButton.text(remainingTime);
+			submitEmailButton.text(failedAttemptsRetryTimeout);
 		}
+	}
+
+	function <portlet:namespace />setResendCountdown(resendDuration) {
+		if (resendDuration < 1) {
+			sendEmailButton.text(originalSendButtonText);
+
+			sendEmailButton.removeAttribute('disabled');
+
+			clearInterval(resendCountdown);
+
+			messageContainer.html(
+				'<span class="alert alert-success"><liferay-ui:message key="your-otp-has-been-sent-by-email" /></span>'
+			);
+		}
+		else {
+			sendEmailButton.text(resendDuration);
+		}
+	}
+
+	if (
+		elapsedTime > 0 &&
+		elapsedTime < configuredResendDuration &&
+		previousSetTime > 0
+	) {
+		sendEmailButton.setAttribute('disabled', 'disabled');
+
+		var resendDuration = configuredResendDuration - elapsedTime;
+
+		resendCountdown = <portlet:namespace />createCountdown(
+			<portlet:namespace />setResendCountdown,
+			resendDuration,
+			1000
+		);
 	}
 
 	if (failedAttemptsRetryTimeout > 0) {
@@ -143,7 +143,7 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 
 		var resendDuration = <%= mfaEmailOTPConfiguration.resendEmailTimeout() %>;
 
-		countdown = <portlet:namespace />createCountdown(
+		resendCountdown = <portlet:namespace />createCountdown(
 			<portlet:namespace />setResendCountdown,
 			resendDuration,
 			1000

--- a/modules/test/playwright/pages/multi-factor-authentication/MultiFactorAuthenticationConfigurationPage.ts
+++ b/modules/test/playwright/pages/multi-factor-authentication/MultiFactorAuthenticationConfigurationPage.ts
@@ -11,27 +11,36 @@ import {InstanceSettingsPage} from '../configuration-admin-web/InstanceSettingsP
 export class MultiFactorAuthenticationConfigurationPage {
 	readonly actions: Locator;
 	readonly enabledCheckBox: Locator;
+	readonly failedAttemptsAllowed: Locator;
 	readonly instanceSettingsPage: InstanceSettingsPage;
 	readonly oneTimePasswordLength: Locator;
 	readonly page: Page;
 	readonly resetDefaultValues: Locator;
+	readonly retryTimeout: Locator;
 	readonly saveButton: Locator;
 	readonly updateButton: Locator;
 
 	constructor(page: Page) {
 		this.actions = page.getByRole('button', {name: 'Actions'});
 		this.enabledCheckBox = page.getByLabel('Enabled');
+		this.failedAttemptsAllowed = page.getByLabel(
+			'Set the number of allowed failed attempts'
+		);
 		this.instanceSettingsPage = new InstanceSettingsPage(page);
 		this.oneTimePasswordLength = page.getByLabel(
 			'One-Time Password Length'
 		);
 		this.page = page;
 		this.resetDefaultValues = page.getByText('Reset Default Values');
+		this.retryTimeout = page.getByLabel('Retry Timeout');
 		this.saveButton = page.getByRole('button', {name: 'Save'});
 		this.updateButton = page.getByRole('button', {name: 'Update'});
 	}
 
-	async enable() {
+	async enable({
+		failedAttemptsAllowed,
+		retryTimeout,
+	}: {failedAttemptsAllowed?: number; retryTimeout?: number} = {}) {
 		await expect(this.enabledCheckBox).toBeVisible();
 
 		await expect(async () => {
@@ -39,6 +48,16 @@ export class MultiFactorAuthenticationConfigurationPage {
 
 			await expect(this.enabledCheckBox).toBeChecked();
 		}).toPass();
+
+		if (failedAttemptsAllowed !== undefined) {
+			await this.failedAttemptsAllowed.fill(
+				String(failedAttemptsAllowed)
+			);
+		}
+
+		if (retryTimeout !== undefined) {
+			await this.retryTimeout.fill(String(retryTimeout));
+		}
 
 		await this.instanceSettingsPage.saveAndWaitForAlert();
 	}

--- a/modules/test/playwright/tests/multi-factor-authentication-web/main/emailOneTimePassword.spec.ts
+++ b/modules/test/playwright/tests/multi-factor-authentication-web/main/emailOneTimePassword.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {multiFactorAuthenticationPagesTest} from '../../../fixtures/multiFactorAuthenticationPagesTest';
+import {UserLoginPage} from '../../../pages/users-admin-web/UserLoginPage';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import {getRandomInt} from '../../../utils/getRandomInt';
+
+export const test = mergeTests(
+	dataApiHelpersTest,
+	loginTest(),
+	multiFactorAuthenticationPagesTest
+);
+
+test(
+	'maximum attempts warning is removed once the retry timeout expires',
+	{tag: '@LPD-95283'},
+	async ({
+		apiHelpers,
+		browser,
+		multiFactorAuthenticationConfigurationPage,
+	}) => {
+		await multiFactorAuthenticationConfigurationPage.goto();
+
+		try {
+			await multiFactorAuthenticationConfigurationPage.enable({
+				failedAttemptsAllowed: 1,
+				retryTimeout: 10,
+			});
+
+			const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+			const userContext = await browser.newContext();
+			const userPage = await userContext.newPage();
+
+			const userLoginPage = new UserLoginPage(userPage);
+
+			const maximumAllowedAttemptsError = userPage.getByText(
+				'You have reached the maximum allowed failed attempts'
+			);
+			const otpInput = userPage.getByLabel(
+				'Enter the one-time password from the email'
+			);
+			const submitButton = userPage.getByRole('button', {name: 'Submit'});
+
+			try {
+				await userPage.goto('/');
+
+				await clickAndExpectToBeVisible({
+					target: userLoginPage.emailAddressInput,
+					trigger: userLoginPage.signInNavButton,
+				});
+
+				await userLoginPage.emailAddressInput.fill(user.emailAddress);
+				await userLoginPage.passwordInput.fill('test');
+
+				await userLoginPage.signInButton.click();
+
+				await expect(otpInput).toBeVisible({timeout: 10000});
+
+				await otpInput.fill(String(getRandomInt()));
+
+				await submitButton.click();
+
+				await expect(maximumAllowedAttemptsError).toBeVisible({
+					timeout: 10000,
+				});
+
+				await expect(maximumAllowedAttemptsError).toBeHidden({
+					timeout: 20000,
+				});
+
+				await expect(submitButton).toBeEnabled();
+			}
+			finally {
+				await userContext.close();
+			}
+		}
+		finally {
+			await multiFactorAuthenticationConfigurationPage.goto();
+
+			await multiFactorAuthenticationConfigurationPage.resetConfiguration();
+		}
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95283

## What Is Being Fixed

On the email one-time password verification page, exceeding the maximum number of allowed attempts shows a warning message and starts a retry countdown while the send and submit buttons are disabled. After the retry timeout elapsed, the warning message stayed visible: the page never removed it, and the retry interval was never actually stopped because the code cleared the countdown value instead of the interval handle. The user was left looking at a stale error even though the attempt limit had reset.

## How It Is Being Fixed

The inline retry-countdown interval is replaced with a named callback driven by the same createCountdown helper the resend countdown already uses. When the retry timeout reaches zero, the callback removes the warning message from the DOM (the alert is given an id so it can be located), re-enables the send and submit buttons, restores the submit button label, and clears the correct interval handle. The two countdowns are tracked in separate variables, resendCountdown and failedAttemptsRetryCountdown, so each can be cleared independently, and the original button-label values are split per button.

## PR Check

**pr-check: PASS** — tested on `8dc33739108de84441d22008851931f909f69a81`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |

<!-- pr-check {"result": "success", "sha": "8dc33739108de84441d22008851931f909f69a81"} -->
