### PR TITLE
[FIPS] LPD-94045 Require FIPS-approved PBKDF2/HMAC-SHA-256 password hashing

### DIFF
--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/DefaultPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/DefaultPasswordEncryptor.java
@@ -5,8 +5,13 @@
 
 package com.liferay.portal.security.password.encryptor.internal;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PwdEncryptorException;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.util.DigesterUtil;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -22,8 +27,21 @@ public class DefaultPasswordEncryptor implements PasswordEncryptor {
 
 	@Override
 	public String encrypt(
-		String algorithm, String plainTextPassword, String encryptedPassword,
-		boolean upgradeHashSecurity) {
+			String algorithm, String plainTextPassword,
+			String encryptedPassword, boolean upgradeHashSecurity)
+		throws PwdEncryptorException {
+
+		try {
+			MessageDigest.getInstance(algorithm);
+		}
+		catch (NoSuchAlgorithmException noSuchAlgorithmException) {
+			throw new PwdEncryptorException.UnavailableAlgorithm(
+				StringBundler.concat(
+					"The algorithm \"", algorithm,
+					"\" is not available from the configured security ",
+					"provider"),
+				noSuchAlgorithmException);
+		}
 
 		return DigesterUtil.digest(algorithm, plainTextPassword);
 	}

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/DefaultPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/DefaultPasswordEncryptor.java
@@ -37,9 +37,7 @@ public class DefaultPasswordEncryptor implements PasswordEncryptor {
 		catch (NoSuchAlgorithmException noSuchAlgorithmException) {
 			throw new PwdEncryptorException.UnavailableAlgorithm(
 				StringBundler.concat(
-					"The algorithm \"", algorithm,
-					"\" is not available from the configured security ",
-					"provider"),
+					"The algorithm \"", algorithm, "\" is not available"),
 				noSuchAlgorithmException);
 		}
 

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/PBKDF2PasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/PBKDF2PasswordEncryptor.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.security.SecureRandomUtil;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.nio.BufferUnderflowException;
@@ -114,14 +115,18 @@ public class PBKDF2PasswordEncryptor implements PasswordEncryptor {
 		}
 	}
 
-	private static final int _KEY_SIZE = 160;
+	private static final int _KEY_SIZE = 256;
+
+	private static final int _KEY_SIZE_FLOOR = 112;
 
 	private static final int _ROUNDS = 1300000;
