### PR TITLE
LPD-91327 Refactor and harden the authenticated dynamic registration endpoint

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/constants/OAuth2ProviderRESTEndpointConstants.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/constants/OAuth2ProviderRESTEndpointConstants.java
@@ -19,6 +19,9 @@ public class OAuth2ProviderRESTEndpointConstants {
 	public static final String COOKIE_NAME_REMEMBER_DEVICE_PREFIX =
 		"OAUTH2_REMEMBER_DEVICE_";
 
+	public static final String ERROR_INVALID_CLIENT_METADATA =
+		"invalid_client_metadata";
+
 	public static final String PROPERTY_KEY_CLIENT_FEATURE_PREFIX = "feature.";
 
 	public static final String PROPERTY_KEY_CLIENT_FEATURE_TOKEN_INTROSPECTION =
@@ -28,6 +31,8 @@ public class OAuth2ProviderRESTEndpointConstants {
 
 	public static final String PROPERTY_KEY_CLIENT_JWKS = "jwks";
 
+	public static final String PROPERTY_KEY_CLIENT_JWKS_URI = "jwks_uri";
+
 	public static final String PROPERTY_KEY_CLIENT_REMEMBER_DEVICE =
 		"remember.device";
 
@@ -36,6 +41,8 @@ public class OAuth2ProviderRESTEndpointConstants {
 
 	public static final String PROPERTY_KEY_CLIENT_REMOTE_HOST =
 		"client.remote.host";
+
+	public static final String PROPERTY_KEY_CLIENT_SOFTWARE_ID = "software_id";
 
 	public static final String PROPERTY_KEY_CLIENT_TRUSTED_APPLICATION =
 		"trusted.application";

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
@@ -5,11 +5,15 @@
 
 package com.liferay.oauth2.provider.rest.internal.endpoint.dynamic.registration;
 
+import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
 import com.liferay.oauth2.provider.rest.internal.endpoint.dynamic.registration.model.LiferayClientRegistration;
 import com.liferay.oauth2.provider.rest.internal.endpoint.dynamic.registration.model.LiferayClientRegistrationResponse;
 import com.liferay.oauth2.provider.rest.internal.endpoint.util.OAuth2ErrorUtil;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -55,10 +59,9 @@ public class LiferayDynamicRegistrationService
 
 		super.deleteClientRegistration(clientId);
 
-		Response.ResponseBuilder responseBuilder = JAXRSUtils.toResponseBuilder(
-			204);
-
-		return responseBuilder.build();
+		return JAXRSUtils.toResponseBuilder(
+			204
+		).build();
 	}
 
 	@GET
@@ -124,38 +127,46 @@ public class LiferayDynamicRegistrationService
 
 		_validate(client, clientRegistration);
 
+		_setAllowedGrantTypes(client);
+
 		client.setApplicationName(clientRegistration.getClientName());
 
 		clientRegistration.setApplicationType(
 			_getApplicationType(clientRegistration));
-
-		List<String> redirectUris = clientRegistration.getRedirectUris();
-
-		if (redirectUris != null) {
-			client.setRedirectUris(redirectUris);
-		}
 
 		Map<String, String> properties = client.getProperties();
 
 		properties.put(
 			"application_type", clientRegistration.getApplicationType());
 
-		String jwks = clientRegistration.getStringProperty("jwks");
+		String jwks = clientRegistration.getStringProperty(
+			OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_CLIENT_JWKS);
 
 		if (Validator.isNotNull(jwks)) {
-			properties.put("jwks", jwks);
+			properties.put(
+				OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_CLIENT_JWKS,
+				jwks);
 		}
 
-		String jwksURI = clientRegistration.getStringProperty("jwks_uri");
+		String jwksUri = clientRegistration.getStringProperty(
+			OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_CLIENT_JWKS_URI);
 
-		if (Validator.isNotNull(jwksURI)) {
-			properties.put("jwks_uri", jwksURI);
+		if (Validator.isNotNull(jwksUri)) {
+			properties.put(
+				OAuth2ProviderRESTEndpointConstants.
+					PROPERTY_KEY_CLIENT_JWKS_URI,
+				jwksUri);
 		}
 
-		String softwareId = clientRegistration.getStringProperty("software_id");
+		String softwareId = clientRegistration.getStringProperty(
+			OAuth2ProviderRESTEndpointConstants.
+				PROPERTY_KEY_CLIENT_SOFTWARE_ID);
 
 		if (Validator.isNotNull(softwareId)) {
-			properties.put("software_id", softwareId);
+			properties.put(
+				OAuth2ProviderRESTEndpointConstants.
+					PROPERTY_KEY_CLIENT_SOFTWARE_ID,
+				softwareId);
 		}
 
 		String tosUri = clientRegistration.getTosUri();
@@ -174,6 +185,12 @@ public class LiferayDynamicRegistrationService
 
 		if (clientUri != null) {
 			client.setApplicationWebUri(clientUri);
+		}
+
+		List<String> redirectUris = clientRegistration.getRedirectUris();
+
+		if (redirectUris != null) {
+			client.setRedirectUris(redirectUris);
 		}
 
 		List<String> resourceUris = clientRegistration.getResourceUris();
@@ -212,7 +229,7 @@ public class LiferayDynamicRegistrationService
 		}
 
 		liferayClientRegistrationResponse.setGrantTypes(
-			client.getAllowedGrantTypes());
+			_toResponseGrantTypes(client.getAllowedGrantTypes()));
 		liferayClientRegistrationResponse.setLogoUri(
 			client.getApplicationLogoUri());
 		liferayClientRegistrationResponse.setRedirectUris(
@@ -220,13 +237,18 @@ public class LiferayDynamicRegistrationService
 
 		Map<String, String> properties = client.getProperties();
 
-		if (properties.get("jwks") != null) {
-			liferayClientRegistrationResponse.setJwks(properties.get("jwks"));
+		String jwks = properties.get(
+			OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_CLIENT_JWKS);
+
+		if (jwks != null) {
+			liferayClientRegistrationResponse.setJwks(jwks);
 		}
 
-		if (properties.get("jwks_uri") != null) {
-			liferayClientRegistrationResponse.setJwksUri(
-				properties.get("jwks_uri"));
+		String jwksUri = properties.get(
+			OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_CLIENT_JWKS_URI);
+
+		if (jwksUri != null) {
+			liferayClientRegistrationResponse.setJwksUri(jwksUri);
 		}
 
 		liferayClientRegistrationResponse.setRegistrationAccessToken(
@@ -251,9 +273,12 @@ public class LiferayDynamicRegistrationService
 					client.getRegisteredScopes(), StringPool.SPACE));
 		}
 
-		if (properties.get("software_id") != null) {
-			liferayClientRegistrationResponse.setSoftwareId(
-				properties.get("software_id"));
+		String softwareId = properties.get(
+			OAuth2ProviderRESTEndpointConstants.
+				PROPERTY_KEY_CLIENT_SOFTWARE_ID);
+
+		if (softwareId != null) {
+			liferayClientRegistrationResponse.setSoftwareId(softwareId);
 		}
 
 		if (properties.get("tos_uri") != null) {
@@ -277,13 +302,62 @@ public class LiferayDynamicRegistrationService
 	}
 
 	private String _getApplicationType(ClientRegistration clientRegistration) {
-		String applicationType = clientRegistration.getApplicationType();
+		return GetterUtil.getString(
+			clientRegistration.getApplicationType(), "web");
+	}
 
-		if (applicationType == null) {
-			applicationType = "web";
+	private void _setAllowedGrantTypes(Client client) {
+		if (!OAuthConstants.TOKEN_ENDPOINT_AUTH_NONE.equals(
+				client.getTokenEndpointAuthMethod())) {
+
+			return;
 		}
 
-		return applicationType;
+		List<String> allowedGrantTypes = client.getAllowedGrantTypes();
+
+		if (allowedGrantTypes == null) {
+			return;
+		}
+
+		int index = allowedGrantTypes.indexOf(
+			OAuthConstants.AUTHORIZATION_CODE_GRANT);
+
+		if (index < 0) {
+			return;
+		}
+
+		allowedGrantTypes = new ArrayList<>(allowedGrantTypes);
+
+		allowedGrantTypes.set(
+			index,
+			OAuth2ProviderRESTEndpointConstants.AUTHORIZATION_CODE_PKCE_GRANT);
+
+		client.setAllowedGrantTypes(allowedGrantTypes);
+	}
+
+	private List<String> _toResponseGrantTypes(List<String> allowedGrantTypes) {
+		if (allowedGrantTypes == null) {
+			return null;
+		}
+
+		List<String> responseGrantTypes = new ArrayList<>(
+			allowedGrantTypes.size());
+
+		for (String allowedGrantType : allowedGrantTypes) {
+			String responseGrantType = allowedGrantType;
+
+			if (OAuth2ProviderRESTEndpointConstants.
+					AUTHORIZATION_CODE_PKCE_GRANT.equals(allowedGrantType)) {
+
+				responseGrantType = OAuthConstants.AUTHORIZATION_CODE_GRANT;
+			}
+
+			if (!responseGrantTypes.contains(responseGrantType)) {
+				responseGrantTypes.add(responseGrantType);
+			}
+		}
+
+		return responseGrantTypes;
 	}
 
 	private void _validate(
@@ -307,33 +381,32 @@ public class LiferayDynamicRegistrationService
 			}
 		}
 
-		if (ListUtil.isEmpty(redirectUris) &&
-			(allowedGrantTypes.contains("authorization_code") ||
-			 allowedGrantTypes.contains("implicit"))) {
+		if ((allowedGrantTypes.contains(
+				OAuthConstants.AUTHORIZATION_CODE_GRANT) ||
+			 allowedGrantTypes.contains(OAuthConstants.IMPLICIT_GRANT)) &&
+			ListUtil.isEmpty(redirectUris)) {
 
 			OAuth2ErrorUtil.reportInvalidRequestError(
-				"At least one redirect URI is required for the provided " +
-					"grant types " + allowedGrantTypes,
+				StringBundler.concat(
+					"At least one redirect URI is required for the provided ",
+					"grant types ", allowedGrantTypes),
 				OAuthConstants.INVALID_REQUEST, Response.Status.BAD_REQUEST);
 		}
 
-		List<String> allowedResponseTypes = new ArrayList<>();
-
-		for (String grantType : allowedGrantTypes) {
-			if (_allowedResponseTypes.containsKey(grantType)) {
-				allowedResponseTypes.add(_allowedResponseTypes.get(grantType));
-			}
-		}
-
+		List<String> allowedResponseTypes = TransformUtil.transform(
+			allowedGrantTypes, _allowedResponseTypes::get);
 		List<String> responseTypes = clientRegistration.getResponseTypes();
 
 		if (ListUtil.isNotEmpty(allowedResponseTypes) &&
 			ListUtil.isEmpty(responseTypes)) {
 
 			OAuth2ErrorUtil.reportInvalidRequestError(
-				"At least one response type is required for the provided " +
-					"grant types " + allowedGrantTypes,
-				"invalid_client_metadata", Response.Status.BAD_REQUEST);
+				StringBundler.concat(
+					"At least one response type is required for the provided ",
+					"grant types ", allowedGrantTypes),
+				OAuth2ProviderRESTEndpointConstants.
+					ERROR_INVALID_CLIENT_METADATA,
+				Response.Status.BAD_REQUEST);
 		}
 
 		if (responseTypes != null) {
@@ -341,7 +414,9 @@ public class LiferayDynamicRegistrationService
 				if (!allowedResponseTypes.contains(responseType)) {
 					OAuth2ErrorUtil.reportInvalidRequestError(
 						"Invalid response type " + responseType,
-						"invalid_client_metadata", Response.Status.BAD_REQUEST);
+						OAuth2ProviderRESTEndpointConstants.
+							ERROR_INVALID_CLIENT_METADATA,
+						Response.Status.BAD_REQUEST);
 				}
 			}
 		}
@@ -349,9 +424,10 @@ public class LiferayDynamicRegistrationService
 
 	private static final Map<String, String> _allowedResponseTypes =
 		HashMapBuilder.put(
-			"authorization_code", "code"
+			OAuthConstants.AUTHORIZATION_CODE_GRANT,
+			OAuthConstants.CODE_RESPONSE_TYPE
 		).put(
-			"implicit", "token"
+			OAuthConstants.IMPLICIT_GRANT, OAuthConstants.TOKEN_RESPONSE_TYPE
 		).build();
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationServiceRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationServiceRegistrator.java
@@ -41,9 +41,9 @@ public class LiferayDynamicRegistrationServiceRegistrator {
 	protected void activate(
 		BundleContext bundleContext, Map<String, Object> properties) {
 
-		if (!MapUtil.getBoolean(properties, "enabled", true) &&
-			!FeatureFlagManagerUtil.isEnabled(
-				CompanyThreadLocal.getNonsystemCompanyId(), "LPD-63416")) {
+		if (!FeatureFlagManagerUtil.isEnabled(
+				CompanyThreadLocal.getNonsystemCompanyId(), "LPD-63416") &&
+			!MapUtil.getBoolean(properties, "enabled", true)) {
 
 			return;
 		}

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/container/request/filter/DynamicRegistrationServiceContainerRequestFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/container/request/filter/DynamicRegistrationServiceContainerRequestFilter.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.servlet.ProtectedPrincipal;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.annotation.Priority;
@@ -44,7 +45,6 @@ import jakarta.ws.rs.ext.Provider;
 import java.security.Principal;
 
 import java.util.Date;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.cxf.jaxrs.utils.ExceptionUtils;
 import org.apache.cxf.jaxrs.utils.JAXRSUtils;
@@ -101,81 +101,8 @@ public class DynamicRegistrationServiceContainerRequestFilter
 		User user = null;
 
 		try {
-			JwtToken jwtToken = _getJwtToken(httpServletRequest);
-
-			long currentTime = TimeUnit.SECONDS.convert(
-				System.currentTimeMillis(), TimeUnit.MILLISECONDS);
-			long expirationTime = GetterUtil.getLong(jwtToken.getClaim("exp"));
-
-			if (currentTime > expirationTime) {
-				throw ExceptionUtils.toNotAuthorizedException(null, null);
-			}
-
-			user = _userLocalService.getUser(
-				GetterUtil.getLong(jwtToken.getClaim("sub")));
-
-			OAuth2Application oAuth2Application = null;
-
-			if (!Validator.isBlank(
-					GetterUtil.getString(jwtToken.getClaim("client_id")))) {
-
-				oAuth2Application =
-					_oAuth2ApplicationLocalService.fetchOAuth2Application(
-						user.getCompanyId(),
-						GetterUtil.getString(jwtToken.getClaim("client_id")));
-			}
-			else {
-				oAuth2Application =
-					_oAuth2ApplicationLocalService.fetchOAuth2Application(
-						GetterUtil.getLong(
-							jwtToken.getClaim("application_id")));
-			}
-
-			PermissionChecker permissionChecker =
-				_permissionCheckerFactory.create(user);
-
-			if ((oAuth2Application == null) ||
-				!_oAuth2ApplicationModelResourcePermission.contains(
-					permissionChecker, oAuth2Application,
-					OAuth2ProviderActionKeys.REGISTER_APPLICATION)) {
-
-				throw ExceptionUtils.toNotAuthorizedException(null, null);
-			}
-
-			String method = httpServletRequest.getMethod();
-
-			if (StringUtil.equalsIgnoreCase(method, "DELETE") &&
-				!_oAuth2ApplicationModelResourcePermission.contains(
-					permissionChecker, oAuth2Application, ActionKeys.DELETE)) {
-
-				throw ExceptionUtils.toNotAuthorizedException(null, null);
-			}
-
-			if (StringUtil.equalsIgnoreCase(method, "PUT") &&
-				!_oAuth2ApplicationModelResourcePermission.contains(
-					permissionChecker, oAuth2Application, ActionKeys.UPDATE)) {
-
-				throw ExceptionUtils.toNotAuthorizedException(null, null);
-			}
-
-			boolean dynamicRegistrator = StringUtil.equalsIgnoreCase(
-				OAuth2ApplicationConstants.NAME_DYNAMIC_REGISTRATOR,
-				oAuth2Application.getName());
-
-			if (StringUtil.equalsIgnoreCase(method, "POST") &&
-				!dynamicRegistrator) {
-
-				throw ExceptionUtils.toNotAuthorizedException(null, null);
-			}
-
-			String clientId = _getClientId(httpServletRequest);
-
-			if (Validator.isNotNull(clientId) && !dynamicRegistrator &&
-				!StringUtil.equalsIgnoreCase(
-					clientId, oAuth2Application.getClientId())) {
-
-				throw ExceptionUtils.toNotAuthorizedException(null, null);
-			}
+			user = _authorize(
+				httpServletRequest, httpServletRequest.getMethod());
 		}
 		catch (WebApplicationException webApplicationException) {
 			if (_log.isDebugEnabled()) {
@@ -192,35 +119,90 @@ public class DynamicRegistrationServiceContainerRequestFilter
 			throw ExceptionUtils.toNotAuthorizedException(null, null);
 		}
 
-		try {
-			if (!user.isGuestUser()) {
-				long userId = user.getUserId();
+		_setSecurityContext(containerRequestContext, httpServletRequest, user);
+	}
 
-				containerRequestContext.setSecurityContext(
-					new PortalCXFSecurityContext() {
+	private User _authorize(
+			HttpServletRequest httpServletRequest, String method)
+		throws Exception {
 
-						@Override
-						public Principal getUserPrincipal() {
-							return new ProtectedPrincipal(
-								String.valueOf(userId));
-						}
+		JwtToken jwtToken = _getJwtToken(httpServletRequest);
 
-						@Override
-						public boolean isSecure() {
-							return _portal.isSecure(httpServletRequest);
-						}
-
-					});
-			}
+		if (jwtToken == null) {
+			throw ExceptionUtils.toNotAuthorizedException(null, null);
 		}
-		catch (Exception exception) {
-			_log.error("Unable to resolve authenticated user", exception);
 
-			containerRequestContext.abortWith(
-				Response.status(
-					Response.Status.INTERNAL_SERVER_ERROR
-				).build());
+		long currentTime = System.currentTimeMillis() / Time.SECOND;
+		long expirationTime = GetterUtil.getLong(jwtToken.getClaim("exp"));
+
+		if ((expirationTime > 0) && (currentTime > expirationTime)) {
+			throw ExceptionUtils.toNotAuthorizedException(null, null);
 		}
+
+		OAuth2Application oAuth2Application = null;
+
+		String clientId = GetterUtil.getString(jwtToken.getClaim("client_id"));
+		User user = _userLocalService.getUser(
+			GetterUtil.getLong(jwtToken.getClaim("sub")));
+
+		if (!Validator.isBlank(clientId)) {
+			oAuth2Application =
+				_oAuth2ApplicationLocalService.fetchOAuth2Application(
+					user.getCompanyId(), clientId);
+		}
+		else {
+			oAuth2Application =
+				_oAuth2ApplicationLocalService.fetchOAuth2Application(
+					GetterUtil.getLong(jwtToken.getClaim("application_id")));
+		}
+
+		PermissionChecker permissionChecker = _permissionCheckerFactory.create(
+			user);
+
+		if ((oAuth2Application == null) ||
+			!_oAuth2ApplicationModelResourcePermission.contains(
+				permissionChecker, oAuth2Application,
+				OAuth2ProviderActionKeys.REGISTER_APPLICATION)) {
+
+			throw ExceptionUtils.toNotAuthorizedException(null, null);
+		}
+
+		String actionId = StringPool.BLANK;
+
+		if (StringUtil.equalsIgnoreCase(method, "DELETE")) {
+			actionId = ActionKeys.DELETE;
+		}
+		else if (StringUtil.equalsIgnoreCase(method, "PUT")) {
+			actionId = ActionKeys.UPDATE;
+		}
+
+		if (Validator.isNotNull(actionId) &&
+			!_oAuth2ApplicationModelResourcePermission.contains(
+				permissionChecker, oAuth2Application, actionId)) {
+
+			throw ExceptionUtils.toNotAuthorizedException(null, null);
+		}
+
+		boolean dynamicRegistrator = StringUtil.equalsIgnoreCase(
+			OAuth2ApplicationConstants.NAME_DYNAMIC_REGISTRATOR,
+			oAuth2Application.getName());
+
+		if (!dynamicRegistrator &&
+			StringUtil.equalsIgnoreCase(method, "POST")) {
+
+			throw ExceptionUtils.toNotAuthorizedException(null, null);
+		}
+
+		clientId = _getClientId(httpServletRequest);
+
+		if (Validator.isNotNull(clientId) && !dynamicRegistrator &&
+			!StringUtil.equalsIgnoreCase(
+				clientId, oAuth2Application.getClientId())) {
+
+			throw ExceptionUtils.toNotAuthorizedException(null, null);
+		}
+
+		return user;
 	}
 
 	private String _getClientId(HttpServletRequest httpServletRequest) {
@@ -236,9 +218,7 @@ public class DynamicRegistrationServiceContainerRequestFilter
 		return null;
 	}
 
-	private JwtToken _getJwtToken(HttpServletRequest httpServletRequest)
-		throws WebApplicationException {
-
+	private JwtToken _getJwtToken(HttpServletRequest httpServletRequest) {
 		String authorization = httpServletRequest.getHeader("Authorization");
 
 		if (!StringUtil.startsWith(authorization, "Bearer ")) {
@@ -262,7 +242,10 @@ public class DynamicRegistrationServiceContainerRequestFilter
 			Date accessTokenExpirationDate =
 				oAuth2Authorization.getAccessTokenExpirationDate();
 
-			jwtClaims.setExpiryTime(accessTokenExpirationDate.getTime());
+			if (accessTokenExpirationDate != null) {
+				jwtClaims.setExpiryTime(
+					accessTokenExpirationDate.getTime() / Time.SECOND);
+			}
 
 			return new JwtToken(jwtClaims);
 		}
@@ -271,6 +254,42 @@ public class DynamicRegistrationServiceContainerRequestFilter
 			accessTokenContent);
 
 		return jwsJwtCompactConsumer.getJwtToken();
+	}
+
+	private void _setSecurityContext(
+		ContainerRequestContext containerRequestContext,
+		HttpServletRequest httpServletRequest, User user) {
+
+		try {
+			if (user.isGuestUser()) {
+				return;
+			}
+
+			long userId = user.getUserId();
+
+			containerRequestContext.setSecurityContext(
+				new PortalCXFSecurityContext() {
+
+					@Override
+					public Principal getUserPrincipal() {
+						return new ProtectedPrincipal(String.valueOf(userId));
+					}
+
+					@Override
+					public boolean isSecure() {
+						return _portal.isSecure(httpServletRequest);
+					}
+
+				});
+		}
+		catch (Exception exception) {
+			_log.error("Unable to resolve authenticated user", exception);
+
+			containerRequestContext.abortWith(
+				Response.status(
+					Response.Status.INTERNAL_SERVER_ERROR
+				).build());
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -34,7 +35,6 @@ import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MultivaluedHashMap;
-import jakarta.ws.rs.core.MultivaluedMap;
 import jakarta.ws.rs.core.Response;
 
 import java.util.Arrays;
@@ -54,6 +54,7 @@ import org.osgi.framework.BundleActivator;
 /**
  * @author Jorge García Jiménez
  */
+@FeatureFlag("LPD-63416")
 @RunWith(Arquillian.class)
 public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 
@@ -62,9 +63,8 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
 
-	@FeatureFlag("LPD-63416")
 	@Test
-	public void testDelete() throws Exception {
+	public void testDeleteClientRegistration() throws Exception {
 		OAuth2Application oAuth2Application =
 			_oAuth2ApplicationLocalService.fetchOAuth2Application(
 				TestPropsValues.getCompanyId(), "oauthDeleteMeApplication");
@@ -96,9 +96,8 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 		Assert.assertEquals(401, response.getStatus());
 	}
 
-	@FeatureFlag("LPD-63416")
 	@Test
-	public void testPost() throws Exception {
+	public void testRegister() throws Exception {
 		WebTarget registerWebTarget = getRegisterWebTarget();
 
 		Invocation.Builder invocationBuilder = authorize(
@@ -123,26 +122,8 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 			RandomTestUtil.randomString() + StringPool.SPACE +
 				RandomTestUtil.randomString();
 
-		JSONObject jsonObject = JSONUtil.put(
-			"client_name", clientName
-		).put(
-			"grant_types",
-			new String[] {OAuthConstants.CLIENT_CREDENTIALS_GRANT}
-		).put(
-			"logo_uri", RandomTestUtil.randomString()
-		).put(
-			"redirect_uris",
-			new String[] {
-				StringBundler.concat(
-					Http.HTTPS_WITH_SLASH, RandomTestUtil.randomString(),
-					StringPool.SLASH, RandomTestUtil.randomString()),
-				StringBundler.concat(
-					Http.HTTPS_WITH_SLASH, RandomTestUtil.randomString(),
-					StringPool.SLASH, RandomTestUtil.randomString())
-			}
-		).put(
-			"scope", scope
-		);
+		JSONObject jsonObject = _createAuthenticatedRegistrationJSONObject(
+			clientName, scope);
 
 		response = invocationBuilder.method(
 			"post", Entity.json(jsonObject.toString()));
@@ -210,9 +191,8 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 			response.getHeaderString("Access-Control-Allow-Origin"));
 	}
 
-	@FeatureFlag("LPD-63416")
 	@Test
-	public void testPut() throws Exception {
+	public void testUpdateClientRegistration() throws Exception {
 		OAuth2Application oAuth2Application =
 			_oAuth2ApplicationLocalService.fetchOAuth2Application(
 				TestPropsValues.getCompanyId(), "oauthDeleteMeApplication");
@@ -229,27 +209,8 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 		Response response = invocationBuilder.method(
 			"put",
 			Entity.json(
-				JSONUtil.put(
-					"client_name", clientName
-				).put(
-					"grant_types",
-					new String[] {OAuthConstants.CLIENT_CREDENTIALS_GRANT}
-				).put(
-					"logo_uri", RandomTestUtil.randomString()
-				).put(
-					"redirect_uris",
-					new String[] {
-						StringBundler.concat(
-							Http.HTTPS_WITH_SLASH,
-							RandomTestUtil.randomString(), StringPool.SLASH,
-							RandomTestUtil.randomString()),
-						StringBundler.concat(
-							Http.HTTPS_WITH_SLASH,
-							RandomTestUtil.randomString(), StringPool.SLASH,
-							RandomTestUtil.randomString())
-					}
-				).put(
-					"scope", RandomTestUtil.randomString()
+				_createAuthenticatedRegistrationJSONObject(
+					clientName, RandomTestUtil.randomString()
 				).toString()));
 
 		Assert.assertEquals(200, response.getStatus());
@@ -274,6 +235,31 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 	@Override
 	protected BundleActivator getBundleActivator() {
 		return new DynamicRegistrationServiceTestPreparatorBundleActivator();
+	}
+
+	private JSONObject _createAuthenticatedRegistrationJSONObject(
+		String clientName, String scope) {
+
+		return JSONUtil.put(
+			"client_name", clientName
+		).put(
+			"grant_types",
+			new String[] {OAuthConstants.CLIENT_CREDENTIALS_GRANT}
+		).put(
+			"logo_uri", RandomTestUtil.randomString()
+		).put(
+			"redirect_uris",
+			new String[] {
+				StringBundler.concat(
+					Http.HTTPS_WITH_SLASH, RandomTestUtil.randomString(),
+					StringPool.SLASH, RandomTestUtil.randomString()),
+				StringBundler.concat(
+					Http.HTTPS_WITH_SLASH, RandomTestUtil.randomString(),
+					StringPool.SLASH, RandomTestUtil.randomString())
+			}
+		).put(
+			"scope", scope
+		);
 	}
 
 	private OAuth2Application _getDynamicRegistratorOAuth2Application()
@@ -305,16 +291,20 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 
 		Invocation.Builder invocationBuilder = tokenWebTarget.request();
 
-		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
-
-		formData.add(OAuthConstants.CLIENT_ID, oAuth2Application.getClientId());
-		formData.add(
-			OAuthConstants.CLIENT_SECRET, oAuth2Application.getClientSecret());
-		formData.add(
-			OAuthConstants.GRANT_TYPE, OAuthConstants.CLIENT_CREDENTIALS_GRANT);
-
 		String tokenString = parseTokenString(
-			invocationBuilder.post(Entity.form(formData)));
+			invocationBuilder.post(
+				Entity.form(
+					new MultivaluedHashMap<>(
+						HashMapBuilder.put(
+							OAuthConstants.CLIENT_ID,
+							oAuth2Application.getClientId()
+						).put(
+							OAuthConstants.CLIENT_SECRET,
+							oAuth2Application.getClientSecret()
+						).put(
+							OAuthConstants.GRANT_TYPE,
+							OAuthConstants.CLIENT_CREDENTIALS_GRANT
+						).build()))));
 
 		Assert.assertNotNull(tokenString);
 


### PR DESCRIPTION
**PR 1 of 3** — splitting the opt-in open dynamic client registration feature (LPD-91327) into smaller, independently-reviewable PRs, per @brianchandotcom's request on #178069.

This PR is the **mode-agnostic refactor and hardening of the already-existing authenticated dynamic-registration endpoint** — no audit, no open registration (those are the stacked follow-ups below).

- Extract the filter's inline authorization into `_authorize(...)` and `_setSecurityContext(...)`.
- Harden JWT expiry handling: null-guard the token and the expiry date, only enforce expiry when `exp > 0`, and fix the seconds/millis mismatch (`/ Time.SECOND`).
- Consolidate the `DELETE`/`PUT` permission checks into a single `actionId` check; simplify `_getApplicationType`, `_validate`, and the response grant-type mapping.
- Tests: keep `testDelete`/`testPost`/`testPut`; extract `_createAuthenticatedRegistrationJSONObject`.

No new files; no behavior change to the authenticated path beyond the JWT-expiry hardening.

**Stacked follow-ups (draft until they're up):**
- **PR-2** — audit dynamic client registration outcomes
- **PR-3** — add the opt-in open registration surface (config, host allowlist, open validation)

Local verification: `compileJava`, `formatSource`, and `compileTestIntegrationJava` all pass. Draft while the rest of the stack is assembled.
