### PR TITLE
LPD-88765 Follow Up - Evaluate cookie consent when the cookie manager is disabled

### DIFF
--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/consent/DefaultCookiesConsentChecker.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/consent/DefaultCookiesConsentChecker.java
@@ -38,14 +38,6 @@ public class DefaultCookiesConsentChecker implements CookiesConsentChecker {
 			return true;
 		}
 
-		String consentCookieValue = CookiesManagerUtil.getCookieValue(
-			CookiesConstants.getConsentTypeName(consentType),
-			httpServletRequest);
-
-		if (Validator.isNotNull(consentCookieValue)) {
-			return GetterUtil.getBoolean(consentCookieValue);
-		}
-
 		try {
 			CookiesPreferenceHandlingConfiguration
 				cookiesPreferenceHandlingConfiguration = null;
@@ -70,6 +62,18 @@ public class DefaultCookiesConsentChecker implements CookiesConsentChecker {
 				cookiesPreferenceHandlingConfiguration =
 					_configurationProvider.getSystemConfiguration(
 						CookiesPreferenceHandlingConfiguration.class);
+			}
+
+			if (!cookiesPreferenceHandlingConfiguration.enabled()) {
+				return true;
+			}
+
+			String consentCookieValue = CookiesManagerUtil.getCookieValue(
+				CookiesConstants.getConsentTypeName(consentType),
+				httpServletRequest);
+
+			if (Validator.isNotNull(consentCookieValue)) {
+				return GetterUtil.getBoolean(consentCookieValue);
 			}
 
 			return !cookiesPreferenceHandlingConfiguration.

--- a/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
+++ b/modules/apps/cookies/cookies-impl/src/main/java/com/liferay/cookies/internal/manager/CookiesManagerImpl.java
@@ -152,7 +152,8 @@ public class CookiesManagerImpl implements CookiesManager {
 				_deleteCookieConsentCookies(
 					httpServletRequest, httpServletResponse);
 			}
-			else if (!hasConsentType(consentType, httpServletRequest)) {
+
+			if (!hasConsentType(consentType, httpServletRequest)) {
 				return false;
 			}
 		}

--- a/modules/apps/cookies/cookies-test/src/testIntegration/java/com/liferay/cookies/internal/consent/test/DefaultCookiesConsentCheckerTest.java
+++ b/modules/apps/cookies/cookies-test/src/testIntegration/java/com/liferay/cookies/internal/consent/test/DefaultCookiesConsentCheckerTest.java
@@ -48,16 +48,27 @@ public class DefaultCookiesConsentCheckerTest {
 				CookiesConstants.CONSENT_TYPE_NECESSARY,
 				_createMockHttpServletRequest()));
 
-		MockHttpServletRequest mockHttpServletRequest =
-			_createMockHttpServletRequest();
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						CookiesPreferenceHandlingConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"enabled", true
+						).build())) {
 
-		mockHttpServletRequest.setCookies(
-			new Cookie(CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL, "true"));
+			MockHttpServletRequest mockHttpServletRequest =
+				_createMockHttpServletRequest();
 
-		Assert.assertTrue(
-			cookiesConsentChecker.hasConsent(
-				CookiesConstants.CONSENT_TYPE_FUNCTIONAL,
-				mockHttpServletRequest));
+			mockHttpServletRequest.setCookies(
+				new Cookie(
+					CookiesConstants.NAME_CONSENT_TYPE_FUNCTIONAL, "true"));
+
+			Assert.assertTrue(
+				cookiesConsentChecker.hasConsent(
+					CookiesConstants.CONSENT_TYPE_FUNCTIONAL,
+					mockHttpServletRequest));
+		}
 
 		try (CompanyConfigurationTemporarySwapper
 				companyConfigurationTemporarySwapper =
@@ -65,6 +76,8 @@ public class DefaultCookiesConsentCheckerTest {
 						TestPropsValues.getCompanyId(),
 						CookiesPreferenceHandlingConfiguration.class.getName(),
 						HashMapDictionaryBuilder.<String, Object>put(
+							"enabled", true
+						).put(
 							"explicitConsentMode", false
 						).build())) {
 
@@ -80,6 +93,8 @@ public class DefaultCookiesConsentCheckerTest {
 						TestPropsValues.getCompanyId(),
 						CookiesPreferenceHandlingConfiguration.class.getName(),
 						HashMapDictionaryBuilder.<String, Object>put(
+							"enabled", true
+						).put(
 							"explicitConsentMode", true
 						).build())) {
 
@@ -88,6 +103,11 @@ public class DefaultCookiesConsentCheckerTest {
 					CookiesConstants.CONSENT_TYPE_FUNCTIONAL,
 					_createMockHttpServletRequest()));
 		}
+
+		Assert.assertTrue(
+			cookiesConsentChecker.hasConsent(
+				CookiesConstants.CONSENT_TYPE_FUNCTIONAL,
+				_createMockHttpServletRequest()));
 	}
 
 	private MockHttpServletRequest _createMockHttpServletRequest()

--- a/modules/test/playwright/tests/consent-management-platform-integration/main/consentManagementPlatformConsentMappingScript.spec.ts
+++ b/modules/test/playwright/tests/consent-management-platform-integration/main/consentManagementPlatformConsentMappingScript.spec.ts
@@ -5,49 +5,27 @@
 
 import {Page, expect, mergeTests} from '@playwright/test';
 
-import {consentManagerConfigurationPageTest} from '../../../fixtures/consentManagerConfigurationPageTest';
 import {loginTest} from '../../../fixtures/loginTest';
-import {systemSettingsPageTest} from '../../../fixtures/systemSettingsPageTest';
 import {SiteSettingsPage} from '../../../pages/site-admin-web/SiteSettingsPage';
