### PR TITLE
LPD-95294 LPD-95735 Keep the resend button disabled during cooldown

### DIFF
--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 page import="com.liferay.multi.factor.authentication.email.otp.web.internal.constants.MFAEmailOTPPortletKeys" %><%@
 page import="com.liferay.multi.factor.authentication.email.otp.web.internal.constants.MFAEmailOTPWebKeys" %><%@
 page import="com.liferay.portal.configuration.module.configuration.ConfigurationProviderUtil" %><%@
+page import="com.liferay.portal.kernel.language.UnicodeLanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %>
 

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
@@ -203,10 +203,12 @@ if ((mfaEmailOTPSetAtTime > 0) && (mfaEmailOTPResendEmailTimeout > 0)) {
 						'<span class="alert alert-danger"><liferay-ui:message key="failed-to-send-email" /></span>'
 					);
 
-					sendEmailButton.text(buttonText);
+					sendEmailButton.text(originalSendButtonText);
 					sendEmailButton.removeAttribute('disabled');
 
-					clearInterval(interval);
+					clearInterval(resendCountdown);
+
+					resendCountdown = null;
 				},
 				success: function (event, id, obj) {
 					messageContainer.html(

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
@@ -54,9 +54,6 @@ if ((mfaEmailOTPSetAtTime > 0) && (mfaEmailOTPResendEmailTimeout > 0)) {
 <aui:script use="aui-base,aui-io-request">
 	<liferay-portlet:resourceURL id="/mfa_email_otp_verify/send_mfa_email_otp" portletName="<%= MFAEmailOTPPortletKeys.MFA_EMAIL_OTP_VERIFY %>" var="sendEmailOTPURL" />
 
-	var configuredResendDuration =
-		<%= mfaEmailOTPConfiguration.resendEmailTimeout() %>;
-
 	var failedAttemptsRetryTimeout = <%= mfaEmailOTPFailedAttemptsRetryTimeout %>;
 
 	var failedAttemptsRetryCountdown;
@@ -73,10 +70,7 @@ if ((mfaEmailOTPSetAtTime > 0) && (mfaEmailOTPResendEmailTimeout > 0)) {
 
 	var originalSubmitButtonText = submitEmailButton.text();
 
-	var previousSetTime =
-		<%= GetterUtil.getLong(request.getAttribute(MFAEmailOTPWebKeys.MFA_EMAIL_OTP_SET_AT_TIME)) %>;
-
-	var elapsedTime = Math.floor((Date.now() - previousSetTime) / 1000);
+	var remainingResendTime = <%= mfaEmailOTPRemainingResendTime %>;
 
 	function <portlet:namespace />createCountdown(f, countdown, interval) {
 		return setInterval(() => {
@@ -99,6 +93,8 @@ if ((mfaEmailOTPSetAtTime > 0) && (mfaEmailOTPResendEmailTimeout > 0)) {
 
 			if (!resendCountdown) {
 				sendEmailButton.removeAttribute('disabled');
+
+				sendEmailButton.removeClass('disabled');
 			}
 
 			submitEmailButton.text(originalSubmitButtonText);
@@ -120,6 +116,8 @@ if ((mfaEmailOTPSetAtTime > 0) && (mfaEmailOTPResendEmailTimeout > 0)) {
 
 			if (!failedAttemptsRetryCountdown) {
 				sendEmailButton.removeAttribute('disabled');
+
+				sendEmailButton.removeClass('disabled');
 			}
 
 			clearInterval(resendCountdown);
@@ -135,20 +133,14 @@ if ((mfaEmailOTPSetAtTime > 0) && (mfaEmailOTPResendEmailTimeout > 0)) {
 		}
 	}
 
-	if (
-		elapsedTime > 0 &&
-		elapsedTime < configuredResendDuration &&
-		previousSetTime > 0
-	) {
+	if (remainingResendTime > 0) {
 		sendEmailButton.setAttribute('disabled', 'disabled');
 
-		var resendDuration = configuredResendDuration - elapsedTime;
-
-		<portlet:namespace />setResendCountdown(resendDuration);
+		<portlet:namespace />setResendCountdown(remainingResendTime);
 
 		resendCountdown = <portlet:namespace />createCountdown(
 			<portlet:namespace />setResendCountdown,
-			resendDuration,
+			remainingResendTime,
 			1000
 		);
 	}
@@ -205,6 +197,7 @@ if ((mfaEmailOTPSetAtTime > 0) && (mfaEmailOTPResendEmailTimeout > 0)) {
 
 					sendEmailButton.text(originalSendButtonText);
 					sendEmailButton.removeAttribute('disabled');
+					sendEmailButton.removeClass('disabled');
 
 					clearInterval(resendCountdown);
 

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
@@ -9,6 +9,20 @@
 
 <%
 long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttribute(MFAEmailOTPWebKeys.MFA_EMAIL_OTP_FAILED_ATTEMPTS_RETRY_TIMEOUT));
+
+long mfaEmailOTPResendEmailTimeout = mfaEmailOTPConfiguration.resendEmailTimeout();
+
+long mfaEmailOTPSetAtTime = GetterUtil.getLong(request.getAttribute(MFAEmailOTPWebKeys.MFA_EMAIL_OTP_SET_AT_TIME));
+
+long mfaEmailOTPRemainingResendTime = 0;
+
+if ((mfaEmailOTPSetAtTime > 0) && (mfaEmailOTPResendEmailTimeout > 0)) {
+	long mfaEmailOTPElapsedTime = (System.currentTimeMillis() - mfaEmailOTPSetAtTime) / 1000;
+
+	if (mfaEmailOTPElapsedTime < mfaEmailOTPResendEmailTimeout) {
+		mfaEmailOTPRemainingResendTime = mfaEmailOTPResendEmailTimeout - Math.max(0, mfaEmailOTPElapsedTime);
+	}
+}
 %>
 
 <c:if test="<%= mfaEmailOTPFailedAttemptsRetryTimeout > 0 %>">
@@ -23,7 +37,7 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 	</div>
 
 	<aui:button-row>
-		<aui:button id="sendEmailButton" value="send" />
+		<aui:button disabled="<%= mfaEmailOTPRemainingResendTime > 0 %>" id="sendEmailButton" value='<%= (mfaEmailOTPRemainingResendTime > 0) ? String.valueOf(mfaEmailOTPRemainingResendTime) : "send" %>' />
 	</aui:button-row>
 </div>
 
@@ -55,7 +69,7 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 
 	var submitEmailButton = A.one('#<portlet:namespace />submitEmailButton');
 
-	var originalSendButtonText = sendEmailButton.text();
+	var originalSendButtonText = '<%= UnicodeLanguageUtil.get(request, "send") %>';
 
 	var originalSubmitButtonText = submitEmailButton.text();
 
@@ -130,6 +144,8 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 
 		var resendDuration = configuredResendDuration - elapsedTime;
 
+		<portlet:namespace />setResendCountdown(resendDuration);
+
 		resendCountdown = <portlet:namespace />createCountdown(
 			<portlet:namespace />setResendCountdown,
 			resendDuration,
@@ -152,6 +168,8 @@ long mfaEmailOTPFailedAttemptsRetryTimeout = GetterUtil.getLong(request.getAttri
 		sendEmailButton.setAttribute('disabled', 'disabled');
 
 		var resendDuration = <%= mfaEmailOTPConfiguration.resendEmailTimeout() %>;
+
+		<portlet:namespace />setResendCountdown(resendDuration);
 
 		resendCountdown = <portlet:namespace />createCountdown(
 			<portlet:namespace />setResendCountdown,

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/test.properties
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/test.properties
@@ -1,0 +1,9 @@
+modified.files.includes[relevant][multi-factor-authentication-email-otp-web-playwright-rule]=**
+
+playwright.projects.includes[playwright-js-tomcat101-postgresql163][relevant][multi-factor-authentication-email-otp-web-playwright-rule]=\
+    multi-factor-authentication-email-otp-web.main
+
+relevant.rule.names=multi-factor-authentication-email-otp-web-playwright-rule
+
+test.batch.names[relevant][multi-factor-authentication-email-otp-web-playwright-rule]=\
+    playwright-js-tomcat101-postgresql163

--- a/modules/test/playwright/pages/multi-factor-authentication/MultiFactorAuthenticationConfigurationPage.ts
+++ b/modules/test/playwright/pages/multi-factor-authentication/MultiFactorAuthenticationConfigurationPage.ts
@@ -15,6 +15,7 @@ export class MultiFactorAuthenticationConfigurationPage {
 	readonly instanceSettingsPage: InstanceSettingsPage;
 	readonly oneTimePasswordLength: Locator;
 	readonly page: Page;
+	readonly resendEmailTimeout: Locator;
 	readonly resetDefaultValues: Locator;
 	readonly retryTimeout: Locator;
 	readonly saveButton: Locator;
@@ -31,6 +32,7 @@ export class MultiFactorAuthenticationConfigurationPage {
 			'One-Time Password Length'
 		);
 		this.page = page;
+		this.resendEmailTimeout = page.getByLabel('Resend Email Timeout');
 		this.resetDefaultValues = page.getByText('Reset Default Values');
 		this.retryTimeout = page.getByLabel('Retry Timeout');
 		this.saveButton = page.getByRole('button', {name: 'Save'});
@@ -39,8 +41,13 @@ export class MultiFactorAuthenticationConfigurationPage {
 
 	async enable({
 		failedAttemptsAllowed,
+		resendEmailTimeout,
 		retryTimeout,
-	}: {failedAttemptsAllowed?: number; retryTimeout?: number} = {}) {
+	}: {
+		failedAttemptsAllowed?: number;
+		resendEmailTimeout?: number;
+		retryTimeout?: number;
+	} = {}) {
 		await expect(this.enabledCheckBox).toBeVisible();
 
 		await expect(async () => {
@@ -53,6 +60,10 @@ export class MultiFactorAuthenticationConfigurationPage {
 			await this.failedAttemptsAllowed.fill(
 				String(failedAttemptsAllowed)
 			);
+		}
+
+		if (resendEmailTimeout !== undefined) {
+			await this.resendEmailTimeout.fill(String(resendEmailTimeout));
 		}
 
 		if (retryTimeout !== undefined) {

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -117,6 +117,7 @@ import {config as loginWebConfig} from './tests/login-web/main/config';
 import {config as loginWebSetupAdminConfig} from './tests/login-web/setup-admin/config';
 import {config as marketplaceAppManagerWebConfig} from './tests/marketplace-app-manager-web/main/config';
 import {config as messageBoardsWebConfig} from './tests/message-boards-web/main/config';
+import {config as multifactorAuthenticationEmailOTPConfig} from './tests/multi-factor-authentication-email-otp-web/main/config';
 import {config as multifactorAuthenticationConfig} from './tests/multi-factor-authentication-timebased-otp-web/main/config';
 import {config as multifactorAuthenticationWebConfig} from './tests/multi-factor-authentication-web/main/config';
 import {config as nestedPortletsWebConfig} from './tests/nested-portlets-web/main/config';
@@ -350,6 +351,7 @@ export default defineConfig({
 		marketplaceConfig,
 		messageBoardsWebConfig,
 		multifactorAuthenticationConfig,
+		multifactorAuthenticationEmailOTPConfig,
 		multifactorAuthenticationWebConfig,
 		nestedPortletsWebConfig,
 		notificationWebConfig,

--- a/modules/test/playwright/tests/multi-factor-authentication-email-otp-web/main/config.ts
+++ b/modules/test/playwright/tests/multi-factor-authentication-email-otp-web/main/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'multi-factor-authentication-email-otp-web.main',
+	testDir: 'tests/multi-factor-authentication-email-otp-web/main',
+};

--- a/modules/test/playwright/tests/multi-factor-authentication-email-otp-web/main/multi-factor-authentication-email-otp.spec.ts
+++ b/modules/test/playwright/tests/multi-factor-authentication-email-otp-web/main/multi-factor-authentication-email-otp.spec.ts
@@ -104,3 +104,119 @@ test(
 		}
 	}
 );
+
+test(
+	'LPD-95735 keeps the send button disabled while the resend cooldown is still running after the retry lockout expires',
+	{tag: '@LPD-95735'},
+	async ({
+		apiHelpers,
+		browser,
+		multiFactorAuthenticationConfigurationPage,
+	}) => {
+		test.setTimeout(60000);
+
+		// Enable email OTP and configure a resend cooldown that outlasts the
+		// failed-attempts retry lockout, so the two timers expire at clearly
+		// different moments. A single failed attempt is enough to trigger the
+		// lockout.
+
+		await multiFactorAuthenticationConfigurationPage.goto();
+
+		await multiFactorAuthenticationConfigurationPage.enable({
+			failedAttemptsAllowed: 1,
+			resendEmailTimeout: 12,
+			retryTimeout: 4,
+		});
+
+		// Create a user that will be challenged with email OTP when signing in
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		// Reach the MFA stage in a clean context, leaving the admin signed in
+
+		const userContext = await browser.newContext();
+		const userPage = await userContext.newPage();
+
+		try {
+			await userPage.goto('/');
+
+			await userPage
+				.getByRole('button', {name: 'Sign In'})
+				.last()
+				.click();
+
+			await userPage.getByLabel('Email Address').fill(user.emailAddress);
+			await userPage.getByLabel('Password').fill('test');
+
+			await userPage
+				.getByRole('button', {name: 'Sign In'})
+				.last()
+				.click();
+
+			// Request a one-time password so the send button starts its cooldown
+
+			const sendEmailButton = userPage.locator('[id$="sendEmailButton"]');
+
+			const submitEmailButton = userPage.locator(
+				'[id$="submitEmailButton"]'
+			);
+
+			await expect(sendEmailButton).toHaveText('Send');
+
+			await clickAndExpectToBeVisible({
+				target: userPage.getByText(
+					'Your one-time password has been sent by email.'
+				),
+				trigger: sendEmailButton,
+			});
+
+			// Submit an incorrect OTP to exhaust the single allowed attempt. The
+			// full-page re-render brings back the challenge with the retry
+			// lockout active: both buttons are disabled and the submit button
+			// shows the lockout countdown.
+
+			await userPage
+				.getByLabel('Enter the one-time password from the email')
+				.fill(getRandomString());
+
+			await submitEmailButton.click();
+
+			await expect(
+				userPage.getByText('Multi-factor authentication has failed.')
+			).toBeVisible();
+
+			await expect(submitEmailButton).toBeDisabled();
+
+			await expect(sendEmailButton).toBeDisabled();
+
+			// Once the retry lockout expires the submit button is re-enabled,
+			// but the resend cooldown is still running. LPD-95735: the send
+			// button must stay disabled and keep showing its countdown instead
+			// of becoming clickable while the cooldown has not elapsed.
+
+			await expect(submitEmailButton).toBeEnabled({timeout: 15000});
+
+			await expect(sendEmailButton).toBeDisabled();
+
+			await expect(sendEmailButton).not.toHaveText('Send');
+
+			await expect(sendEmailButton).toHaveText(/^\s*\d+\s*$/);
+
+			// Once the resend cooldown also elapses, the send button must
+			// become fully usable again, not merely lose its disabled
+			// attribute. A leftover server-rendered "disabled" CSS class would
+			// keep it greyed out and unclickable.
+
+			await expect(sendEmailButton).toBeEnabled({timeout: 15000});
+
+			await expect(sendEmailButton).not.toHaveClass(/\bdisabled\b/);
+		}
+		finally {
+			await userContext.close();
+
+			await multiFactorAuthenticationConfigurationPage.goto();
+
+			await multiFactorAuthenticationConfigurationPage.resetConfiguration();
+		}
+	}
+);

--- a/modules/test/playwright/tests/multi-factor-authentication-email-otp-web/main/multi-factor-authentication-email-otp.spec.ts
+++ b/modules/test/playwright/tests/multi-factor-authentication-email-otp-web/main/multi-factor-authentication-email-otp.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {multiFactorAuthenticationPagesTest} from '../../../fixtures/multiFactorAuthenticationPagesTest';
+import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
+import getRandomString from '../../../utils/getRandomString';
+
+export const test = mergeTests(
+	dataApiHelpersTest,
+	loginTest(),
+	multiFactorAuthenticationPagesTest
+);
+
+test(
+	'LPD-95294 keeps the resend countdown without flipping back to Send when an incorrect OTP is submitted',
+	{tag: '@LPD-95294'},
+	async ({
+		apiHelpers,
+		browser,
+		multiFactorAuthenticationConfigurationPage,
+	}) => {
+
+		// Enable the email OTP checker for the instance. The admin browser
+		// session stays authenticated, so the configuration can be reset later.
+
+		await multiFactorAuthenticationConfigurationPage.goto();
+
+		await multiFactorAuthenticationConfigurationPage.enable();
+
+		// Create a user that will be challenged with email OTP when signing in
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		// Reach the MFA stage in a clean context, leaving the admin signed in
+
+		const userContext = await browser.newContext();
+		const userPage = await userContext.newPage();
+
+		try {
+			await userPage.goto('/');
+
+			await userPage
+				.getByRole('button', {name: 'Sign In'})
+				.last()
+				.click();
+
+			await userPage.getByLabel('Email Address').fill(user.emailAddress);
+			await userPage.getByLabel('Password').fill('test');
+
+			await userPage
+				.getByRole('button', {name: 'Sign In'})
+				.last()
+				.click();
+
+			// Request a one-time password so the send button starts its cooldown
+
+			const sendEmailButton = userPage.locator('[id$="sendEmailButton"]');
+
+			await expect(sendEmailButton).toHaveText('Send');
+
+			await clickAndExpectToBeVisible({
+				target: userPage.getByText(
+					'Your one-time password has been sent by email.'
+				),
+				trigger: sendEmailButton,
+			});
+
+			// Submit an incorrect OTP. The send button is wired with type="submit"
+			// inside a data-senna-off form, so this is a full-page server
+			// re-render of the challenge (not an AJAX update).
+
+			await userPage
+				.getByLabel('Enter the one-time password from the email')
+				.fill(getRandomString());
+
+			await userPage.locator('[id$="submitEmailButton"]').click();
+
+			await expect(
+				userPage.getByText('Multi-factor authentication has failed.')
+			).toBeVisible();
+
+			// LPD-95294: on the re-render the cooldown must already be in place,
+			// never reverting to "Send". The button is rendered server-side as a
+			// disabled countdown (its label is the remaining seconds).
+
+			await expect(sendEmailButton).toBeDisabled();
+
+			await expect(sendEmailButton).not.toHaveText('Send');
+
+			await expect(sendEmailButton).toHaveText(/^\s*\d+\s*$/);
+		}
+		finally {
+			await userContext.close();
+
+			await multiFactorAuthenticationConfigurationPage.goto();
+
+			await multiFactorAuthenticationConfigurationPage.resetConfiguration();
+		}
+	}
+);

--- a/modules/test/playwright/tests/multi-factor-authentication-email-otp-web/main/test.properties
+++ b/modules/test/playwright/tests/multi-factor-authentication-email-otp-web/main/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=Multi Factor Authentication


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95294
https://liferay.atlassian.net/browse/LPD-95735

## What Is Being Fixed

On the second stage of login, the MFA email one-time code screen shows a "Send" button that turns into a cooldown countdown once a code is requested.

LPD-95294: when the user submitted an incorrect code, the full-page re-render brought the button back with its default "Send" label and only restored the countdown after the client timer's first tick a second later. The resulting flicker misleadingly suggested a new code could be requested immediately while the cooldown was in fact still running.

LPD-95735: when the resend interval is configured to be longer than the failed-attempts retry timeout, the send button became enabled as soon as the retry lockout expired, before the resend interval had elapsed. Because the code email is sent asynchronously, the stored send timestamp could be essentially the render time, so the client-computed elapsed time was zero and the resend countdown never started. When the retry lockout then expired, its completion handler re-enabled the send button because the resend countdown handle it guards on was never created, letting the user request a new code and start a second countdown that ran concurrently with the first. A second, related defect surfaced in manual testing: once both countdowns were active, the server renders the send button with the `disabled` attribute and the matching `disabled` CSS class, but the client only removed the attribute on re-enable, so the lingering class left the button greyed out and unclickable (Clay sets `pointer-events: none`) even after both timers finished.

## How It Is Being Fixed

The remaining cooldown time is computed from the session timestamp and rendered on the server, so the re-rendered verification page already shows the countdown on a disabled button instead of the default "Send" label, and the client script paints the value immediately without waiting for the first tick. The client no longer derives the cooldown from a client-side elapsed-time calculation; it starts the resend countdown from the server-computed remaining time, so the countdown handle is reliably present whenever the cooldown is active and the existing guard keeps the send button disabled until the resend interval fully elapses, even after the retry lockout expires. The server-side computation clamps the elapsed time with Math.max so a minor clock difference between cluster nodes cannot zero out the cooldown. When either countdown re-enables the send button it now also drops the server-rendered `disabled` CSS class, so the button is genuinely usable again rather than merely losing its `disabled` attribute.

Two Playwright tests cover the behavior. The first signs in as a user challenged with email OTP, requests a code, submits an incorrect one, and asserts the resend button stays disabled and keeps showing the countdown rather than reverting to "Send". The second configures a resend interval longer than the retry timeout and asserts that, once the retry lockout expires, the submit button is re-enabled while the send button stays disabled and keeps its countdown, and that once the resend cooldown also elapses the send button becomes fully usable again with no leftover `disabled` class. The configuration is driven through the MultiFactorAuthenticationConfigurationPage page object. The tests run in their own project and the module's test.properties registers them in CI.

## PR Check

**pr-check: PASS** — tested on `071b36ecc03bb3b462951ad4843c7e1c1e323baf`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JSP Compile | PASS |
| Per-Module Compile | PASS |

The Playwright tests for both tickets pass locally; functional tests are out of pr-check scope.

<!-- pr-check {"result": "success", "sha": "071b36ecc03bb3b462951ad4843c7e1c1e323baf"} -->
