### PR TITLE
LPD-96858 Clear the email OTP message when the resend countdown ends

### DIFF
--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
@@ -123,9 +123,7 @@ if ((mfaEmailOTPResendEmailTimeout > 0) && (mfaEmailOTPSetAtTime > 0)) {
 
 			resendCountdown = null;
 
-			messageContainer.html(
-				'<span class="alert alert-success"><liferay-ui:message key="your-otp-has-been-sent-by-email" /></span>'
-			);
+			messageContainer.html('');
 		}
 		else {
 			sendEmailButton.text(resendDuration);

--- a/modules/test/playwright/tests/multi-factor-authentication-email-otp-web/main/multi-factor-authentication-email-otp.spec.ts
+++ b/modules/test/playwright/tests/multi-factor-authentication-email-otp-web/main/multi-factor-authentication-email-otp.spec.ts
@@ -220,3 +220,79 @@ test(
 		}
 	}
 );
+
+test(
+	'LPD-96858 removes the sent-by-email message once the resend countdown finishes',
+	{tag: '@LPD-96858'},
+	async ({
+		apiHelpers,
+		browser,
+		multiFactorAuthenticationConfigurationPage,
+	}) => {
+		test.setTimeout(60000);
+
+		// Enable email OTP with a short resend cooldown so the countdown
+		// finishes quickly within the test.
+
+		await multiFactorAuthenticationConfigurationPage.goto();
+
+		await multiFactorAuthenticationConfigurationPage.enable({
+			resendEmailTimeout: 5,
+		});
+
+		// Create a user that will be challenged with email OTP when signing in
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		// Reach the MFA stage in a clean context, leaving the admin signed in
+
+		const userContext = await browser.newContext();
+		const userPage = await userContext.newPage();
+
+		try {
+			await userPage.goto('/');
+
+			await userPage
+				.getByRole('button', {name: 'Sign In'})
+				.last()
+				.click();
+
+			await userPage.getByLabel('Email Address').fill(user.emailAddress);
+			await userPage.getByLabel('Password').fill('test');
+
+			await userPage
+				.getByRole('button', {name: 'Sign In'})
+				.last()
+				.click();
+
+			const sendEmailButton = userPage.locator('[id$="sendEmailButton"]');
+
+			const sentMessage = userPage.getByText(
+				'Your one-time password has been sent by email.'
+			);
+
+			// Request a code: the confirmation message appears and the send
+			// button starts its cooldown countdown.
+
+			await clickAndExpectToBeVisible({
+				target: sentMessage,
+				trigger: sendEmailButton,
+			});
+
+			// When the cooldown ends the send button returns to "Send" and the
+			// confirmation message must be removed entirely, not just shortened
+			// to the version without the "please wait" notice.
+
+			await expect(sendEmailButton).toBeEnabled({timeout: 15000});
+
+			await expect(sentMessage).toBeHidden();
+		}
+		finally {
+			await userContext.close();
+
+			await multiFactorAuthenticationConfigurationPage.goto();
+
+			await multiFactorAuthenticationConfigurationPage.resetConfiguration();
+		}
+	}
+);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96858

## What Is Being Fixed

On the MFA email OTP verification screen, after the Send cooldown countdown expires the confirmation message "Your one-time password has been sent by email." is displayed automatically, even though the user did not press Send. The message should appear only right after the user clicks Send to request a new code.

## How It Is Being Fixed

When the resend countdown ends, the client now clears the message container instead of repainting the confirmation message, so the message is shown only in response to a Send click. A Playwright test signs in with a user challenged with email OTP, requests a code, and asserts that once the countdown ends the confirmation message is removed rather than reappearing on its own.

## PR Check

**pr-check: PASS** — tested on `bc18364f163e90b4306795ec77b55c1e7503c256`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| JSP Compile | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "bc18364f163e90b4306795ec77b55c1e7503c256"} -->
