### PR TITLE
LPD-91332 Secure the MCP server with OAuth and RFC 9728 metadata

### DIFF
--- a/modules/apps/mcp/mcp-server-rest-impl/build.gradle
+++ b/modules/apps/mcp/mcp-server-rest-impl/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:configuration-admin:configuration-admin-api")
 	compileOnly project(":apps:mcp:mcp-server-rest-api")
+	compileOnly project(":apps:oauth2-provider:oauth2-provider-api")
 	compileOnly project(":apps:object:object-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:portal-odata:portal-odata-api")

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/constants/MCPServerConstants.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/constants/MCPServerConstants.java
@@ -23,4 +23,9 @@ public class MCPServerConstants {
 	public static final String EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROMPT =
 		"L_MCP_SERVER_PROMPT";
 
+	public static final String MCP_PATH = "/o/mcp";
+
+	public static final String WELL_KNOWN_PROTECTED_RESOURCE_PATH =
+		"/o/.well-known/oauth-protected-resource";
+
 }

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/constants/MCPServerConstants.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/constants/MCPServerConstants.java
@@ -23,9 +23,9 @@ public class MCPServerConstants {
 	public static final String EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROMPT =
 		"L_MCP_SERVER_PROMPT";
 
-	public static final String MCP_PATH = "/o/mcp";
+	public static final String MCP_PATH = "/mcp";
 
 	public static final String WELL_KNOWN_PROTECTED_RESOURCE_PATH =
-		"/o/.well-known/oauth-protected-resource";
+		"/.well-known/oauth-protected-resource";
 
 }

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/constants/MCPServerConstants.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/constants/MCPServerConstants.java
@@ -23,9 +23,9 @@ public class MCPServerConstants {
 	public static final String EXTERNAL_REFERENCE_CODE_MCP_SERVER_PROMPT =
 		"L_MCP_SERVER_PROMPT";
 
-	public static final String MCP_PATH = "/mcp";
+	public static final String PATH_MCP = "/mcp";
 
-	public static final String WELL_KNOWN_PROTECTED_RESOURCE_PATH =
+	public static final String PATH_WELL_KNOWN_PROTECTED_RESOURCE =
 		"/.well-known/oauth-protected-resource";
 
 }

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPProtectedResourceMetadataServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPProtectedResourceMetadataServlet.java
@@ -1,0 +1,74 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.mcp.server.rest.internal.servlet;
+
+import com.liferay.mcp.server.rest.internal.constants.MCPServerConstants;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.Portal;
+
+import jakarta.servlet.Servlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jorge García Jiménez
+ */
+@Component(
+	property = {
+		"osgi.http.whiteboard.servlet.name=com.liferay.mcp.server.rest.internal.servlet.MCPProtectedResourceMetadataServlet",
+		"osgi.http.whiteboard.servlet.pattern=/.well-known/oauth-protected-resource",
+		"osgi.http.whiteboard.servlet.pattern=/.well-known/oauth-protected-resource/*"
+	},
+	service = Servlet.class
+)
+public class MCPProtectedResourceMetadataServlet extends HttpServlet {
+
+	@Override
+	protected void doGet(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException {
+
+		String portalURL =
+			_portal.getPortalURL(httpServletRequest) + _portal.getPathContext();
+
+		String resource = portalURL + MCPServerConstants.MCP_PATH;
+
+		JSONObject metadataJSONObject = JSONUtil.put(
+			"authorization_servers", JSONUtil.putAll(portalURL)
+		).put(
+			"bearer_methods_supported", JSONUtil.putAll("header")
+		).put(
+			"resource", resource
+		).put(
+			"resource_name", "Liferay MCP Server"
+		);
+
+		httpServletResponse.setCharacterEncoding(StringPool.UTF8);
+		httpServletResponse.setContentType(ContentTypes.APPLICATION_JSON);
+		httpServletResponse.setHeader(
+			HttpHeaders.CACHE_CONTROL, "public, max-age=300");
+
+		try (PrintWriter printWriter = httpServletResponse.getWriter()) {
+			printWriter.write(metadataJSONObject.toString());
+		}
+	}
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPProtectedResourceMetadataServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPProtectedResourceMetadataServlet.java
@@ -7,9 +7,10 @@ package com.liferay.mcp.server.rest.internal.servlet;
 
 import com.liferay.mcp.server.rest.internal.constants.MCPServerConstants;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -19,7 +20,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
-import java.io.PrintWriter;
+
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -38,34 +40,68 @@ import org.osgi.service.component.annotations.Reference;
 public class MCPProtectedResourceMetadataServlet extends HttpServlet {
 
 	@Override
-	protected void doGet(
+	protected void service(
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws IOException {
 
-		String portalURL =
-			_portal.getPortalURL(httpServletRequest) + _portal.getPathContext();
+		if (!FeatureFlagManagerUtil.isEnabled(
+				_portal.getCompanyId(httpServletRequest), "LPD-63415")) {
 
-		String resource = portalURL + MCPServerConstants.MCP_PATH;
+			httpServletResponse.sendError(HttpServletResponse.SC_NOT_FOUND);
 
-		JSONObject metadataJSONObject = JSONUtil.put(
-			"authorization_servers", JSONUtil.putAll(portalURL)
-		).put(
-			"bearer_methods_supported", JSONUtil.putAll("header")
-		).put(
-			"resource", resource
-		).put(
-			"resource_name", "Liferay MCP Server"
-		);
+			return;
+		}
+
+		httpServletResponse.setHeader(
+			"Access-Control-Allow-Headers", "Authorization, Content-Type");
+		httpServletResponse.setHeader(
+			"Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");
+		httpServletResponse.setHeader("Access-Control-Allow-Origin", "*");
+		httpServletResponse.setHeader("Access-Control-Max-Age", "300");
+
+		String method = httpServletRequest.getMethod();
+
+		if (Objects.equals(method, "OPTIONS")) {
+			httpServletResponse.setStatus(HttpServletResponse.SC_NO_CONTENT);
+
+			return;
+		}
+
+		if (!Objects.equals(method, "GET") && !Objects.equals(method, "HEAD")) {
+			httpServletResponse.setHeader("Allow", "GET, HEAD, OPTIONS");
+			httpServletResponse.sendError(
+				HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+
+			return;
+		}
 
 		httpServletResponse.setCharacterEncoding(StringPool.UTF8);
 		httpServletResponse.setContentType(ContentTypes.APPLICATION_JSON);
 		httpServletResponse.setHeader(
 			HttpHeaders.CACHE_CONTROL, "public, max-age=300");
+		httpServletResponse.setStatus(HttpServletResponse.SC_OK);
 
-		PrintWriter printWriter = httpServletResponse.getWriter();
+		if (Objects.equals(method, "GET")) {
+			String portalURL =
+				_portal.getPortalURL(httpServletRequest) +
+					_portal.getPathContext();
 
-		printWriter.write(metadataJSONObject.toString());
+			ServletResponseUtil.write(
+				httpServletResponse,
+				JSONUtil.put(
+					"authorization_servers", JSONUtil.putAll(portalURL)
+				).put(
+					"bearer_methods_supported", JSONUtil.putAll("header")
+				).put(
+					"resource",
+					portalURL + Portal.PATH_MODULE + MCPServerConstants.MCP_PATH
+				).put(
+					"resource_name", "Liferay MCP Server"
+				).toString());
+		}
+
+		httpServletResponse.flushBuffer();
 	}
 
 	@Reference

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPProtectedResourceMetadataServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPProtectedResourceMetadataServlet.java
@@ -63,9 +63,9 @@ public class MCPProtectedResourceMetadataServlet extends HttpServlet {
 		httpServletResponse.setHeader(
 			HttpHeaders.CACHE_CONTROL, "public, max-age=300");
 
-		try (PrintWriter printWriter = httpServletResponse.getWriter()) {
-			printWriter.write(metadataJSONObject.toString());
-		}
+		PrintWriter printWriter = httpServletResponse.getWriter();
+
+		printWriter.write(metadataJSONObject.toString());
 	}
 
 	@Reference

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerProtectedResourceMetadataServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerProtectedResourceMetadataServlet.java
@@ -31,13 +31,13 @@ import org.osgi.service.component.annotations.Reference;
  */
 @Component(
 	property = {
-		"osgi.http.whiteboard.servlet.name=com.liferay.mcp.server.rest.internal.servlet.MCPProtectedResourceMetadataServlet",
+		"osgi.http.whiteboard.servlet.name=com.liferay.mcp.server.rest.internal.servlet.MCPServerProtectedResourceMetadataServlet",
 		"osgi.http.whiteboard.servlet.pattern=/.well-known/oauth-protected-resource",
 		"osgi.http.whiteboard.servlet.pattern=/.well-known/oauth-protected-resource/*"
 	},
 	service = Servlet.class
 )
-public class MCPProtectedResourceMetadataServlet extends HttpServlet {
+public class MCPServerProtectedResourceMetadataServlet extends HttpServlet {
 
 	@Override
 	protected void service(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerProtectedResourceMetadataServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerProtectedResourceMetadataServlet.java
@@ -54,7 +54,8 @@ public class MCPServerProtectedResourceMetadataServlet extends HttpServlet {
 		}
 
 		httpServletResponse.setHeader(
-			"Access-Control-Allow-Headers", "Authorization, Content-Type");
+			"Access-Control-Allow-Headers",
+			"Authorization, Content-Type, MCP-Protocol-Version");
 		httpServletResponse.setHeader(
 			"Access-Control-Allow-Methods", "GET, HEAD, OPTIONS");
 		httpServletResponse.setHeader("Access-Control-Allow-Origin", "*");

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerProtectedResourceMetadataServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerProtectedResourceMetadataServlet.java
@@ -96,7 +96,7 @@ public class MCPServerProtectedResourceMetadataServlet extends HttpServlet {
 					"bearer_methods_supported", JSONUtil.putAll("header")
 				).put(
 					"resource",
-					portalURL + Portal.PATH_MODULE + MCPServerConstants.MCP_PATH
+					portalURL + Portal.PATH_MODULE + MCPServerConstants.PATH_MCP
 				).put(
 					"resource_name", "Liferay MCP Server"
 				).toString());

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
@@ -208,11 +208,10 @@ public class MCPServerServlet extends HttpServlet {
 			return false;
 		}
 
+		List<String> audiences = oAuth2Authorization.getAudiencesList();
 		String mcpResourceURI = StringBundler.concat(
 			_portal.getPortalURL(httpServletRequest), _portal.getPathContext(),
 			Portal.PATH_MODULE, MCPServerConstants.MCP_PATH);
-
-		List<String> audiences = oAuth2Authorization.getAudiencesList();
 
 		if ((audiences == null) || !audiences.contains(mcpResourceURI)) {
 			_sendInvalidTokenChallenge(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
@@ -388,6 +388,14 @@ public class MCPServerServlet extends HttpServlet {
 		}
 	}
 
+	private String _getChallenge(HttpServletRequest httpServletRequest) {
+		return StringBundler.concat(
+			"Bearer realm=\"mcp\", resource_metadata=\"",
+			_portal.getPortalURL(httpServletRequest), _portal.getPathContext(),
+			Portal.PATH_MODULE,
+			MCPServerConstants.PATH_WELL_KNOWN_PROTECTED_RESOURCE, "\"");
+	}
+
 	private String _getMCPServerProfileName(
 		HttpServletRequest httpServletRequest) {
 
@@ -549,11 +557,8 @@ public class MCPServerServlet extends HttpServlet {
 		httpServletResponse.setHeader(
 			HttpHeaders.WWW_AUTHENTICATE,
 			StringBundler.concat(
-				"Bearer realm=\"mcp\", resource_metadata=\"",
-				_portal.getPortalURL(httpServletRequest),
-				_portal.getPathContext(), Portal.PATH_MODULE,
-				MCPServerConstants.PATH_WELL_KNOWN_PROTECTED_RESOURCE, "\", ",
-				"error=\"invalid_token\", error_description=\"", description,
+				_getChallenge(httpServletRequest),
+				", error=\"invalid_token\", error_description=\"", description,
 				"\""));
 		httpServletResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 	}
@@ -564,12 +569,7 @@ public class MCPServerServlet extends HttpServlet {
 		throws IOException {
 
 		httpServletResponse.setHeader(
-			HttpHeaders.WWW_AUTHENTICATE,
-			StringBundler.concat(
-				"Bearer realm=\"mcp\", resource_metadata=\"",
-				_portal.getPortalURL(httpServletRequest),
-				_portal.getPathContext(), Portal.PATH_MODULE,
-				MCPServerConstants.PATH_WELL_KNOWN_PROTECTED_RESOURCE, "\""));
+			HttpHeaders.WWW_AUTHENTICATE, _getChallenge(httpServletRequest));
 		httpServletResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 	}
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
@@ -165,13 +165,13 @@ public class MCPServerServlet extends HttpServlet {
 			return false;
 		}
 
-		String[] parts = authorization.trim(
-		).split(
-			"\\s+"
-		);
+		String trimmedAuthorization = authorization.trim();
 
-		if ((parts.length != 2) ||
-			!StringUtil.equalsIgnoreCase(parts[0], "Bearer")) {
+		int spaceIndex = trimmedAuthorization.indexOf(' ');
+
+		if ((spaceIndex == -1) ||
+			!StringUtil.equalsIgnoreCase(
+				trimmedAuthorization.substring(0, spaceIndex), "Bearer")) {
 
 			_sendInvalidTokenChallenge(
 				httpServletRequest, httpServletResponse,
@@ -180,7 +180,9 @@ public class MCPServerServlet extends HttpServlet {
 			return false;
 		}
 
-		String accessToken = parts[1];
+		String accessToken = trimmedAuthorization.substring(
+			spaceIndex + 1
+		).trim();
 
 		OAuth2Authorization oAuth2Authorization =
 			_oAuth2AuthorizationLocalService.

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
@@ -156,7 +156,8 @@ public class MCPServerServlet extends HttpServlet {
 			HttpServletResponse httpServletResponse)
 		throws IOException {
 
-		String authorization = httpServletRequest.getHeader("Authorization");
+		String authorization = httpServletRequest.getHeader(
+			HttpHeaders.AUTHORIZATION);
 
 		if (Validator.isBlank(authorization)) {
 			_sendUnauthenticatedChallenge(
@@ -165,28 +166,22 @@ public class MCPServerServlet extends HttpServlet {
 			return false;
 		}
 
-		String trimmedAuthorization = authorization.trim();
+		authorization = authorization.trim();
 
-		int spaceIndex = trimmedAuthorization.indexOf(' ');
-
-		if ((spaceIndex == -1) ||
-			!StringUtil.equalsIgnoreCase(
-				trimmedAuthorization.substring(0, spaceIndex), "Bearer")) {
-
+		if (!StringUtil.startsWith(authorization, "Bearer ")) {
 			_sendInvalidTokenChallenge(
-				httpServletRequest, httpServletResponse,
-				"Authorization header is not a Bearer token");
+				"Authorization header is not a Bearer token",
+				httpServletRequest, httpServletResponse);
 
 			return false;
 		}
 
-		String accessToken = trimmedAuthorization.substring(
-			spaceIndex + 1
-		).trim();
+		String accessTokenContent = authorization.substring("Bearer ".length());
 
 		OAuth2Authorization oAuth2Authorization =
 			_oAuth2AuthorizationLocalService.
-				fetchOAuth2AuthorizationByAccessTokenContent(accessToken);
+				fetchOAuth2AuthorizationByAccessTokenContent(
+					accessTokenContent);
 
 		if ((oAuth2Authorization == null) ||
 			(oAuth2Authorization.getCompanyId() != companyId) ||
@@ -194,8 +189,8 @@ public class MCPServerServlet extends HttpServlet {
 				equals(oAuth2Authorization.getAccessTokenContent())) {
 
 			_sendInvalidTokenChallenge(
-				httpServletRequest, httpServletResponse,
-				"Access token is unknown or revoked");
+				"Access token is unknown or revoked", httpServletRequest,
+				httpServletResponse);
 
 			return false;
 		}
@@ -207,22 +202,22 @@ public class MCPServerServlet extends HttpServlet {
 			(expirationDate.getTime() < System.currentTimeMillis())) {
 
 			_sendInvalidTokenChallenge(
-				httpServletRequest, httpServletResponse,
-				"Access token has expired");
+				"Access token has expired", httpServletRequest,
+				httpServletResponse);
 
 			return false;
 		}
 
-		String mcpResourceURI =
-			_portal.getPortalURL(httpServletRequest) +
-				_portal.getPathContext() + MCPServerConstants.MCP_PATH;
+		String mcpResourceURI = StringBundler.concat(
+			_portal.getPortalURL(httpServletRequest), _portal.getPathContext(),
+			Portal.PATH_MODULE, MCPServerConstants.MCP_PATH);
 
 		List<String> audiences = oAuth2Authorization.getAudiencesList();
 
 		if ((audiences == null) || !audiences.contains(mcpResourceURI)) {
 			_sendInvalidTokenChallenge(
-				httpServletRequest, httpServletResponse,
-				"Access token is not bound to this MCP server");
+				"Access token is not bound to this MCP server",
+				httpServletRequest, httpServletResponse);
 
 			return false;
 		}
@@ -534,8 +529,8 @@ public class MCPServerServlet extends HttpServlet {
 	}
 
 	private void _sendInvalidTokenChallenge(
-			HttpServletRequest httpServletRequest,
-			HttpServletResponse httpServletResponse, String description)
+			String description, HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
 		throws IOException {
 
 		httpServletResponse.setHeader(
@@ -543,7 +538,7 @@ public class MCPServerServlet extends HttpServlet {
 			StringBundler.concat(
 				"Bearer realm=\"mcp\", resource_metadata=\"",
 				_portal.getPortalURL(httpServletRequest),
-				_portal.getPathContext(),
+				_portal.getPathContext(), Portal.PATH_MODULE,
 				MCPServerConstants.WELL_KNOWN_PROTECTED_RESOURCE_PATH, "\", ",
 				"error=\"invalid_token\", error_description=\"", description,
 				"\""));
@@ -560,7 +555,7 @@ public class MCPServerServlet extends HttpServlet {
 			StringBundler.concat(
 				"Bearer realm=\"mcp\", resource_metadata=\"",
 				_portal.getPortalURL(httpServletRequest),
-				_portal.getPathContext(),
+				_portal.getPathContext(), Portal.PATH_MODULE,
 				MCPServerConstants.WELL_KNOWN_PROTECTED_RESOURCE_PATH, "\""));
 		httpServletResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 	}

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
@@ -130,7 +130,9 @@ public class MCPServerServlet extends HttpServlet {
 			return;
 		}
 
-		if (!_authenticate(httpServletRequest, httpServletResponse)) {
+		if (!_authenticate(
+				companyId, httpServletRequest, httpServletResponse)) {
+
 			return;
 		}
 
@@ -150,7 +152,7 @@ public class MCPServerServlet extends HttpServlet {
 	}
 
 	private boolean _authenticate(
-			HttpServletRequest httpServletRequest,
+			long companyId, HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws IOException {
 
@@ -185,8 +187,7 @@ public class MCPServerServlet extends HttpServlet {
 				fetchOAuth2AuthorizationByAccessTokenContent(accessToken);
 
 		if ((oAuth2Authorization == null) ||
-			(oAuth2Authorization.getCompanyId() != _portal.getCompanyId(
-				httpServletRequest)) ||
+			(oAuth2Authorization.getCompanyId() != companyId) ||
 			OAuth2AuthorizationConstants.ACCESS_TOKEN_CONTENT_EXPIRED_TOKEN.
 				equals(oAuth2Authorization.getAccessTokenContent())) {
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
@@ -262,11 +262,25 @@ public class MCPServerServlet extends HttpServlet {
 					String toolName = tokens[1];
 					String toolSetName = tokens[0];
 
-					return new McpStatelessServerFeatures.SyncToolSpecification(
-						_getTool(httpServletRequest, toolName, toolSetName),
-						(mcpTransportContext, callToolRequest) -> _call(
-							mcpTransportContext, callToolRequest.arguments(),
-							toolName, toolSetName));
+					try {
+						return new McpStatelessServerFeatures.
+							SyncToolSpecification(
+								_getTool(
+									httpServletRequest, toolName, toolSetName),
+								(mcpTransportContext, callToolRequest) -> _call(
+									mcpTransportContext,
+									callToolRequest.arguments(), toolName,
+									toolSetName));
+					}
+					catch (Exception exception) {
+						_log.error(
+							StringBundler.concat(
+								"Skipping MCP tool \"", toolName,
+								"\" from tool set \"", toolSetName, "\""),
+							exception);
+
+						return null;
+					}
 				});
 
 		McpStatelessSyncServer mcpStatelessSyncServer = McpServer.sync(

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
@@ -211,7 +211,7 @@ public class MCPServerServlet extends HttpServlet {
 		List<String> audiences = oAuth2Authorization.getAudiencesList();
 		String mcpResourceURI = StringBundler.concat(
 			_portal.getPortalURL(httpServletRequest), _portal.getPathContext(),
-			Portal.PATH_MODULE, MCPServerConstants.MCP_PATH);
+			Portal.PATH_MODULE, MCPServerConstants.PATH_MCP);
 
 		if ((audiences == null) || !audiences.contains(mcpResourceURI)) {
 			_sendInvalidTokenChallenge(
@@ -552,7 +552,7 @@ public class MCPServerServlet extends HttpServlet {
 				"Bearer realm=\"mcp\", resource_metadata=\"",
 				_portal.getPortalURL(httpServletRequest),
 				_portal.getPathContext(), Portal.PATH_MODULE,
-				MCPServerConstants.WELL_KNOWN_PROTECTED_RESOURCE_PATH, "\", ",
+				MCPServerConstants.PATH_WELL_KNOWN_PROTECTED_RESOURCE, "\", ",
 				"error=\"invalid_token\", error_description=\"", description,
 				"\""));
 		httpServletResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
@@ -569,7 +569,7 @@ public class MCPServerServlet extends HttpServlet {
 				"Bearer realm=\"mcp\", resource_metadata=\"",
 				_portal.getPortalURL(httpServletRequest),
 				_portal.getPathContext(), Portal.PATH_MODULE,
-				MCPServerConstants.WELL_KNOWN_PROTECTED_RESOURCE_PATH, "\""));
+				MCPServerConstants.PATH_WELL_KNOWN_PROTECTED_RESOURCE, "\""));
 		httpServletResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 	}
 

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerServlet.java
@@ -11,6 +11,9 @@ import com.liferay.mcp.server.rest.dto.v1_0.Tool;
 import com.liferay.mcp.server.rest.internal.configuration.MCPServerConfiguration;
 import com.liferay.mcp.server.rest.internal.constants.MCPServerConstants;
 import com.liferay.mcp.server.rest.internal.util.ToolSetUtil;
+import com.liferay.oauth2.provider.constants.OAuth2AuthorizationConstants;
+import com.liferay.oauth2.provider.model.OAuth2Authorization;
+import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
@@ -25,6 +28,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -55,6 +59,7 @@ import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -125,6 +130,10 @@ public class MCPServerServlet extends HttpServlet {
 			return;
 		}
 
+		if (!_authenticate(httpServletRequest, httpServletResponse)) {
+			return;
+		}
+
 		ObjectEntry mcpServerProfileObjectEntry =
 			_getMCPServerProfileObjectEntry(companyId, httpServletRequest);
 
@@ -138,6 +147,84 @@ public class MCPServerServlet extends HttpServlet {
 			httpServletRequest, companyId, mcpServerProfileObjectEntry);
 
 		servlet.service(httpServletRequest, httpServletResponse);
+	}
+
+	private boolean _authenticate(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException {
+
+		String authorization = httpServletRequest.getHeader("Authorization");
+
+		if (Validator.isBlank(authorization)) {
+			_sendUnauthenticatedChallenge(
+				httpServletRequest, httpServletResponse);
+
+			return false;
+		}
+
+		String[] parts = authorization.trim(
+		).split(
+			"\\s+"
+		);
+
+		if ((parts.length != 2) ||
+			!StringUtil.equalsIgnoreCase(parts[0], "Bearer")) {
+
+			_sendInvalidTokenChallenge(
+				httpServletRequest, httpServletResponse,
+				"Authorization header is not a Bearer token");
+
+			return false;
+		}
+
+		String accessToken = parts[1];
+
+		OAuth2Authorization oAuth2Authorization =
+			_oAuth2AuthorizationLocalService.
+				fetchOAuth2AuthorizationByAccessTokenContent(accessToken);
+
+		if ((oAuth2Authorization == null) ||
+			(oAuth2Authorization.getCompanyId() != _portal.getCompanyId(
+				httpServletRequest)) ||
+			OAuth2AuthorizationConstants.ACCESS_TOKEN_CONTENT_EXPIRED_TOKEN.
+				equals(oAuth2Authorization.getAccessTokenContent())) {
+
+			_sendInvalidTokenChallenge(
+				httpServletRequest, httpServletResponse,
+				"Access token is unknown or revoked");
+
+			return false;
+		}
+
+		Date expirationDate =
+			oAuth2Authorization.getAccessTokenExpirationDate();
+
+		if ((expirationDate != null) &&
+			(expirationDate.getTime() < System.currentTimeMillis())) {
+
+			_sendInvalidTokenChallenge(
+				httpServletRequest, httpServletResponse,
+				"Access token has expired");
+
+			return false;
+		}
+
+		String mcpResourceURI =
+			_portal.getPortalURL(httpServletRequest) +
+				_portal.getPathContext() + MCPServerConstants.MCP_PATH;
+
+		List<String> audiences = oAuth2Authorization.getAudiencesList();
+
+		if ((audiences == null) || !audiences.contains(mcpResourceURI)) {
+			_sendInvalidTokenChallenge(
+				httpServletRequest, httpServletResponse,
+				"Access token is not bound to this MCP server");
+
+			return false;
+		}
+
+		return true;
 	}
 
 	private Servlet _buildServlet(
@@ -443,6 +530,38 @@ public class MCPServerServlet extends HttpServlet {
 		}
 	}
 
+	private void _sendInvalidTokenChallenge(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, String description)
+		throws IOException {
+
+		httpServletResponse.setHeader(
+			HttpHeaders.WWW_AUTHENTICATE,
+			StringBundler.concat(
+				"Bearer realm=\"mcp\", resource_metadata=\"",
+				_portal.getPortalURL(httpServletRequest),
+				_portal.getPathContext(),
+				MCPServerConstants.WELL_KNOWN_PROTECTED_RESOURCE_PATH, "\", ",
+				"error=\"invalid_token\", error_description=\"", description,
+				"\""));
+		httpServletResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+	}
+
+	private void _sendUnauthenticatedChallenge(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws IOException {
+
+		httpServletResponse.setHeader(
+			HttpHeaders.WWW_AUTHENTICATE,
+			StringBundler.concat(
+				"Bearer realm=\"mcp\", resource_metadata=\"",
+				_portal.getPortalURL(httpServletRequest),
+				_portal.getPathContext(),
+				MCPServerConstants.WELL_KNOWN_PROTECTED_RESOURCE_PATH, "\""));
+		httpServletResponse.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		MCPServerServlet.class);
 
@@ -450,6 +569,9 @@ public class MCPServerServlet extends HttpServlet {
 
 	@Reference
 	private ConfigurationProvider _configurationProvider;
+
+	@Reference
+	private OAuth2AuthorizationLocalService _oAuth2AuthorizationLocalService;
 
 	@Reference
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/util/ToolSetUtil.java
@@ -338,12 +338,21 @@ public class ToolSetUtil {
 			_getBaseURL(httpServletRequest) + openAPIBrief._basePath +
 				openAPIBrief._openAPIPath,
 			url -> {
+				String content = null;
+
 				try {
-					return JSONFactoryUtil.createJSONObject(
-						_get(httpServletRequest, url));
+					content = _get(httpServletRequest, url);
+
+					return JSONFactoryUtil.createJSONObject(content);
 				}
 				catch (Exception exception) {
-					throw new RuntimeException(exception);
+					throw new RuntimeException(
+						StringBundler.concat(
+							"Unable to read a valid OpenAPI document from \"",
+							url, "\": ",
+							StringUtil.shorten(
+								GetterUtil.getString(content), 200)),
+						exception);
 				}
 			});
 	}

--- a/modules/apps/mcp/mcp-server-rest-test/build.gradle
+++ b/modules/apps/mcp/mcp-server-rest-test/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:batch-engine:batch-engine-test-util")
 	testIntegrationImplementation project(":apps:mcp:mcp-server-rest-api")
 	testIntegrationImplementation project(":apps:mcp:mcp-server-rest-client")
+	testIntegrationImplementation project(":apps:oauth2-provider:oauth2-provider-api")
 	testIntegrationImplementation project(":apps:object:object-api")
 	testIntegrationImplementation project(":apps:object:object-test-util")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerProtectedResourceMetadataServletTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerProtectedResourceMetadataServletTest.java
@@ -53,21 +53,14 @@ public class MCPServerProtectedResourceMetadataServletTest {
 			httpResponse.headers());
 		_assertHeader(
 			"public, max-age=300", "Cache-Control", httpResponse.headers());
-
 		Assert.assertEquals(
 			HttpServletResponse.SC_OK, httpResponse.statusCode());
 
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 			httpResponse.body());
 
-		String portalURL =
-			"http://localhost:" + PortalUtil.getPortalServerPort(false);
-
-		JSONArray authorizationServersJSONArray = jsonObject.getJSONArray(
-			"authorization_servers");
-
 		Assert.assertEquals(
-			portalURL, authorizationServersJSONArray.getString(0));
+			"Liferay MCP Server", jsonObject.getString("resource_name"));
 
 		JSONArray bearerMethodsSupportedJSONArray = jsonObject.getJSONArray(
 			"bearer_methods_supported");
@@ -75,10 +68,17 @@ public class MCPServerProtectedResourceMetadataServletTest {
 		Assert.assertEquals(
 			"header", bearerMethodsSupportedJSONArray.getString(0));
 
+		String portalURL =
+			"http://localhost:" + PortalUtil.getPortalServerPort(false);
+
 		Assert.assertEquals(
 			portalURL + "/o/mcp", jsonObject.getString("resource"));
+
+		JSONArray authorizationServersJSONArray = jsonObject.getJSONArray(
+			"authorization_servers");
+
 		Assert.assertEquals(
-			"Liferay MCP Server", jsonObject.getString("resource_name"));
+			portalURL, authorizationServersJSONArray.getString(0));
 
 		httpResponse = _send("HEAD");
 
@@ -101,14 +101,12 @@ public class MCPServerProtectedResourceMetadataServletTest {
 			StringPool.STAR, "Access-Control-Allow-Origin",
 			httpResponse.headers());
 		_assertHeader("300", "Access-Control-Max-Age", httpResponse.headers());
-
 		Assert.assertEquals(
 			HttpServletResponse.SC_NO_CONTENT, httpResponse.statusCode());
 
 		httpResponse = _send("POST");
 
 		_assertHeader("GET, HEAD, OPTIONS", "Allow", httpResponse.headers());
-
 		Assert.assertEquals(
 			HttpServletResponse.SC_METHOD_NOT_ALLOWED,
 			httpResponse.statusCode());

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerProtectedResourceMetadataServletTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerProtectedResourceMetadataServletTest.java
@@ -1,0 +1,109 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.mcp.server.rest.internal.servlet.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Christopher Kian
+ */
+@FeatureFlag("LPD-63415")
+@RunWith(Arquillian.class)
+public class MCPServerProtectedResourceMetadataServletTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testServiceWithGet() throws Exception {
+		Http.Options options = new Http.Options();
+
+		options.setLocation(_getURL());
+
+		String body = _http.URLtoString(options);
+
+		Http.Response response = options.getResponse();
+
+		Assert.assertEquals(200, response.getResponseCode());
+
+		Assert.assertTrue(
+			response.getContentType(),
+			response.getContentType(
+			).contains(
+				"application/json"
+			));
+		Assert.assertEquals(
+			"public, max-age=300",
+			response.getHeader(HttpHeaders.CACHE_CONTROL));
+		Assert.assertEquals(
+			"*", response.getHeader("Access-Control-Allow-Origin"));
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(body);
+
+		String portalURL =
+			"http://localhost:" + PortalUtil.getPortalServerPort(false);
+
+		JSONArray authorizationServersJSONArray = jsonObject.getJSONArray(
+			"authorization_servers");
+
+		Assert.assertEquals(
+			portalURL, authorizationServersJSONArray.getString(0));
+
+		JSONArray bearerMethodsSupportedJSONArray = jsonObject.getJSONArray(
+			"bearer_methods_supported");
+
+		Assert.assertEquals(
+			"header", bearerMethodsSupportedJSONArray.getString(0));
+
+		Assert.assertEquals(
+			portalURL + "/o/mcp", jsonObject.getString("resource"));
+		Assert.assertEquals(
+			"Liferay MCP Server", jsonObject.getString("resource_name"));
+	}
+
+	@Test
+	public void testServiceWithPost() throws Exception {
+		Http.Options options = new Http.Options();
+
+		options.setLocation(_getURL());
+		options.setPost(true);
+
+		_http.URLtoString(options);
+
+		Http.Response response = options.getResponse();
+
+		Assert.assertEquals(405, response.getResponseCode());
+
+		Assert.assertEquals("GET, HEAD, OPTIONS", response.getHeader("Allow"));
+	}
+
+	private String _getURL() {
+		return "http://localhost:" + PortalUtil.getPortalServerPort(false) +
+			"/o/.well-known/oauth-protected-resource";
+	}
+
+	@Inject
+	private Http _http;
+
+}

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerProtectedResourceMetadataServletTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerProtectedResourceMetadataServletTest.java
@@ -6,16 +6,25 @@
 package com.liferay.mcp.server.rest.internal.servlet.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
-import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
-import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -36,30 +45,20 @@ public class MCPServerProtectedResourceMetadataServletTest {
 		new LiferayIntegrationTestRule();
 
 	@Test
-	public void testServiceWithGet() throws Exception {
-		Http.Options options = new Http.Options();
+	public void testService() throws Exception {
+		HttpResponse<String> httpResponse = _send("GET");
 
-		options.setLocation(_getURL());
+		_assertHeader(
+			StringPool.STAR, "Access-Control-Allow-Origin",
+			httpResponse.headers());
+		_assertHeader(
+			"public, max-age=300", "Cache-Control", httpResponse.headers());
 
-		String body = _http.URLtoString(options);
-
-		Http.Response response = options.getResponse();
-
-		Assert.assertEquals(200, response.getResponseCode());
-
-		Assert.assertTrue(
-			response.getContentType(),
-			response.getContentType(
-			).contains(
-				"application/json"
-			));
 		Assert.assertEquals(
-			"public, max-age=300",
-			response.getHeader(HttpHeaders.CACHE_CONTROL));
-		Assert.assertEquals(
-			"*", response.getHeader("Access-Control-Allow-Origin"));
+			HttpServletResponse.SC_OK, httpResponse.statusCode());
 
-		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(body);
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			httpResponse.body());
 
 		String portalURL =
 			"http://localhost:" + PortalUtil.getPortalServerPort(false);
@@ -80,30 +79,69 @@ public class MCPServerProtectedResourceMetadataServletTest {
 			portalURL + "/o/mcp", jsonObject.getString("resource"));
 		Assert.assertEquals(
 			"Liferay MCP Server", jsonObject.getString("resource_name"));
+
+		httpResponse = _send("HEAD");
+
+		_assertHeader(
+			"public, max-age=300", "Cache-Control", httpResponse.headers());
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_OK, httpResponse.statusCode());
+		Assert.assertEquals(StringPool.BLANK, httpResponse.body());
+
+		httpResponse = _send("OPTIONS");
+
+		_assertHeader(
+			"Authorization, Content-Type, MCP-Protocol-Version",
+			"Access-Control-Allow-Headers", httpResponse.headers());
+		_assertHeader(
+			"GET, HEAD, OPTIONS", "Access-Control-Allow-Methods",
+			httpResponse.headers());
+		_assertHeader(
+			StringPool.STAR, "Access-Control-Allow-Origin",
+			httpResponse.headers());
+		_assertHeader("300", "Access-Control-Max-Age", httpResponse.headers());
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_NO_CONTENT, httpResponse.statusCode());
+
+		httpResponse = _send("POST");
+
+		_assertHeader("GET, HEAD, OPTIONS", "Allow", httpResponse.headers());
+
+		Assert.assertEquals(
+			HttpServletResponse.SC_METHOD_NOT_ALLOWED,
+			httpResponse.statusCode());
 	}
 
-	@Test
-	public void testServiceWithPost() throws Exception {
-		Http.Options options = new Http.Options();
+	private void _assertHeader(
+		String expectedHeaderValue, String headerName,
+		HttpHeaders httpHeaders) {
 
-		options.setLocation(_getURL());
-		options.setPost(true);
+		Map<String, List<String>> map = httpHeaders.map();
 
-		_http.URLtoString(options);
+		List<String> headerValues = map.get(headerName);
 
-		Http.Response response = options.getResponse();
-
-		Assert.assertEquals(405, response.getResponseCode());
-
-		Assert.assertEquals("GET, HEAD, OPTIONS", response.getHeader("Allow"));
+		Assert.assertEquals(expectedHeaderValue, headerValues.get(0));
 	}
 
-	private String _getURL() {
-		return "http://localhost:" + PortalUtil.getPortalServerPort(false) +
-			"/o/.well-known/oauth-protected-resource";
+	private HttpResponse<String> _send(String method) throws Exception {
+		return _httpClient.send(
+			HttpRequest.newBuilder(
+			).uri(
+				URI.create(
+					"http://localhost:" +
+						PortalUtil.getPortalServerPort(false) +
+							"/o/.well-known/oauth-protected-resource")
+			).method(
+				method, HttpRequest.BodyPublishers.noBody()
+			).build(),
+			HttpResponse.BodyHandlers.ofString());
 	}
 
-	@Inject
-	private Http _http;
+	private final HttpClient _httpClient = HttpClient.newBuilder(
+	).followRedirects(
+		HttpClient.Redirect.NEVER
+	).build();
 
 }

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerServletTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerServletTest.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.batch.engine.test.util.BatchEngineTestUtil;
+import com.liferay.oauth2.provider.model.OAuth2Authorization;
+import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
@@ -19,6 +21,7 @@ import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.HTTPTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -29,8 +32,8 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -42,10 +45,9 @@ import io.modelcontextprotocol.spec.McpSchema;
 
 import java.io.Serializable;
 
-import java.nio.charset.StandardCharsets;
-
-import java.util.Base64;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 
 import org.junit.After;
@@ -84,11 +86,140 @@ public class MCPServerServletTest {
 					"definition",
 				".com.liferay.mcp.server.rest.internal.batch.03.object.entry"
 			});
+
+		_accessTokenContent = RandomTestUtil.randomString();
+
+		_addOAuth2Authorization(
+			_accessTokenContent,
+			new Date(System.currentTimeMillis() + Time.HOUR),
+			Collections.singletonList(_getMCPURL()));
 	}
 
 	@After
 	public void tearDown() throws Exception {
-		_updateMCPServerConfiguration(false);
+		try {
+			for (OAuth2Authorization oAuth2Authorization :
+					_oAuth2Authorizations) {
+
+				_oAuth2AuthorizationLocalService.deleteOAuth2Authorization(
+					oAuth2Authorization);
+			}
+
+			_oAuth2Authorizations.clear();
+		}
+		finally {
+			_updateMCPServerConfiguration(false);
+		}
+	}
+
+	@Test
+	public void testServiceWhenAccessTokenAudienceIsNotBound()
+		throws Exception {
+
+		String accessTokenContent = RandomTestUtil.randomString();
+
+		_addOAuth2Authorization(
+			accessTokenContent,
+			new Date(System.currentTimeMillis() + Time.HOUR),
+			Collections.singletonList("http://localhost/o/other-resource"));
+
+		Http.Response response = _getResponse("Bearer " + accessTokenContent);
+
+		Assert.assertEquals(401, response.getResponseCode());
+
+		String wwwAuthenticate = response.getHeader(
+			HttpHeaders.WWW_AUTHENTICATE);
+
+		Assert.assertTrue(
+			wwwAuthenticate,
+			wwwAuthenticate.contains("error=\"invalid_token\""));
+		Assert.assertTrue(
+			wwwAuthenticate,
+			wwwAuthenticate.contains(
+				"error_description=\"Access token is not bound to this MCP " +
+					"server\""));
+	}
+
+	@Test
+	public void testServiceWhenAccessTokenIsExpired() throws Exception {
+		String accessTokenContent = RandomTestUtil.randomString();
+
+		_addOAuth2Authorization(
+			accessTokenContent,
+			new Date(System.currentTimeMillis() - Time.HOUR),
+			Collections.singletonList(_getMCPURL()));
+
+		Http.Response response = _getResponse("Bearer " + accessTokenContent);
+
+		Assert.assertEquals(401, response.getResponseCode());
+
+		String wwwAuthenticate = response.getHeader(
+			HttpHeaders.WWW_AUTHENTICATE);
+
+		Assert.assertTrue(
+			wwwAuthenticate,
+			wwwAuthenticate.contains("error=\"invalid_token\""));
+		Assert.assertTrue(
+			wwwAuthenticate,
+			wwwAuthenticate.contains(
+				"error_description=\"Access token has expired\""));
+	}
+
+	@Test
+	public void testServiceWhenAccessTokenIsUnknown() throws Exception {
+		Http.Response response = _getResponse(
+			"Bearer " + RandomTestUtil.randomString());
+
+		Assert.assertEquals(401, response.getResponseCode());
+
+		String wwwAuthenticate = response.getHeader(
+			HttpHeaders.WWW_AUTHENTICATE);
+
+		Assert.assertTrue(
+			wwwAuthenticate,
+			wwwAuthenticate.contains("error=\"invalid_token\""));
+		Assert.assertTrue(
+			wwwAuthenticate,
+			wwwAuthenticate.contains(
+				"error_description=\"Access token is unknown or revoked\""));
+	}
+
+	@Test
+	public void testServiceWhenAuthorizationHeaderIsMissing() throws Exception {
+		Http.Response response = _getResponse(null);
+
+		Assert.assertEquals(401, response.getResponseCode());
+
+		String wwwAuthenticate = response.getHeader(
+			HttpHeaders.WWW_AUTHENTICATE);
+
+		Assert.assertTrue(
+			wwwAuthenticate,
+			wwwAuthenticate.startsWith("Bearer realm=\"mcp\""));
+		Assert.assertTrue(
+			wwwAuthenticate, wwwAuthenticate.contains("resource_metadata="));
+		Assert.assertFalse(wwwAuthenticate, wwwAuthenticate.contains("error="));
+	}
+
+	@Test
+	public void testServiceWhenAuthorizationHeaderIsNotBearer()
+		throws Exception {
+
+		Http.Response response = _getResponse("Basic dGVzdDp0ZXN0");
+
+		Assert.assertEquals(401, response.getResponseCode());
+
+		String wwwAuthenticate = response.getHeader(
+			HttpHeaders.WWW_AUTHENTICATE);
+
+		Assert.assertTrue(
+			wwwAuthenticate,
+			wwwAuthenticate.contains("error=\"invalid_token\""));
+		Assert.assertTrue(
+			wwwAuthenticate,
+			wwwAuthenticate.contains(
+				"error_description=\"Authorization header is not a Bearer " +
+					"token\""));
 	}
 
 	@Test
@@ -451,6 +582,23 @@ public class MCPServerServletTest {
 		mcpSyncClient.closeGracefully();
 	}
 
+	private OAuth2Authorization _addOAuth2Authorization(
+			String accessTokenContent, Date accessTokenExpirationDate,
+			List<String> audiencesList)
+		throws Exception {
+
+		OAuth2Authorization oAuth2Authorization =
+			_oAuth2AuthorizationLocalService.addOAuth2Authorization(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				"test@liferay.com", 0, 0, accessTokenContent, new Date(),
+				accessTokenExpirationDate, audiencesList, "localhost",
+				"127.0.0.1", null, null, null);
+
+		_oAuth2Authorizations.add(oAuth2Authorization);
+
+		return oAuth2Authorization;
+	}
+
 	private ObjectEntry _addObjectEntry(String name, String... tools)
 		throws Exception {
 
@@ -493,16 +641,7 @@ public class MCPServerServletTest {
 	}
 
 	private String _getAuthorization() {
-		Base64.Encoder encoder = Base64.getEncoder();
-
-		String userNameAndPassword =
-			"test@liferay.com:" + PropsValues.DEFAULT_ADMIN_PASSWORD;
-
-		return "Basic " +
-			new String(
-				encoder.encode(
-					userNameAndPassword.getBytes(StandardCharsets.UTF_8)),
-				StandardCharsets.UTF_8);
+		return "Bearer " + _accessTokenContent;
 	}
 
 	private McpSyncClient _getMcpSyncClient(String profileName) {
@@ -523,6 +662,25 @@ public class MCPServerServletTest {
 		).build();
 	}
 
+	private String _getMCPURL() {
+		return "http://localhost:" + PortalUtil.getPortalServerPort(false) +
+			"/o/mcp";
+	}
+
+	private Http.Response _getResponse(String authorization) throws Exception {
+		Http.Options options = new Http.Options();
+
+		if (authorization != null) {
+			options.addHeader("Authorization", authorization);
+		}
+
+		options.setLocation(_getMCPURL());
+
+		_http.URLtoString(options);
+
+		return options.getResponse();
+	}
+
 	private void _updateMCPServerConfiguration(boolean enabled)
 		throws Exception {
 
@@ -536,8 +694,16 @@ public class MCPServerServletTest {
 			).build());
 	}
 
+	private String _accessTokenContent;
+
 	@Inject
 	private Http _http;
+
+	@Inject
+	private OAuth2AuthorizationLocalService _oAuth2AuthorizationLocalService;
+
+	private final List<OAuth2Authorization> _oAuth2Authorizations =
+		new ArrayList<>();
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerServletTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerServletTest.java
@@ -121,23 +121,11 @@ public class MCPServerServletTest {
 		_addOAuth2Authorization(
 			accessTokenContent,
 			new Date(System.currentTimeMillis() + Time.HOUR),
-			Collections.singletonList("http://localhost/o/other-resource"));
+			Collections.singletonList(RandomTestUtil.randomString()));
 
-		Http.Response response = _getResponse("Bearer " + accessTokenContent);
-
-		Assert.assertEquals(401, response.getResponseCode());
-
-		String wwwAuthenticate = response.getHeader(
-			HttpHeaders.WWW_AUTHENTICATE);
-
-		Assert.assertTrue(
-			wwwAuthenticate,
-			wwwAuthenticate.contains("error=\"invalid_token\""));
-		Assert.assertTrue(
-			wwwAuthenticate,
-			wwwAuthenticate.contains(
-				"error_description=\"Access token is not bound to this MCP " +
-					"server\""));
+		_assertInvalidTokenChallenge(
+			_getResponse("Bearer " + accessTokenContent),
+			"Access token is not bound to this MCP server");
 	}
 
 	@Test
@@ -149,39 +137,16 @@ public class MCPServerServletTest {
 			new Date(System.currentTimeMillis() - Time.HOUR),
 			Collections.singletonList(_getMCPURL()));
 
-		Http.Response response = _getResponse("Bearer " + accessTokenContent);
-
-		Assert.assertEquals(401, response.getResponseCode());
-
-		String wwwAuthenticate = response.getHeader(
-			HttpHeaders.WWW_AUTHENTICATE);
-
-		Assert.assertTrue(
-			wwwAuthenticate,
-			wwwAuthenticate.contains("error=\"invalid_token\""));
-		Assert.assertTrue(
-			wwwAuthenticate,
-			wwwAuthenticate.contains(
-				"error_description=\"Access token has expired\""));
+		_assertInvalidTokenChallenge(
+			_getResponse("Bearer " + accessTokenContent),
+			"Access token has expired");
 	}
 
 	@Test
 	public void testServiceWhenAccessTokenIsUnknown() throws Exception {
-		Http.Response response = _getResponse(
-			"Bearer " + RandomTestUtil.randomString());
-
-		Assert.assertEquals(401, response.getResponseCode());
-
-		String wwwAuthenticate = response.getHeader(
-			HttpHeaders.WWW_AUTHENTICATE);
-
-		Assert.assertTrue(
-			wwwAuthenticate,
-			wwwAuthenticate.contains("error=\"invalid_token\""));
-		Assert.assertTrue(
-			wwwAuthenticate,
-			wwwAuthenticate.contains(
-				"error_description=\"Access token is unknown or revoked\""));
+		_assertInvalidTokenChallenge(
+			_getResponse("Bearer " + RandomTestUtil.randomString()),
+			"Access token is unknown or revoked");
 	}
 
 	@Test
@@ -205,21 +170,9 @@ public class MCPServerServletTest {
 	public void testServiceWhenAuthorizationHeaderIsNotBearer()
 		throws Exception {
 
-		Http.Response response = _getResponse("Basic dGVzdDp0ZXN0");
-
-		Assert.assertEquals(401, response.getResponseCode());
-
-		String wwwAuthenticate = response.getHeader(
-			HttpHeaders.WWW_AUTHENTICATE);
-
-		Assert.assertTrue(
-			wwwAuthenticate,
-			wwwAuthenticate.contains("error=\"invalid_token\""));
-		Assert.assertTrue(
-			wwwAuthenticate,
-			wwwAuthenticate.contains(
-				"error_description=\"Authorization header is not a Bearer " +
-					"token\""));
+		_assertInvalidTokenChallenge(
+			_getResponse(RandomTestUtil.randomString()),
+			"Authorization header is not a Bearer token");
 	}
 
 	@Test
@@ -590,9 +543,11 @@ public class MCPServerServletTest {
 		OAuth2Authorization oAuth2Authorization =
 			_oAuth2AuthorizationLocalService.addOAuth2Authorization(
 				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
-				"test@liferay.com", 0, 0, accessTokenContent, new Date(),
-				accessTokenExpirationDate, audiencesList, "localhost",
-				"127.0.0.1", null, null, null);
+				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+				RandomTestUtil.randomLong(), accessTokenContent, new Date(),
+				accessTokenExpirationDate, audiencesList,
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				null, null, null);
 
 		_oAuth2Authorizations.add(oAuth2Authorization);
 
@@ -620,6 +575,23 @@ public class MCPServerServletTest {
 				"tools", StringUtil.merge(tools, "\n")
 			).build(),
 			ServiceContextTestUtil.getServiceContext());
+	}
+
+	private void _assertInvalidTokenChallenge(
+		Http.Response response, String description) {
+
+		Assert.assertEquals(401, response.getResponseCode());
+
+		String wwwAuthenticate = response.getHeader(
+			HttpHeaders.WWW_AUTHENTICATE);
+
+		Assert.assertTrue(
+			wwwAuthenticate,
+			wwwAuthenticate.contains("error=\"invalid_token\""));
+		Assert.assertTrue(
+			wwwAuthenticate,
+			wwwAuthenticate.contains(
+				"error_description=\"" + description + "\""));
 	}
 
 	private void _assertTool(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91332

## What Is Being Fixed

The MCP server's streamable HTTP endpoint accepted any authenticated portal session and exposed no OAuth metadata, so an MCP client had no standards-based way to discover how to obtain a token or to confirm its token was bound to this resource. The endpoint also failed opaquely when a tool set's OpenAPI document could not be fetched.

## How It Is Being Fixed

The MCP servlet now requires an OAuth 2.0 Bearer access token and rejects requests whose token is missing, malformed, unknown, expired, or not audience-bound to the MCP resource, answering each rejection with an RFC 9728 WWW-Authenticate challenge that points at the protected-resource metadata. A companion servlet publishes that metadata at /.well-known/oauth-protected-resource and honors the MCP-Protocol-Version header on discovery preflights. Tool registration now logs and skips a tool set whose OpenAPI document cannot be read instead of failing the whole request. The path constants lead with their PATH group prefix to match Portal.PATH_*.

## PR Check

**pr-check: PASS** — tested on `bc96aa1dbc27bb815f3842a419702c98b4d0697c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "bc96aa1dbc27bb815f3842a419702c98b4d0697c"} -->