+
+	private static final int _ROUNDS_FLOOR = 1300000;
 
 	private static final int _SALT_BYTES_LENGTH = 16;
 
 	private static final Pattern _pattern = Pattern.compile(
-		"^.*/?([0-9]+)?/([0-9]+)$");
+		"^[^/]*(?:/([0-9]+))?/([0-9]+)$");
 
 	private static class PBKDF2EncryptionConfiguration {
 
@@ -140,8 +145,30 @@ public class PBKDF2PasswordEncryptor implements PasswordEncryptor {
 					_rounds = GetterUtil.getInteger(matcher.group(2), _ROUNDS);
 				}
 
-				BigEndianCodec.putLong(
-					_saltBytes, 0, SecureRandomUtil.nextLong());
+				if (PropsValues.FIPS_ENABLED) {
+					if (_rounds < _ROUNDS_FLOOR) {
+						throw new PwdEncryptorException.InvalidAlgorithm(
+							StringBundler.concat(
+								"PBKDF2 iteration count ", _rounds,
+								" is below the minimum allowed value of ",
+								_ROUNDS_FLOOR),
+							null);
+					}
+
+					if (_keySize < _KEY_SIZE_FLOOR) {
+						throw new PwdEncryptorException.InvalidAlgorithm(
+							StringBundler.concat(
+								"PBKDF2 output length ", _keySize,
+								" bits is below the minimum allowed value of ",
+								_KEY_SIZE_FLOOR, " bits"),
+							null);
+					}
+				}
+
+				for (int i = 0; i < _SALT_BYTES_LENGTH; i += 8) {
+					BigEndianCodec.putLong(
+						_saltBytes, i, SecureRandomUtil.nextLong());
+				}
 			}
 			else {
 				ByteBuffer byteBuffer = ByteBuffer.wrap(

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/PBKDF2PasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/PBKDF2PasswordEncryptor.java
@@ -117,11 +117,11 @@ public class PBKDF2PasswordEncryptor implements PasswordEncryptor {
 
 	private static final int _KEY_SIZE = 256;
 
-	private static final int _KEY_SIZE_FLOOR = 112;
+	private static final int _KEY_SIZE_MIN = 112;
 
 	private static final int _ROUNDS = 1300000;
 
-	private static final int _ROUNDS_FLOOR = 1300000;
+	private static final int _ROUNDS_MIN = 1300000;
 
 	private static final int _SALT_BYTES_LENGTH = 16;
 
@@ -146,21 +146,21 @@ public class PBKDF2PasswordEncryptor implements PasswordEncryptor {
 				}
 
 				if (PropsValues.FIPS_ENABLED) {
-					if (_rounds < _ROUNDS_FLOOR) {
+					if (_rounds < _ROUNDS_MIN) {
 						throw new PwdEncryptorException.InvalidAlgorithm(
 							StringBundler.concat(
 								"PBKDF2 iteration count ", _rounds,
 								" is below the minimum allowed value of ",
-								_ROUNDS_FLOOR),
+								_ROUNDS_MIN),
 							null);
 					}
 
-					if (_keySize < _KEY_SIZE_FLOOR) {
+					if (_keySize < _KEY_SIZE_MIN) {
 						throw new PwdEncryptorException.InvalidAlgorithm(
 							StringBundler.concat(
 								"PBKDF2 output length ", _keySize,
 								" bits is below the minimum allowed value of ",
-								_KEY_SIZE_FLOOR, " bits"),
+								_KEY_SIZE_MIN, " bits"),
 							null);
 					}
 				}

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/PBKDF2PasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/PBKDF2PasswordEncryptor.java
@@ -146,21 +146,21 @@ public class PBKDF2PasswordEncryptor implements PasswordEncryptor {
 				}
 
 				if (PropsValues.FIPS_ENABLED) {
-					if (_rounds < _ROUNDS_MIN) {
-						throw new PwdEncryptorException.InvalidAlgorithm(
-							StringBundler.concat(
-								"PBKDF2 iteration count ", _rounds,
-								" is below the minimum allowed value of ",
-								_ROUNDS_MIN),
-							null);
-					}
-
 					if (_keySize < _KEY_SIZE_MIN) {
 						throw new PwdEncryptorException.InvalidAlgorithm(
 							StringBundler.concat(
 								"PBKDF2 output length ", _keySize,
 								" bits is below the minimum allowed value of ",
 								_KEY_SIZE_MIN, " bits"),
+							null);
+					}
+
+					if (_rounds < _ROUNDS_MIN) {
+						throw new PwdEncryptorException.InvalidAlgorithm(
+							StringBundler.concat(
+								"PBKDF2 iteration count ", _rounds,
+								" is below the minimum allowed value of ",
+								_ROUNDS_MIN),
 							null);
 					}
 				}

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
@@ -209,6 +209,33 @@ public class PasswordEncryptorUtilTest {
 	}
 
 	@Test
+	public void testEncryptPBKDF2WithFIPSMode() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			_testEncryptFailure(
+				PasswordEncryptor.TYPE_BCRYPT + "/10",
+				RandomTestUtil.randomString(), null);
+
+			_testEncryptFailure(
+				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA1/160/1300000",
+				RandomTestUtil.randomString(), null);
+
+			_testEncryptFailure(
+				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA256/256/600000",
+				RandomTestUtil.randomString(), null);
+
+			_testEncryptFailure(
+				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA256/64/1300000",
+				RandomTestUtil.randomString(), null);
+
+			_testEncrypt(
+				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA256/256/1300000");
+		}
+	}
+
+	@Test
 	public void testEncryptPBKDF2WithHmacSHA256() throws Exception {
 		_runTests(
 			PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA256", "password",
@@ -266,7 +293,8 @@ public class PasswordEncryptorUtilTest {
 
 		try {
 			defaultPasswordEncryptor.encrypt(
-				"Some Nonexistent Algorithm", "password", null, false);
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				null, false);
 
 			Assert.fail();
 		}
@@ -279,29 +307,6 @@ public class PasswordEncryptorUtilTest {
 	public void testEncryptWithLegacyAlgorithm() throws Exception {
 		_testEncryptWithLegacyAlgorithm(
 			null, RandomTestUtil.randomString(), RandomTestUtil.randomString());
-	}
-
-	@Test
-	public void testFIPSModeEnforcesPBKDF2WithHmacSHA256() throws Exception {
-		try (SafeCloseable safeCloseable =
-				PropsValuesTestUtil.swapWithSafeCloseable(
-					"FIPS_ENABLED", true)) {
-
-			_testEncryptGenerationFailure(
-				PasswordEncryptor.TYPE_BCRYPT + "/10");
-
-			_testEncryptGenerationFailure(
-				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA1/160/1300000");
-
-			_testEncryptGenerationFailure(
-				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA256/256/600000");
-
-			_testEncryptGenerationFailure(
-				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA256/64/1300000");
-
-			_testEncrypt(
-				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA256/256/1300000");
-		}
 	}
 
 	private void _runTests(
@@ -348,16 +353,6 @@ public class PasswordEncryptorUtilTest {
 			Assert.fail();
 		}
 		catch (Exception exception) {
-		}
-	}
-
-	private void _testEncryptGenerationFailure(String algorithm) {
-		try {
-			PasswordEncryptorUtil.encrypt(algorithm, "password", null);
-
-			Assert.fail();
-		}
-		catch (PwdEncryptorException pwdEncryptorException) {
 		}
 	}
 

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
@@ -259,10 +259,49 @@ public class PasswordEncryptorUtilTest {
 			PasswordEncryptor.TYPE_UFC_CRYPT);
 	}
 
+	@Test
+	public void testEncryptUnavailableAlgorithm() throws Exception {
+		DefaultPasswordEncryptor defaultPasswordEncryptor =
+			new DefaultPasswordEncryptor();
+
+		try {
+			defaultPasswordEncryptor.encrypt(
+				"Some Nonexistent Algorithm", "password", null, false);
+
+			Assert.fail();
+		}
+		catch (PwdEncryptorException.UnavailableAlgorithm
+					pwdEncryptorException) {
+		}
+	}
+
 	@Test(expected = PwdEncryptorException.MustSetLegacyAlgorithmProperty.class)
 	public void testEncryptWithLegacyAlgorithm() throws Exception {
 		_testEncryptWithLegacyAlgorithm(
 			null, RandomTestUtil.randomString(), RandomTestUtil.randomString());
+	}
+
+	@Test
+	public void testFIPSModeEnforcesPBKDF2WithHmacSHA256() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			_testEncryptGenerationFailure(
+				PasswordEncryptor.TYPE_BCRYPT + "/10");
+
+			_testEncryptGenerationFailure(
+				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA1/160/1300000");
+
+			_testEncryptGenerationFailure(
+				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA256/256/600000");
+
+			_testEncryptGenerationFailure(
+				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA256/64/1300000");
+
+			_testEncrypt(
+				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA256/256/1300000");
+		}
 	}
 
 	private void _runTests(
@@ -309,6 +348,16 @@ public class PasswordEncryptorUtilTest {
 			Assert.fail();
 		}
 		catch (Exception exception) {
+		}
+	}
+
+	private void _testEncryptGenerationFailure(String algorithm) {
+		try {
+			PasswordEncryptorUtil.encrypt(algorithm, "password", null);
+
+			Assert.fail();
+		}
+		catch (PwdEncryptorException pwdEncryptorException) {
 		}
 	}
 

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
@@ -217,15 +217,12 @@ public class PasswordEncryptorUtilTest {
 			_testEncryptFailure(
 				PasswordEncryptor.TYPE_BCRYPT + "/10",
 				RandomTestUtil.randomString(), null);
-
 			_testEncryptFailure(
 				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA1/160/1300000",
 				RandomTestUtil.randomString(), null);
-
 			_testEncryptFailure(
 				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA256/256/600000",
 				RandomTestUtil.randomString(), null);
-
 			_testEncryptFailure(
 				PasswordEncryptor.TYPE_PBKDF2 + "WithHmacSHA256/64/1300000",
 				RandomTestUtil.randomString(), null);
@@ -291,16 +288,11 @@ public class PasswordEncryptorUtilTest {
 		DefaultPasswordEncryptor defaultPasswordEncryptor =
 			new DefaultPasswordEncryptor();
 
-		try {
-			defaultPasswordEncryptor.encrypt(
+		Assert.assertThrows(
+			PwdEncryptorException.UnavailableAlgorithm.class,
+			() -> defaultPasswordEncryptor.encrypt(
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
-				null, false);
-
-			Assert.fail();
-		}
-		catch (PwdEncryptorException.UnavailableAlgorithm
-					pwdEncryptorException) {
-		}
+				null, false));
 	}
 
 	@Test(expected = PwdEncryptorException.MustSetLegacyAlgorithmProperty.class)

--- a/portal-impl/src/com/liferay/portal/security/pwd/PwdAuthenticator.java
+++ b/portal-impl/src/com/liferay/portal/security/pwd/PwdAuthenticator.java
@@ -42,8 +42,7 @@ public class PwdAuthenticator {
 					pwdEncryptorException1) {
 
 			if (_log.isDebugEnabled()) {
-				_log.debug(
-					"Unable to verify a password", pwdEncryptorException1);
+				_log.debug("Unable to verify password", pwdEncryptorException1);
 			}
 
 			try {

--- a/portal-impl/src/com/liferay/portal/security/pwd/PwdAuthenticator.java
+++ b/portal-impl/src/com/liferay/portal/security/pwd/PwdAuthenticator.java
@@ -43,9 +43,7 @@ public class PwdAuthenticator {
 
 			if (_log.isDebugEnabled()) {
 				_log.debug(
-					"Unable to verify a password hashed with an unavailable " +
-						"algorithm",
-					pwdEncryptorException1);
+					"Unable to verify a password", pwdEncryptorException1);
 			}
 
 			try {
@@ -54,8 +52,7 @@ public class PwdAuthenticator {
 			}
 			catch (PwdEncryptorException pwdEncryptorException2) {
 				if (_log.isDebugEnabled()) {
-					_log.debug(
-						"Unable to perform decoy hash", pwdEncryptorException2);
+					_log.debug(pwdEncryptorException2);
 				}
 			}
 

--- a/portal-impl/src/com/liferay/portal/security/pwd/PwdAuthenticator.java
+++ b/portal-impl/src/com/liferay/portal/security/pwd/PwdAuthenticator.java
@@ -32,8 +32,35 @@ public class PwdAuthenticator {
 			String currentEncryptedPassword)
 		throws PwdEncryptorException {
 
-		String encryptedPassword = PasswordEncryptorUtil.encrypt(
-			clearTextPassword, currentEncryptedPassword);
+		String encryptedPassword = null;
+
+		try {
+			encryptedPassword = PasswordEncryptorUtil.encrypt(
+				clearTextPassword, currentEncryptedPassword);
+		}
+		catch (PwdEncryptorException.UnavailableAlgorithm
+					pwdEncryptorException1) {
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					"Unable to verify a password hashed with an unavailable " +
+						"algorithm",
+					pwdEncryptorException1);
+			}
+
+			try {
+				PasswordEncryptorUtil.encrypt(
+					clearTextPassword, _PRETENDED_CURRENT_ENCRYPTED_PASSWORD);
+			}
+			catch (PwdEncryptorException pwdEncryptorException2) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Unable to perform decoy hash", pwdEncryptorException2);
+				}
+			}
+
+			return false;
+		}
 
 		if (currentEncryptedPassword.equals(encryptedPassword)) {
 			return true;

--- a/portal-kernel/src/com/liferay/portal/kernel/exception/PwdEncryptorException.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/exception/PwdEncryptorException.java
@@ -48,6 +48,14 @@ public class PwdEncryptorException extends PortalException {
 
 	}
 
+	public static class UnavailableAlgorithm extends PwdEncryptorException {
+
+		public UnavailableAlgorithm(String msg, Throwable throwable) {
+			super(msg, throwable);
+		}
+
+	}
+
 	public static class UnsupportedEncoding extends PwdEncryptorException {
 
 		public UnsupportedEncoding(String msg, Throwable throwable) {

--- a/portal-kernel/src/com/liferay/portal/kernel/exception/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/exception/packageinfo
@@ -1,1 +1,1 @@
-version 16.7.0
+version 16.8.0

--- a/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptorUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptorUtil.java
@@ -150,11 +150,7 @@ public class PasswordEncryptorUtil {
 
 			throw new PwdEncryptorException.InvalidAlgorithm(
 				StringBundler.concat(
-					"FIPS mode requires the property \"",
-					PropsKeys.PASSWORDS_ENCRYPTION_ALGORITHM,
-					"\" to use PBKDF2 with HMAC-SHA-256 (for example, ",
-					"PBKDF2WithHmacSHA256/256/600000), but was \"", algorithm,
-					"\""),
+					"Algorithm \"", algorithm, "\" is not allowed"),
 				null);
 		}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptorUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptorUtil.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.util.ClassUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -142,6 +143,19 @@ public class PasswordEncryptorUtil {
 			if (Validator.isNull(algorithm)) {
 				algorithm = _PASSWORDS_ENCRYPTION_ALGORITHM;
 			}
+		}
+
+		if (PropsValues.FIPS_ENABLED && Validator.isNull(encryptedPassword) &&
+			!_isFIPSApprovedAlgorithm(algorithm)) {
+
+			throw new PwdEncryptorException.InvalidAlgorithm(
+				StringBundler.concat(
+					"FIPS mode requires the property \"",
+					PropsKeys.PASSWORDS_ENCRYPTION_ALGORITHM,
+					"\" to use PBKDF2 with HMAC-SHA-256 (for example, ",
+					"PBKDF2WithHmacSHA256/256/600000), but was \"", algorithm,
+					"\""),
+				null);
 		}
 
 		PasswordEncryptor passwordEncryptor = _getPasswordEncryptor(algorithm);
@@ -281,6 +295,22 @@ public class PasswordEncryptorUtil {
 		}
 
 		return passwordEncryptor;
+	}
+
+	private static boolean _isFIPSApprovedAlgorithm(String algorithm) {
+		if (Validator.isNull(algorithm)) {
+			return false;
+		}
+
+		String upperCaseAlgorithm = StringUtil.toUpperCase(algorithm);
+
+		if (upperCaseAlgorithm.startsWith(PasswordEncryptor.TYPE_PBKDF2) &&
+			upperCaseAlgorithm.contains("SHA256")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private static final String _PASSWORDS_ENCRYPTION_ALGORITHM =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94045

## What Is Being Fixed

bcrypt, the previous default password hashing algorithm, is not FIPS-approved. When the portal runs in FIPS mode the validated JCE provider rejects it, so new hashes cannot be generated and sign-in breaks. The PBKDF2 encryptor also had two latent weaknesses for FIPS use: it filled only the first 8 of its 16 salt bytes (about 64 bits of entropy, below the 128-bit requirement), and it enforced no minimum iteration count or output length. Finally, when the validated provider rejects a legacy hash's algorithm (for example MD5), sign-in failed in a way that could let an attacker tell which accounts still held legacy hashes, by either the error shown or the response timing.

## How It Is Being Fixed

The PBKDF2 encryptor now enforces FIPS parameter floors — a 1,300,000 iteration-count minimum and a 112-bit output-length minimum — applied only when `fips.enabled` is true and only on the generation path, so existing hashes can still be verified and migrated. Sub-floor parameters fail fast with a clear exception rather than being silently clamped. The salt fill now covers the full 16-byte (128-bit) salt instead of only the first half.

`PasswordEncryptorUtil` gates new-hash generation so that, in FIPS mode, only PBKDF2/HMAC-SHA-256 is accepted; any other algorithm throws with a message naming the offending algorithm. Verification of stored hashes is left untouched, so the existing rehash-on-next-sign-in flow keeps migrating legacy hashes transparently.

To keep failures safe, `DefaultPasswordEncryptor` now throws a typed `PwdEncryptorException.UnavailableAlgorithm` when the validated provider cannot resolve a digest, and `PwdAuthenticator` handles it by performing a decoy hash and returning a generic failure. This closes both the message and timing enumeration vectors, so an unavailable legacy algorithm is indistinguishable from a wrong password.

A note on the algorithm check: the FIPS-approved test matches `PBKDF2` plus `SHA256` without a hyphen because PBKDF2 HMAC uses the standard JCA name `PBKDF2WithHmacSHA256` (no hyphen) — the same form used by `passwords.encryption.algorithm`, the FIPS `portal-ext`, and BouncyCastle. `SHA-256` is the `MessageDigest` name and never appears in a PBKDF2 HMAC algorithm string, so `contains("SHA256")` matches every valid configuration. A hyphenated form is not a real algorithm name and would be rejected with a clear message anyway.

## PR Check

**pr-check: PASS** — tested on `7aab1f5fdd6253e8a7040872a47aed3a77f91f75`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7aab1f5fdd6253e8a7040872a47aed3a77f91f75"} -->
