### PR TITLE
LPD-95987 Avoid caching the PwdModifiedFilter logout redirect

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilter.java
@@ -10,6 +10,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -39,6 +40,10 @@ public class PasswordModifiedFilter extends BasePortalFilter {
 
 		if (!requestPath.equals("/c/portal/logout") &&
 			_isPasswordModified(httpServletRequest)) {
+
+			httpServletResponse.setHeader(
+				HttpHeaders.CACHE_CONTROL,
+				HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE);
 
 			httpServletResponse.sendRedirect(
 				PortalUtil.getPathMain() + "/portal/logout");

--- a/portal-impl/test/unit/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilterTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/servlet/filters/password/modified/PasswordModifiedFilterTest.java
@@ -5,14 +5,23 @@
 
 package com.liferay.portal.servlet.filters.password.modified;
 
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.servlet.HttpHeaders;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ProxyFactory;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.util.PortalImpl;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+import java.util.Date;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -68,6 +77,103 @@ public class PasswordModifiedFilterTest {
 
 		Mockito.verify(
 			filterChain
+		).doFilter(
+			Mockito.any(), Mockito.any()
+		);
+	}
+
+	@Test
+	public void testProcessFilterWhenPasswordModified() throws Exception {
+		User user = Mockito.mock(User.class);
+
+		Mockito.when(
+			user.getPasswordModifiedDate()
+		).thenReturn(
+			new Date()
+		);
+
+		long userId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			user.getUserId()
+		).thenReturn(
+			userId
+		);
+
+		PortalUtil portalUtil = new PortalUtil();
+
+		portalUtil.setPortal(
+			new PortalImpl() {
+
+				@Override
+				public String getPathContext() {
+					return StringPool.BLANK;
+				}
+
+				@Override
+				public String getPathMain() {
+					return "/c";
+				}
+
+				@Override
+				public User getUser(HttpServletRequest httpServletRequest) {
+					return user;
+				}
+
+			});
+
+		HttpSession httpSession = Mockito.mock(HttpSession.class);
+
+		Mockito.when(
+			httpSession.getAttribute(WebKeys.USER_ID)
+		).thenReturn(
+			userId
+		);
+
+		PasswordModifiedFilter passwordModifiedFilter =
+			new PasswordModifiedFilter();
+
+		HttpServletResponse httpServletResponse = Mockito.mock(
+			HttpServletResponse.class);
+
+		FilterChain filterChain = Mockito.mock(FilterChain.class);
+
+		passwordModifiedFilter.processFilter(
+			new HttpServletRequestWrapper(
+				ProxyFactory.newDummyInstance(HttpServletRequest.class)) {
+
+				@Override
+				public String getRequestURI() {
+					return "/combo";
+				}
+
+				@Override
+				public HttpSession getSession(boolean create) {
+					return httpSession;
+				}
+
+				@Override
+				public boolean isRequestedSessionIdValid() {
+					return true;
+				}
+
+			},
+			httpServletResponse, filterChain);
+
+		Mockito.verify(
+			httpServletResponse
+		).setHeader(
+			HttpHeaders.CACHE_CONTROL, HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE
+		);
+
+		Mockito.verify(
+			httpServletResponse
+		).sendRedirect(
+			"/c/portal/logout"
+		);
+
+		Mockito.verify(
+			filterChain, Mockito.never()
 		).doFilter(
 			Mockito.any(), Mockito.any()
 		);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-95987

## What Is Being Fixed

When a user whose p******d was modified requests an otherwise cacheable static resource (for example under `/combo` or `/o`), the header filter sets `Cache-Control: public, max-age=315360000` before PwdModifiedFilter redirects the request to `/c/portal/logout`. `sendRedirect` does not clear that header, so the 302 response carries a long-lived public cache directive — CDNs and proxies then cache the redirect and log out every user that requests the same resource.

## How It Is Being Fixed

PwdModifiedFilter now overrides the response with `Cache-Control: private, no-cache, no-store, must-revalidate` before issuing the logout redirect, so the 302 is not cacheable (`no-store` supersedes the existing `Expires` per RFC 7234). A unit test covers the no-cache header and the redirect.

## PR Check

**pr-check: SKIPPED** — Running pr-check separately right after PR creation.

<!-- pr-check {"reason": "Running pr-check separately right after PR creation.", "result": "skipped", "sha": "21e7c67b7d8ed231d0e799a2b46dda259a8eb71e"} -->
