### PR TITLE
LPD-96985 Distinguish the banner privacy link without relying on color

### DIFF
--- a/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner/css/main.scss
+++ b/modules/apps/cookies/cookies-banner-web/src/main/resources/META-INF/resources/cookies_banner/css/main.scss
@@ -18,6 +18,10 @@
 		position: fixed;
 		top: 0;
 	}
+
+	p a {
+		text-decoration: underline;
+	}
 }
 
 .cookies-banner-preview-mode {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96985

## What Is Being Fixed

The cookie consent banner's privacy-policy link fails an accessibility check (axe `link-in-text-block`, WCAG 1.4.1 Use of Color, Level A): it is distinguished from the surrounding banner text by color alone. The link text (`#0b5fff`) and the surrounding text (`#272833`) have a contrast ratio of only 2.85:1 — below the 3:1 threshold — and the link has no underline. The condition surfaced after LPD-94502 gave the banner an opaque background, which let axe measure the previously indeterminate contrast and flip the rule from incomplete to a hard violation.

## How It Is Being Fixed

Add an at-rest underline to the banner's in-paragraph link (`.cookies-banner p a`). Underline is the canonical WCAG non-color affordance and satisfies the rule in both light and dark mode, without touching the link or text colors — so the Atlas brand link color and dark-mode readability are preserved. It is a minimal, theme-robust one-rule change.

## Why Are There No Tests?

The change is CSS-only and is already covered by the existing `cookiesBannerAccessibility.spec.ts` "LPD-30822 Cookie Banner Accessibility" test, whose axe assertion (`link-in-text-block`, hard `soft:false`) fails without this change and passes with it. No new test is warranted; the regression is guarded by the existing spec.

## PR Check

**pr-check: PASS** — tested on `9d94c5f9efaa8e04587e005177467426063e2e6f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |

<!-- pr-check {"result": "success", "sha": "9d94c5f9efaa8e04587e005177467426063e2e6f"} -->
