### PR TITLE
[FIPS] LPD-85743 Update SAML keystore default type to PKCS12

### DIFF
--- a/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/runtime/configuration/SamlConfiguration.java
+++ b/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/runtime/configuration/SamlConfiguration.java
@@ -20,7 +20,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 public interface SamlConfiguration {
 
 	public static String KEYSTORE_PATH_DEFAULT =
-		"${liferay.home}/data/keystore.jks";
+		"${liferay.home}/data/keystore.p12";
 
 	/**
 	 * Set the interval in minutes on how often to check for and delete SAML
@@ -109,7 +109,8 @@ public interface SamlConfiguration {
 
 	@Meta.AD(
 		deflt = "liferay", id = "saml.keystore.password",
-		name = "saml-key-store-password", required = false
+		name = "saml-key-store-password", required = false,
+		type = Meta.Type.Password
 	)
 	public String keyStorePassword();
 
@@ -122,8 +123,8 @@ public interface SamlConfiguration {
 	public String keyStorePath();
 
 	@Meta.AD(
-		deflt = "jks", id = "saml.keystore.type", name = "saml-key-store-type",
-		required = false
+		deflt = "PKCS12", id = "saml.keystore.type",
+		name = "saml-key-store-type", required = false
 	)
 	public String keyStoreType();
 

--- a/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/runtime/configuration/SamlProviderConfiguration.java
+++ b/modules/dxp/apps/saml/saml-api/src/main/java/com/liferay/saml/runtime/configuration/SamlProviderConfiguration.java
@@ -89,7 +89,8 @@ public interface SamlProviderConfiguration {
 		deflt = "liferay",
 		description = "saml-keystore-credential-password-description",
 		id = "saml.keystore.credential.password",
-		name = "saml-keystore-credential-password", required = false
+		name = "saml-keystore-credential-password", required = false,
+		type = Meta.Type.Password
 	)
 	public String keyStoreCredentialPassword();
 
@@ -97,7 +98,8 @@ public interface SamlProviderConfiguration {
 		deflt = "liferay",
 		description = "saml-keystore-encryption-credential-password-description",
 		id = "saml.keystore.encryption.credential.password",
-		name = "saml-keystore-encryption-credential-password", required = false
+		name = "saml-keystore-encryption-credential-password", required = false,
+		type = Meta.Type.Password
 	)
 	public String keyStoreEncryptionCredentialPassword();
 

--- a/modules/dxp/apps/saml/saml-api/src/main/resources/com/liferay/saml/runtime/configuration/packageinfo
+++ b/modules/dxp/apps/saml/saml-api/src/main/resources/com/liferay/saml/runtime/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 7.0.0
+version 7.0.1

--- a/modules/dxp/apps/saml/saml-impl/build.gradle
+++ b/modules/dxp/apps/saml/saml-impl/build.gradle
@@ -7,6 +7,8 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:configuration-admin:configuration-admin-api")
+	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:portal-security:portal-security-export-import-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")

--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/upgrade/registry/SamlImplUpgradeStepRegistrator.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/upgrade/registry/SamlImplUpgradeStepRegistrator.java
@@ -5,6 +5,8 @@
 
 package com.liferay.saml.internal.upgrade.registry;
 
+import com.liferay.document.library.kernel.store.Store;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.util.PrefsProps;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -12,6 +14,7 @@ import com.liferay.saml.internal.upgrade.v1_0_0.SamlConfigurationPreferencesUpgr
 import com.liferay.saml.internal.upgrade.v1_0_0.SamlIdpSsoSessionMaxAgePropertyUpgradeProcess;
 import com.liferay.saml.internal.upgrade.v1_0_0.SamlKeyStorePropertiesUpgradeProcess;
 import com.liferay.saml.internal.upgrade.v1_0_0.SamlProviderConfigurationPreferencesUpgradeProcess;
+import com.liferay.saml.internal.upgrade.v2_0_0.SamlConfigurationUpgradeProcess;
 import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
 
 import org.osgi.service.cm.ConfigurationAdmin;
@@ -48,6 +51,12 @@ public class SamlImplUpgradeStepRegistrator implements UpgradeStepRegistrator {
 			"0.0.2", "1.0.0",
 			new SamlIdpSsoSessionMaxAgePropertyUpgradeProcess(
 				_configurationAdmin));
+
+		registry.register(
+			"1.0.0", "2.0.0",
+			new SamlConfigurationUpgradeProcess(
+				_companyLocalService, _configurationAdmin,
+				_configurationProvider, _store));
 	}
 
 	@Reference
@@ -57,9 +66,15 @@ public class SamlImplUpgradeStepRegistrator implements UpgradeStepRegistrator {
 	private ConfigurationAdmin _configurationAdmin;
 
 	@Reference
+	private ConfigurationProvider _configurationProvider;
+
+	@Reference
 	private PrefsProps _prefsProps;
 
 	@Reference
 	private SamlProviderConfigurationHelper _samlProviderConfigurationHelper;
+
+	@Reference(target = "(default=true)")
+	private Store _store;
 
 }

--- a/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/upgrade/v2_0_0/SamlConfigurationUpgradeProcess.java
+++ b/modules/dxp/apps/saml/saml-impl/src/main/java/com/liferay/saml/internal/upgrade/v2_0_0/SamlConfigurationUpgradeProcess.java
@@ -1,0 +1,371 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.saml.internal.upgrade.v2_0_0;
+
+import com.liferay.document.library.kernel.store.Store;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.saml.runtime.configuration.SamlConfiguration;
+import com.liferay.saml.runtime.configuration.SamlProviderConfiguration;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+
+import java.security.KeyStore;
+
+import java.util.Arrays;
+import java.util.Dictionary;
+import java.util.Enumeration;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author Manuele Castro
+ * @author Rafael Praxedes
+ */
+public class SamlConfigurationUpgradeProcess extends UpgradeProcess {
+
+	public SamlConfigurationUpgradeProcess(
+		CompanyLocalService companyLocalService,
+		ConfigurationAdmin configurationAdmin,
+		ConfigurationProvider configurationProvider, Store store) {
+
+		_companyLocalService = companyLocalService;
+		_configurationAdmin = configurationAdmin;
+		_configurationProvider = configurationProvider;
+		_store = store;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_upgradeConfiguration();
+		_upgradeDLKeyStores();
+		_upgradeFileSystemKeyStore();
+	}
+
+	private KeyStore _convertJKSToPKCS12(
+			InputStream inputStream, char[] keyStorePassword)
+		throws Exception {
+
+		KeyStore jksKeyStore = KeyStore.getInstance("JKS");
+
+		jksKeyStore.load(inputStream, keyStorePassword);
+
+		KeyStore pkcs12KeyStore = KeyStore.getInstance("PKCS12");
+
+		pkcs12KeyStore.load(null, null);
+
+		Enumeration<String> aliasesEnumeration = jksKeyStore.aliases();
+
+		while (aliasesEnumeration.hasMoreElements()) {
+			String alias = aliasesEnumeration.nextElement();
+
+			if (jksKeyStore.isCertificateEntry(alias)) {
+				pkcs12KeyStore.setCertificateEntry(
+					alias, jksKeyStore.getCertificate(alias));
+			}
+			else if (jksKeyStore.isKeyEntry(alias)) {
+				char[] keyEntryPassword = null;
+
+				try {
+					keyEntryPassword = _getKeyEntryPassword(alias);
+
+					KeyStore.Entry entry = jksKeyStore.getEntry(
+						alias,
+						new KeyStore.PasswordProtection(keyEntryPassword));
+
+					pkcs12KeyStore.setEntry(
+						alias, entry,
+						new KeyStore.PasswordProtection(keyEntryPassword));
+				}
+				catch (Exception exception) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							"Skipping inactive key: " + alias, exception);
+					}
+				}
+				finally {
+					if (ArrayUtil.isNotEmpty(keyEntryPassword)) {
+						Arrays.fill(keyEntryPassword, '\0');
+					}
+				}
+			}
+		}
+
+		return pkcs12KeyStore;
+	}
+
+	private char[] _getKeyEntryPassword(String entityId) throws Exception {
+		String passwordProperty = "saml.keystore.credential.password";
+
+		if (entityId.endsWith("-encryption")) {
+			entityId = entityId.substring(
+				0, entityId.lastIndexOf("-encryption"));
+
+			passwordProperty = "saml.keystore.encryption.credential.password";
+		}
+
+		Configuration[] configurations = _configurationAdmin.listConfigurations(
+			StringBundler.concat(
+				"(&(companyId=*)(service.pid=",
+				SamlProviderConfiguration.class.getName(), "*))"));
+
+		if (configurations == null) {
+			throw new IllegalStateException(
+				"There is no SAML configuration associated with key: " +
+					entityId);
+		}
+
+		String password = null;
+
+		for (Configuration configuration : configurations) {
+			Dictionary<String, Object> properties =
+				configuration.getProperties();
+
+			if ((properties != null) &&
+				StringUtil.equalsIgnoreCase(
+					entityId,
+					GetterUtil.getString(properties.get("saml.entity.id")))) {
+
+				password = GetterUtil.getString(
+					properties.get(passwordProperty));
+
+				break;
+			}
+		}
+
+		if (Validator.isNull(password)) {
+			throw new IllegalStateException(
+				"No password match was found for key: " + entityId);
+		}
+
+		return password.toCharArray();
+	}
+
+	private char[] _getKeyStorePassword() throws Exception {
+		SamlConfiguration samlConfiguration =
+			_configurationProvider.getSystemConfiguration(
+				SamlConfiguration.class);
+
+		String keyStorePassword = samlConfiguration.keyStorePassword();
+
+		if (Validator.isNull(keyStorePassword)) {
+			return new char[0];
+		}
+
+		return keyStorePassword.toCharArray();
+	}
+
+	private String _getKeyStorePath(boolean jks) throws Exception {
+		SamlConfiguration samlConfiguration =
+			_configurationProvider.getSystemConfiguration(
+				SamlConfiguration.class);
+
+		String keyStorePath = samlConfiguration.keyStorePath();
+
+		if (Validator.isNull(keyStorePath) ||
+			(!keyStorePath.endsWith(".jks") &&
+			 !keyStorePath.endsWith(".p12"))) {
+
+			return null;
+		}
+
+		if (!jks && keyStorePath.endsWith(".jks")) {
+			keyStorePath = StringUtil.replaceLast(keyStorePath, ".jks", ".p12");
+		}
+		else if (jks && keyStorePath.endsWith(".p12")) {
+			keyStorePath = StringUtil.replaceLast(keyStorePath, ".p12", ".jks");
+		}
+
+		return StringUtil.replace(
+			keyStorePath, "${liferay.home}",
+			PropsUtil.get(PropsKeys.LIFERAY_HOME));
+	}
+
+	private void _saveDLKeyStore(
+			long companyId, KeyStore keyStore, char[] password)
+		throws Exception {
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
+
+		keyStore.store(byteArrayOutputStream, password);
+
+		if (_store.hasFile(
+				companyId, CompanyConstants.SYSTEM, _PKCS12_DL_KEYSTORE_PATH,
+				Store.VERSION_DEFAULT)) {
+
+			_store.deleteDirectory(
+				companyId, CompanyConstants.SYSTEM, _PKCS12_DL_KEYSTORE_PATH);
+		}
+
+		_store.addFile(
+			companyId, CompanyConstants.SYSTEM, _PKCS12_DL_KEYSTORE_PATH,
+			Store.VERSION_DEFAULT,
+			new ByteArrayInputStream(byteArrayOutputStream.toByteArray()));
+	}
+
+	private void _upgradeConfiguration() throws Exception {
+		Configuration configuration = _configurationAdmin.getConfiguration(
+			SamlConfiguration.class.getName(), StringPool.QUESTION);
+
+		Dictionary<String, Object> properties = configuration.getProperties();
+
+		if (properties == null) {
+			return;
+		}
+
+		String keyStoreType = GetterUtil.getString(
+			properties.get("saml.keystore.type"));
+
+		if (Validator.isNull(keyStoreType) ||
+			StringUtil.equalsIgnoreCase(keyStoreType, "jks")) {
+
+			properties.put("saml.keystore.type", "PKCS12");
+
+			String keyStorePath = GetterUtil.getString(
+				properties.get("saml.keystore.path"));
+
+			if (keyStorePath.endsWith(".jks")) {
+				properties.put(
+					"saml.keystore.path",
+					StringUtil.replaceLast(keyStorePath, ".jks", ".p12"));
+			}
+
+			configuration.update(properties);
+		}
+	}
+
+	private void _upgradeDLKeyStores() {
+		_companyLocalService.forEachCompanyId(
+			companyId -> {
+				char[] keyStorePassword = null;
+
+				try {
+					boolean hasJKSKeyStore = _store.hasFile(
+						companyId, CompanyConstants.SYSTEM,
+						_JKS_DL_KEYSTORE_PATH, Store.VERSION_DEFAULT);
+
+					boolean hasPKCS12KeyStore = _store.hasFile(
+						companyId, CompanyConstants.SYSTEM,
+						_PKCS12_DL_KEYSTORE_PATH, Store.VERSION_DEFAULT);
+
+					if (!hasJKSKeyStore || hasPKCS12KeyStore) {
+						return;
+					}
+
+					keyStorePassword = _getKeyStorePassword();
+
+					try (InputStream inputStream = _store.getFileAsStream(
+							companyId, CompanyConstants.SYSTEM,
+							_JKS_DL_KEYSTORE_PATH, Store.VERSION_DEFAULT)) {
+
+						_saveDLKeyStore(
+							companyId,
+							_convertJKSToPKCS12(inputStream, keyStorePassword),
+							keyStorePassword);
+					}
+				}
+				catch (Exception exception) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(
+							"Unable to migrate DL SAML keystore for company " +
+								companyId,
+							exception);
+					}
+				}
+				finally {
+					if (keyStorePassword != null) {
+						Arrays.fill(keyStorePassword, '\0');
+					}
+				}
+			});
+	}
+
+	private void _upgradeFileSystemKeyStore() throws Exception {
+		String jksFileSystemKeyStorePath = _getKeyStorePath(true);
+		String pkcs12FileSystemKeyStorePath = _getKeyStorePath(false);
+
+		if ((jksFileSystemKeyStorePath == null) ||
+			(pkcs12FileSystemKeyStorePath == null)) {
+
+			return;
+		}
+
+		File oldFile = new File(jksFileSystemKeyStorePath);
+		File newFile = new File(pkcs12FileSystemKeyStorePath);
+
+		char[] keyStorePassword = null;
+
+		try {
+			if (!oldFile.exists() || newFile.exists()) {
+				return;
+			}
+
+			keyStorePassword = _getKeyStorePassword();
+
+			try (FileInputStream fileInputStream = new FileInputStream(
+					oldFile)) {
+
+				File parentDir = newFile.getParentFile();
+
+				if (!parentDir.exists()) {
+					parentDir.mkdirs();
+				}
+
+				KeyStore pkcs12KeyStore = _convertJKSToPKCS12(
+					fileInputStream, keyStorePassword);
+
+				try (FileOutputStream fileOutputStream = new FileOutputStream(
+						newFile)) {
+
+					pkcs12KeyStore.store(fileOutputStream, keyStorePassword);
+				}
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to migrate filesystem SAML keystore", exception);
+			}
+		}
+		finally {
+			if (keyStorePassword != null) {
+				Arrays.fill(keyStorePassword, '\0');
+			}
+		}
+	}
+
+	private static final String _JKS_DL_KEYSTORE_PATH = "saml/keystore.jks";
+
+	private static final String _PKCS12_DL_KEYSTORE_PATH = "saml/keystore.p12";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SamlConfigurationUpgradeProcess.class);
+
+	private final CompanyLocalService _companyLocalService;
+	private final ConfigurationAdmin _configurationAdmin;
+	private final ConfigurationProvider _configurationProvider;
+	private final Store _store;
+
+}

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/BaseKeyStoreManagerImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/BaseKeyStoreManagerImpl.java
@@ -35,7 +35,7 @@ public abstract class BaseKeyStoreManagerImpl implements KeyStoreManager {
 		String liferayHome = PropsUtil.get(PropsKeys.LIFERAY_HOME);
 
 		if (Validator.isNull(keyStorePath)) {
-			return liferayHome.concat("/data/keystore.jks");
+			return liferayHome.concat("/data/keystore.p12");
 		}
 
 		return StringUtil.replace(keyStorePath, "${liferay.home}", liferayHome);

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/DLKeyStoreManagerImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/DLKeyStoreManagerImpl.java
@@ -11,12 +11,10 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CompanyConstants;
-import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.saml.runtime.credential.KeyStoreManager;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 
 import java.security.KeyStore;
@@ -85,31 +83,26 @@ public class DLKeyStoreManagerImpl extends BaseKeyStoreManagerImpl {
 
 	@Override
 	public void saveKeyStore(KeyStore keyStore) throws Exception {
-		File tempFile = FileUtil.createTempFile("jks");
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
 
-		try {
-			String samlKeyStorePassword = getSamlKeyStorePassword();
+		String samlKeyStorePassword = getSamlKeyStorePassword();
 
-			keyStore.store(
-				new FileOutputStream(tempFile),
-				samlKeyStorePassword.toCharArray());
+		keyStore.store(
+			byteArrayOutputStream, samlKeyStorePassword.toCharArray());
 
-			if (_store.hasFile(
-					getCompanyId(), CompanyConstants.SYSTEM,
-					_SAML_KEYSTORE_PATH, Store.VERSION_DEFAULT)) {
-
-				_store.deleteDirectory(
-					getCompanyId(), CompanyConstants.SYSTEM,
-					_SAML_KEYSTORE_PATH);
-			}
-
-			_store.addFile(
+		if (_store.hasFile(
 				getCompanyId(), CompanyConstants.SYSTEM, _SAML_KEYSTORE_PATH,
-				Store.VERSION_DEFAULT, new FileInputStream(tempFile));
+				Store.VERSION_DEFAULT)) {
+
+			_store.deleteDirectory(
+				getCompanyId(), CompanyConstants.SYSTEM, _SAML_KEYSTORE_PATH);
 		}
-		finally {
-			tempFile.delete();
-		}
+
+		_store.addFile(
+			getCompanyId(), CompanyConstants.SYSTEM, _SAML_KEYSTORE_PATH,
+			Store.VERSION_DEFAULT,
+			new ByteArrayInputStream(byteArrayOutputStream.toByteArray()));
 	}
 
 	@Activate
@@ -118,7 +111,7 @@ public class DLKeyStoreManagerImpl extends BaseKeyStoreManagerImpl {
 		updateConfigurations(properties);
 	}
 
-	private static final String _SAML_KEYSTORE_PATH = "saml/keystore.jks";
+	private static final String _SAML_KEYSTORE_PATH = "saml/keystore.p12";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DLKeyStoreManagerImpl.class);

--- a/modules/dxp/apps/saml/saml-test/build.gradle
+++ b/modules/dxp/apps/saml/saml-test/build.gradle
@@ -4,7 +4,11 @@ dependencies {
 	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.util.java", version: "default"
 	testIntegrationImplementation group: "jakarta.annotation", name: "jakarta.annotation-api", version: "2.1.1"
 	testIntegrationImplementation group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-module-configuration-api")
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
+	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-upload-test-util")
+	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":dxp:apps:saml:saml-api")
 	testIntegrationImplementation project(":dxp:apps:saml:saml-impl")
 	testIntegrationImplementation project(":dxp:apps:saml:saml-opensaml-integration")

--- a/modules/dxp/apps/saml/saml-test/src/testIntegration/java/com/liferay/saml/internal/upgrade/v2_0_0/test/SamlConfigurationUpgradeProcessTest.java
+++ b/modules/dxp/apps/saml/saml-test/src/testIntegration/java/com/liferay/saml/internal/upgrade/v2_0_0/test/SamlConfigurationUpgradeProcessTest.java
@@ -1,0 +1,327 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.saml.internal.upgrade.v2_0_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.kernel.store.Store;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.saml.runtime.certificate.CertificateEntityId;
+import com.liferay.saml.runtime.certificate.CertificateTool;
+import com.liferay.saml.runtime.configuration.SamlConfiguration;
+import com.liferay.saml.runtime.configuration.SamlProviderConfiguration;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+
+import java.util.Calendar;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+
+/**
+ * @author Manuele Castro
+ * @author Rafael Praxedes
+ */
+@RunWith(Arquillian.class)
+public class SamlConfigurationUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@After
+	public void tearDown() throws Exception {
+		_deleteDLKeyStores();
+		_deleteFileSystemKeyStores();
+
+		if (_configuration != null) {
+			ConfigurationTestUtil.deleteConfiguration(_configuration);
+		}
+
+		if (_pid != null) {
+			ConfigurationTestUtil.deleteConfiguration(_pid);
+		}
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		String entityId = RandomTestUtil.randomString();
+
+		String encryptionAlias = entityId + "-encryption";
+
+		String encryptionCredentialPassword = RandomTestUtil.randomString();
+
+		String credentialPassword = RandomTestUtil.randomString();
+
+		String keyStorePassword = RandomTestUtil.randomString();
+
+		byte[] bytes = _createJKSKeyStoreBytes(
+			HashMapBuilder.put(
+				encryptionAlias, encryptionCredentialPassword
+			).put(
+				entityId, credentialPassword
+			).build(),
+			keyStorePassword);
+
+		long companyId = TestPropsValues.getCompanyId();
+
+		_store.addFile(
+			companyId, CompanyConstants.SYSTEM, _JKS_DL_KEYSTORE_PATH,
+			Store.VERSION_DEFAULT, new ByteArrayInputStream(bytes));
+
+		String liferayHome = PropsUtil.get(PropsKeys.LIFERAY_HOME);
+
+		File file = new File(liferayHome + "/data/keystore.jks");
+
+		try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+			fileOutputStream.write(bytes);
+		}
+
+		_pid = ConfigurationTestUtil.createFactoryConfiguration(
+			SamlProviderConfiguration.class.getName(),
+			HashMapDictionaryBuilder.<String, Object>put(
+				"companyId", RandomTestUtil.randomLong()
+			).put(
+				"saml.entity.id", entityId
+			).put(
+				"saml.keystore.credential.password", credentialPassword
+			).put(
+				"saml.keystore.encryption.credential.password",
+				encryptionCredentialPassword
+			).build());
+
+		_updateSamlConfiguration(keyStorePassword);
+
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		upgradeProcess.upgrade();
+
+		_assertSamlConfiguration(
+			keyStorePassword, "${liferay.home}/data/keystore.p12", "PKCS12");
+
+		Assert.assertTrue(
+			_store.hasFile(
+				companyId, CompanyConstants.SYSTEM, _PKCS12_DL_KEYSTORE_PATH,
+				Store.VERSION_DEFAULT));
+
+		KeyStore keyStore = KeyStore.getInstance("PKCS12");
+
+		try (InputStream inputStream = _store.getFileAsStream(
+				companyId, CompanyConstants.SYSTEM, _PKCS12_DL_KEYSTORE_PATH,
+				Store.VERSION_DEFAULT)) {
+
+			keyStore.load(inputStream, keyStorePassword.toCharArray());
+
+			Assert.assertTrue(keyStore.containsAlias(encryptionAlias));
+			Assert.assertTrue(keyStore.containsAlias(entityId));
+		}
+
+		file = new File(liferayHome + "/data/keystore.p12");
+
+		Assert.assertTrue(file.exists());
+
+		try (FileInputStream fileInputStream = new FileInputStream(file)) {
+			keyStore.load(fileInputStream, keyStorePassword.toCharArray());
+
+			Assert.assertTrue(keyStore.containsAlias(encryptionAlias));
+			Assert.assertTrue(keyStore.containsAlias(entityId));
+		}
+	}
+
+	private void _assertSamlConfiguration(
+			String keyStorePassword, String keyStorePath, String keyStoreType)
+		throws Exception {
+
+		_configuration = _configurationAdmin.getConfiguration(
+			SamlConfiguration.class.getName(), StringPool.QUESTION);
+
+		Dictionary<String, Object> properties = _configuration.getProperties();
+
+		if (Validator.isNotNull(keyStorePassword)) {
+			Assert.assertEquals(
+				keyStorePassword, properties.get("saml.keystore.password"));
+		}
+
+		if (Validator.isNotNull(keyStorePath)) {
+			Assert.assertEquals(
+				keyStorePath, properties.get("saml.keystore.path"));
+		}
+
+		if (Validator.isNotNull(keyStoreType)) {
+			Assert.assertEquals(
+				keyStoreType, properties.get("saml.keystore.type"));
+		}
+	}
+
+	private byte[] _createJKSKeyStoreBytes(
+			Map<String, String> keyPasswords, String keyStorePassword)
+		throws Exception {
+
+		KeyStore keyStore = KeyStore.getInstance("JKS");
+
+		keyStore.load(null, null);
+
+		for (Map.Entry<String, String> entry : keyPasswords.entrySet()) {
+			KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance(
+				"RSA");
+
+			keyPairGenerator.initialize(2048);
+
+			KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+			CertificateEntityId certificateEntityId = new CertificateEntityId(
+				RandomTestUtil.randomString(), null, null, null, null, null);
+
+			Calendar startDate = Calendar.getInstance();
+
+			Calendar endDate = (Calendar)startDate.clone();
+
+			endDate.add(Calendar.DAY_OF_YEAR, 365);
+
+			X509Certificate x509Certificate =
+				_certificateTool.generateCertificate(
+					keyPair, certificateEntityId, certificateEntityId,
+					startDate.getTime(), endDate.getTime(), "SHA256withRSA");
+
+			String keyPassword = entry.getValue();
+
+			keyStore.setKeyEntry(
+				entry.getKey(), keyPair.getPrivate(), keyPassword.toCharArray(),
+				new X509Certificate[] {x509Certificate});
+		}
+
+		ByteArrayOutputStream byteArrayOutputStream =
+			new ByteArrayOutputStream();
+
+		keyStore.store(byteArrayOutputStream, keyStorePassword.toCharArray());
+
+		return byteArrayOutputStream.toByteArray();
+	}
+
+	private void _deleteDLKeyStores() throws Exception {
+		long companyId = TestPropsValues.getCompanyId();
+
+		if (_store.hasFile(
+				companyId, CompanyConstants.SYSTEM, _JKS_DL_KEYSTORE_PATH,
+				Store.VERSION_DEFAULT)) {
+
+			_store.deleteDirectory(
+				companyId, CompanyConstants.SYSTEM, _JKS_DL_KEYSTORE_PATH);
+		}
+
+		if (_store.hasFile(
+				companyId, CompanyConstants.SYSTEM, _PKCS12_DL_KEYSTORE_PATH,
+				Store.VERSION_DEFAULT)) {
+
+			_store.deleteDirectory(
+				companyId, CompanyConstants.SYSTEM, _PKCS12_DL_KEYSTORE_PATH);
+		}
+	}
+
+	private void _deleteFileSystemKeyStores() {
+		String liferayHome = PropsUtil.get(PropsKeys.LIFERAY_HOME);
+
+		File jksFile = new File(liferayHome + "/data/keystore.jks");
+
+		if (jksFile.exists()) {
+			jksFile.delete();
+		}
+
+		File p12File = new File(liferayHome + "/data/keystore.p12");
+
+		if (p12File.exists()) {
+			p12File.delete();
+		}
+	}
+
+	private void _updateSamlConfiguration(String keyStorePassword)
+		throws Exception {
+
+		_configuration = _configurationAdmin.getConfiguration(
+			SamlConfiguration.class.getName(), StringPool.QUESTION);
+
+		Dictionary<String, Object> properties = new Hashtable<>();
+
+		properties.put("saml.keystore.password", keyStorePassword);
+
+		String keyStorePath = "${liferay.home}/data/keystore.jks";
+
+		properties.put("saml.keystore.path", keyStorePath);
+
+		String keyStoreType = "jks";
+
+		properties.put("saml.keystore.type", keyStoreType);
+
+		_configuration.update(properties);
+
+		_assertSamlConfiguration(keyStorePassword, keyStorePath, keyStoreType);
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.saml.internal.upgrade.v2_0_0." +
+			"SamlConfigurationUpgradeProcess";
+
+	private static final String _JKS_DL_KEYSTORE_PATH = "saml/keystore.jks";
+
+	private static final String _PKCS12_DL_KEYSTORE_PATH = "saml/keystore.p12";
+
+	@Inject
+	private CertificateTool _certificateTool;
+
+	private Configuration _configuration;
+
+	@Inject
+	private ConfigurationAdmin _configurationAdmin;
+
+	private String _pid;
+
+	@Inject(
+		filter = "(&(objectClass=com.liferay.document.library.kernel.store.Store)(default=true))"
+	)
+	private Store _store;
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.saml.internal.upgrade.registry.SamlImplUpgradeStepRegistrator))"
+	)
+	private UpgradeStepRegistrator _upgradeStepRegistrator;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-85743

## What Is Being Fixed

SAML keystores were created as JKS by default. JKS is a proprietary Java format deprecated in favour of the standard PKCS12 format since Java 9. New portal installations and upgrades should use PKCS12 instead.

## How It Is Being Fixed

The default keystore type in `SamlConfiguration` and the default path suffix in `BaseKeyStoreManagerImpl` are changed from JKS to PKCS12. `DLKeyStoreManagerImpl` and `FileSystemKeyStoreManagerImpl` are updated to load and store keystores using the PKCS12 format.

A new `SamlConfigurationUpgradeProcess` (v2.0.0) migrates existing installations: it converts any JKS keystore stored in the document library or on the filesystem to PKCS12 and updates the system configuration to point to the new `.p12` path. Key entry passwords are resolved by looking up the matching `SamlProviderConfiguration` for each key alias.

## PR Check

**pr-check: PASS** — tested on `80e4ea6f308b7e68435e3b2c5c3e9447bb686ada`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "80e4ea6f308b7e68435e3b2c5c3e9447bb686ada"} -->
