### PR TITLE
LPD-95782 Honor the CSP configuration for internally excluded paths

### DIFF
--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
@@ -9,6 +9,7 @@ import com.liferay.portal.configuration.module.configuration.ConfigurationProvid
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -120,24 +121,28 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 		ContentSecurityPolicyConfiguration contentSecurityPolicyConfiguration,
 		HttpServletRequest httpServletRequest) {
 
-		String requestURI = (String)httpServletRequest.getAttribute(
-			JavaConstants.JAKARTA_SERVLET_FORWARD_REQUEST_URI);
+		String requestURI = httpServletRequest.getRequestURI();
 
-		if (Validator.isNull(requestURI)) {
-			requestURI = httpServletRequest.getRequestURI();
+		if (Validator.isNotNull(requestURI)) {
+			requestURI = StringUtil.toLowerCase(requestURI);
+
+			for (String internallyExcludedPath : _INTERNALLY_EXCLUDED_PATHS) {
+				if (Validator.isNotNull(internallyExcludedPath) &&
+					requestURI.startsWith(
+						StringUtil.toLowerCase(internallyExcludedPath))) {
+
+					return true;
+				}
+			}
 		}
+
+		requestURI = GetterUtil.getString(
+			httpServletRequest.getAttribute(
+				JavaConstants.JAKARTA_SERVLET_FORWARD_REQUEST_URI),
+			requestURI);
 
 		if (Validator.isNull(requestURI)) {
 			return false;
-		}
-
-		for (String internallyExcludedPath : _INTERNALLY_EXCLUDED_PATHS) {
-			if (Validator.isNotNull(internallyExcludedPath) &&
-				requestURI.startsWith(
-					StringUtil.toLowerCase(internallyExcludedPath))) {
-
-				return true;
-			}
 		}
 
 		requestURI = StringUtil.toLowerCase(requestURI);

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
@@ -32,27 +32,36 @@ public class ContentSecurityPolicyFilterTest {
 
 	@Before
 	public void setUp() {
-		_contentSecurityPolicyConfiguration = Mockito.mock(
-			ContentSecurityPolicyConfiguration.class);
-
-		Mockito.when(
-			_contentSecurityPolicyConfiguration.excludedPaths()
-		).thenReturn(
-			new String[] {"/group"}
-		);
-
 		_contentSecurityPolicyFilter = new ContentSecurityPolicyFilter();
 	}
 
 	@Test
 	public void testIsExcludedURIPath() {
-		_testIsExcludedURIPath(false, null, "/c/portal/layout");
-		_testIsExcludedURIPath(true, "/group/guest/home", "/c/portal/layout");
-		_testIsExcludedURIPath(true, null, "/group/guest/home");
+		_testIsExcludedURIPath(
+			new String[] {"/group"}, false, null, "/c/portal/layout");
+		_testIsExcludedURIPath(
+			new String[] {"/group"}, false, "/web/mysite/home",
+			"/c/portal/layout");
+		_testIsExcludedURIPath(
+			new String[] {"/group"}, true, "/group/guest/home",
+			"/c/portal/layout");
+		_testIsExcludedURIPath(
+			new String[] {"/group"}, true, null, "/group/guest/home");
+		_testIsExcludedURIPath(new String[0], true, null, "/GROUP/guest/home");
 	}
 
 	private void _testIsExcludedURIPath(
-		boolean excludedURIPath, String forwardRequestURI, String requestURI) {
+		String[] excludedPaths, boolean excludedURIPath,
+		String forwardRequestURI, String requestURI) {
+
+		ContentSecurityPolicyConfiguration contentSecurityPolicyConfiguration =
+			Mockito.mock(ContentSecurityPolicyConfiguration.class);
+
+		Mockito.when(
+			contentSecurityPolicyConfiguration.excludedPaths()
+		).thenReturn(
+			excludedPaths
+		);
 
 		HttpServletRequest httpServletRequest = Mockito.mock(
 			HttpServletRequest.class);
@@ -78,11 +87,9 @@ public class ContentSecurityPolicyFilterTest {
 					ContentSecurityPolicyConfiguration.class,
 					HttpServletRequest.class
 				},
-				_contentSecurityPolicyConfiguration, httpServletRequest));
+				contentSecurityPolicyConfiguration, httpServletRequest));
 	}
 
-	private ContentSecurityPolicyConfiguration
-		_contentSecurityPolicyConfiguration;
 	private ContentSecurityPolicyFilter _contentSecurityPolicyFilter;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95782

## What Is Being Fixed

When a Content Security Policy is enabled, the CSP header was not applied to pages on manually created sites; only the default site was protected. This is a regression from LPD-91078, which started reading the forwarded original request URI first when deciding whether a path is excluded.

## How It Is Being Fixed

A /web, /group, or /user friendly URL is forwarded to /c/portal/layout to render the page, and the filter runs on both the outer request and the inner forward. After LPD-91078 the inner forward matched the original friendly URL against the internally excluded paths and disabled CSP on the very dispatch that renders the page, so no header was written. The default site was unaffected because its home page is served from the root path, which is not internally excluded.

This separates the two exclusion checks by the URI each one reads. The internally excluded paths are matched against the current request URI, so only the outer friendly URL request is skipped while the /c/portal/layout forward renders with CSP. The configured excluded paths are matched against the forwarded original URI, so an administrator can still exclude a /web, /group, or /user path through configuration and have it honored through the forward. A regression test asserts that a forwarded site page with no matching exclusion is not excluded.

## PR Check

**pr-check: PASS** — tested on `6226df73010187d92c0b081aed414b75992f0d65`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "6226df73010187d92c0b081aed414b75992f0d65"} -->
