### PR TITLE
LPD-94237 Fix unsafe JNDI referral handling in LDAP connections

### DIFF
--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -11353,7 +11353,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank.
 ldap-import-configuration-name=Import
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option.
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered.
 ldap-server-configuration-name=Servers
 ldap-server-id=LDAP Server ID
 ldap-servers=LDAP Servers

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -11353,6 +11353,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank.
 ldap-import-configuration-name=Import
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option.
 ldap-server-configuration-name=Servers
 ldap-server-id=LDAP Server ID
 ldap-servers=LDAP Servers

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=لا يتم استيراد سمة الاسم بالكامل إلا عندما يكون الاسم الأول أو اسم العائلة فارغًا فقط.
 ldap-import-configuration-name=استيراد
 ldap-password-policy-help=لاحظ أنه في حالة تمكين هذا الخيار، لن يتحقق المدخل من وجود كلمات مرور صالحة أو كلمات مرور منتهية الصلاحية أو المستخدمين الذين تم حظرهم. يتم التعامل مع هذا الآن بواسطة سياسة كلمة مرور خادم LDAP.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=الخوادم
 ldap-server-id=خوادم LDAP
 ldap-servers=خوادم LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=لا يتم استيراد سمة الاسم بالكامل إلا عندما يكون الاسم الأول أو اسم العائلة فارغًا فقط.
 ldap-import-configuration-name=استيراد
 ldap-password-policy-help=لاحظ أنه في حالة تمكين هذا الخيار، لن يتحقق المدخل من وجود كلمات مرور صالحة أو كلمات مرور منتهية الصلاحية أو المستخدمين الذين تم حظرهم. يتم التعامل مع هذا الآن بواسطة سياسة كلمة مرور خادم LDAP.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=الخوادم
 ldap-server-id=خوادم LDAP
 ldap-servers=خوادم LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Атрибутът пълното име се импортира само когато името или фамилията е празно. (Automatic Translation)
 ldap-import-configuration-name=Вмъкване
 ldap-password-policy-help=Имайте предвид, че ако това е разрешено, порталът няма да проверява за валидни пароли, пароли с изтекъл срок или потребители, които са блокирани. Това сега се обработва от правилата за пароли на LDAP сървъра. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Сървър
 ldap-server-id=ИД на LDAP сървър (Automatic Translation)
 ldap-servers=LDAP сървъри (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Атрибутът пълното име се импортира само когато името или фамилията е празно. (Automatic Translation)
 ldap-import-configuration-name=Вмъкване
 ldap-password-policy-help=Имайте предвид, че ако това е разрешено, порталът няма да проверява за валидни пароли, пароли с изтекъл срок или потребители, които са блокирани. Това сега се обработва от правилата за пароли на LDAP сървъра. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Сървър
 ldap-server-id=ИД на LDAP сървър (Automatic Translation)
 ldap-servers=LDAP сървъри (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -11349,7 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Només s'importa l'atribut de nom complet quan el nom o el cognom són buits.
 ldap-import-configuration-name=Importa
 ldap-password-policy-help=Tingueu en compte que, si se selecciona aquesta opció, el portal no busca contrasenyes vàlides, contrasenyes caducades ni usuaris bloquejats. Ara això ho gestiona la política de contrasenyes del servidor LDAP.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servidors
 ldap-server-id=ID del servidor LDAP
 ldap-servers=Servidors de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -11349,6 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Només s'importa l'atribut de nom complet quan el nom o el cognom són buits.
 ldap-import-configuration-name=Importa
 ldap-password-policy-help=Tingueu en compte que, si se selecciona aquesta opció, el portal no busca contrasenyes vàlides, contrasenyes caducades ni usuaris bloquejats. Ara això ho gestiona la política de contrasenyes del servidor LDAP.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servidors
 ldap-server-id=ID del servidor LDAP
 ldap-servers=Servidors de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atribut celé jméno je importován pouze pokud je jméno nebo příjmení prázdné.
 ldap-import-configuration-name=Importovat
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servery
 ldap-server-id=ID LDAP serveru
 ldap-servers=LDAP Servery

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atribut celé jméno je importován pouze pokud je jméno nebo příjmení prázdné.
 ldap-import-configuration-name=Importovat
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servery
 ldap-server-id=ID LDAP serveru
 ldap-servers=LDAP Servery

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Importer
 ldap-password-policy-help=Bemærk, at hvis dette er aktiveret, kontrollerer portalen ikke, om der er gyldige adgangskoder, udløbne adgangskoder eller brugere, der er låst ude. Dette håndteres nu af LDAP-serverens adgangskodepolitik. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servere (Automatic Translation)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP-servere (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Importer
 ldap-password-policy-help=Bemærk, at hvis dette er aktiveret, kontrollerer portalen ikke, om der er gyldige adgangskoder, udløbne adgangskoder eller brugere, der er låst ude. Dette håndteres nu af LDAP-serverens adgangskodepolitik. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servere (Automatic Translation)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP-servere (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -11349,6 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Das Attribut für den vollständigen Namen wird nur importiert, falls die Felder Vor- oder Nachname leer sind.
 ldap-import-configuration-name=Importieren
 ldap-password-policy-help=Beachten Sie bitte, dass das Portal nicht nach gültigen Kennwörtern, abgelaufenen Kennwörtern oder Benutzern, die gesperrt sind, sucht, wenn diese Option aktiviert ist. Das wird nun von der Kennwortrichtlinie des LDAP-Servers ausgeführt.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Server
 ldap-server-id=ID des LDAP-Servers
 ldap-servers=LDAP-Server

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -11349,7 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Das Attribut für den vollständigen Namen wird nur importiert, falls die Felder Vor- oder Nachname leer sind.
 ldap-import-configuration-name=Importieren
 ldap-password-policy-help=Beachten Sie bitte, dass das Portal nicht nach gültigen Kennwörtern, abgelaufenen Kennwörtern oder Benutzern, die gesperrt sind, sucht, wenn diese Option aktiviert ist. Das wird nun von der Kennwortrichtlinie des LDAP-Servers ausgeführt.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Server
 ldap-server-id=ID des LDAP-Servers
 ldap-servers=LDAP-Server

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
@@ -11349,6 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Das Attribut für den vollständigen Namen wird nur importiert, falls die Felder Vor- oder Nachname leer sind.
 ldap-import-configuration-name=Importieren
 ldap-password-policy-help=Beachten Sie bitte, dass das Portal nicht nach gültigen Kennwörtern, abgelaufenen Kennwörtern oder Benutzern, die gesperrt sind, sucht, wenn diese Option aktiviert ist. Das wird nun von der Kennwortrichtlinie des LDAP-Servers ausgeführt.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Server
 ldap-server-id=ID des LDAP-Servers
 ldap-servers=LDAP-Server

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_AT.properties
@@ -11349,7 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Das Attribut für den vollständigen Namen wird nur importiert, falls die Felder Vor- oder Nachname leer sind.
 ldap-import-configuration-name=Importieren
 ldap-password-policy-help=Beachten Sie bitte, dass das Portal nicht nach gültigen Kennwörtern, abgelaufenen Kennwörtern oder Benutzern, die gesperrt sind, sucht, wenn diese Option aktiviert ist. Das wird nun von der Kennwortrichtlinie des LDAP-Servers ausgeführt.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Server
 ldap-server-id=ID des LDAP-Servers
 ldap-servers=LDAP-Server

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
@@ -11349,6 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Das Attribut für den vollständigen Namen wird nur importiert, falls die Felder Vor- oder Nachname leer sind.
 ldap-import-configuration-name=Importieren
 ldap-password-policy-help=Beachten Sie bitte, dass das Portal nicht nach gültigen Kennwörtern, abgelaufenen Kennwörtern oder Benutzern, die gesperrt sind, sucht, wenn diese Option aktiviert ist. Das wird nun von der Kennwortrichtlinie des LDAP-Servers ausgeführt.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Server
 ldap-server-id=ID des LDAP-Servers
 ldap-servers=LDAP-Server

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de_CH.properties
@@ -11349,7 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Das Attribut für den vollständigen Namen wird nur importiert, falls die Felder Vor- oder Nachname leer sind.
 ldap-import-configuration-name=Importieren
 ldap-password-policy-help=Beachten Sie bitte, dass das Portal nicht nach gültigen Kennwörtern, abgelaufenen Kennwörtern oder Benutzern, die gesperrt sind, sucht, wenn diese Option aktiviert ist. Das wird nun von der Kennwortrichtlinie des LDAP-Servers ausgeführt.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Server
 ldap-server-id=ID des LDAP-Servers
 ldap-servers=LDAP-Server

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Το πεδίο "πλήρες όνομα" εισάγεται μόνο όταν είτε το όνομα είτε το επώνυμο είναι κενά.
 ldap-import-configuration-name=Εισαγωγή
 ldap-password-policy-help=Σημειώστε ότι εάν αυτό είναι ενεργοποιημένο, η πύλη δεν θα ελέγξει για έγκυρους κωδικούς πρόσβασης, ληγμένους κωδικούς πρόσβασης ή χρήστες που είναι κλειδωμένοι. Αυτό αντιμετωπίζεται τώρα από την πολιτική κωδικού πρόσβασης του διακομιστή LDAP. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Διακομιστές (Automatic Translation)
 ldap-server-id=Ταυτότητα του LDAP server
 ldap-servers=LDAP servers

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Το πεδίο "πλήρες όνομα" εισάγεται μόνο όταν είτε το όνομα είτε το επώνυμο είναι κενά.
 ldap-import-configuration-name=Εισαγωγή
 ldap-password-policy-help=Σημειώστε ότι εάν αυτό είναι ενεργοποιημένο, η πύλη δεν θα ελέγξει για έγκυρους κωδικούς πρόσβασης, ληγμένους κωδικούς πρόσβασης ή χρήστες που είναι κλειδωμένοι. Αυτό αντιμετωπίζεται τώρα από την πολιτική κωδικού πρόσβασης του διακομιστή LDAP. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Διακομιστές (Automatic Translation)
 ldap-server-id=Ταυτότητα του LDAP server
 ldap-servers=LDAP servers

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -11353,7 +11353,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank.
 ldap-import-configuration-name=Import
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option.
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered.
 ldap-server-configuration-name=Servers
 ldap-server-id=LDAP Server ID
 ldap-servers=LDAP Servers

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -11353,6 +11353,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank.
 ldap-import-configuration-name=Import
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option.
 ldap-server-configuration-name=Servers
 ldap-server-id=LDAP Server ID
 ldap-servers=LDAP Servers

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Import (Automatic Copy)
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servers (Automatic Copy)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Servers (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Import (Automatic Copy)
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servers (Automatic Copy)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Servers (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Import (Automatic Copy)
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servers (Automatic Copy)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Servers (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_CA.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Import (Automatic Copy)
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servers (Automatic Copy)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Servers (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Import (Automatic Copy)
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servers (Automatic Copy)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Servers (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Import (Automatic Copy)
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servers (Automatic Copy)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Servers (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Import (Automatic Copy)
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servers (Automatic Copy)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Servers (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_IE.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Import (Automatic Copy)
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servers (Automatic Copy)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Servers (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -11349,6 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=El atributo nombre completo se importa únicamente cuando el nombre o el apellido están en blanco.
 ldap-import-configuration-name=Importar
 ldap-password-policy-help=Tenga en cuenta que, si esta opción está habilitada, el portal no verificará contraseñas, contraseñas expiradas o usuarios que estén bloqueados. Esto se gestiona ahora por la política de constraseñas del servidor LDAP.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servidores
 ldap-server-id=Identificador del servidor LDAP
 ldap-servers=Servidores de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -11349,7 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=El atributo nombre completo se importa únicamente cuando el nombre o el apellido están en blanco.
 ldap-import-configuration-name=Importar
 ldap-password-policy-help=Tenga en cuenta que, si esta opción está habilitada, el portal no verificará contraseñas, contraseñas expiradas o usuarios que estén bloqueados. Esto se gestiona ahora por la política de constraseñas del servidor LDAP.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servidores
 ldap-server-id=Identificador del servidor LDAP
 ldap-servers=Servidores de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -11349,6 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=El atributo nombre completo se importa únicamente cuando el nombre o el apellido están en blanco.
 ldap-import-configuration-name=Importar
 ldap-password-policy-help=Tenga en cuenta que, si esta opción está habilitada, el portal no verificará contraseñas, contraseñas expiradas o usuarios que estén bloqueados. Esto se gestiona ahora por la política de constraseñas del servidor LDAP.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servidores
 ldap-server-id=Identificador del servidor LDAP
 ldap-servers=Servidores de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -11349,7 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=El atributo nombre completo se importa únicamente cuando el nombre o el apellido están en blanco.
 ldap-import-configuration-name=Importar
 ldap-password-policy-help=Tenga en cuenta que, si esta opción está habilitada, el portal no verificará contraseñas, contraseñas expiradas o usuarios que estén bloqueados. Esto se gestiona ahora por la política de constraseñas del servidor LDAP.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servidores
 ldap-server-id=Identificador del servidor LDAP
 ldap-servers=Servidores de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -11349,6 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=El atributo nombre completo se importa únicamente cuando el nombre o el apellido están en blanco.
 ldap-import-configuration-name=Importar
 ldap-password-policy-help=Tenga en cuenta que, si esta opción está habilitada, el portal no verificará contraseñas, contraseñas expiradas o usuarios que estén bloqueados. Esto se gestiona ahora por la política de constraseñas del servidor LDAP.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servidores
 ldap-server-id=Identificador del servidor LDAP
 ldap-servers=Servidores de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -11349,7 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=El atributo nombre completo se importa únicamente cuando el nombre o el apellido están en blanco.
 ldap-import-configuration-name=Importar
 ldap-password-policy-help=Tenga en cuenta que, si esta opción está habilitada, el portal no verificará contraseñas, contraseñas expiradas o usuarios que estén bloqueados. Esto se gestiona ahora por la política de constraseñas del servidor LDAP.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servidores
 ldap-server-id=Identificador del servidor LDAP
 ldap-servers=Servidores de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -11349,6 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=El atributo nombre completo se importa únicamente cuando el nombre o el apellido están en blanco.
 ldap-import-configuration-name=Importar
 ldap-password-policy-help=Tenga en cuenta que, si esta opción está habilitada, el portal no verificará contraseñas, contraseñas expiradas o usuarios que estén bloqueados. Esto se gestiona ahora por la política de constraseñas del servidor LDAP.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servidores
 ldap-server-id=Identificador del servidor LDAP
 ldap-servers=Servidores de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -11349,7 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=El atributo nombre completo se importa únicamente cuando el nombre o el apellido están en blanco.
 ldap-import-configuration-name=Importar
 ldap-password-policy-help=Tenga en cuenta que, si esta opción está habilitada, el portal no verificará contraseñas, contraseñas expiradas o usuarios que estén bloqueados. Esto se gestiona ahora por la política de constraseñas del servidor LDAP.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servidores
 ldap-server-id=Identificador del servidor LDAP
 ldap-servers=Servidores de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Täisnime atribuut imporditakse ainult siis, kui eesnimi või perekonnanimi on tühi. (Automatic Translation)
 ldap-import-configuration-name=Impordi
 ldap-password-policy-help=Pange tähele, et kui see on lubatud, ei kontrolli portaal kehtivaid paroole, aegunud paroole ega lukustatud kasutajaid. Seda käsitleb nüüd LDAP-serveri paroolipoliitika. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Serverid (Automatic Translation)
 ldap-server-id=LDAP-serveri ID (Automatic Translation)
 ldap-servers=LDAP-serverid (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Täisnime atribuut imporditakse ainult siis, kui eesnimi või perekonnanimi on tühi. (Automatic Translation)
 ldap-import-configuration-name=Impordi
 ldap-password-policy-help=Pange tähele, et kui see on lubatud, ei kontrolli portaal kehtivaid paroole, aegunud paroole ega lukustatud kasutajaid. Seda käsitleb nüüd LDAP-serveri paroolipoliitika. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Serverid (Automatic Translation)
 ldap-server-id=LDAP-serveri ID (Automatic Translation)
 ldap-servers=LDAP-serverid (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Inportatu
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Zerbitzariak
 ldap-server-id=LDAP zerbitzariak
 ldap-servers=LDAP zerbitzariak

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Inportatu
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Zerbitzariak
 ldap-server-id=LDAP zerbitzariak
 ldap-servers=LDAP zerbitzariak

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=نام و نام خانوادگی وارد شده تنها زمانی بارگذاری می‌شود که هر دو نام یا نام خانوادگی خالی است.
 ldap-import-configuration-name=وارد کردن
 ldap-password-policy-help=توجه داشته باشید که اگر این کار فعال باشد، پورتال رمزهای عبور معتبر، رمزهای عبور منقضی شده یا کاربرانی که قفل شده اند را بررسی نخواهد کرد. این در حال حاضر توسط سیاست رمز عبور سرور LDAP رسیدگی می شود. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=سرورها
 ldap-server-id=شناسه سرورهای LDAP
 ldap-servers=سرورهای LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=نام و نام خانوادگی وارد شده تنها زمانی بارگذاری می‌شود که هر دو نام یا نام خانوادگی خالی است.
 ldap-import-configuration-name=وارد کردن
 ldap-password-policy-help=توجه داشته باشید که اگر این کار فعال باشد، پورتال رمزهای عبور معتبر، رمزهای عبور منقضی شده یا کاربرانی که قفل شده اند را بررسی نخواهد کرد. این در حال حاضر توسط سیاست رمز عبور سرور LDAP رسیدگی می شود. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=سرورها
 ldap-server-id=شناسه سرورهای LDAP
 ldap-servers=سرورهای LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Kokonimen attribuutti tuodaan vain jos etunimi tai sukunimi ovat tyhjiä.
 ldap-import-configuration-name=Tuonti
 ldap-password-policy-help=Huomaa, että jos tämä on käytössä, portaali ei tarkasta kelvollisia salasanoja, vanhentuneita salasanoja tai käyttäjiä, jotka on lukittu ulos. Nämä käsittelevät nyt LDAP-palvelimen salasanakäytänteet.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Palvelimet
 ldap-server-id=LDAP palvelimen ID
 ldap-servers=LDAP palvelimet

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Kokonimen attribuutti tuodaan vain jos etunimi tai sukunimi ovat tyhjiä.
 ldap-import-configuration-name=Tuonti
 ldap-password-policy-help=Huomaa, että jos tämä on käytössä, portaali ei tarkasta kelvollisia salasanoja, vanhentuneita salasanoja tai käyttäjiä, jotka on lukittu ulos. Nämä käsittelevät nyt LDAP-palvelimen salasanakäytänteet.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Palvelimet
 ldap-server-id=LDAP palvelimen ID
 ldap-servers=LDAP palvelimet

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -11349,7 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=L'attribut 'nom complet' est seulement importé quand le prénom ou le nom est vide.
 ldap-import-configuration-name=Importer
 ldap-password-policy-help=Notez que si vous activez cela, le portail ne recherchera pas les mots de passe valides, mots de passe expirés ou utilisateurs verrouillés. Tout cela est maintenant géré par la police de mots de passe du serveur LDAP.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Serveurs
 ldap-server-id=ID du Serveur LDAP
 ldap-servers=Serveurs de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -11349,6 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=L'attribut 'nom complet' est seulement importé quand le prénom ou le nom est vide.
 ldap-import-configuration-name=Importer
 ldap-password-policy-help=Notez que si vous activez cela, le portail ne recherchera pas les mots de passe valides, mots de passe expirés ou utilisateurs verrouillés. Tout cela est maintenant géré par la police de mots de passe du serveur LDAP.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Serveurs
 ldap-server-id=ID du Serveur LDAP
 ldap-servers=Serveurs de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
@@ -11349,7 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=L'attribut 'nom complet' est seulement importé quand le prénom ou le nom est vide.
 ldap-import-configuration-name=Importer
 ldap-password-policy-help=Notez que si vous activez cela, le portail ne recherchera pas les mots de passe valides, mots de passe expirés ou utilisateurs verrouillés. Tout cela est maintenant géré par la police de mots de passe du serveur LDAP.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Serveurs
 ldap-server-id=ID du Serveur LDAP
 ldap-servers=Serveurs de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_BE.properties
@@ -11349,6 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=L'attribut 'nom complet' est seulement importé quand le prénom ou le nom est vide.
 ldap-import-configuration-name=Importer
 ldap-password-policy-help=Notez que si vous activez cela, le portail ne recherchera pas les mots de passe valides, mots de passe expirés ou utilisateurs verrouillés. Tout cela est maintenant géré par la police de mots de passe du serveur LDAP.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Serveurs
 ldap-server-id=ID du Serveur LDAP
 ldap-servers=Serveurs de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=L'attribut 'nom complet' est seulement importé quand le prénom ou le nom est vide.
 ldap-import-configuration-name=Importer
 ldap-password-policy-help=Notez que si vous activez cela, le portail ne recherchera pas les mots de passe valides, mots de passe expirés ou utilisateurs verrouillés. Tout cela est maintenant géré par la police de mots de passe du serveur LDAP.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Serveurs
 ldap-server-id=ID du Serveur LDAP
 ldap-servers=Serveurs de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=L'attribut 'nom complet' est seulement importé quand le prénom ou le nom est vide.
 ldap-import-configuration-name=Importer
 ldap-password-policy-help=Notez que si vous activez cela, le portail ne recherchera pas les mots de passe valides, mots de passe expirés ou utilisateurs verrouillés. Tout cela est maintenant géré par la police de mots de passe du serveur LDAP.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Serveurs
 ldap-server-id=ID du Serveur LDAP
 ldap-servers=Serveurs de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
@@ -11349,7 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=L'attribut 'nom complet' est seulement importé quand le prénom ou le nom est vide.
 ldap-import-configuration-name=Importer
 ldap-password-policy-help=Notez que si vous activez cela, le portail ne recherchera pas les mots de passe valides, mots de passe expirés ou utilisateurs verrouillés. Tout cela est maintenant géré par la police de mots de passe du serveur LDAP.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Serveurs
 ldap-server-id=ID du Serveur LDAP
 ldap-servers=Serveurs de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CH.properties
@@ -11349,6 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=L'attribut 'nom complet' est seulement importé quand le prénom ou le nom est vide.
 ldap-import-configuration-name=Importer
 ldap-password-policy-help=Notez que si vous activez cela, le portail ne recherchera pas les mots de passe valides, mots de passe expirés ou utilisateurs verrouillés. Tout cela est maintenant géré par la police de mots de passe du serveur LDAP.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Serveurs
 ldap-server-id=ID du Serveur LDAP
 ldap-servers=Serveurs de LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Importar
 ldap-password-policy-help=Teña en conta que se está activado, o portal non comprobará se hai contrasinais válidos, contrasinais caducados ou usuarios que están bloqueados. Isto é agora manexado pola política de contrasinal do servidor LDAP.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servidores
 ldap-server-id=Servidores LDAP
 ldap-servers=Servidores LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Importar
 ldap-password-policy-help=Teña en conta que se está activado, o portal non comprobará se hai contrasinais válidos, contrasinais caducados ou usuarios que están bloqueados. Isto é agora manexado pola política de contrasinal do servidor LDAP.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servidores
 ldap-server-id=Servidores LDAP
 ldap-servers=Servidores LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=पूरा नाम विशेषता केवल तभी आयात की जाती है जब या तो पहला नाम या अंतिम नाम खाली हो। (Automatic Translation)
 ldap-import-configuration-name=इम्पोर्ट
 ldap-password-policy-help=ध्यान दें कि यदि यह सक्षम है, तो पोर्टल वैध पासवर्ड, समाप्त हो चुके पासवर्ड या लॉक किए गए उपयोगकर्ताओं की जांच नहीं करेगा। इसे अब एलडीएपी सर्वर की पासवर्ड पॉलिसी द्वारा संभाला जाता है। (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=सर्वर्स
 ldap-server-id=LDAP सर्वर्स
 ldap-servers=LDAP सर्वर्स

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=पूरा नाम विशेषता केवल तभी आयात की जाती है जब या तो पहला नाम या अंतिम नाम खाली हो। (Automatic Translation)
 ldap-import-configuration-name=इम्पोर्ट
 ldap-password-policy-help=ध्यान दें कि यदि यह सक्षम है, तो पोर्टल वैध पासवर्ड, समाप्त हो चुके पासवर्ड या लॉक किए गए उपयोगकर्ताओं की जांच नहीं करेगा। इसे अब एलडीएपी सर्वर की पासवर्ड पॉलिसी द्वारा संभाला जाता है। (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=सर्वर्स
 ldap-server-id=LDAP सर्वर्स
 ldap-servers=LDAP सर्वर्स

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atribut punog imena se uvozi jedino kada je neispunjeno ime ili prezime.
 ldap-import-configuration-name=Uvezi
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Poslužitelji
 ldap-server-id=LDAP poslužitelj ID
 ldap-servers=LDAP poslužiteljima

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atribut punog imena se uvozi jedino kada je neispunjeno ime ili prezime.
 ldap-import-configuration-name=Uvezi
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Poslužitelji
 ldap-server-id=LDAP poslužitelj ID
 ldap-servers=LDAP poslužiteljima

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Import (Automatic Copy)
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servers (Automatic Copy)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Servers (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr_BA.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Import (Automatic Copy)
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servers (Automatic Copy)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Servers (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -11350,7 +11350,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=A teljes név attribútum csak akkor lesz importálva, ha az első név vagy a vezetéknév üres.
 ldap-import-configuration-name=Import
 ldap-password-policy-help=Megjegyezzük, hogy ha aktiválva van, a portál nem ellenőrzi a jelszavak érvényességét, lejárt állapotát, vagy a kizárt felhasználókat. Ezt most az LDAP kiszolgáló jelszó-politikája kezeli.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Kiszolgálók
 ldap-server-id=LDAP Kiszolgáló azonosító
 ldap-servers=LDAP Kiszolgálók

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -11350,6 +11350,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=A teljes név attribútum csak akkor lesz importálva, ha az első név vagy a vezetéknév üres.
 ldap-import-configuration-name=Import
 ldap-password-policy-help=Megjegyezzük, hogy ha aktiválva van, a portál nem ellenőrzi a jelszavak érvényességét, lejárt állapotát, vagy a kizárt felhasználókat. Ezt most az LDAP kiszolgáló jelszó-politikája kezeli.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Kiszolgálók
 ldap-server-id=LDAP Kiszolgáló azonosító
 ldap-servers=LDAP Kiszolgálók

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atribut nama lengkap hanya diimpor ketika nama depan atau nama belakang kosong. (Automatic Translation)
 ldap-import-configuration-name=Impor
 ldap-password-policy-help=Perhatikan bahwa jika ini diaktifkan, portal tidak akan memeriksa kata sandi yang valid, kata sandi kedaluwarsa, atau pengguna yang dikunci. Ini sekarang ditangani oleh kebijakan kata sandi server LDAP. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Server
 ldap-server-id=LDAP Server
 ldap-servers=LDAP Server

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atribut nama lengkap hanya diimpor ketika nama depan atau nama belakang kosong. (Automatic Translation)
 ldap-import-configuration-name=Impor
 ldap-password-policy-help=Perhatikan bahwa jika ini diaktifkan, portal tidak akan memeriksa kata sandi yang valid, kata sandi kedaluwarsa, atau pengguna yang dikunci. Ini sekarang ditangani oleh kebijakan kata sandi server LDAP. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Server
 ldap-server-id=LDAP Server
 ldap-servers=LDAP Server

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -11348,7 +11348,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Il nome completo sarà importato solo quando il nome e cognome restano vuoti.
 ldap-import-configuration-name=Importa
 ldap-password-policy-help=Si noti che se questa opzione è abilitata, il portale non controllerà la presenza di password valide, password scadute o utenti bloccati. Questo problema viene ora gestito dai criteri password del server LDAP. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Server
 ldap-server-id=ID Server LDAP
 ldap-servers=Server LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -11348,6 +11348,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Il nome completo sarà importato solo quando il nome e cognome restano vuoti.
 ldap-import-configuration-name=Importa
 ldap-password-policy-help=Si noti che se questa opzione è abilitata, il portale non controllerà la presenza di password valide, password scadute o utenti bloccati. Questo problema viene ora gestito dai criteri password del server LDAP. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Server
 ldap-server-id=ID Server LDAP
 ldap-servers=Server LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
@@ -11349,7 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Il nome completo sarà importato solo quando il nome e cognome restano vuoti.
 ldap-import-configuration-name=Importa
 ldap-password-policy-help=Si noti che se questa opzione è abilitata, il portale non controllerà la presenza di password valide, password scadute o utenti bloccati. Questo problema viene ora gestito dai criteri password del server LDAP. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Server (Automatic Translation)
 ldap-server-id=ID Server LDAP
 ldap-servers=Server LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it_CH.properties
@@ -11349,6 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Il nome completo sarà importato solo quando il nome e cognome restano vuoti.
 ldap-import-configuration-name=Importa
 ldap-password-policy-help=Si noti che se questa opzione è abilitata, il portale non controllerà la presenza di password valide, password scadute o utenti bloccati. Questo problema viene ora gestito dai criteri password del server LDAP. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Server (Automatic Translation)
 ldap-server-id=ID Server LDAP
 ldap-servers=Server LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=מאפיין השם המלא מיובא רק כאשר שדה השם הפרטי או שם המשפחה נשאר ריק.
 ldap-import-configuration-name=יבוא
 ldap-password-policy-help=שימו לב: אם זה מופעל, הפורטל לא יבצע בדיקה של חוקיות סיסמאות, מועד תפוגת סיסמאות או משתמשים חסומים. זה מטופל כעת על-ידי מדיניות הסיסמאות של שרת ה-LDAP.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=שרתים
 ldap-server-id=ה- ID של שרת ה- LDAP
 ldap-servers=שרתי LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=מאפיין השם המלא מיובא רק כאשר שדה השם הפרטי או שם המשפחה נשאר ריק.
 ldap-import-configuration-name=יבוא
 ldap-password-policy-help=שימו לב: אם זה מופעל, הפורטל לא יבצע בדיקה של חוקיות סיסמאות, מועד תפוגת סיסמאות או משתמשים חסומים. זה מטופל כעת על-ידי מדיניות הסיסמאות של שרת ה-LDAP.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=שרתים
 ldap-server-id=ה- ID של שרת ה- LDAP
 ldap-servers=שרתי LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -11349,7 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=フルネームは姓か名前が空白の時にのみインポートされます。
 ldap-import-configuration-name=インポート
 ldap-password-policy-help=これが有効な場合、ポータルは有効なパスワードや期限切れのパスワード、ロックアウトされたユーザーをチェックしません。現在はLDAP サーバーのパスワード ポリシーによって処理されています。
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=サーバー
 ldap-server-id=LDAPサーバID
 ldap-servers=LDAPサーバ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -11349,6 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=フルネームは姓か名前が空白の時にのみインポートされます。
 ldap-import-configuration-name=インポート
 ldap-password-policy-help=これが有効な場合、ポータルは有効なパスワードや期限切れのパスワード、ロックアウトされたユーザーをチェックしません。現在はLDAP サーバーのパスワード ポリシーによって処理されています。
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=サーバー
 ldap-server-id=LDAPサーバID
 ldap-servers=LDAPサーバ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Import (Automatic Copy)
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servers (Automatic Copy)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Servers (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Import (Automatic Copy)
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servers (Automatic Copy)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Servers (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -11353,7 +11353,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank.
 ldap-import-configuration-name=Import
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servers
 ldap-server-id=LDAP Server ID
 ldap-servers=LDAP Servers

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -11353,6 +11353,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank.
 ldap-import-configuration-name=Import
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servers
 ldap-server-id=LDAP Server ID
 ldap-servers=LDAP Servers

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=전체 이름 속성은 이름이나 성이 비어 있는 경우에만 가져옵니다.
 ldap-import-configuration-name=수입품
 ldap-password-policy-help=활성화된 경우 포털은 유효한 비밀번호, 만료된 비밀번호 또는 잠긴 사용자를 확인하지 않습니다. 이것은 이제 LDAP 서버의 암호 정책에 의해 처리됩니다.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=서버
 ldap-server-id=LDAP 서버 ID
 ldap-servers=LDAP 서버

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=전체 이름 속성은 이름이나 성이 비어 있는 경우에만 가져옵니다.
 ldap-import-configuration-name=수입품
 ldap-password-policy-help=활성화된 경우 포털은 유효한 비밀번호, 만료된 비밀번호 또는 잠긴 사용자를 확인하지 않습니다. 이것은 이제 LDAP 서버의 암호 정책에 의해 처리됩니다.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=서버
 ldap-server-id=LDAP 서버 ID
 ldap-servers=LDAP 서버

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=ແອັດທຣິບິວຊື່ເຕັມຈະຖືກນຳເຂົ້າສະເພາະເມື່ອຊື່ ຫຼື ນາມສະກຸນວ່າງເປົ່າເທົ່ານັ້ນ.
 ldap-import-configuration-name=ການນຳເຂົ້າ
 ldap-password-policy-help=ໝາຍເຫດ: ຖ້າເປີດໃຊ້ສິ່ງນີ້, ພໍທໍຈະບໍ່ກວດສອບລະຫັດຜ່ານທີ່ຖືກຕ້ອງ, ລະຫັດຜ່ານທີ່ໝົດອາຍຸ ຫຼື ຜູ້ໃຊ້ທີ່ຖືກລັອກ. ສິ່ງເຫຼົ່ານີ້ຈະຖືກຈັດການໂດຍນະໂຍບາຍລະຫັດຜ່ານຂອງເຊີເວີ LDAP.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=ເຊີເວີຕ່າງໆ
 ldap-server-id=LDAP ເຊີເວີ້
 ldap-servers=LDAP ເຊີເວີ້

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=ແອັດທຣິບິວຊື່ເຕັມຈະຖືກນຳເຂົ້າສະເພາະເມື່ອຊື່ ຫຼື ນາມສະກຸນວ່າງເປົ່າເທົ່ານັ້ນ.
 ldap-import-configuration-name=ການນຳເຂົ້າ
 ldap-password-policy-help=ໝາຍເຫດ: ຖ້າເປີດໃຊ້ສິ່ງນີ້, ພໍທໍຈະບໍ່ກວດສອບລະຫັດຜ່ານທີ່ຖືກຕ້ອງ, ລະຫັດຜ່ານທີ່ໝົດອາຍຸ ຫຼື ຜູ້ໃຊ້ທີ່ຖືກລັອກ. ສິ່ງເຫຼົ່ານີ້ຈະຖືກຈັດການໂດຍນະໂຍບາຍລະຫັດຜ່ານຂອງເຊີເວີ LDAP.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=ເຊີເວີຕ່າງໆ
 ldap-server-id=LDAP ເຊີເວີ້
 ldap-servers=LDAP ເຊີເວີ້

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atributas vardas ir pavardė importuojami tik tada, kai vardas arba pavardė yra tušti. (Automatic Translation)
 ldap-import-configuration-name=importuoti (Automatic Translation)
 ldap-password-policy-help=Atminkite, kad jei tai įgalinta, portalas netikrins galiojančių slaptažodžių, nebegaliojančių slaptažodžių arba užrakintų vartotojų. Dabar tai tvarko LDAP serverio slaptažodžio strategija. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Serveriai (Automatic Translation)
 ldap-server-id=LDAP serverio ID (Automatic Translation)
 ldap-servers=LDAP serveriai (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atributas vardas ir pavardė importuojami tik tada, kai vardas arba pavardė yra tušti. (Automatic Translation)
 ldap-import-configuration-name=importuoti (Automatic Translation)
 ldap-password-policy-help=Atminkite, kad jei tai įgalinta, portalas netikrins galiojančių slaptažodžių, nebegaliojančių slaptažodžių arba užrakintų vartotojų. Dabar tai tvarko LDAP serverio slaptažodžio strategija. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Serveriai (Automatic Translation)
 ldap-server-id=LDAP serverio ID (Automatic Translation)
 ldap-servers=LDAP serveriai (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Import (Automatic Copy)
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servers (Automatic Copy)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Servers (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_mk.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Import (Automatic Copy)
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servers (Automatic Copy)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Servers (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atribut nama penuh hanya diimport apabila nama pertama atau nama terakhir adalah kosong. (Automatic Translation)
 ldap-import-configuration-name=Import (Automatic Translation)
 ldap-password-policy-help=Sila ambil perhatian bahawa jika ini didayakan, portal ini tidak akan menyemak kata laluan yang sah, kata laluan yang telah luput, atau pengguna yang dikunci. Ini kini dikendalikan oleh dasar kata laluan pelayan LDAP. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Pelayan (Automatic Translation)
 ldap-server-id=ID Pelayan LDAP (Automatic Translation)
 ldap-servers=Pelayan LDAP (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atribut nama penuh hanya diimport apabila nama pertama atau nama terakhir adalah kosong. (Automatic Translation)
 ldap-import-configuration-name=Import (Automatic Translation)
 ldap-password-policy-help=Sila ambil perhatian bahawa jika ini didayakan, portal ini tidak akan menyemak kata laluan yang sah, kata laluan yang telah luput, atau pengguna yang dikunci. Ini kini dikendalikan oleh dasar kata laluan pelayan LDAP. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Pelayan (Automatic Translation)
 ldap-server-id=ID Pelayan LDAP (Automatic Translation)
 ldap-servers=Pelayan LDAP (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Import (Automatic Copy)
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servers (Automatic Copy)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Servers (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_my.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Import (Automatic Copy)
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servers (Automatic Copy)
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Servers (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Fullt navn attributtet blir bare importert når enten fornavn eller etternavn er blankt.
 ldap-import-configuration-name=Importer
 ldap-password-policy-help=Vær oppmerksom på at hvis dette er aktivert, vil ikke portalen se etter gyldige passord, utløpte passord eller brukere som er låst ute. Dette håndteres nå av passordpolicyen for LDAP-serveren. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Tjenere
 ldap-server-id=LDAP-tjener-ID
 ldap-servers=LDAP-tjenere

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Fullt navn attributtet blir bare importert når enten fornavn eller etternavn er blankt.
 ldap-import-configuration-name=Importer
 ldap-password-policy-help=Vær oppmerksom på at hvis dette er aktivert, vil ikke portalen se etter gyldige passord, utløpte passord eller brukere som er låst ute. Dette håndteres nå av passordpolicyen for LDAP-serveren. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Tjenere
 ldap-server-id=LDAP-tjener-ID
 ldap-servers=LDAP-tjenere

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -11350,6 +11350,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Het volledige naam-kenmerk wordt alleen geïmporteerd als de voornaam of de achternaam leeg is.
 ldap-import-configuration-name=Importeren
 ldap-password-policy-help=Let wel: als dit is ingeschakeld, zal de portal niet controleren of wachtwoorden geldig of verlopen zijn, of als gebruikers vergrendeld zijn. Dit wordt nu afgehandeld door het wachtwoordbeleid van de LDAP-server.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servers
 ldap-server-id=LDAP-server ID
 ldap-servers=LDAP-servers

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -11350,7 +11350,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Het volledige naam-kenmerk wordt alleen geïmporteerd als de voornaam of de achternaam leeg is.
 ldap-import-configuration-name=Importeren
 ldap-password-policy-help=Let wel: als dit is ingeschakeld, zal de portal niet controleren of wachtwoorden geldig of verlopen zijn, of als gebruikers vergrendeld zijn. Dit wordt nu afgehandeld door het wachtwoordbeleid van de LDAP-server.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servers
 ldap-server-id=LDAP-server ID
 ldap-servers=LDAP-servers

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -11350,6 +11350,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=De volledige naam wordt alleen geïmporteerd als de voornaam of de achternaam leeg is.
 ldap-import-configuration-name=Importeren
 ldap-password-policy-help=Let wel: als dit is ingeschakeld, zal de portal niet controleren of wachtwoorden geldig of verlopen zijn, of als gebruikers vergrendeld zijn. Dit wordt nu afgehandeld door het wachtwoordbeleid van de LDAP-server.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servers
 ldap-server-id=LDAP-servers
 ldap-servers=LDAP-servers

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -11350,7 +11350,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=De volledige naam wordt alleen geïmporteerd als de voornaam of de achternaam leeg is.
 ldap-import-configuration-name=Importeren
 ldap-password-policy-help=Let wel: als dit is ingeschakeld, zal de portal niet controleren of wachtwoorden geldig of verlopen zijn, of als gebruikers vergrendeld zijn. Dit wordt nu afgehandeld door het wachtwoordbeleid van de LDAP-server.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servers
 ldap-server-id=LDAP-servers
 ldap-servers=LDAP-servers

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_no.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Fullt navn attributtet blir bare importert når enten fornavn eller etternavn er blankt.
 ldap-import-configuration-name=Importer
 ldap-password-policy-help=Vær oppmerksom på at hvis dette er aktivert, vil ikke portalen se etter gyldige passord, utløpte passord eller brukere som er låst ute. Dette håndteres nå av passordpolicyen for LDAP-serveren. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servere (Automatic Translation)
 ldap-server-id=LDAP-tjener-ID
 ldap-servers=LDAP-tjenere

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atrybut 'full name' jest importowany tylko wtedy, gdy atrybut 'first name' lub atrybut 'last name' jest pusty.
 ldap-import-configuration-name=Importuj
 ldap-password-policy-help=Należy zauważyć, że jeśli ta opcja jest włączona, portal nie będzie sprawdzał prawidłowych haseł, wygasłych haseł ani użytkowników, którzy są zablokowani. Jest to teraz obsługiwane przez zasady haseł serwera LDAP. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Serwery
 ldap-server-id=ID serwera LDAP
 ldap-servers=Serwery LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atrybut 'full name' jest importowany tylko wtedy, gdy atrybut 'first name' lub atrybut 'last name' jest pusty.
 ldap-import-configuration-name=Importuj
 ldap-password-policy-help=Należy zauważyć, że jeśli ta opcja jest włączona, portal nie będzie sprawdzał prawidłowych haseł, wygasłych haseł ani użytkowników, którzy są zablokowani. Jest to teraz obsługiwane przez zasady haseł serwera LDAP. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Serwery
 ldap-server-id=ID serwera LDAP
 ldap-servers=Serwery LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=O atributo nome completo é importado somente quando o primeiro nome ou o segundo estiverem em branco.
 ldap-import-configuration-name=Importar
 ldap-password-policy-help=Saiba que se estiver habilitado, o portal não verificará se as senhas são válidas, estão expiradas ou usuários bloqueados. Isso agora é tratado pela política de senha do servidor LDAP.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servidores
 ldap-server-id=ID do servidor LDAP
 ldap-servers=Servidores LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=O atributo nome completo é importado somente quando o primeiro nome ou o segundo estiverem em branco.
 ldap-import-configuration-name=Importar
 ldap-password-policy-help=Saiba que se estiver habilitado, o portal não verificará se as senhas são válidas, estão expiradas ou usuários bloqueados. Isso agora é tratado pela política de senha do servidor LDAP.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servidores
 ldap-server-id=ID do servidor LDAP
 ldap-servers=Servidores LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -11349,6 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=O atributo nome completo apenas é importado quando o primeiro ou o último nome estiverem em branco.
 ldap-import-configuration-name=Importar
 ldap-password-policy-help=Saiba que se estiver habilitado, o portal não verificará se as senhas são válidas, estão expiradas ou usuários bloqueados. Isso agora é tratado pela política de senha do servidor LDAP.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servidores
 ldap-server-id=ID do servidor LDAP
 ldap-servers=Servidores LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -11349,7 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=O atributo nome completo apenas é importado quando o primeiro ou o último nome estiverem em branco.
 ldap-import-configuration-name=Importar
 ldap-password-policy-help=Saiba que se estiver habilitado, o portal não verificará se as senhas são válidas, estão expiradas ou usuários bloqueados. Isso agora é tratado pela política de senha do servidor LDAP.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servidores
 ldap-server-id=ID do servidor LDAP
 ldap-servers=Servidores LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atributul nume complet este importat numai atunci când numele sau prenumele este necompletat. (Automatic Translation)
 ldap-import-configuration-name=importa (Automatic Translation)
 ldap-password-policy-help=Rețineți că, dacă acest lucru este activat, portalul nu va căuta parole valide, parole expirate sau utilizatori care sunt blocați. Acest lucru este acum tratat de politica de parolă a serverului LDAP. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servere
 ldap-server-id=Serverele LDAP
 ldap-servers=Serverele LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atributul nume complet este importat numai atunci când numele sau prenumele este necompletat. (Automatic Translation)
 ldap-import-configuration-name=importa (Automatic Translation)
 ldap-password-policy-help=Rețineți că, dacă acest lucru este activat, portalul nu va căuta parole valide, parole expirate sau utilizatori care sunt blocați. Acest lucru este acum tratat de politica de parolă a serverului LDAP. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servere
 ldap-server-id=Serverele LDAP
 ldap-servers=Serverele LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Атрибут полное имя импортируется только тогда, когда имя и фамилия пустые.
 ldap-import-configuration-name=Импорт
 ldap-password-policy-help=Обратите внимание, что если это включено, портал не будет проверять действительные пароли, просроченные пароли или заблокированных пользователей. Теперь этим занимается политика паролей сервера LDAP. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Серверы
 ldap-server-id=LDAP ID сервера
 ldap-servers=Сервера LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Атрибут полное имя импортируется только тогда, когда имя и фамилия пустые.
 ldap-import-configuration-name=Импорт
 ldap-password-policy-help=Обратите внимание, что если это включено, портал не будет проверять действительные пароли, просроченные пароли или заблокированных пользователей. Теперь этим занимается политика паролей сервера LDAP. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Серверы
 ldap-server-id=LDAP ID сервера
 ldap-servers=Сервера LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atribút Celé meno je importovaný len vtedy, keď je priezvisko alebo je krstné meno prázdne.
 ldap-import-configuration-name=Importuj
 ldap-password-policy-help=Všimnite si, že ak je táto možnosť zapnutá, portál nebude kontrolovať platné heslá, heslá s uplynutou platnosťou alebo používateľov, ktorí sú uzamknutí. To je teraz spracované LDAP server heslo politiky. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servery
 ldap-server-id=ID LDAP servera
 ldap-servers=LDAP servery

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atribút Celé meno je importovaný len vtedy, keď je priezvisko alebo je krstné meno prázdne.
 ldap-import-configuration-name=Importuj
 ldap-password-policy-help=Všimnite si, že ak je táto možnosť zapnutá, portál nebude kontrolovať platné heslá, heslá s uplynutou platnosťou alebo používateľov, ktorí sú uzamknutí. To je teraz spracované LDAP server heslo politiky. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servery
 ldap-server-id=ID LDAP servera
 ldap-servers=LDAP servery

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atribut polnega imena se uvozi le, če je ime ali priimek prazno. (Automatic Translation)
 ldap-import-configuration-name=Uvoz
 ldap-password-policy-help=Upoštevajte, da če je to omogočeno, portal ne bo preveril, ali obstajajo veljavna gesla, gesla, ki so potekla ali uporabniki, ki so zaklenjeni. To zdaj obravnava pravilnik o geselih strežnika LDAP. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Strežnik
 ldap-server-id=ID strežnika LDAP (Automatic Translation)
 ldap-servers=Strežniki LDAP (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Atribut polnega imena se uvozi le, če je ime ali priimek prazno. (Automatic Translation)
 ldap-import-configuration-name=Uvoz
 ldap-password-policy-help=Upoštevajte, da če je to omogočeno, portal ne bo preveril, ali obstajajo veljavna gesla, gesla, ki so potekla ali uporabniki, ki so zaklenjeni. To zdaj obravnava pravilnik o geselih strežnika LDAP. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Strežnik
 ldap-server-id=ID strežnika LDAP (Automatic Translation)
 ldap-servers=Strežniki LDAP (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Увоз
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Сервери
 ldap-server-id=ЛДАП Сервер
 ldap-servers=ЛДАП Сервер

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Увоз
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Сервери
 ldap-server-id=ЛДАП Сервер
 ldap-servers=ЛДАП Сервер

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Uvoz
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Serveri
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Server

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=The full name attribute is only imported when either the first name or last name is blank. (Automatic Copy)
 ldap-import-configuration-name=Uvoz
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Serveri
 ldap-server-id=LDAP Server ID (Automatic Copy)
 ldap-servers=LDAP Server

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Det fullständiga namnattributet importeras bara när antingen för- eller efternamnet är tomt.
 ldap-import-configuration-name=Importera
 ldap-password-policy-help=Observera att portalen, när detta är aktiverat, inte kommer att kontrollera giltiga lösenord, utgångna lösenord eller låsta användare. Detta hanteras nu av LDAP-serverns lösenordsregler.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Servrar
 ldap-server-id=LDAP Servrar
 ldap-servers=LDAP Servrar

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Det fullständiga namnattributet importeras bara när antingen för- eller efternamnet är tomt.
 ldap-import-configuration-name=Importera
 ldap-password-policy-help=Observera att portalen, när detta är aktiverat, inte kommer att kontrollera giltiga lösenord, utgångna lösenord eller låsta användare. Detta hanteras nu av LDAP-serverns lösenordsregler.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Servrar
 ldap-server-id=LDAP Servrar
 ldap-servers=LDAP Servrar

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=முதல் பெயர் or கடைசி பெயர் காலியாக இருக்கும் போது முழு பெயர் Attribute மட்டுமே இறக்குமதி செய்யப்படுகிறது.
 ldap-import-configuration-name=இறக்குமதி
 ldap-password-policy-help=இது இயக்கப்பட்டால், போர்ட்டல் ஆனது செல்லுபடியாகும் பாஸ்வேர்டுகள், காலாவதியான பாஸ்வேர்டுகள் அல்லது locked பயனர்கள் ஆகியவற்றைச் சரிபார்க்காது. இது இப்போது LDAP Server-ன் பாஸ்வேர்டு பாலிசியால் கையாளப்படுகிறது.
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=சர்வர்கள்
 ldap-server-id=LDAP சேவையகம் ID
 ldap-servers=LDAP சர்வர்கள்

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=முதல் பெயர் or கடைசி பெயர் காலியாக இருக்கும் போது முழு பெயர் Attribute மட்டுமே இறக்குமதி செய்யப்படுகிறது.
 ldap-import-configuration-name=இறக்குமதி
 ldap-password-policy-help=இது இயக்கப்பட்டால், போர்ட்டல் ஆனது செல்லுபடியாகும் பாஸ்வேர்டுகள், காலாவதியான பாஸ்வேர்டுகள் அல்லது locked பயனர்கள் ஆகியவற்றைச் சரிபார்க்காது. இது இப்போது LDAP Server-ன் பாஸ்வேர்டு பாலிசியால் கையாளப்படுகிறது.
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=சர்வர்கள்
 ldap-server-id=LDAP சேவையகம் ID
 ldap-servers=LDAP சர்வர்கள்

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=แอตทริบิวต์ชื่อจะถูกนำเข้าเมื่อชื่อหรือนามสกุลว่างเปล่าเท่านั้น
 ldap-import-configuration-name=อิมพอร์ต
 ldap-password-policy-help=โปรดทราบว่าหากเปิดใช้งาน พอร์ทัลจะไม่ตรวจสอบรหัสผ่านที่ถูกต้อง รหัสผ่านหมดอายุ หรือผู้ใช้ที่ถูกล็อคออก สิ่งนี้ถูกจัดการโดยนโยบายรหัสผ่านของเซิร์ฟเวอร์ LDAP
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=เซิร์ฟเวอร์
 ldap-server-id=LDAP Server ID
 ldap-servers=LDAP Servers

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=แอตทริบิวต์ชื่อจะถูกนำเข้าเมื่อชื่อหรือนามสกุลว่างเปล่าเท่านั้น
 ldap-import-configuration-name=อิมพอร์ต
 ldap-password-policy-help=โปรดทราบว่าหากเปิดใช้งาน พอร์ทัลจะไม่ตรวจสอบรหัสผ่านที่ถูกต้อง รหัสผ่านหมดอายุ หรือผู้ใช้ที่ถูกล็อคออก สิ่งนี้ถูกจัดการโดยนโยบายรหัสผ่านของเซิร์ฟเวอร์ LDAP
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=เซิร์ฟเวอร์
 ldap-server-id=LDAP Server ID
 ldap-servers=LDAP Servers

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Tam ad özniteliği yalnızca ad veya soyadı boş olduğunda alınır. (Automatic Translation)
 ldap-import-configuration-name=İçe Aktar
 ldap-password-policy-help=Bu etkinleştirilirse, portalın geçerli parolaları, süresi dolan parolaları veya kilitlenen kullanıcıları denetlemeyeceğini unutmayın. Bu artık LDAP sunucusunun parola ilkesi tarafından işlenir. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Sunucu
 ldap-server-id=LDAP Sunucu Kimliği (Automatic Translation)
 ldap-servers=LDAP Sunucuları (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Tam ad özniteliği yalnızca ad veya soyadı boş olduğunda alınır. (Automatic Translation)
 ldap-import-configuration-name=İçe Aktar
 ldap-password-policy-help=Bu etkinleştirilirse, portalın geçerli parolaları, süresi dolan parolaları veya kilitlenen kullanıcıları denetlemeyeceğini unutmayın. Bu artık LDAP sunucusunun parola ilkesi tarafından işlenir. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Sunucu
 ldap-server-id=LDAP Sunucu Kimliği (Automatic Translation)
 ldap-servers=LDAP Sunucuları (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Атрибут full name імпортується, лише якщо ім'я або прізвище пусті. (Automatic Translation)
 ldap-import-configuration-name=Імпорт
 ldap-password-policy-help=Зауважте, що якщо цей параметр увімкнено, портал не перевірятиме дійсні паролі, термін дії яких минув, або заблокованих користувачів. Зараз це обробляється політикою паролів сервера LDAP. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Сервер
 ldap-server-id=Ідентифікатор сервера LDAP (Automatic Translation)
 ldap-servers=Сервери LDAP (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Атрибут full name імпортується, лише якщо ім'я або прізвище пусті. (Automatic Translation)
 ldap-import-configuration-name=Імпорт
 ldap-password-policy-help=Зауважте, що якщо цей параметр увімкнено, портал не перевірятиме дійсні паролі, термін дії яких минув, або заблокованих користувачів. Зараз це обробляється політикою паролів сервера LDAP. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Сервер
 ldap-server-id=Ідентифікатор сервера LDAP (Automatic Translation)
 ldap-servers=Сервери LDAP (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -11347,7 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Tên đầy đủ chỉ được nhập vào hệ thống khi hoặc Tên hoặc Họ được nhập
 ldap-import-configuration-name=Nhập vào
 ldap-password-policy-help=Lưu ý rằng nếu điều này được bật, cổng thông tin sẽ không kiểm tra mật khẩu hợp lệ, mật khẩu hết hạn hoặc người dùng bị khóa. Điều này bây giờ được xử lý bởi chính sách mật khẩu của máy chủ LDAP. (Automatic Translation)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=Các máy chủ
 ldap-server-id=Máy chủ LDAP
 ldap-servers=Máy chủ LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -11347,6 +11347,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=Tên đầy đủ chỉ được nhập vào hệ thống khi hoặc Tên hoặc Họ được nhập
 ldap-import-configuration-name=Nhập vào
 ldap-password-policy-help=Lưu ý rằng nếu điều này được bật, cổng thông tin sẽ không kiểm tra mật khẩu hợp lệ, mật khẩu hết hạn hoặc người dùng bị khóa. Điều này bây giờ được xử lý bởi chính sách mật khẩu của máy chủ LDAP. (Automatic Translation)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=Các máy chủ
 ldap-server-id=Máy chủ LDAP
 ldap-servers=Máy chủ LDAP

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -11349,6 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=只有在名字或者姓氏为空时才导入全名特性。
 ldap-import-configuration-name=导入
 ldap-password-policy-help=请注意如果选中此项，门户将不会检查有效密码、过期密码或被锁定的用户。由LDAP服务器和密码策略处理。
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=服务器
 ldap-server-id=LDAP服务器ID
 ldap-servers=LDAP服务器

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -11349,7 +11349,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=只有在名字或者姓氏为空时才导入全名特性。
 ldap-import-configuration-name=导入
 ldap-password-policy-help=请注意如果选中此项，门户将不会检查有效密码、过期密码或被锁定的用户。由LDAP服务器和密码策略处理。
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=服务器
 ldap-server-id=LDAP服务器ID
 ldap-servers=LDAP服务器

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -11348,6 +11348,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=全名屬性只會在當姓或名是空白時被匯入。
 ldap-import-configuration-name=匯入
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
 ldap-server-configuration-name=伺服器
 ldap-server-id=LDAP伺服器ID
 ldap-servers=LDAP伺服器

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -11348,7 +11348,7 @@ ldap-export-must-not-be-enabled-when-autogeneration-of-user-passwords-is-enabled
 ldap-full-name-attribute-help=全名屬性只會在當姓或名是空白時被匯入。
 ldap-import-configuration-name=匯入
 ldap-password-policy-help=Note that if this is enabled, the portal will not check for valid passwords, expired passwords, or users that are locked out. This is now handled by the LDAP server's password policy. (Automatic Copy)
-ldap-referral-help=Controls how the server handles LDAP referrals. Choosing "follow" lets a malicious or compromised LDAP server redirect the server to an attacker controlled endpoint, which can lead to remote code execution through unsafe deserialization. Only "ldap" and "ldaps" referrals are followed, but "ignore" is the most secure option. (Automatic Copy)
+ldap-referral-help=Controls how the server handles LDAP referrals, which point to entries stored on another server. Choose "follow" when your directory spans multiple servers and those entries must be resolved; for safety the server follows only "ldap" and "ldaps" referrals and does not load remote code. Choose "ignore", the default, when referrals are not needed, or "throw" to raise an error when a referral is encountered. (Automatic Copy)
 ldap-server-configuration-name=伺服器
 ldap-server-id=LDAP伺服器ID
 ldap-servers=LDAP伺服器

--- a/modules/apps/portal-security/portal-security-ldap-api/bnd.bnd
+++ b/modules/apps/portal-security/portal-security-ldap-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Security LDAP API
 Bundle-SymbolicName: com.liferay.portal.security.ldap.api
-Bundle-Version: 9.0.5
+Bundle-Version: 9.1.0
 Export-Package:\
 	com.liferay.portal.security.ldap,\
 	com.liferay.portal.security.ldap.authenticator.configuration,\

--- a/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/configuration/SystemLDAPConfiguration.java
+++ b/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/configuration/SystemLDAPConfiguration.java
@@ -8,6 +8,7 @@ package com.liferay.portal.security.ldap.configuration;
 import aQute.bnd.annotation.metatype.Meta;
 
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+import com.liferay.portal.security.ldap.constants.LDAPConstants;
 
 /**
  * @author Michael C. Han
@@ -68,9 +69,16 @@ public interface SystemLDAPConfiguration extends CompanyScopedConfiguration {
 	public int rangeSize();
 
 	@Meta.AD(
-		deflt = "follow", name = "referral",
-		optionLabels = {"follow", "ignore", "throws"},
-		optionValues = {"follow", "ignore", "throws"}, required = false
+		deflt = LDAPConstants.REFERRAL_IGNORE, name = "referral",
+		optionLabels = {
+			LDAPConstants.REFERRAL_FOLLOW, LDAPConstants.REFERRAL_IGNORE,
+			LDAPConstants.REFERRAL_THROWS
+		},
+		optionValues = {
+			LDAPConstants.REFERRAL_FOLLOW, LDAPConstants.REFERRAL_IGNORE,
+			LDAPConstants.REFERRAL_THROWS
+		},
+		required = false
 	)
 	public String referral();
 

--- a/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/configuration/SystemLDAPConfiguration.java
+++ b/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/configuration/SystemLDAPConfiguration.java
@@ -69,7 +69,8 @@ public interface SystemLDAPConfiguration extends CompanyScopedConfiguration {
 	public int rangeSize();
 
 	@Meta.AD(
-		deflt = LDAPConstants.REFERRAL_IGNORE, name = "referral",
+		deflt = LDAPConstants.REFERRAL_IGNORE,
+		description = "ldap-referral-help", name = "referral",
 		optionLabels = {
 			LDAPConstants.REFERRAL_FOLLOW, LDAPConstants.REFERRAL_IGNORE,
 			LDAPConstants.REFERRAL_THROWS

--- a/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/configuration/SystemLDAPConfiguration.java
+++ b/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/configuration/SystemLDAPConfiguration.java
@@ -73,11 +73,11 @@ public interface SystemLDAPConfiguration extends CompanyScopedConfiguration {
 		description = "ldap-referral-help", name = "referral",
 		optionLabels = {
 			LDAPConstants.REFERRAL_FOLLOW, LDAPConstants.REFERRAL_IGNORE,
-			LDAPConstants.REFERRAL_THROWS
+			LDAPConstants.REFERRAL_THROW
 		},
 		optionValues = {
 			LDAPConstants.REFERRAL_FOLLOW, LDAPConstants.REFERRAL_IGNORE,
-			LDAPConstants.REFERRAL_THROWS
+			LDAPConstants.REFERRAL_THROW
 		},
 		required = false
 	)

--- a/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/constants/LDAPConstants.java
+++ b/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/constants/LDAPConstants.java
@@ -131,7 +131,7 @@ public class LDAPConstants {
 
 	public static final String REFERRAL_IGNORE = "ignore";
 
-	public static final String REFERRAL_THROWS = "throws";
+	public static final String REFERRAL_THROW = "throw";
 
 	public static final String SECURITY_CREDENTIAL = "securityCredential";
 

--- a/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/constants/LDAPConstants.java
+++ b/modules/apps/portal-security/portal-security-ldap-api/src/main/java/com/liferay/portal/security/ldap/constants/LDAPConstants.java
@@ -127,6 +127,12 @@ public class LDAPConstants {
 
 	public static final String REFERRAL = "referral";
 
+	public static final String REFERRAL_FOLLOW = "follow";
+
+	public static final String REFERRAL_IGNORE = "ignore";
+
+	public static final String REFERRAL_THROWS = "throws";
+
 	public static final String SECURITY_CREDENTIAL = "securityCredential";
 
 	public static final String SECURITY_PRINCIPAL = "securityPrincipal";

--- a/modules/apps/portal-security/portal-security-ldap-api/src/main/resources/com/liferay/portal/security/ldap/configuration/packageinfo
+++ b/modules/apps/portal-security/portal-security-ldap-api/src/main/resources/com/liferay/portal/security/ldap/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.1
+version 4.0.2

--- a/modules/apps/portal-security/portal-security-ldap-api/src/main/resources/com/liferay/portal/security/ldap/constants/packageinfo
+++ b/modules/apps/portal-security/portal-security-ldap-api/src/main/resources/com/liferay/portal/security/ldap/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 2.4.0

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
@@ -27,7 +27,7 @@ import com.liferay.portal.security.ldap.UserConverterKeys;
 import com.liferay.portal.security.ldap.configuration.ConfigurationProvider;
 import com.liferay.portal.security.ldap.configuration.LDAPServerConfiguration;
 import com.liferay.portal.security.ldap.configuration.SystemLDAPConfiguration;
-import com.liferay.portal.security.ldap.internal.util.SafeLDAPReferralUtil;
+import com.liferay.portal.security.ldap.internal.util.SafeLdapReferralUtil;
 import com.liferay.portal.security.ldap.util.LDAPUtil;
 import com.liferay.portal.security.ldap.validator.LDAPFilterValidator;
 
@@ -158,7 +158,7 @@ public class DefaultPortalLDAP implements PortalLDAP {
 				connectionPropertySplit[0], connectionPropertySplit[1]);
 		}
 
-		SafeLDAPReferralUtil.setProperties(
+		SafeLdapReferralUtil.setProperties(
 			environmentProperties, systemLDAPConfiguration.referral());
 
 		if (_log.isDebugEnabled()) {

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/DefaultPortalLDAP.java
@@ -27,6 +27,7 @@ import com.liferay.portal.security.ldap.UserConverterKeys;
 import com.liferay.portal.security.ldap.configuration.ConfigurationProvider;
 import com.liferay.portal.security.ldap.configuration.LDAPServerConfiguration;
 import com.liferay.portal.security.ldap.configuration.SystemLDAPConfiguration;
+import com.liferay.portal.security.ldap.internal.util.SafeLDAPReferralUtil;
 import com.liferay.portal.security.ldap.util.LDAPUtil;
 import com.liferay.portal.security.ldap.validator.LDAPFilterValidator;
 
@@ -133,8 +134,6 @@ public class DefaultPortalLDAP implements PortalLDAP {
 			Context.INITIAL_CONTEXT_FACTORY,
 			systemLDAPConfiguration.factoryInitial());
 		environmentProperties.put(Context.PROVIDER_URL, providerURL);
-		environmentProperties.put(
-			Context.REFERRAL, systemLDAPConfiguration.referral());
 		environmentProperties.put(Context.SECURITY_CREDENTIALS, credentials);
 		environmentProperties.put(Context.SECURITY_PRINCIPAL, principal);
 
@@ -158,6 +157,9 @@ public class DefaultPortalLDAP implements PortalLDAP {
 			environmentProperties.put(
 				connectionPropertySplit[0], connectionPropertySplit[1]);
 		}
+
+		SafeLDAPReferralUtil.setProperties(
+			environmentProperties, systemLDAPConfiguration.referral());
 
 		if (_log.isDebugEnabled()) {
 			_log.debug(

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/SafePortalLDAPImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/SafePortalLDAPImpl.java
@@ -34,7 +34,7 @@ import com.liferay.portal.security.ldap.configuration.ConfigurationProvider;
 import com.liferay.portal.security.ldap.configuration.LDAPServerConfiguration;
 import com.liferay.portal.security.ldap.configuration.SystemLDAPConfiguration;
 import com.liferay.portal.security.ldap.constants.LDAPConstants;
-import com.liferay.portal.security.ldap.internal.util.SafeLDAPReferralUtil;
+import com.liferay.portal.security.ldap.internal.util.SafeLdapReferralUtil;
 import com.liferay.portal.security.ldap.internal.validator.SafeLdapContextImpl;
 import com.liferay.portal.security.ldap.util.LDAPUtil;
 import com.liferay.portal.security.ldap.validator.LDAPFilterValidator;
@@ -454,7 +454,7 @@ public class SafePortalLDAPImpl implements SafePortalLDAP {
 				connectionProperty[0], connectionProperty[1]);
 		}
 
-		SafeLDAPReferralUtil.setProperties(
+		SafeLdapReferralUtil.setProperties(
 			environmentProperties, systemLDAPConfiguration.referral());
 
 		if (_log.isDebugEnabled()) {

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/SafePortalLDAPImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/SafePortalLDAPImpl.java
@@ -33,6 +33,8 @@ import com.liferay.portal.security.ldap.UserConverterKeys;
 import com.liferay.portal.security.ldap.configuration.ConfigurationProvider;
 import com.liferay.portal.security.ldap.configuration.LDAPServerConfiguration;
 import com.liferay.portal.security.ldap.configuration.SystemLDAPConfiguration;
+import com.liferay.portal.security.ldap.constants.LDAPConstants;
+import com.liferay.portal.security.ldap.internal.util.SafeLDAPReferralUtil;
 import com.liferay.portal.security.ldap.internal.validator.SafeLdapContextImpl;
 import com.liferay.portal.security.ldap.util.LDAPUtil;
 import com.liferay.portal.security.ldap.validator.LDAPFilterValidator;
@@ -40,6 +42,7 @@ import com.liferay.portal.security.ldap.validator.LDAPFilterValidator;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.Properties;
 
 import javax.naming.Binding;
@@ -427,8 +430,6 @@ public class SafePortalLDAPImpl implements SafePortalLDAP {
 			Context.INITIAL_CONTEXT_FACTORY,
 			systemLDAPConfiguration.factoryInitial());
 		environmentProperties.put(Context.PROVIDER_URL, providerURL);
-		environmentProperties.put(
-			Context.REFERRAL, systemLDAPConfiguration.referral());
 		environmentProperties.put(Context.SECURITY_CREDENTIALS, credentials);
 		environmentProperties.put(Context.SECURITY_PRINCIPAL, principal);
 
@@ -453,6 +454,9 @@ public class SafePortalLDAPImpl implements SafePortalLDAP {
 				connectionProperty[0], connectionProperty[1]);
 		}
 
+		SafeLDAPReferralUtil.setProperties(
+			environmentProperties, systemLDAPConfiguration.referral());
+
 		if (_log.isDebugEnabled()) {
 			_log.debug(
 				MapUtil.toString(
@@ -463,7 +467,10 @@ public class SafePortalLDAPImpl implements SafePortalLDAP {
 				SafeLdapContextImpl.class.getClassLoader())) {
 
 			return new SafeLdapContextImpl(
-				new InitialLdapContext(environmentProperties, null));
+				new InitialLdapContext(environmentProperties, null),
+				Objects.equals(
+					systemLDAPConfiguration.referral(),
+					LDAPConstants.REFERRAL_FOLLOW));
 		}
 		catch (Exception exception) {
 			if (_log.isWarnEnabled()) {

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
@@ -37,7 +37,7 @@ import com.liferay.portal.security.ldap.configuration.SystemLDAPConfiguration;
 import com.liferay.portal.security.ldap.constants.LDAPConstants;
 import com.liferay.portal.security.ldap.exportimport.LDAPUserImporter;
 import com.liferay.portal.security.ldap.exportimport.configuration.LDAPImportConfiguration;
-import com.liferay.portal.security.ldap.internal.util.SafeLDAPReferralUtil;
+import com.liferay.portal.security.ldap.internal.util.SafeLdapReferralUtil;
 import com.liferay.portal.security.ldap.util.LDAPUtil;
 import com.liferay.portal.security.ldap.validator.LDAPFilterValidator;
 import com.liferay.portlet.admin.util.OmniadminUtil;
@@ -160,7 +160,7 @@ public class LDAPAuth implements Authenticator {
 			SystemLDAPConfiguration systemLDAPConfiguration =
 				_systemLDAPConfigurationProvider.getConfiguration(companyId);
 
-			SafeLDAPReferralUtil.setProperties(
+			SafeLdapReferralUtil.setProperties(
 				env, systemLDAPConfiguration.referral());
 
 			env.put(Context.SECURITY_CREDENTIALS, password);

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/authenticator/LDAPAuth.java
@@ -37,6 +37,7 @@ import com.liferay.portal.security.ldap.configuration.SystemLDAPConfiguration;
 import com.liferay.portal.security.ldap.constants.LDAPConstants;
 import com.liferay.portal.security.ldap.exportimport.LDAPUserImporter;
 import com.liferay.portal.security.ldap.exportimport.configuration.LDAPImportConfiguration;
+import com.liferay.portal.security.ldap.internal.util.SafeLDAPReferralUtil;
 import com.liferay.portal.security.ldap.util.LDAPUtil;
 import com.liferay.portal.security.ldap.validator.LDAPFilterValidator;
 import com.liferay.portlet.admin.util.OmniadminUtil;
@@ -159,7 +160,8 @@ public class LDAPAuth implements Authenticator {
 			SystemLDAPConfiguration systemLDAPConfiguration =
 				_systemLDAPConfigurationProvider.getConfiguration(companyId);
 
-			env.put(Context.REFERRAL, systemLDAPConfiguration.referral());
+			SafeLDAPReferralUtil.setProperties(
+				env, systemLDAPConfiguration.referral());
 
 			env.put(Context.SECURITY_CREDENTIALS, password);
 			env.put(Context.SECURITY_PRINCIPAL, userDN);

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/upgrade/registry/LDAPServiceUpgradeStepRegistrator.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/upgrade/registry/LDAPServiceUpgradeStepRegistrator.java
@@ -16,6 +16,7 @@ import com.liferay.portal.security.ldap.exportimport.configuration.LDAPExportCon
 import com.liferay.portal.security.ldap.exportimport.configuration.LDAPImportConfiguration;
 import com.liferay.portal.security.ldap.internal.upgrade.v0_0_2.LDAPPropertiesUpgradeProcess;
 import com.liferay.portal.security.ldap.internal.upgrade.v1_0_0.LDAPSystemConfigurationsUpgradeProcess;
+import com.liferay.portal.security.ldap.internal.upgrade.v1_0_1.LDAPReferralUpgradeProcess;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -46,6 +47,10 @@ public class LDAPServiceUpgradeStepRegistrator
 			"0.0.2", "1.0.0",
 			new LDAPSystemConfigurationsUpgradeProcess(
 				_configurationAdmin, _configurationProvider));
+
+		registry.register(
+			"1.0.0", "1.0.1",
+			new LDAPReferralUpgradeProcess(_configurationAdmin));
 	}
 
 	@Reference

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/upgrade/v0_0_2/LDAPPropertiesUpgradeProcess.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/upgrade/v0_0_2/LDAPPropertiesUpgradeProcess.java
@@ -469,7 +469,8 @@ public class LDAPPropertiesUpgradeProcess extends UpgradeProcess {
 			).put(
 				LDAPConstants.REFERRAL,
 				_prefsProps.getString(
-					companyId, LegacyLDAPPropsKeys.LDAP_REFERRAL, "follow")
+					companyId, LegacyLDAPPropsKeys.LDAP_REFERRAL,
+					LDAPConstants.REFERRAL_FOLLOW)
 			).build();
 
 		if (_log.isInfoEnabled()) {

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/upgrade/v1_0_1/LDAPReferralUpgradeProcess.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/upgrade/v1_0_1/LDAPReferralUpgradeProcess.java
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.ldap.internal.upgrade.v1_0_1;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.security.ldap.configuration.SystemLDAPConfiguration;
+import com.liferay.portal.security.ldap.constants.LDAPConstants;
+
+import java.util.Dictionary;
+import java.util.Objects;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author Christian Moura
+ */
+public class LDAPReferralUpgradeProcess extends UpgradeProcess {
+
+	public LDAPReferralUpgradeProcess(ConfigurationAdmin configurationAdmin) {
+		_configurationAdmin = configurationAdmin;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			"(service.factoryPid=" + SystemLDAPConfiguration.class.getName() +
+				")");
+
+		if (configurations == null) {
+			return;
+		}
+
+		for (Configuration configuration : configurations) {
+			Dictionary<String, Object> properties =
+				configuration.getProperties();
+
+			if (properties == null) {
+				continue;
+			}
+
+			if (Objects.equals(
+					properties.get(LDAPConstants.REFERRAL), "throws")) {
+
+				properties.put(
+					LDAPConstants.REFERRAL, LDAPConstants.REFERRAL_THROW);
+
+				configuration.update(properties);
+			}
+		}
+	}
+
+	private final ConfigurationAdmin _configurationAdmin;
+
+}

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/util/SafeLDAPReferralUtil.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/util/SafeLDAPReferralUtil.java
@@ -116,7 +116,7 @@ public class SafeLDAPReferralUtil {
 		environment.put("com.sun.jndi.rmi.object.trustURLCodebase", "false");
 
 		if (Objects.equals(referral, LDAPConstants.REFERRAL_FOLLOW)) {
-			environment.put(Context.REFERRAL, LDAPConstants.REFERRAL_THROWS);
+			environment.put(Context.REFERRAL, LDAPConstants.REFERRAL_THROW);
 		}
 		else {
 			environment.put(Context.REFERRAL, referral);

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/util/SafeLDAPReferralUtil.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/util/SafeLDAPReferralUtil.java
@@ -1,0 +1,185 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.ldap.internal.util;
+
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.security.ldap.constants.LDAPConstants;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Queue;
+
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.NamingEnumeration;
+import javax.naming.NamingException;
+import javax.naming.ReferralException;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+
+/**
+ * @author Lucas Miranda
+ */
+public class SafeLDAPReferralUtil {
+
+	public static NamingEnumeration<SearchResult> search(
+			DirContext dirContext, String filter, Object[] filterArguments,
+			Name name, SearchControls searchControls)
+		throws NamingException {
+
+		List<SearchResult> searchResults = new ArrayList<>();
+
+		Queue<DirContext> dirContexts = new ArrayDeque<>();
+
+		dirContexts.add(dirContext);
+
+		int referralCount = 0;
+
+		try {
+			while (!dirContexts.isEmpty()) {
+				DirContext currentDirContext = dirContexts.poll();
+
+				NamingEnumeration<SearchResult> enumeration = null;
+
+				try {
+					enumeration = currentDirContext.search(
+						name, filter, filterArguments, searchControls);
+
+					while (enumeration.hasMore()) {
+						searchResults.add(enumeration.next());
+					}
+				}
+				catch (ReferralException referralException) {
+					boolean hasReferral = true;
+
+					while (hasReferral) {
+						Object referralInfo =
+							referralException.getReferralInfo();
+
+						if (!(referralInfo instanceof String) ||
+							!_isAllowedReferralURL((String)referralInfo) ||
+							(referralCount >= _MAX_REFERRAL_COUNT)) {
+
+							hasReferral = referralException.skipReferral();
+
+							continue;
+						}
+
+						referralCount++;
+
+						dirContexts.add(
+							(DirContext)referralException.getReferralContext());
+
+						hasReferral = referralException.skipReferral();
+					}
+				}
+				finally {
+					if (enumeration != null) {
+						enumeration.close();
+					}
+
+					if (currentDirContext != dirContext) {
+						currentDirContext.close();
+					}
+				}
+			}
+		}
+		finally {
+			for (DirContext remainingDirContext : dirContexts) {
+				if (remainingDirContext == dirContext) {
+					continue;
+				}
+
+				remainingDirContext.close();
+			}
+		}
+
+		return new ListNamingEnumeration(searchResults);
+	}
+
+	public static void setProperties(
+		Map<? super String, ? super String> environment, String referral) {
+
+		environment.put(
+			"com.sun.jndi.cosnaming.object.trustURLCodebase", "false");
+		environment.put("com.sun.jndi.ldap.object.trustURLCodebase", "false");
+		environment.put("com.sun.jndi.rmi.object.trustURLCodebase", "false");
+
+		if (Objects.equals(referral, LDAPConstants.REFERRAL_FOLLOW)) {
+			environment.put(Context.REFERRAL, LDAPConstants.REFERRAL_THROWS);
+		}
+		else {
+			environment.put(Context.REFERRAL, referral);
+		}
+	}
+
+	private static boolean _isAllowedReferralURL(String url) {
+		if (Validator.isNull(url)) {
+			return false;
+		}
+
+		String normalizedURL = StringUtil.toLowerCase(StringUtil.trim(url));
+
+		for (String referralURL : normalizedURL.split("\\s+")) {
+			if (!referralURL.startsWith("ldap://") &&
+				!referralURL.startsWith("ldaps://")) {
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	private static final int _MAX_REFERRAL_COUNT = 10;
+
+	private static class ListNamingEnumeration
+		implements NamingEnumeration<SearchResult> {
+
+		public ListNamingEnumeration(List<SearchResult> searchResults) {
+			_iterator = searchResults.iterator();
+		}
+
+		@Override
+		public void close() {
+		}
+
+		@Override
+		public boolean hasMore() {
+			return _iterator.hasNext();
+		}
+
+		@Override
+		public boolean hasMoreElements() {
+			return _iterator.hasNext();
+		}
+
+		@Override
+		public SearchResult next() {
+			return _iterator.next();
+		}
+
+		@Override
+		public SearchResult nextElement() {
+			if (!_iterator.hasNext()) {
+				throw new NoSuchElementException();
+			}
+
+			return _iterator.next();
+		}
+
+		private final Iterator<SearchResult> _iterator;
+
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtil.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtil.java
@@ -47,7 +47,6 @@ public class SafeLdapReferralUtil {
 		try {
 			while (!dirContexts.isEmpty()) {
 				DirContext currentDirContext = dirContexts.poll();
-
 				NamingEnumeration<SearchResult> enumeration = null;
 
 				try {
@@ -74,12 +73,10 @@ public class SafeLdapReferralUtil {
 							continue;
 						}
 
-						referralCount++;
-
 						dirContexts.add(
 							(DirContext)referralException.getReferralContext());
-
 						hasReferral = referralException.skipReferral();
+						referralCount++;
 					}
 				}
 				finally {

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtil.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtil.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Queue;
 
@@ -171,10 +170,6 @@ public class SafeLdapReferralUtil {
 
 		@Override
 		public SearchResult nextElement() {
-			if (!_iterator.hasNext()) {
-				throw new NoSuchElementException();
-			}
-
 			return _iterator.next();
 		}
 

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtil.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtil.java
@@ -32,51 +32,50 @@ import javax.naming.directory.SearchResult;
 public class SafeLdapReferralUtil {
 
 	public static NamingEnumeration<SearchResult> search(
-			DirContext dirContext, String filter, Object[] filterArguments,
-			Name name, SearchControls searchControls)
+			String filter, Object[] filterArguments, Name name,
+			DirContext rootDirContext, SearchControls searchControls)
 		throws NamingException {
 
-		List<SearchResult> searchResults = new ArrayList<>();
+		ListNamingEnumeration listNamingEnumeration =
+			new ListNamingEnumeration();
 
 		Queue<DirContext> dirContexts = new ArrayDeque<>();
 
-		dirContexts.add(dirContext);
+		dirContexts.add(rootDirContext);
 
 		int referralCount = 0;
 
 		try {
 			while (!dirContexts.isEmpty()) {
-				DirContext currentDirContext = dirContexts.poll();
+				DirContext dirContext = dirContexts.poll();
+
 				NamingEnumeration<SearchResult> enumeration = null;
 
 				try {
-					enumeration = currentDirContext.search(
+					enumeration = dirContext.search(
 						name, filter, filterArguments, searchControls);
 
-					while (enumeration.hasMore()) {
-						searchResults.add(enumeration.next());
-					}
+					listNamingEnumeration.addAll(enumeration);
 				}
 				catch (ReferralException referralException) {
-					boolean hasReferral = true;
+					boolean skipReferral = true;
 
-					while (hasReferral) {
+					while (skipReferral) {
 						Object referralInfo =
 							referralException.getReferralInfo();
 
-						if (!(referralInfo instanceof String) ||
-							!_isAllowedReferralURL((String)referralInfo) ||
-							(referralCount >= _MAX_REFERRAL_COUNT)) {
+						if ((referralInfo instanceof String) &&
+							_isAllowedReferralURL((String)referralInfo) &&
+							(referralCount < _MAX_REFERRAL_COUNT)) {
 
-							hasReferral = referralException.skipReferral();
+							dirContexts.add(
+								(DirContext)
+									referralException.getReferralContext());
 
-							continue;
+							referralCount++;
 						}
 
-						dirContexts.add(
-							(DirContext)referralException.getReferralContext());
-						hasReferral = referralException.skipReferral();
-						referralCount++;
+						skipReferral = referralException.skipReferral();
 					}
 				}
 				finally {
@@ -84,23 +83,23 @@ public class SafeLdapReferralUtil {
 						enumeration.close();
 					}
 
-					if (currentDirContext != dirContext) {
-						currentDirContext.close();
+					if (dirContext != rootDirContext) {
+						dirContext.close();
 					}
 				}
 			}
 		}
 		finally {
-			for (DirContext remainingDirContext : dirContexts) {
-				if (remainingDirContext == dirContext) {
+			for (DirContext dirContext : dirContexts) {
+				if (dirContext == rootDirContext) {
 					continue;
 				}
 
-				remainingDirContext.close();
+				dirContext.close();
 			}
 		}
 
-		return new ListNamingEnumeration(searchResults);
+		return listNamingEnumeration;
 	}
 
 	public static void setProperties(
@@ -142,8 +141,12 @@ public class SafeLdapReferralUtil {
 	private static class ListNamingEnumeration
 		implements NamingEnumeration<SearchResult> {
 
-		public ListNamingEnumeration(List<SearchResult> searchResults) {
-			_iterator = searchResults.iterator();
+		public void addAll(NamingEnumeration<SearchResult> namingEnumeration)
+			throws NamingException {
+
+			while (namingEnumeration.hasMore()) {
+				_searchResults.add(namingEnumeration.next());
+			}
 		}
 
 		@Override
@@ -152,25 +155,42 @@ public class SafeLdapReferralUtil {
 
 		@Override
 		public boolean hasMore() {
-			return _iterator.hasNext();
+			Iterator<SearchResult> iterator = _getIterator();
+
+			return iterator.hasNext();
 		}
 
 		@Override
 		public boolean hasMoreElements() {
-			return _iterator.hasNext();
+			Iterator<SearchResult> iterator = _getIterator();
+
+			return iterator.hasNext();
 		}
 
 		@Override
 		public SearchResult next() {
-			return _iterator.next();
+			Iterator<SearchResult> iterator = _getIterator();
+
+			return iterator.next();
 		}
 
 		@Override
 		public SearchResult nextElement() {
-			return _iterator.next();
+			Iterator<SearchResult> iterator = _getIterator();
+
+			return iterator.next();
 		}
 
-		private final Iterator<SearchResult> _iterator;
+		private Iterator<SearchResult> _getIterator() {
+			if (_iterator == null) {
+				_iterator = _searchResults.iterator();
+			}
+
+			return _iterator;
+		}
+
+		private Iterator<SearchResult> _iterator;
+		private final List<SearchResult> _searchResults = new ArrayList<>();
 
 	}
 

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtil.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtil.java
@@ -30,7 +30,7 @@ import javax.naming.directory.SearchResult;
 /**
  * @author Lucas Miranda
  */
-public class SafeLDAPReferralUtil {
+public class SafeLdapReferralUtil {
 
 	public static NamingEnumeration<SearchResult> search(
 			DirContext dirContext, String filter, Object[] filterArguments,

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/validator/SafeLdapContextImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/validator/SafeLdapContextImpl.java
@@ -538,8 +538,8 @@ public class SafeLdapContextImpl implements SafeLdapContext {
 
 		if (_manageReferrals) {
 			return SafeLdapReferralUtil.search(
-				_ldapContext, safeLdapFilter.getFilterString(),
-				safeLdapFilter.getArguments(), safeLdapName, searchControls);
+				safeLdapFilter.getFilterString(), safeLdapFilter.getArguments(),
+				safeLdapName, _ldapContext, searchControls);
 		}
 
 		return _ldapContext.search(

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/validator/SafeLdapContextImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/validator/SafeLdapContextImpl.java
@@ -11,6 +11,7 @@ import com.liferay.portal.security.ldap.SafeLdapContext;
 import com.liferay.portal.security.ldap.SafeLdapFilter;
 import com.liferay.portal.security.ldap.SafeLdapName;
 import com.liferay.portal.security.ldap.SafeLdapNameFactory;
+import com.liferay.portal.security.ldap.internal.util.SafeLDAPReferralUtil;
 
 import java.util.Hashtable;
 
@@ -37,7 +38,14 @@ import javax.naming.ldap.LdapContext;
 public class SafeLdapContextImpl implements SafeLdapContext {
 
 	public SafeLdapContextImpl(LdapContext ldapContext) {
+		this(ldapContext, false);
+	}
+
+	public SafeLdapContextImpl(
+		LdapContext ldapContext, boolean manageReferrals) {
+
 		_ldapContext = ldapContext;
+		_manageReferrals = manageReferrals;
 	}
 
 	@Override
@@ -528,6 +536,12 @@ public class SafeLdapContextImpl implements SafeLdapContext {
 			SearchControls searchControls)
 		throws NamingException {
 
+		if (_manageReferrals) {
+			return SafeLDAPReferralUtil.search(
+				_ldapContext, safeLdapFilter.getFilterString(),
+				safeLdapFilter.getArguments(), safeLdapName, searchControls);
+		}
+
 		return _ldapContext.search(
 			safeLdapName, safeLdapFilter.getFilterString(),
 			safeLdapFilter.getArguments(), searchControls);
@@ -629,5 +643,6 @@ public class SafeLdapContextImpl implements SafeLdapContext {
 		SafeLdapContextImpl.class);
 
 	private final LdapContext _ldapContext;
+	private final boolean _manageReferrals;
 
 }

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/validator/SafeLdapContextImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/validator/SafeLdapContextImpl.java
@@ -11,7 +11,7 @@ import com.liferay.portal.security.ldap.SafeLdapContext;
 import com.liferay.portal.security.ldap.SafeLdapFilter;
 import com.liferay.portal.security.ldap.SafeLdapName;
 import com.liferay.portal.security.ldap.SafeLdapNameFactory;
-import com.liferay.portal.security.ldap.internal.util.SafeLDAPReferralUtil;
+import com.liferay.portal.security.ldap.internal.util.SafeLdapReferralUtil;
 
 import java.util.Hashtable;
 
@@ -537,7 +537,7 @@ public class SafeLdapContextImpl implements SafeLdapContext {
 		throws NamingException {
 
 		if (_manageReferrals) {
-			return SafeLDAPReferralUtil.search(
+			return SafeLdapReferralUtil.search(
 				_ldapContext, safeLdapFilter.getFilterString(),
 				safeLdapFilter.getArguments(), safeLdapName, searchControls);
 		}

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLDAPReferralUtilTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLDAPReferralUtilTest.java
@@ -47,6 +47,10 @@ public class SafeLDAPReferralUtilTest {
 			ReflectionTestUtil.invoke(
 				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
 				new Class<?>[] {String.class}, "  ldap://host:389  "));
+		Assert.assertTrue(
+			ReflectionTestUtil.invoke(
+				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				new Class<?>[] {String.class}, "LDAP://host:389"));
 		Assert.assertFalse(
 			ReflectionTestUtil.invoke(
 				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
@@ -73,10 +77,6 @@ public class SafeLDAPReferralUtilTest {
 				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
 				new Class<?>[] {String.class},
 				"ldap://host1:389 rmi://host2:1099/exploit"));
-		Assert.assertTrue(
-			ReflectionTestUtil.invoke(
-				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
-				new Class<?>[] {String.class}, "LDAP://host:389"));
 		Assert.assertTrue(
 			ReflectionTestUtil.invoke(
 				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLDAPReferralUtilTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLDAPReferralUtilTest.java
@@ -103,6 +103,9 @@ public class SafeLDAPReferralUtilTest {
 	public void testSearch() throws Exception {
 		DirContext dirContext = Mockito.mock(DirContext.class);
 
+		NamingEnumeration<SearchResult> enumeration = Mockito.mock(
+			NamingEnumeration.class);
+
 		ReferralException referralException = Mockito.mock(
 			ReferralException.class);
 
@@ -117,9 +120,6 @@ public class SafeLDAPReferralUtilTest {
 		).thenReturn(
 			false
 		);
-
-		NamingEnumeration<SearchResult> enumeration = Mockito.mock(
-			NamingEnumeration.class);
 
 		Mockito.when(
 			enumeration.hasMore()
@@ -148,7 +148,17 @@ public class SafeLDAPReferralUtilTest {
 
 		dirContext = Mockito.mock(DirContext.class);
 
+		enumeration = Mockito.mock(NamingEnumeration.class);
+
 		referralException = Mockito.mock(ReferralException.class);
+
+		DirContext referralContext = Mockito.mock(DirContext.class);
+
+		NamingEnumeration<SearchResult> referralEnumeration = Mockito.mock(
+			NamingEnumeration.class);
+
+		SearchResult searchResult = new SearchResult(
+			"cn=test", null, new BasicAttributes());
 
 		Mockito.when(
 			referralException.getReferralInfo()
@@ -162,7 +172,23 @@ public class SafeLDAPReferralUtilTest {
 			false
 		);
 
-		enumeration = Mockito.mock(NamingEnumeration.class);
+		Mockito.when(
+			referralException.getReferralContext()
+		).thenReturn(
+			referralContext
+		);
+
+		Mockito.when(
+			referralEnumeration.hasMore()
+		).thenReturn(
+			true, false
+		);
+
+		Mockito.when(
+			referralEnumeration.next()
+		).thenReturn(
+			searchResult
+		);
 
 		Mockito.when(
 			enumeration.hasMore()
@@ -176,32 +202,6 @@ public class SafeLDAPReferralUtilTest {
 				Mockito.any(Object[].class), Mockito.any(SearchControls.class))
 		).thenReturn(
 			enumeration
-		);
-
-		DirContext referralContext = Mockito.mock(DirContext.class);
-
-		Mockito.when(
-			referralException.getReferralContext()
-		).thenReturn(
-			referralContext
-		);
-
-		SearchResult searchResult = new SearchResult(
-			"cn=test", null, new BasicAttributes());
-
-		NamingEnumeration<SearchResult> referralEnumeration = Mockito.mock(
-			NamingEnumeration.class);
-
-		Mockito.when(
-			referralEnumeration.hasMore()
-		).thenReturn(
-			true, false
-		);
-
-		Mockito.when(
-			referralEnumeration.next()
-		).thenReturn(
-			searchResult
 		);
 
 		Mockito.when(

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLDAPReferralUtilTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLDAPReferralUtilTest.java
@@ -231,7 +231,7 @@ public class SafeLDAPReferralUtilTest {
 
 		SafeLDAPReferralUtil.setProperties(environment, "follow");
 
-		Assert.assertEquals("throws", environment.get(Context.REFERRAL));
+		Assert.assertEquals("throw", environment.get(Context.REFERRAL));
 
 		_assertTrustURLCodebaseDisabled(environment);
 
@@ -241,9 +241,9 @@ public class SafeLDAPReferralUtilTest {
 
 		_assertTrustURLCodebaseDisabled(environment);
 
-		SafeLDAPReferralUtil.setProperties(environment, "throws");
+		SafeLDAPReferralUtil.setProperties(environment, "throw");
 
-		Assert.assertEquals("throws", environment.get(Context.REFERRAL));
+		Assert.assertEquals("throw", environment.get(Context.REFERRAL));
 
 		_assertTrustURLCodebaseDisabled(environment);
 	}

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLDAPReferralUtilTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLDAPReferralUtilTest.java
@@ -1,0 +1,265 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.ldap.internal.util;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.naming.Context;
+import javax.naming.Name;
+import javax.naming.NamingEnumeration;
+import javax.naming.ReferralException;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Lucas Miranda
+ */
+public class SafeLDAPReferralUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testIsAllowedReferralURL() {
+		Assert.assertFalse(
+			ReflectionTestUtil.invoke(
+				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				new Class<?>[] {String.class}, ""));
+		Assert.assertTrue(
+			ReflectionTestUtil.invoke(
+				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				new Class<?>[] {String.class}, "  ldap://host:389  "));
+		Assert.assertFalse(
+			ReflectionTestUtil.invoke(
+				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				new Class<?>[] {String.class}, "corba://host/exploit"));
+		Assert.assertFalse(
+			ReflectionTestUtil.invoke(
+				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				new Class<?>[] {String.class}, "dns://host"));
+		Assert.assertFalse(
+			ReflectionTestUtil.invoke(
+				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				new Class<?>[] {String.class}, "host:389"));
+		Assert.assertFalse(
+			ReflectionTestUtil.invoke(
+				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				new Class<?>[] {String.class}, "http://host/exploit"));
+		Assert.assertTrue(
+			ReflectionTestUtil.invoke(
+				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				new Class<?>[] {String.class},
+				"ldap://host1:389 ldap://host2:389"));
+		Assert.assertFalse(
+			ReflectionTestUtil.invoke(
+				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				new Class<?>[] {String.class},
+				"ldap://host1:389 rmi://host2:1099/exploit"));
+		Assert.assertTrue(
+			ReflectionTestUtil.invoke(
+				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				new Class<?>[] {String.class}, "LDAP://host:389"));
+		Assert.assertTrue(
+			ReflectionTestUtil.invoke(
+				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				new Class<?>[] {String.class}, "ldap://host:389"));
+		Assert.assertTrue(
+			ReflectionTestUtil.invoke(
+				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				new Class<?>[] {String.class}, "ldaps://host:636"));
+		Assert.assertFalse(
+			ReflectionTestUtil.invoke(
+				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				new Class<?>[] {String.class}, "ldapx://host"));
+		Assert.assertFalse(
+			ReflectionTestUtil.invoke(
+				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				new Class<?>[] {String.class}, "rmi://host:1099/exploit"));
+		Assert.assertFalse(
+			ReflectionTestUtil.invoke(
+				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				new Class<?>[] {String.class}, (String)null));
+	}
+
+	@Test
+	public void testSearch() throws Exception {
+		DirContext dirContext = Mockito.mock(DirContext.class);
+
+		ReferralException referralException = Mockito.mock(
+			ReferralException.class);
+
+		Mockito.when(
+			referralException.getReferralInfo()
+		).thenReturn(
+			"rmi://attacker:1099/exploit"
+		);
+
+		Mockito.when(
+			referralException.skipReferral()
+		).thenReturn(
+			false
+		);
+
+		NamingEnumeration<SearchResult> enumeration = Mockito.mock(
+			NamingEnumeration.class);
+
+		Mockito.when(
+			enumeration.hasMore()
+		).thenThrow(
+			referralException
+		);
+
+		Mockito.when(
+			dirContext.search(
+				Mockito.any(Name.class), Mockito.anyString(),
+				Mockito.any(Object[].class), Mockito.any(SearchControls.class))
+		).thenReturn(
+			enumeration
+		);
+
+		NamingEnumeration<SearchResult> resultEnumeration =
+			SafeLDAPReferralUtil.search(
+				dirContext, "(cn=*)", new Object[0], Mockito.mock(Name.class),
+				new SearchControls());
+
+		Assert.assertFalse(resultEnumeration.hasMore());
+
+		Mockito.verify(
+			referralException, Mockito.never()
+		).getReferralContext();
+
+		dirContext = Mockito.mock(DirContext.class);
+
+		referralException = Mockito.mock(ReferralException.class);
+
+		Mockito.when(
+			referralException.getReferralInfo()
+		).thenReturn(
+			"ldap://other:389"
+		);
+
+		Mockito.when(
+			referralException.skipReferral()
+		).thenReturn(
+			false
+		);
+
+		enumeration = Mockito.mock(NamingEnumeration.class);
+
+		Mockito.when(
+			enumeration.hasMore()
+		).thenThrow(
+			referralException
+		);
+
+		Mockito.when(
+			dirContext.search(
+				Mockito.any(Name.class), Mockito.anyString(),
+				Mockito.any(Object[].class), Mockito.any(SearchControls.class))
+		).thenReturn(
+			enumeration
+		);
+
+		DirContext referralContext = Mockito.mock(DirContext.class);
+
+		Mockito.when(
+			referralException.getReferralContext()
+		).thenReturn(
+			referralContext
+		);
+
+		SearchResult searchResult = new SearchResult(
+			"cn=test", null, new BasicAttributes());
+
+		NamingEnumeration<SearchResult> referralEnumeration = Mockito.mock(
+			NamingEnumeration.class);
+
+		Mockito.when(
+			referralEnumeration.hasMore()
+		).thenReturn(
+			true, false
+		);
+
+		Mockito.when(
+			referralEnumeration.next()
+		).thenReturn(
+			searchResult
+		);
+
+		Mockito.when(
+			referralContext.search(
+				Mockito.any(Name.class), Mockito.anyString(),
+				Mockito.any(Object[].class), Mockito.any(SearchControls.class))
+		).thenReturn(
+			referralEnumeration
+		);
+
+		resultEnumeration = SafeLDAPReferralUtil.search(
+			dirContext, "(cn=*)", new Object[0], Mockito.mock(Name.class),
+			new SearchControls());
+
+		Assert.assertTrue(resultEnumeration.hasMore());
+		Assert.assertSame(searchResult, resultEnumeration.next());
+		Assert.assertFalse(resultEnumeration.hasMore());
+
+		Mockito.verify(
+			referralException, Mockito.times(1)
+		).getReferralContext();
+	}
+
+	@Test
+	public void testSetProperties() {
+		Map<String, String> environment = new HashMap<>();
+
+		SafeLDAPReferralUtil.setProperties(environment, "follow");
+
+		Assert.assertEquals("throws", environment.get(Context.REFERRAL));
+
+		_assertTrustURLCodebaseDisabled(environment);
+
+		SafeLDAPReferralUtil.setProperties(environment, "ignore");
+
+		Assert.assertEquals("ignore", environment.get(Context.REFERRAL));
+
+		_assertTrustURLCodebaseDisabled(environment);
+
+		SafeLDAPReferralUtil.setProperties(environment, "throws");
+
+		Assert.assertEquals("throws", environment.get(Context.REFERRAL));
+
+		_assertTrustURLCodebaseDisabled(environment);
+	}
+
+	private void _assertTrustURLCodebaseDisabled(
+		Map<String, String> environment) {
+
+		Assert.assertEquals(
+			"false",
+			environment.get("com.sun.jndi.cosnaming.object.trustURLCodebase"));
+		Assert.assertEquals(
+			"false",
+			environment.get("com.sun.jndi.ldap.object.trustURLCodebase"));
+		Assert.assertEquals(
+			"false",
+			environment.get("com.sun.jndi.rmi.object.trustURLCodebase"));
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtilTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtilTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.security.ldap.internal.util;
 
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.security.ldap.constants.LDAPConstants;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.HashMap;
@@ -100,12 +101,74 @@ public class SafeLdapReferralUtilTest {
 	}
 
 	@Test
-	public void testSearch() throws Exception {
-		DirContext dirContext = Mockito.mock(DirContext.class);
+	public void testSearchWithAllowedReferral() throws Exception {
+		ReferralException referralException = Mockito.mock(
+			ReferralException.class);
 
-		NamingEnumeration<SearchResult> enumeration = Mockito.mock(
+		SearchResult searchResult = new SearchResult(
+			"cn=test", null, new BasicAttributes());
+
+		NamingEnumeration<SearchResult> referralEnumeration = Mockito.mock(
 			NamingEnumeration.class);
 
+		Mockito.when(
+			referralEnumeration.hasMore()
+		).thenReturn(
+			true, false
+		);
+
+		Mockito.when(
+			referralEnumeration.next()
+		).thenReturn(
+			searchResult
+		);
+
+		DirContext referralContext = Mockito.mock(DirContext.class);
+
+		Mockito.when(
+			referralContext.search(
+				Mockito.any(Name.class), Mockito.anyString(),
+				Mockito.any(Object[].class), Mockito.any(SearchControls.class))
+		).thenReturn(
+			referralEnumeration
+		);
+
+		Mockito.when(
+			referralException.getReferralContext()
+		).thenReturn(
+			referralContext
+		);
+
+		Mockito.when(
+			referralException.getReferralInfo()
+		).thenReturn(
+			"ldap://other:389"
+		);
+
+		Mockito.when(
+			referralException.skipReferral()
+		).thenReturn(
+			false
+		);
+
+		DirContext dirContext = _mockDirContext(referralException);
+
+		NamingEnumeration<SearchResult> resultEnumeration =
+			SafeLdapReferralUtil.search(
+				dirContext, "(cn=*)", new Object[0], Mockito.mock(Name.class),
+				new SearchControls());
+
+		Assert.assertTrue(resultEnumeration.hasMore());
+		Assert.assertSame(searchResult, resultEnumeration.next());
+		Assert.assertFalse(resultEnumeration.hasMore());
+
+		Mockito.verify(
+			referralException, Mockito.times(1)
+		).getReferralContext();
+	}
+
+	@Test
+	public void testSearchWithDisallowedReferral() throws Exception {
 		ReferralException referralException = Mockito.mock(
 			ReferralException.class);
 
@@ -121,19 +184,7 @@ public class SafeLdapReferralUtilTest {
 			false
 		);
 
-		Mockito.when(
-			enumeration.hasMore()
-		).thenThrow(
-			referralException
-		);
-
-		Mockito.when(
-			dirContext.search(
-				Mockito.any(Name.class), Mockito.anyString(),
-				Mockito.any(Object[].class), Mockito.any(SearchControls.class))
-		).thenReturn(
-			enumeration
-		);
+		DirContext dirContext = _mockDirContext(referralException);
 
 		NamingEnumeration<SearchResult> resultEnumeration =
 			SafeLdapReferralUtil.search(
@@ -145,105 +196,33 @@ public class SafeLdapReferralUtilTest {
 		Mockito.verify(
 			referralException, Mockito.never()
 		).getReferralContext();
-
-		dirContext = Mockito.mock(DirContext.class);
-
-		enumeration = Mockito.mock(NamingEnumeration.class);
-
-		referralException = Mockito.mock(ReferralException.class);
-
-		DirContext referralContext = Mockito.mock(DirContext.class);
-
-		NamingEnumeration<SearchResult> referralEnumeration = Mockito.mock(
-			NamingEnumeration.class);
-
-		SearchResult searchResult = new SearchResult(
-			"cn=test", null, new BasicAttributes());
-
-		Mockito.when(
-			referralException.getReferralInfo()
-		).thenReturn(
-			"ldap://other:389"
-		);
-
-		Mockito.when(
-			referralException.skipReferral()
-		).thenReturn(
-			false
-		);
-
-		Mockito.when(
-			referralException.getReferralContext()
-		).thenReturn(
-			referralContext
-		);
-
-		Mockito.when(
-			referralEnumeration.hasMore()
-		).thenReturn(
-			true, false
-		);
-
-		Mockito.when(
-			referralEnumeration.next()
-		).thenReturn(
-			searchResult
-		);
-
-		Mockito.when(
-			enumeration.hasMore()
-		).thenThrow(
-			referralException
-		);
-
-		Mockito.when(
-			dirContext.search(
-				Mockito.any(Name.class), Mockito.anyString(),
-				Mockito.any(Object[].class), Mockito.any(SearchControls.class))
-		).thenReturn(
-			enumeration
-		);
-
-		Mockito.when(
-			referralContext.search(
-				Mockito.any(Name.class), Mockito.anyString(),
-				Mockito.any(Object[].class), Mockito.any(SearchControls.class))
-		).thenReturn(
-			referralEnumeration
-		);
-
-		resultEnumeration = SafeLdapReferralUtil.search(
-			dirContext, "(cn=*)", new Object[0], Mockito.mock(Name.class),
-			new SearchControls());
-
-		Assert.assertTrue(resultEnumeration.hasMore());
-		Assert.assertSame(searchResult, resultEnumeration.next());
-		Assert.assertFalse(resultEnumeration.hasMore());
-
-		Mockito.verify(
-			referralException, Mockito.times(1)
-		).getReferralContext();
 	}
 
 	@Test
 	public void testSetProperties() {
 		Map<String, String> environment = new HashMap<>();
 
-		SafeLdapReferralUtil.setProperties(environment, "follow");
+		SafeLdapReferralUtil.setProperties(
+			environment, LDAPConstants.REFERRAL_FOLLOW);
 
-		Assert.assertEquals("throw", environment.get(Context.REFERRAL));
-
-		_assertTrustURLCodebaseDisabled(environment);
-
-		SafeLdapReferralUtil.setProperties(environment, "ignore");
-
-		Assert.assertEquals("ignore", environment.get(Context.REFERRAL));
+		Assert.assertEquals(
+			LDAPConstants.REFERRAL_THROW, environment.get(Context.REFERRAL));
 
 		_assertTrustURLCodebaseDisabled(environment);
 
-		SafeLdapReferralUtil.setProperties(environment, "throw");
+		SafeLdapReferralUtil.setProperties(
+			environment, LDAPConstants.REFERRAL_IGNORE);
 
-		Assert.assertEquals("throw", environment.get(Context.REFERRAL));
+		Assert.assertEquals(
+			LDAPConstants.REFERRAL_IGNORE, environment.get(Context.REFERRAL));
+
+		_assertTrustURLCodebaseDisabled(environment);
+
+		SafeLdapReferralUtil.setProperties(
+			environment, LDAPConstants.REFERRAL_THROW);
+
+		Assert.assertEquals(
+			LDAPConstants.REFERRAL_THROW, environment.get(Context.REFERRAL));
 
 		_assertTrustURLCodebaseDisabled(environment);
 	}
@@ -260,6 +239,31 @@ public class SafeLdapReferralUtilTest {
 		Assert.assertEquals(
 			"false",
 			environment.get("com.sun.jndi.rmi.object.trustURLCodebase"));
+	}
+
+	private DirContext _mockDirContext(ReferralException referralException)
+		throws Exception {
+
+		DirContext dirContext = Mockito.mock(DirContext.class);
+
+		NamingEnumeration<SearchResult> enumeration = Mockito.mock(
+			NamingEnumeration.class);
+
+		Mockito.when(
+			enumeration.hasMore()
+		).thenThrow(
+			referralException
+		);
+
+		Mockito.when(
+			dirContext.search(
+				Mockito.any(Name.class), Mockito.anyString(),
+				Mockito.any(Object[].class), Mockito.any(SearchControls.class))
+		).thenReturn(
+			enumeration
+		);
+
+		return dirContext;
 	}
 
 }

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtilTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtilTest.java
@@ -30,7 +30,7 @@ import org.mockito.Mockito;
 /**
  * @author Lucas Miranda
  */
-public class SafeLDAPReferralUtilTest {
+public class SafeLdapReferralUtilTest {
 
 	@ClassRule
 	@Rule
@@ -41,61 +41,61 @@ public class SafeLDAPReferralUtilTest {
 	public void testIsAllowedReferralURL() {
 		Assert.assertFalse(
 			ReflectionTestUtil.invoke(
-				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
 				new Class<?>[] {String.class}, ""));
 		Assert.assertTrue(
 			ReflectionTestUtil.invoke(
-				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
 				new Class<?>[] {String.class}, "  ldap://host:389  "));
 		Assert.assertTrue(
 			ReflectionTestUtil.invoke(
-				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
 				new Class<?>[] {String.class}, "LDAP://host:389"));
 		Assert.assertFalse(
 			ReflectionTestUtil.invoke(
-				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
 				new Class<?>[] {String.class}, "corba://host/exploit"));
 		Assert.assertFalse(
 			ReflectionTestUtil.invoke(
-				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
 				new Class<?>[] {String.class}, "dns://host"));
 		Assert.assertFalse(
 			ReflectionTestUtil.invoke(
-				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
 				new Class<?>[] {String.class}, "host:389"));
 		Assert.assertFalse(
 			ReflectionTestUtil.invoke(
-				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
 				new Class<?>[] {String.class}, "http://host/exploit"));
 		Assert.assertTrue(
 			ReflectionTestUtil.invoke(
-				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
 				new Class<?>[] {String.class},
 				"ldap://host1:389 ldap://host2:389"));
 		Assert.assertFalse(
 			ReflectionTestUtil.invoke(
-				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
 				new Class<?>[] {String.class},
 				"ldap://host1:389 rmi://host2:1099/exploit"));
 		Assert.assertTrue(
 			ReflectionTestUtil.invoke(
-				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
 				new Class<?>[] {String.class}, "ldap://host:389"));
 		Assert.assertTrue(
 			ReflectionTestUtil.invoke(
-				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
 				new Class<?>[] {String.class}, "ldaps://host:636"));
 		Assert.assertFalse(
 			ReflectionTestUtil.invoke(
-				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
 				new Class<?>[] {String.class}, "ldapx://host"));
 		Assert.assertFalse(
 			ReflectionTestUtil.invoke(
-				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
 				new Class<?>[] {String.class}, "rmi://host:1099/exploit"));
 		Assert.assertFalse(
 			ReflectionTestUtil.invoke(
-				SafeLDAPReferralUtil.class, "_isAllowedReferralURL",
+				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
 				new Class<?>[] {String.class}, (String)null));
 	}
 
@@ -136,7 +136,7 @@ public class SafeLDAPReferralUtilTest {
 		);
 
 		NamingEnumeration<SearchResult> resultEnumeration =
-			SafeLDAPReferralUtil.search(
+			SafeLdapReferralUtil.search(
 				dirContext, "(cn=*)", new Object[0], Mockito.mock(Name.class),
 				new SearchControls());
 
@@ -212,7 +212,7 @@ public class SafeLDAPReferralUtilTest {
 			referralEnumeration
 		);
 
-		resultEnumeration = SafeLDAPReferralUtil.search(
+		resultEnumeration = SafeLdapReferralUtil.search(
 			dirContext, "(cn=*)", new Object[0], Mockito.mock(Name.class),
 			new SearchControls());
 
@@ -229,19 +229,19 @@ public class SafeLDAPReferralUtilTest {
 	public void testSetProperties() {
 		Map<String, String> environment = new HashMap<>();
 
-		SafeLDAPReferralUtil.setProperties(environment, "follow");
+		SafeLdapReferralUtil.setProperties(environment, "follow");
 
 		Assert.assertEquals("throw", environment.get(Context.REFERRAL));
 
 		_assertTrustURLCodebaseDisabled(environment);
 
-		SafeLDAPReferralUtil.setProperties(environment, "ignore");
+		SafeLdapReferralUtil.setProperties(environment, "ignore");
 
 		Assert.assertEquals("ignore", environment.get(Context.REFERRAL));
 
 		_assertTrustURLCodebaseDisabled(environment);
 
-		SafeLDAPReferralUtil.setProperties(environment, "throw");
+		SafeLdapReferralUtil.setProperties(environment, "throw");
 
 		Assert.assertEquals("throw", environment.get(Context.REFERRAL));
 

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtilTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtilTest.java
@@ -207,7 +207,6 @@ public class SafeLdapReferralUtilTest {
 
 		Assert.assertEquals(
 			LDAPConstants.REFERRAL_THROW, environment.get(Context.REFERRAL));
-
 		_assertTrustURLCodebaseDisabled(environment);
 
 		SafeLdapReferralUtil.setProperties(
@@ -215,7 +214,6 @@ public class SafeLdapReferralUtilTest {
 
 		Assert.assertEquals(
 			LDAPConstants.REFERRAL_IGNORE, environment.get(Context.REFERRAL));
-
 		_assertTrustURLCodebaseDisabled(environment);
 
 		SafeLdapReferralUtil.setProperties(
@@ -223,7 +221,6 @@ public class SafeLdapReferralUtilTest {
 
 		Assert.assertEquals(
 			LDAPConstants.REFERRAL_THROW, environment.get(Context.REFERRAL));
-
 		_assertTrustURLCodebaseDisabled(environment);
 	}
 

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtilTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtilTest.java
@@ -5,8 +5,10 @@
 
 package com.liferay.portal.security.ldap.internal.util;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.security.ldap.constants.LDAPConstants;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
@@ -41,21 +43,39 @@ public class SafeLdapReferralUtilTest {
 
 	@Test
 	public void testIsAllowedReferralURL() {
-		_testIsAllowedReferralURL(false, "corba://host/exploit");
-		_testIsAllowedReferralURL(false, "dns://host");
-		_testIsAllowedReferralURL(false, "host:389");
-		_testIsAllowedReferralURL(false, "http://host/exploit");
 		_testIsAllowedReferralURL(
-			false, "ldap://host1:389 rmi://host2:1099/exploit");
-		_testIsAllowedReferralURL(false, "ldapx://host");
-		_testIsAllowedReferralURL(false, "rmi://host:1099/exploit");
+			false, "corba://" + RandomTestUtil.randomString());
+		_testIsAllowedReferralURL(
+			false, "dns://" + RandomTestUtil.randomString());
+		_testIsAllowedReferralURL(
+			false,
+			RandomTestUtil.randomString() + ":" + RandomTestUtil.randomInt());
+		_testIsAllowedReferralURL(
+			false, "http://" + RandomTestUtil.randomString());
+		_testIsAllowedReferralURL(
+			false,
+			StringBundler.concat(
+				"ldap://", RandomTestUtil.randomString(), " rmi://",
+				RandomTestUtil.randomString()));
+		_testIsAllowedReferralURL(
+			false, "ldapx://" + RandomTestUtil.randomString());
+		_testIsAllowedReferralURL(
+			false, "rmi://" + RandomTestUtil.randomString());
 		_testIsAllowedReferralURL(false, StringPool.BLANK);
 		_testIsAllowedReferralURL(false, null);
-		_testIsAllowedReferralURL(true, "  ldap://host:389  ");
-		_testIsAllowedReferralURL(true, "LDAP://host:389");
-		_testIsAllowedReferralURL(true, "ldap://host1:389 ldap://host2:389");
-		_testIsAllowedReferralURL(true, "ldap://host:389");
-		_testIsAllowedReferralURL(true, "ldaps://host:636");
+		_testIsAllowedReferralURL(
+			true, "  ldap://" + RandomTestUtil.randomString() + "  ");
+		_testIsAllowedReferralURL(
+			true, "LDAP://" + RandomTestUtil.randomString());
+		_testIsAllowedReferralURL(
+			true,
+			StringBundler.concat(
+				"ldap://", RandomTestUtil.randomString(), " ldap://",
+				RandomTestUtil.randomString()));
+		_testIsAllowedReferralURL(
+			true, "ldap://" + RandomTestUtil.randomString());
+		_testIsAllowedReferralURL(
+			true, "ldaps://" + RandomTestUtil.randomString());
 	}
 
 	@Test
@@ -89,7 +109,7 @@ public class SafeLdapReferralUtilTest {
 		);
 
 		ReferralException referralException = _mockReferralException(
-			dirContext, "ldap://other:389");
+			dirContext, "ldap://" + RandomTestUtil.randomString());
 
 		NamingEnumeration<SearchResult> resultEnumeration =
 			SafeLdapReferralUtil.search(
@@ -105,7 +125,7 @@ public class SafeLdapReferralUtilTest {
 		).getReferralContext();
 
 		referralException = _mockReferralException(
-			null, "rmi://attacker:1099/exploit");
+			null, "rmi://" + RandomTestUtil.randomString());
 
 		resultEnumeration = SafeLdapReferralUtil.search(
 			"(cn=*)", new Object[0], Mockito.mock(Name.class),

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtilTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/util/SafeLdapReferralUtilTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.security.ldap.internal.util;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.security.ldap.constants.LDAPConstants;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -40,123 +41,60 @@ public class SafeLdapReferralUtilTest {
 
 	@Test
 	public void testIsAllowedReferralURL() {
-		Assert.assertFalse(
-			ReflectionTestUtil.invoke(
-				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
-				new Class<?>[] {String.class}, ""));
-		Assert.assertTrue(
-			ReflectionTestUtil.invoke(
-				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
-				new Class<?>[] {String.class}, "  ldap://host:389  "));
-		Assert.assertTrue(
-			ReflectionTestUtil.invoke(
-				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
-				new Class<?>[] {String.class}, "LDAP://host:389"));
-		Assert.assertFalse(
-			ReflectionTestUtil.invoke(
-				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
-				new Class<?>[] {String.class}, "corba://host/exploit"));
-		Assert.assertFalse(
-			ReflectionTestUtil.invoke(
-				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
-				new Class<?>[] {String.class}, "dns://host"));
-		Assert.assertFalse(
-			ReflectionTestUtil.invoke(
-				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
-				new Class<?>[] {String.class}, "host:389"));
-		Assert.assertFalse(
-			ReflectionTestUtil.invoke(
-				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
-				new Class<?>[] {String.class}, "http://host/exploit"));
-		Assert.assertTrue(
-			ReflectionTestUtil.invoke(
-				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
-				new Class<?>[] {String.class},
-				"ldap://host1:389 ldap://host2:389"));
-		Assert.assertFalse(
-			ReflectionTestUtil.invoke(
-				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
-				new Class<?>[] {String.class},
-				"ldap://host1:389 rmi://host2:1099/exploit"));
-		Assert.assertTrue(
-			ReflectionTestUtil.invoke(
-				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
-				new Class<?>[] {String.class}, "ldap://host:389"));
-		Assert.assertTrue(
-			ReflectionTestUtil.invoke(
-				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
-				new Class<?>[] {String.class}, "ldaps://host:636"));
-		Assert.assertFalse(
-			ReflectionTestUtil.invoke(
-				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
-				new Class<?>[] {String.class}, "ldapx://host"));
-		Assert.assertFalse(
-			ReflectionTestUtil.invoke(
-				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
-				new Class<?>[] {String.class}, "rmi://host:1099/exploit"));
-		Assert.assertFalse(
-			ReflectionTestUtil.invoke(
-				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
-				new Class<?>[] {String.class}, (String)null));
+		_testIsAllowedReferralURL(false, "corba://host/exploit");
+		_testIsAllowedReferralURL(false, "dns://host");
+		_testIsAllowedReferralURL(false, "host:389");
+		_testIsAllowedReferralURL(false, "http://host/exploit");
+		_testIsAllowedReferralURL(
+			false, "ldap://host1:389 rmi://host2:1099/exploit");
+		_testIsAllowedReferralURL(false, "ldapx://host");
+		_testIsAllowedReferralURL(false, "rmi://host:1099/exploit");
+		_testIsAllowedReferralURL(false, StringPool.BLANK);
+		_testIsAllowedReferralURL(false, null);
+		_testIsAllowedReferralURL(true, "  ldap://host:389  ");
+		_testIsAllowedReferralURL(true, "LDAP://host:389");
+		_testIsAllowedReferralURL(true, "ldap://host1:389 ldap://host2:389");
+		_testIsAllowedReferralURL(true, "ldap://host:389");
+		_testIsAllowedReferralURL(true, "ldaps://host:636");
 	}
 
 	@Test
-	public void testSearchWithAllowedReferral() throws Exception {
-		ReferralException referralException = Mockito.mock(
-			ReferralException.class);
-
-		SearchResult searchResult = new SearchResult(
-			"cn=test", null, new BasicAttributes());
-
-		NamingEnumeration<SearchResult> referralEnumeration = Mockito.mock(
+	public void testSearch() throws Exception {
+		NamingEnumeration<SearchResult> namingEnumeration = Mockito.mock(
 			NamingEnumeration.class);
 
 		Mockito.when(
-			referralEnumeration.hasMore()
+			namingEnumeration.hasMore()
 		).thenReturn(
 			true, false
 		);
 
+		SearchResult searchResult = new SearchResult(
+			"cn=test", null, new BasicAttributes());
+
 		Mockito.when(
-			referralEnumeration.next()
+			namingEnumeration.next()
 		).thenReturn(
 			searchResult
 		);
 
-		DirContext referralContext = Mockito.mock(DirContext.class);
+		DirContext dirContext = Mockito.mock(DirContext.class);
 
 		Mockito.when(
-			referralContext.search(
+			dirContext.search(
 				Mockito.any(Name.class), Mockito.anyString(),
 				Mockito.any(Object[].class), Mockito.any(SearchControls.class))
 		).thenReturn(
-			referralEnumeration
+			namingEnumeration
 		);
 
-		Mockito.when(
-			referralException.getReferralContext()
-		).thenReturn(
-			referralContext
-		);
-
-		Mockito.when(
-			referralException.getReferralInfo()
-		).thenReturn(
-			"ldap://other:389"
-		);
-
-		Mockito.when(
-			referralException.skipReferral()
-		).thenReturn(
-			false
-		);
-
-		DirContext dirContext = _mockDirContext(referralException);
+		ReferralException referralException = _mockReferralException(
+			dirContext, "ldap://other:389");
 
 		NamingEnumeration<SearchResult> resultEnumeration =
 			SafeLdapReferralUtil.search(
-				dirContext, "(cn=*)", new Object[0], Mockito.mock(Name.class),
-				new SearchControls());
+				"(cn=*)", new Object[0], Mockito.mock(Name.class),
+				_mockRootDirContext(referralException), new SearchControls());
 
 		Assert.assertTrue(resultEnumeration.hasMore());
 		Assert.assertSame(searchResult, resultEnumeration.next());
@@ -165,31 +103,13 @@ public class SafeLdapReferralUtilTest {
 		Mockito.verify(
 			referralException, Mockito.times(1)
 		).getReferralContext();
-	}
 
-	@Test
-	public void testSearchWithDisallowedReferral() throws Exception {
-		ReferralException referralException = Mockito.mock(
-			ReferralException.class);
+		referralException = _mockReferralException(
+			null, "rmi://attacker:1099/exploit");
 
-		Mockito.when(
-			referralException.getReferralInfo()
-		).thenReturn(
-			"rmi://attacker:1099/exploit"
-		);
-
-		Mockito.when(
-			referralException.skipReferral()
-		).thenReturn(
-			false
-		);
-
-		DirContext dirContext = _mockDirContext(referralException);
-
-		NamingEnumeration<SearchResult> resultEnumeration =
-			SafeLdapReferralUtil.search(
-				dirContext, "(cn=*)", new Object[0], Mockito.mock(Name.class),
-				new SearchControls());
+		resultEnumeration = SafeLdapReferralUtil.search(
+			"(cn=*)", new Object[0], Mockito.mock(Name.class),
+			_mockRootDirContext(referralException), new SearchControls());
 
 		Assert.assertFalse(resultEnumeration.hasMore());
 
@@ -228,20 +148,50 @@ public class SafeLdapReferralUtilTest {
 		Map<String, String> environment) {
 
 		Assert.assertEquals(
-			"false",
+			StringPool.FALSE,
 			environment.get("com.sun.jndi.cosnaming.object.trustURLCodebase"));
 		Assert.assertEquals(
-			"false",
+			StringPool.FALSE,
 			environment.get("com.sun.jndi.ldap.object.trustURLCodebase"));
 		Assert.assertEquals(
-			"false",
+			StringPool.FALSE,
 			environment.get("com.sun.jndi.rmi.object.trustURLCodebase"));
 	}
 
-	private DirContext _mockDirContext(ReferralException referralException)
+	private ReferralException _mockReferralException(
+			DirContext dirContext, String referralInfo)
 		throws Exception {
 
-		DirContext dirContext = Mockito.mock(DirContext.class);
+		ReferralException referralException = Mockito.mock(
+			ReferralException.class);
+
+		Mockito.when(
+			referralException.getReferralInfo()
+		).thenReturn(
+			referralInfo
+		);
+
+		Mockito.when(
+			referralException.skipReferral()
+		).thenReturn(
+			false
+		);
+
+		if (dirContext != null) {
+			Mockito.when(
+				referralException.getReferralContext()
+			).thenReturn(
+				dirContext
+			);
+		}
+
+		return referralException;
+	}
+
+	private DirContext _mockRootDirContext(ReferralException referralException)
+		throws Exception {
+
+		DirContext rootDirContext = Mockito.mock(DirContext.class);
 
 		NamingEnumeration<SearchResult> enumeration = Mockito.mock(
 			NamingEnumeration.class);
@@ -253,14 +203,22 @@ public class SafeLdapReferralUtilTest {
 		);
 
 		Mockito.when(
-			dirContext.search(
+			rootDirContext.search(
 				Mockito.any(Name.class), Mockito.anyString(),
 				Mockito.any(Object[].class), Mockito.any(SearchControls.class))
 		).thenReturn(
 			enumeration
 		);
 
-		return dirContext;
+		return rootDirContext;
+	}
+
+	private void _testIsAllowedReferralURL(boolean expected, String urlString) {
+		Assert.assertEquals(
+			expected,
+			ReflectionTestUtil.invoke(
+				SafeLdapReferralUtil.class, "_isAllowedReferralURL",
+				new Class<?>[] {String.class}, urlString));
 	}
 
 }

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/validator/SafeLdapContextImplTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/validator/SafeLdapContextImplTest.java
@@ -72,13 +72,10 @@ public class SafeLdapContextImplTest {
 				new SearchControls());
 
 		Assert.assertTrue(resultEnumeration.hasMore());
-
 		Assert.assertSame(searchResult, resultEnumeration.next());
-
 		Assert.assertFalse(resultEnumeration.hasMore());
 
 		ldapContext = Mockito.mock(LdapContext.class);
-
 		enumeration = Mockito.mock(NamingEnumeration.class);
 
 		Mockito.when(

--- a/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/validator/SafeLdapContextImplTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/test/java/com/liferay/portal/security/ldap/internal/validator/SafeLdapContextImplTest.java
@@ -1,0 +1,119 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.ldap.internal.validator;
+
+import com.liferay.portal.security.ldap.SafeLdapFilter;
+import com.liferay.portal.security.ldap.SafeLdapName;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import javax.naming.Name;
+import javax.naming.NamingEnumeration;
+import javax.naming.directory.BasicAttributes;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.naming.ldap.LdapContext;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Lucas Miranda
+ */
+public class SafeLdapContextImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testSearch() throws Exception {
+		LdapContext ldapContext = Mockito.mock(LdapContext.class);
+
+		SearchResult searchResult = new SearchResult(
+			"cn=test", null, new BasicAttributes());
+
+		NamingEnumeration<SearchResult> enumeration = Mockito.mock(
+			NamingEnumeration.class);
+
+		Mockito.when(
+			enumeration.hasMore()
+		).thenReturn(
+			true, false
+		);
+
+		Mockito.when(
+			enumeration.next()
+		).thenReturn(
+			searchResult
+		);
+
+		Mockito.when(
+			ldapContext.search(
+				Mockito.any(Name.class), Mockito.anyString(),
+				Mockito.any(Object[].class), Mockito.any(SearchControls.class))
+		).thenReturn(
+			enumeration
+		);
+
+		SafeLdapContextImpl safeLdapContextImpl = new SafeLdapContextImpl(
+			ldapContext, true);
+
+		NamingEnumeration<SearchResult> resultEnumeration =
+			safeLdapContextImpl.search(
+				Mockito.mock(SafeLdapName.class), _mockSafeLdapFilter(),
+				new SearchControls());
+
+		Assert.assertTrue(resultEnumeration.hasMore());
+
+		Assert.assertSame(searchResult, resultEnumeration.next());
+
+		Assert.assertFalse(resultEnumeration.hasMore());
+
+		ldapContext = Mockito.mock(LdapContext.class);
+
+		enumeration = Mockito.mock(NamingEnumeration.class);
+
+		Mockito.when(
+			ldapContext.search(
+				Mockito.any(Name.class), Mockito.anyString(),
+				Mockito.any(Object[].class), Mockito.any(SearchControls.class))
+		).thenReturn(
+			enumeration
+		);
+
+		safeLdapContextImpl = new SafeLdapContextImpl(ldapContext, false);
+
+		resultEnumeration = safeLdapContextImpl.search(
+			Mockito.mock(SafeLdapName.class), _mockSafeLdapFilter(),
+			new SearchControls());
+
+		Assert.assertSame(enumeration, resultEnumeration);
+	}
+
+	private SafeLdapFilter _mockSafeLdapFilter() {
+		SafeLdapFilter safeLdapFilter = Mockito.mock(SafeLdapFilter.class);
+
+		Mockito.when(
+			safeLdapFilter.getArguments()
+		).thenReturn(
+			new Object[0]
+		);
+
+		Mockito.when(
+			safeLdapFilter.getFilterString()
+		).thenReturn(
+			"(cn=*)"
+		);
+
+		return safeLdapFilter;
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-ldap-test/src/testIntegration/java/com/liferay/portal/security/ldap/internal/upgrade/v1_0_1/test/LDAPReferralUpgradeProcessTest.java
+++ b/modules/apps/portal-security/portal-security-ldap-test/src/testIntegration/java/com/liferay/portal/security/ldap/internal/upgrade/v1_0_1/test/LDAPReferralUpgradeProcessTest.java
@@ -1,0 +1,203 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.ldap.internal.upgrade.v1_0_1.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.security.ldap.SafePortalLDAP;
+import com.liferay.portal.security.ldap.configuration.SystemLDAPConfiguration;
+import com.liferay.portal.security.ldap.constants.LDAPConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.Dictionary;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.service.component.runtime.ServiceComponentRuntime;
+import org.osgi.service.component.runtime.dto.ComponentDescriptionDTO;
+import org.osgi.util.promise.Promise;
+
+/**
+ * @author Christian Moura
+ */
+@RunWith(Arquillian.class)
+public class LDAPReferralUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator,
+			"com.liferay.portal.security.ldap.internal.upgrade.v1_0_1." +
+				"LDAPReferralUpgradeProcess");
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			LDAPReferralUpgradeProcessTest.class);
+
+		_bundleContext = bundle.getBundleContext();
+
+		ServiceReference<ConfigurationAdmin>
+			configurationAdminServiceReference =
+				_bundleContext.getServiceReference(ConfigurationAdmin.class);
+
+		_configurationAdmin = _bundleContext.getService(
+			configurationAdminServiceReference);
+
+		ServiceReference<SafePortalLDAP> serviceReference =
+			_bundleContext.getServiceReference(SafePortalLDAP.class);
+
+		_componentDescriptionDTO =
+			_serviceComponentRuntime.getComponentDescriptionDTO(
+				serviceReference.getBundle(),
+				"com.liferay.portal.security.ldap.internal.configuration." +
+					"LDAPConfigurationListener");
+
+		_enabled = _serviceComponentRuntime.isComponentEnabled(
+			_componentDescriptionDTO);
+
+		if (_enabled) {
+			Promise<?> promise = _serviceComponentRuntime.disableComponent(
+				_componentDescriptionDTO);
+
+			promise.getValue();
+		}
+	}
+
+	@AfterClass
+	public static void tearDownClass() throws Exception {
+		if (_enabled) {
+			Promise<?> promise = _serviceComponentRuntime.enableComponent(
+				_componentDescriptionDTO);
+
+			promise.getValue();
+		}
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			"(service.factoryPid=" + SystemLDAPConfiguration.class.getName() +
+				")");
+
+		if (ArrayUtil.isEmpty(configurations)) {
+			return;
+		}
+
+		for (Configuration configuration : configurations) {
+			configuration.delete();
+		}
+	}
+
+	@Test
+	public void testUpgradeThrowsReferral() throws Exception {
+		long followCompanyId = RandomTestUtil.randomLong();
+		long ignoreCompanyId = RandomTestUtil.randomLong();
+		long legacyThrowsCompanyId = RandomTestUtil.randomLong();
+		long throwCompanyId = RandomTestUtil.randomLong();
+
+		_createConfiguration(followCompanyId, LDAPConstants.REFERRAL_FOLLOW);
+		_createConfiguration(ignoreCompanyId, LDAPConstants.REFERRAL_IGNORE);
+		_createConfiguration(legacyThrowsCompanyId, "throws");
+		_createConfiguration(throwCompanyId, LDAPConstants.REFERRAL_THROW);
+
+		_upgradeProcess.upgrade();
+
+		Assert.assertEquals(
+			LDAPConstants.REFERRAL_FOLLOW, _getReferral(followCompanyId));
+		Assert.assertEquals(
+			LDAPConstants.REFERRAL_IGNORE, _getReferral(ignoreCompanyId));
+		Assert.assertEquals(
+			LDAPConstants.REFERRAL_THROW, _getReferral(legacyThrowsCompanyId));
+		Assert.assertEquals(
+			LDAPConstants.REFERRAL_THROW, _getReferral(throwCompanyId));
+	}
+
+	private void _createConfiguration(long companyId, String referral)
+		throws Exception {
+
+		Configuration configuration =
+			_configurationAdmin.createFactoryConfiguration(
+				SystemLDAPConfiguration.class.getName(), StringPool.QUESTION);
+
+		configuration.update(
+			HashMapDictionaryBuilder.<String, Object>put(
+				LDAPConstants.COMPANY_ID, companyId
+			).put(
+				LDAPConstants.REFERRAL, referral
+			).build());
+	}
+
+	private String _getReferral(long companyId) throws Exception {
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			"(service.factoryPid=" + SystemLDAPConfiguration.class.getName() +
+				")");
+
+		if (ArrayUtil.isEmpty(configurations)) {
+			return null;
+		}
+
+		for (Configuration configuration : configurations) {
+			Dictionary<String, Object> properties =
+				configuration.getProperties();
+
+			if (properties == null) {
+				continue;
+			}
+
+			Long configuredCompanyId = (Long)properties.get(
+				LDAPConstants.COMPANY_ID);
+
+			if ((configuredCompanyId != null) &&
+				(configuredCompanyId == companyId)) {
+
+				return (String)properties.get(LDAPConstants.REFERRAL);
+			}
+		}
+
+		return null;
+	}
+
+	private static BundleContext _bundleContext;
+	private static ComponentDescriptionDTO _componentDescriptionDTO;
+	private static ConfigurationAdmin _configurationAdmin;
+	private static boolean _enabled;
+
+	@Inject
+	private static ServiceComponentRuntime _serviceComponentRuntime;
+
+	private static UpgradeProcess _upgradeProcess;
+
+	@Inject(
+		filter = "component.name=com.liferay.portal.security.ldap.internal.upgrade.registry.LDAPServiceUpgradeStepRegistrator"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-94237

## What Is Being Fixed

DXP was vulnerable to unsafe Java deserialization through its LDAP integration. When the portal connects to a configured LDAP server — via "Test LDAP Users" or the scheduled import job — JNDI automatically follows LDAP referrals. A malicious or compromised LDAP server can answer with a referral pointing at an attacker-controlled RMI or CORBA endpoint, causing the server to deserialize arbitrary Java objects from that response, which is remote code execution (the URLDNS gadget chain confirms the sink is reachable). Because the referral mode defaulted to "follow", this was exploitable out of the box.

## How It Is Being Fixed

The default referral mode is changed to "ignore", so a new installation does not follow referrals unless an administrator explicitly opts in. Remote codebase trust is disabled for the LDAP, RMI, and CORBA JNDI object factories so a followed referral cannot load attacker-hosted classes.

The "follow" option is retained but made safe rather than handed to JNDI. When an administrator selects "follow", the JNDI Context.REFERRAL property is set to "throw" so JNDI stops auto-following and instead surfaces a ReferralException; the portal then follows the referral itself, restricted to an ldap:// and ldaps:// allowlist that blocks rmi://, corba://, and any other scheme, and bounded by a maximum referral count. This preserves the legitimate use of following referrals to other directory servers while removing the deserialization path. A help text warns that enabling "follow" has security consequences.

The legacy referral value "throws" is migrated to "throw" through an upgrade process, and the change is covered by unit tests for the safe-referral and allowlist logic and an integration test for the upgrade.

## PR Check

**pr-check: PASS** — tested on `82ffd4f6074601a078186c20660bb7dc1d67c6c1`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "82ffd4f6074601a078186c20660bb7dc1d67c6c1"} -->