-import {clickAndExpectToBeHidden} from '../../../utils/clickAndExpectToBeHidden';
 import performLogin, {performLogout} from '../../../utils/performLogin';
 import {waitForAlert} from '../../../utils/waitForAlert';
-import {
-	resetConsentManagerConfiguration,
-	updateConsentManagerConfiguration,
-} from '../../cookies-banner-web/main/utils/consentManagerConfigurationHelper';
 
-const test = mergeTests(
-	consentManagerConfigurationPageTest,
-	loginTest(),
-	systemSettingsPageTest
-);
+const test = mergeTests(loginTest());
 
-test.beforeEach(async ({page}) => {
-	await updateConsentManagerConfiguration(page, {
-		enabled: true,
-		forceReload: true,
-	});
-
-	await acceptCookiesBanner(page);
-
-	await setCMPEnabled(page, true);
-});
-
-test.afterEach(async ({page, systemSettingsPage}) => {
+test.afterEach(async ({page}) => {
 	if (await page.getByRole('button', {name: 'Sign In'}).isVisible()) {
 		await performLogin(page, 'test');
 	}
 
 	await setCMPEnabled(page, false);
-
-	await resetConsentManagerConfiguration(systemSettingsPage);
 });
 
 test(
 	'Sign-in does not set the REMEMBER_ME cookie when functional consent is denied via the third-party CMP',
 	{tag: '@LPD-88765'},
 	async ({page}) => {
+		await setCMPEnabled(page, true);
+
 		await signInWithConsentState(page, {CONSENT_TYPE_FUNCTIONAL: false});
 
 		const cookies = await page.context().cookies();
@@ -62,6 +40,8 @@ test(
 	'Sign-in sets the REMEMBER_ME cookie when functional consent is granted via the third-party CMP',
 	{tag: '@LPD-88765'},
 	async ({page}) => {
+		await setCMPEnabled(page, true);
+
 		await signInWithConsentState(page, {CONSENT_TYPE_FUNCTIONAL: true});
 
 		const cookies = await page.context().cookies();
@@ -76,6 +56,8 @@ test(
 	'Necessary consent is honored even when the third-party CMP denies all consent',
 	{tag: '@LPD-88765'},
 	async ({page}) => {
+		await setCMPEnabled(page, true);
+
 		await signInWithConsentState(page, {
 			CONSENT_TYPE_FUNCTIONAL: false,
 			CONSENT_TYPE_NECESSARY: false,
@@ -99,6 +81,8 @@ test(
 	'Consent is granted when the third-party CMP sets no consent-state cookie',
 	{tag: '@LPD-88765'},
 	async ({page}) => {
+		await setCMPEnabled(page, true);
+
 		await signInWithConsentState(page, null);
 
 		const cookies = await page.context().cookies();
@@ -113,6 +97,8 @@ test(
 	'Consent is granted when the consent type is absent from the consent state',
 	{tag: '@LPD-88765'},
 	async ({page}) => {
+		await setCMPEnabled(page, true);
+
 		await signInWithConsentState(page, {CONSENT_TYPE_NECESSARY: true});
 
 		const cookies = await page.context().cookies();
@@ -127,6 +113,8 @@ test(
 	'Consent is granted when the consent state is malformed',
 	{tag: '@LPD-88765'},
 	async ({page}) => {
+		await setCMPEnabled(page, true);
+
 		await signInWithConsentState(page, 'not-json');
 
 		const cookies = await page.context().cookies();
@@ -137,13 +125,6 @@ test(
 	}
 );
 
-async function acceptCookiesBanner(page: Page) {
-	await clickAndExpectToBeHidden({
-		target: page.locator('div[role="dialog"][aria-modal="true"]'),
-		trigger: page.getByRole('button', {name: 'Accept All'}),
-	});
-}
-
 async function setCMPEnabled(page: Page, enabled: boolean) {
 	const siteSettingsPage = new SiteSettingsPage(page);
 
@@ -151,8 +132,6 @@ async function setCMPEnabled(page: Page, enabled: boolean) {
 		'Privacy',
 		'Third Party Consent Management Platform'
 	);
-
-	await acceptCookiesBanner(page);
 
 	await page
 		.getByLabel('Consent Management Platform Provider Name', {exact: true})


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-88765

## What Is Being Fixed

When a portal uses a third-party Consent Management Platform (CMP) instead of Liferay's own cookie manager, backend-set cookies were written without consulting the user's CMP consent. `CookiesManagerImpl.addCookie` only evaluated consent (`hasConsentType`) when Liferay's own cookie manager (`CookiesPreferenceHandlingConfiguration`) was enabled — and a CMP deployment leaves that manager disabled — so the consent resolver, and the CMP checker behind it, were never reached.

## How It Is Being Fixed

`addCookie` now always delegates to `hasConsentType` regardless of whether Liferay's cookie manager is enabled, letting the consent-checker resolver decide which manager answers. The "Liferay manager disabled means allow all" rule moved into the Liferay-manager checker (`DefaultCookiesConsentChecker`), so the two cookie managers share no logic in this path: when a CMP is active the resolver routes to the CMP checker (which reads the consent-state cookie), and when only Liferay's manager is active its checker applies the existing consent-cookie / explicit-consent-mode logic. The `DefaultCookiesConsentChecker` integration test was updated to enable the manager where it exercises that logic and to add a disabled-allows-all assertion; the CMP Playwright spec was reworked to run with the Liferay manager disabled and the CMP enabled — the realistic deployment that actually exercises the fix.

## PR Check

**pr-check: PASS** — tested on `3b7b23f36edd094f1afa8d0fe4c1998d5a01939c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "3b7b23f36edd094f1afa8d0fe4c1998d5a01939c"} -->
