### PR TITLE
LPD-91327 Rename the audit message helpers from _build to _get

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/constants/OAuth2ProviderRESTWebKeys.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/constants/OAuth2ProviderRESTWebKeys.java
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.rest.internal.constants;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class OAuth2ProviderRESTWebKeys {
+
+	public static final String DYNAMIC_REGISTRATION_CLIENT_HOST =
+		"DYNAMIC_REGISTRATION_CLIENT_HOST";
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/constants/OAuth2ProviderRESTEndpointConstants.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/constants/OAuth2ProviderRESTEndpointConstants.java
@@ -19,8 +19,21 @@ public class OAuth2ProviderRESTEndpointConstants {
 	public static final String COOKIE_NAME_REMEMBER_DEVICE_PREFIX =
 		"OAUTH2_REMEMBER_DEVICE_";
 
+	public static final String DYNAMIC_REGISTRATION_MODE_AUTHENTICATED =
+		"authenticated";
+
 	public static final String ERROR_INVALID_CLIENT_METADATA =
 		"invalid_client_metadata";
+
+	public static final String ERROR_INVALID_TOKEN = "invalid_token";
+
+	public static final String ERROR_SERVER_ERROR = "server_error";
+
+	public static final String EVENT_TYPE_DYNAMIC_REGISTRATION_ADD =
+		"DYNAMIC_REGISTRATION_ADD";
+
+	public static final String EVENT_TYPE_DYNAMIC_REGISTRATION_REJECT =
+		"DYNAMIC_REGISTRATION_REJECT";
 
 	public static final String PROPERTY_KEY_CLIENT_FEATURE_PREFIX = "feature.";
 

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
@@ -369,14 +369,14 @@ public class LiferayDynamicRegistrationService
 			return;
 		}
 
-		List<String> redirectUris = clientRegistration.getRedirectUris();
+		List<String> redirectURIs = clientRegistration.getRedirectUris();
 
-		if (redirectUris != null) {
+		if (redirectURIs != null) {
 			String applicationType = _getApplicationType(clientRegistration);
 
-			for (String redirectUri : redirectUris) {
+			for (String redirectURI : redirectURIs) {
 				validateRequestUri(
-					redirectUri, applicationType,
+					redirectURI, applicationType,
 					client.getAllowedGrantTypes());
 			}
 		}
@@ -384,7 +384,7 @@ public class LiferayDynamicRegistrationService
 		if ((allowedGrantTypes.contains(
 				OAuthConstants.AUTHORIZATION_CODE_GRANT) ||
 			 allowedGrantTypes.contains(OAuthConstants.IMPLICIT_GRANT)) &&
-			ListUtil.isEmpty(redirectUris)) {
+			ListUtil.isEmpty(redirectURIs)) {
 
 			OAuth2ErrorUtil.reportInvalidRequestError(
 				StringBundler.concat(

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
@@ -5,6 +5,8 @@
 
 package com.liferay.oauth2.provider.rest.internal.endpoint.dynamic.registration;
 
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.rest.internal.constants.OAuth2ProviderRESTWebKeys;
 import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
 import com.liferay.oauth2.provider.rest.internal.endpoint.dynamic.registration.model.LiferayClientRegistration;
 import com.liferay.oauth2.provider.rest.internal.endpoint.dynamic.registration.model.LiferayClientRegistrationResponse;
@@ -13,11 +15,23 @@ import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.audit.AuditException;
+import com.liferay.portal.kernel.audit.AuditMessage;
+import com.liferay.portal.kernel.audit.AuditRouterUtil;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
@@ -28,6 +42,7 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.WebApplicationException;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
@@ -40,6 +55,7 @@ import java.util.Map;
 import org.apache.cxf.jaxrs.ext.MessageContext;
 import org.apache.cxf.jaxrs.utils.JAXRSUtils;
 import org.apache.cxf.rs.security.oauth2.common.Client;
+import org.apache.cxf.rs.security.oauth2.common.OAuthError;
 import org.apache.cxf.rs.security.oauth2.services.ClientRegistration;
 import org.apache.cxf.rs.security.oauth2.services.DynamicRegistrationService;
 import org.apache.cxf.rs.security.oauth2.utils.OAuthConstants;
@@ -89,7 +105,24 @@ public class LiferayDynamicRegistrationService
 	public Response register(
 		LiferayClientRegistration liferayClientRegistration) {
 
-		return super.register(liferayClientRegistration);
+		try {
+			Response response = super.register(liferayClientRegistration);
+
+			_routeAuditMessage(_buildAddAuditMessage(response));
+
+			return response;
+		}
+		catch (RuntimeException runtimeException) {
+			_routeAuditMessage(
+				_buildRejectAuditMessage(
+					runtimeException, liferayClientRegistration));
+
+			throw runtimeException;
+		}
+	}
+
+	public void setPortal(Portal portal) {
+		_portal = portal;
 	}
 
 	@Consumes(MediaType.APPLICATION_JSON)
@@ -301,9 +334,187 @@ public class LiferayDynamicRegistrationService
 		return OAuth2SecureRandomGenerator.generateClientSecret();
 	}
 
+	private AuditMessage _buildAddAuditMessage(Response response) {
+		if (response == null) {
+			return null;
+		}
+
+		Object entity = response.getEntity();
+
+		if (!(entity instanceof
+				LiferayClientRegistrationResponse
+					liferayClientRegistrationResponse)) {
+
+			return null;
+		}
+
+		JSONObject additionalInfoJSONObject = _getBaseAdditionalInfoJSONObject(
+		).put(
+			"clientId", liferayClientRegistrationResponse.getClientId()
+		).put(
+			"clientName", liferayClientRegistrationResponse.getClientName()
+		).put(
+			"grantTypes",
+			JSONFactoryUtil.createJSONArray(
+				liferayClientRegistrationResponse.getGrantTypes())
+		).put(
+			"redirectUris",
+			JSONFactoryUtil.createJSONArray(
+				liferayClientRegistrationResponse.getRedirectUris())
+		).put(
+			"scope", liferayClientRegistrationResponse.getScope()
+		);
+
+		return new AuditMessage(
+			0, _getCompanyId(), 0, StringPool.BLANK, null,
+			additionalInfoJSONObject, OAuth2Application.class.getName(),
+			GetterUtil.getString(
+				liferayClientRegistrationResponse.getClientId()),
+			OAuth2ProviderRESTEndpointConstants.
+				EVENT_TYPE_DYNAMIC_REGISTRATION_ADD,
+			StringPool.BLANK);
+	}
+
+	private AuditMessage _buildRejectAuditMessage(
+		Exception exception,
+		LiferayClientRegistration liferayClientRegistration) {
+
+		String clientName = StringPool.BLANK;
+
+		if (liferayClientRegistration != null) {
+			clientName = GetterUtil.getString(
+				liferayClientRegistration.getClientName());
+		}
+
+		String error = OAuth2ProviderRESTEndpointConstants.ERROR_SERVER_ERROR;
+		String errorDescription = GetterUtil.getString(exception.getMessage());
+
+		if (exception instanceof
+				WebApplicationException webApplicationException) {
+
+			Object entity = null;
+
+			Response response = webApplicationException.getResponse();
+
+			if (response != null) {
+				entity = response.getEntity();
+			}
+
+			if (entity instanceof OAuthError oAuthError) {
+				error = GetterUtil.getString(oAuthError.getError(), error);
+
+				if (Validator.isNotNull(oAuthError.getErrorDescription())) {
+					errorDescription = oAuthError.getErrorDescription();
+				}
+			}
+		}
+
+		JSONArray grantTypesJSONArray = JSONFactoryUtil.createJSONArray();
+		JSONArray redirectURIsJSONArray = JSONFactoryUtil.createJSONArray();
+		String scope = StringPool.BLANK;
+
+		if (liferayClientRegistration != null) {
+			grantTypesJSONArray = JSONFactoryUtil.createJSONArray(
+				liferayClientRegistration.getGrantTypes());
+			redirectURIsJSONArray = JSONFactoryUtil.createJSONArray(
+				liferayClientRegistration.getRedirectUris());
+			scope = GetterUtil.getString(liferayClientRegistration.getScope());
+		}
+
+		JSONObject additionalInfoJSONObject = _getBaseAdditionalInfoJSONObject(
+		).put(
+			"clientName", clientName
+		).put(
+			"error", error
+		).put(
+			"errorDescription", errorDescription
+		).put(
+			"grantTypes", grantTypesJSONArray
+		).put(
+			"redirectUris", redirectURIsJSONArray
+		).put(
+			"scope", scope
+		);
+
+		return new AuditMessage(
+			0, _getCompanyId(), 0, StringPool.BLANK, null,
+			additionalInfoJSONObject, OAuth2Application.class.getName(),
+			StringPool.BLANK,
+			OAuth2ProviderRESTEndpointConstants.
+				EVENT_TYPE_DYNAMIC_REGISTRATION_REJECT,
+			StringPool.BLANK);
+	}
+
 	private String _getApplicationType(ClientRegistration clientRegistration) {
 		return GetterUtil.getString(
 			clientRegistration.getApplicationType(), "web");
+	}
+
+	private JSONObject _getBaseAdditionalInfoJSONObject() {
+		HttpServletRequest httpServletRequest = _getHttpServletRequest();
+
+		String clientHost = StringPool.BLANK;
+		String userAgent = StringPool.BLANK;
+
+		if (httpServletRequest != null) {
+			clientHost = GetterUtil.getString(
+				httpServletRequest.getAttribute(
+					OAuth2ProviderRESTWebKeys.DYNAMIC_REGISTRATION_CLIENT_HOST),
+				httpServletRequest.getRemoteAddr());
+
+			userAgent = GetterUtil.getString(
+				httpServletRequest.getHeader("User-Agent"));
+		}
+
+		return JSONUtil.put(
+			"clientHost", clientHost
+		).put(
+			"mode",
+			OAuth2ProviderRESTEndpointConstants.
+				DYNAMIC_REGISTRATION_MODE_AUTHENTICATED
+		).put(
+			"userAgent", userAgent
+		);
+	}
+
+	private long _getCompanyId() {
+		HttpServletRequest httpServletRequest = _getHttpServletRequest();
+
+		if ((httpServletRequest == null) || (_portal == null)) {
+			return 0;
+		}
+
+		return _portal.getCompanyId(httpServletRequest);
+	}
+
+	private HttpServletRequest _getHttpServletRequest() {
+		MessageContext messageContext = getMessageContext();
+
+		if (messageContext == null) {
+			return null;
+		}
+
+		return messageContext.getHttpServletRequest();
+	}
+
+	private void _routeAuditMessage(AuditMessage auditMessage) {
+		if (auditMessage == null) {
+			return;
+		}
+
+		try {
+			AuditRouterUtil.route(auditMessage);
+		}
+		catch (AuditException auditException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to route audit message", auditException);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
 	}
 
 	private void _setAllowedGrantTypes(Client client) {
@@ -422,6 +633,9 @@ public class LiferayDynamicRegistrationService
 		}
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		LiferayDynamicRegistrationService.class);
+
 	private static final Map<String, String> _allowedResponseTypes =
 		HashMapBuilder.put(
 			OAuthConstants.AUTHORIZATION_CODE_GRANT,
@@ -429,5 +643,7 @@ public class LiferayDynamicRegistrationService
 		).put(
 			OAuthConstants.IMPLICIT_GRANT, OAuthConstants.TOKEN_RESPONSE_TYPE
 		).build();
+
+	private Portal _portal;
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
@@ -108,13 +108,13 @@ public class LiferayDynamicRegistrationService
 		try {
 			Response response = super.register(liferayClientRegistration);
 
-			_routeAuditMessage(_buildAddAuditMessage(response));
+			_routeAuditMessage(_getAddAuditMessage(response));
 
 			return response;
 		}
 		catch (RuntimeException runtimeException) {
 			_routeAuditMessage(
-				_buildRejectAuditMessage(
+				_getRejectAuditMessage(
 					runtimeException, liferayClientRegistration));
 
 			throw runtimeException;
@@ -334,7 +334,7 @@ public class LiferayDynamicRegistrationService
 		return OAuth2SecureRandomGenerator.generateClientSecret();
 	}
 
-	private AuditMessage _buildAddAuditMessage(Response response) {
+	private AuditMessage _getAddAuditMessage(Response response) {
 		if (response == null) {
 			return null;
 		}
@@ -375,7 +375,59 @@ public class LiferayDynamicRegistrationService
 			StringPool.BLANK);
 	}
 
-	private AuditMessage _buildRejectAuditMessage(
+	private String _getApplicationType(ClientRegistration clientRegistration) {
+		return GetterUtil.getString(
+			clientRegistration.getApplicationType(), "web");
+	}
+
+	private JSONObject _getBaseAdditionalInfoJSONObject() {
+		HttpServletRequest httpServletRequest = _getHttpServletRequest();
+
+		String clientHost = StringPool.BLANK;
+		String userAgent = StringPool.BLANK;
+
+		if (httpServletRequest != null) {
+			clientHost = GetterUtil.getString(
+				httpServletRequest.getAttribute(
+					OAuth2ProviderRESTWebKeys.DYNAMIC_REGISTRATION_CLIENT_HOST),
+				httpServletRequest.getRemoteAddr());
+
+			userAgent = GetterUtil.getString(
+				httpServletRequest.getHeader("User-Agent"));
+		}
+
+		return JSONUtil.put(
+			"clientHost", clientHost
+		).put(
+			"mode",
+			OAuth2ProviderRESTEndpointConstants.
+				DYNAMIC_REGISTRATION_MODE_AUTHENTICATED
+		).put(
+			"userAgent", userAgent
+		);
+	}
+
+	private long _getCompanyId() {
+		HttpServletRequest httpServletRequest = _getHttpServletRequest();
+
+		if ((httpServletRequest == null) || (_portal == null)) {
+			return 0;
+		}
+
+		return _portal.getCompanyId(httpServletRequest);
+	}
+
+	private HttpServletRequest _getHttpServletRequest() {
+		MessageContext messageContext = getMessageContext();
+
+		if (messageContext == null) {
+			return null;
+		}
+
+		return messageContext.getHttpServletRequest();
+	}
+
+	private AuditMessage _getRejectAuditMessage(
 		Exception exception,
 		LiferayClientRegistration liferayClientRegistration) {
 
@@ -443,58 +495,6 @@ public class LiferayDynamicRegistrationService
 			OAuth2ProviderRESTEndpointConstants.
 				EVENT_TYPE_DYNAMIC_REGISTRATION_REJECT,
 			StringPool.BLANK);
-	}
-
-	private String _getApplicationType(ClientRegistration clientRegistration) {
-		return GetterUtil.getString(
-			clientRegistration.getApplicationType(), "web");
-	}
-
-	private JSONObject _getBaseAdditionalInfoJSONObject() {
-		HttpServletRequest httpServletRequest = _getHttpServletRequest();
-
-		String clientHost = StringPool.BLANK;
-		String userAgent = StringPool.BLANK;
-
-		if (httpServletRequest != null) {
-			clientHost = GetterUtil.getString(
-				httpServletRequest.getAttribute(
-					OAuth2ProviderRESTWebKeys.DYNAMIC_REGISTRATION_CLIENT_HOST),
-				httpServletRequest.getRemoteAddr());
-
-			userAgent = GetterUtil.getString(
-				httpServletRequest.getHeader("User-Agent"));
-		}
-
-		return JSONUtil.put(
-			"clientHost", clientHost
-		).put(
-			"mode",
-			OAuth2ProviderRESTEndpointConstants.
-				DYNAMIC_REGISTRATION_MODE_AUTHENTICATED
-		).put(
-			"userAgent", userAgent
-		);
-	}
-
-	private long _getCompanyId() {
-		HttpServletRequest httpServletRequest = _getHttpServletRequest();
-
-		if ((httpServletRequest == null) || (_portal == null)) {
-			return 0;
-		}
-
-		return _portal.getCompanyId(httpServletRequest);
-	}
-
-	private HttpServletRequest _getHttpServletRequest() {
-		MessageContext messageContext = getMessageContext();
-
-		if (messageContext == null) {
-			return null;
-		}
-
-		return messageContext.getHttpServletRequest();
 	}
 
 	private void _routeAuditMessage(AuditMessage auditMessage) {

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
@@ -10,20 +10,17 @@ import com.liferay.oauth2.provider.rest.internal.constants.OAuth2ProviderRESTWeb
 import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
 import com.liferay.oauth2.provider.rest.internal.endpoint.dynamic.registration.model.LiferayClientRegistration;
 import com.liferay.oauth2.provider.rest.internal.endpoint.dynamic.registration.model.LiferayClientRegistrationResponse;
+import com.liferay.oauth2.provider.rest.internal.endpoint.util.DynamicRegistrationAuditMessageUtil;
 import com.liferay.oauth2.provider.rest.internal.endpoint.util.OAuth2ErrorUtil;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.audit.AuditException;
 import com.liferay.portal.kernel.audit.AuditMessage;
-import com.liferay.portal.kernel.audit.AuditRouterUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -108,12 +105,13 @@ public class LiferayDynamicRegistrationService
 		try {
 			Response response = super.register(liferayClientRegistration);
 
-			_routeAuditMessage(_getAddAuditMessage(response));
+			DynamicRegistrationAuditMessageUtil.routeAuditMessage(
+				_getAddAuditMessage(response));
 
 			return response;
 		}
 		catch (RuntimeException runtimeException) {
-			_routeAuditMessage(
+			DynamicRegistrationAuditMessageUtil.routeAuditMessage(
 				_getRejectAuditMessage(
 					runtimeException, liferayClientRegistration));
 
@@ -497,26 +495,6 @@ public class LiferayDynamicRegistrationService
 			StringPool.BLANK);
 	}
 
-	private void _routeAuditMessage(AuditMessage auditMessage) {
-		if (auditMessage == null) {
-			return;
-		}
-
-		try {
-			AuditRouterUtil.route(auditMessage);
-		}
-		catch (AuditException auditException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn("Unable to route audit message", auditException);
-			}
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
-		}
-	}
-
 	private void _setAllowedGrantTypes(Client client) {
 		if (!OAuthConstants.TOKEN_ENDPOINT_AUTH_NONE.equals(
 				client.getTokenEndpointAuthMethod())) {
@@ -632,9 +610,6 @@ public class LiferayDynamicRegistrationService
 			}
 		}
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		LiferayDynamicRegistrationService.class);
 
 	private static final Map<String, String> _allowedResponseTypes =
 		HashMapBuilder.put(

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationServiceRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationServiceRegistrator.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Portal;
 
 import java.util.Map;
 
@@ -67,6 +68,8 @@ public class LiferayDynamicRegistrationServiceRegistrator {
 								liferayDynamicRegistrationService.
 									setClientProvider(
 										_liferayOAuthDataProvider);
+								liferayDynamicRegistrationService.setPortal(
+									_portal);
 								liferayDynamicRegistrationService.
 									setSupportRegistrationAccessTokens(true);
 
@@ -106,6 +109,9 @@ public class LiferayDynamicRegistrationServiceRegistrator {
 
 	@Reference
 	private LiferayOAuthDataProvider _liferayOAuthDataProvider;
+
+	@Reference
+	private Portal _portal;
 
 	private volatile ServiceRegistration<Object> _serviceRegistration;
 

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/container/request/filter/DynamicRegistrationServiceContainerRequestFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/container/request/filter/DynamicRegistrationServiceContainerRequestFilter.java
@@ -11,12 +11,11 @@ import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.rest.internal.constants.OAuth2ProviderRESTWebKeys;
 import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
+import com.liferay.oauth2.provider.rest.internal.endpoint.util.DynamicRegistrationAuditMessageUtil;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
 import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.audit.AuditException;
 import com.liferay.portal.kernel.audit.AuditMessage;
-import com.liferay.portal.kernel.audit.AuditRouterUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -131,7 +130,7 @@ public class DynamicRegistrationServiceContainerRequestFilter
 					OAuth2ProviderRESTWebKeys.DYNAMIC_REGISTRATION_CLIENT_HOST),
 				_normalizeHost(_getClientHost(httpServletRequest, false)));
 
-			_routeAuditMessage(
+			DynamicRegistrationAuditMessageUtil.routeAuditMessage(
 				_getAuthorizationFailureAuditMessage(
 					clientHost, companyId, httpServletRequest));
 
@@ -364,26 +363,6 @@ public class DynamicRegistrationServiceContainerRequestFilter
 		}
 
 		return StringUtil.toLowerCase(normalizedHost);
-	}
-
-	private void _routeAuditMessage(AuditMessage auditMessage) {
-		if (auditMessage == null) {
-			return;
-		}
-
-		try {
-			AuditRouterUtil.route(auditMessage);
-		}
-		catch (AuditException auditException) {
-			if (_log.isWarnEnabled()) {
-				_log.warn("Unable to route audit message", auditException);
-			}
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
-		}
 	}
 
 	private void _setSecurityContext(

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/container/request/filter/DynamicRegistrationServiceContainerRequestFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/container/request/filter/DynamicRegistrationServiceContainerRequestFilter.java
@@ -9,10 +9,16 @@ import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.constants.OAuth2ProviderActionKeys;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
+import com.liferay.oauth2.provider.rest.internal.constants.OAuth2ProviderRESTWebKeys;
+import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.audit.AuditException;
+import com.liferay.portal.kernel.audit.AuditMessage;
+import com.liferay.portal.kernel.audit.AuditRouterUtil;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.User;
@@ -87,9 +93,9 @@ public class DynamicRegistrationServiceContainerRequestFilter
 		HttpServletRequest httpServletRequest = (HttpServletRequest)message.get(
 			AbstractHTTPDestination.HTTP_REQUEST);
 
-		if (!FeatureFlagManagerUtil.isEnabled(
-				_portal.getCompanyId(httpServletRequest), "LPD-63416")) {
+		long companyId = _portal.getCompanyId(httpServletRequest);
 
+		if (!FeatureFlagManagerUtil.isEnabled(companyId, "LPD-63416")) {
 			containerRequestContext.abortWith(
 				Response.status(
 					Response.Status.NOT_FOUND
@@ -101,6 +107,10 @@ public class DynamicRegistrationServiceContainerRequestFilter
 		User user = null;
 
 		try {
+			httpServletRequest.setAttribute(
+				OAuth2ProviderRESTWebKeys.DYNAMIC_REGISTRATION_CLIENT_HOST,
+				_normalizeHost(_getClientHost(httpServletRequest, false)));
+
 			user = _authorize(
 				httpServletRequest, httpServletRequest.getMethod());
 		}
@@ -115,6 +125,15 @@ public class DynamicRegistrationServiceContainerRequestFilter
 			if (_log.isDebugEnabled()) {
 				_log.debug(exception);
 			}
+
+			String clientHost = GetterUtil.getString(
+				httpServletRequest.getAttribute(
+					OAuth2ProviderRESTWebKeys.DYNAMIC_REGISTRATION_CLIENT_HOST),
+				_normalizeHost(_getClientHost(httpServletRequest, false)));
+
+			_routeAuditMessage(
+				_buildAuthorizationFailureAuditMessage(
+					clientHost, companyId, httpServletRequest));
 
 			throw ExceptionUtils.toNotAuthorizedException(null, null);
 		}
@@ -205,6 +224,70 @@ public class DynamicRegistrationServiceContainerRequestFilter
 		return user;
 	}
 
+	private AuditMessage _buildAuthorizationFailureAuditMessage(
+		String clientHost, long companyId,
+		HttpServletRequest httpServletRequest) {
+
+		return _buildRejectAuditMessage(
+			clientHost, companyId,
+			OAuth2ProviderRESTEndpointConstants.ERROR_INVALID_TOKEN,
+			"Authenticated registration authorization failed",
+			httpServletRequest,
+			OAuth2ProviderRESTEndpointConstants.
+				DYNAMIC_REGISTRATION_MODE_AUTHENTICATED);
+	}
+
+	private AuditMessage _buildRejectAuditMessage(
+		String clientHost, long companyId, String error,
+		String errorDescription, HttpServletRequest httpServletRequest,
+		String mode) {
+
+		return new AuditMessage(
+			0, companyId, 0, StringPool.BLANK, null,
+			JSONUtil.put(
+				"clientHost", clientHost
+			).put(
+				"error", error
+			).put(
+				"errorDescription", errorDescription
+			).put(
+				"mode", mode
+			).put(
+				"userAgent",
+				GetterUtil.getString(httpServletRequest.getHeader("User-Agent"))
+			),
+			OAuth2Application.class.getName(), StringPool.BLANK,
+			OAuth2ProviderRESTEndpointConstants.
+				EVENT_TYPE_DYNAMIC_REGISTRATION_REJECT,
+			StringPool.BLANK);
+	}
+
+	private String _getClientHost(
+		HttpServletRequest httpServletRequest, boolean trustProxyHeaders) {
+
+		if (!trustProxyHeaders) {
+			return httpServletRequest.getRemoteAddr();
+		}
+
+		String forwardedFor = httpServletRequest.getHeader("X-Forwarded-For");
+
+		if (!Validator.isBlank(forwardedFor)) {
+			int index = forwardedFor.indexOf(',');
+
+			if (index >= 0) {
+				forwardedFor = forwardedFor.substring(0, index);
+			}
+
+			forwardedFor = forwardedFor.trim();
+
+			if (!Validator.isBlank(forwardedFor)) {
+				return forwardedFor;
+			}
+		}
+
+		return httpServletRequest.getRemoteAddr();
+	}
+
 	private String _getClientId(HttpServletRequest httpServletRequest) {
 		String requestURI = httpServletRequest.getRequestURI();
 
@@ -254,6 +337,53 @@ public class DynamicRegistrationServiceContainerRequestFilter
 			accessTokenContent);
 
 		return jwsJwtCompactConsumer.getJwtToken();
+	}
+
+	private String _normalizeHost(String host) {
+		if (Validator.isBlank(host)) {
+			return StringPool.BLANK;
+		}
+
+		String normalizedHost = host.trim();
+
+		if (normalizedHost.startsWith(StringPool.OPEN_BRACKET)) {
+			int index = normalizedHost.indexOf(StringPool.CLOSE_BRACKET);
+
+			if (index > 1) {
+				normalizedHost = normalizedHost.substring(1, index);
+			}
+		}
+		else {
+			int index = normalizedHost.indexOf(StringPool.COLON);
+
+			if ((index > 0) &&
+				(normalizedHost.indexOf(StringPool.COLON, index + 1) < 0)) {
+
+				normalizedHost = normalizedHost.substring(0, index);
+			}
+		}
+
+		return StringUtil.toLowerCase(normalizedHost);
+	}
+
+	private void _routeAuditMessage(AuditMessage auditMessage) {
+		if (auditMessage == null) {
+			return;
+		}
+
+		try {
+			AuditRouterUtil.route(auditMessage);
+		}
+		catch (AuditException auditException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to route audit message", auditException);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
 	}
 
 	private void _setSecurityContext(

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/container/request/filter/DynamicRegistrationServiceContainerRequestFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/container/request/filter/DynamicRegistrationServiceContainerRequestFilter.java
@@ -132,7 +132,7 @@ public class DynamicRegistrationServiceContainerRequestFilter
 				_normalizeHost(_getClientHost(httpServletRequest, false)));
 
 			_routeAuditMessage(
-				_buildAuthorizationFailureAuditMessage(
+				_getAuthorizationFailureAuditMessage(
 					clientHost, companyId, httpServletRequest));
 
 			throw ExceptionUtils.toNotAuthorizedException(null, null);
@@ -224,42 +224,17 @@ public class DynamicRegistrationServiceContainerRequestFilter
 		return user;
 	}
 
-	private AuditMessage _buildAuthorizationFailureAuditMessage(
+	private AuditMessage _getAuthorizationFailureAuditMessage(
 		String clientHost, long companyId,
 		HttpServletRequest httpServletRequest) {
 
-		return _buildRejectAuditMessage(
+		return _getRejectAuditMessage(
 			clientHost, companyId,
 			OAuth2ProviderRESTEndpointConstants.ERROR_INVALID_TOKEN,
 			"Authenticated registration authorization failed",
 			httpServletRequest,
 			OAuth2ProviderRESTEndpointConstants.
 				DYNAMIC_REGISTRATION_MODE_AUTHENTICATED);
-	}
-
-	private AuditMessage _buildRejectAuditMessage(
-		String clientHost, long companyId, String error,
-		String errorDescription, HttpServletRequest httpServletRequest,
-		String mode) {
-
-		return new AuditMessage(
-			0, companyId, 0, StringPool.BLANK, null,
-			JSONUtil.put(
-				"clientHost", clientHost
-			).put(
-				"error", error
-			).put(
-				"errorDescription", errorDescription
-			).put(
-				"mode", mode
-			).put(
-				"userAgent",
-				GetterUtil.getString(httpServletRequest.getHeader("User-Agent"))
-			),
-			OAuth2Application.class.getName(), StringPool.BLANK,
-			OAuth2ProviderRESTEndpointConstants.
-				EVENT_TYPE_DYNAMIC_REGISTRATION_REJECT,
-			StringPool.BLANK);
 	}
 
 	private String _getClientHost(
@@ -337,6 +312,31 @@ public class DynamicRegistrationServiceContainerRequestFilter
 			accessTokenContent);
 
 		return jwsJwtCompactConsumer.getJwtToken();
+	}
+
+	private AuditMessage _getRejectAuditMessage(
+		String clientHost, long companyId, String error,
+		String errorDescription, HttpServletRequest httpServletRequest,
+		String mode) {
+
+		return new AuditMessage(
+			0, companyId, 0, StringPool.BLANK, null,
+			JSONUtil.put(
+				"clientHost", clientHost
+			).put(
+				"error", error
+			).put(
+				"errorDescription", errorDescription
+			).put(
+				"mode", mode
+			).put(
+				"userAgent",
+				GetterUtil.getString(httpServletRequest.getHeader("User-Agent"))
+			),
+			OAuth2Application.class.getName(), StringPool.BLANK,
+			OAuth2ProviderRESTEndpointConstants.
+				EVENT_TYPE_DYNAMIC_REGISTRATION_REJECT,
+			StringPool.BLANK);
 	}
 
 	private String _normalizeHost(String host) {

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/container/request/filter/DynamicRegistrationServiceContainerRequestFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/container/request/filter/DynamicRegistrationServiceContainerRequestFilter.java
@@ -108,7 +108,7 @@ public class DynamicRegistrationServiceContainerRequestFilter
 		try {
 			httpServletRequest.setAttribute(
 				OAuth2ProviderRESTWebKeys.DYNAMIC_REGISTRATION_CLIENT_HOST,
-				_normalizeHost(_getClientHost(httpServletRequest, false)));
+				_normalizeHost(_getClientHost(httpServletRequest)));
 
 			user = _authorize(
 				httpServletRequest, httpServletRequest.getMethod());
@@ -128,7 +128,7 @@ public class DynamicRegistrationServiceContainerRequestFilter
 			String clientHost = GetterUtil.getString(
 				httpServletRequest.getAttribute(
 					OAuth2ProviderRESTWebKeys.DYNAMIC_REGISTRATION_CLIENT_HOST),
-				_normalizeHost(_getClientHost(httpServletRequest, false)));
+				_normalizeHost(_getClientHost(httpServletRequest)));
 
 			DynamicRegistrationAuditMessageUtil.routeAuditMessage(
 				_getAuthorizationFailureAuditMessage(
@@ -236,29 +236,7 @@ public class DynamicRegistrationServiceContainerRequestFilter
 				DYNAMIC_REGISTRATION_MODE_AUTHENTICATED);
 	}
 
-	private String _getClientHost(
-		HttpServletRequest httpServletRequest, boolean trustProxyHeaders) {
-
-		if (!trustProxyHeaders) {
-			return httpServletRequest.getRemoteAddr();
-		}
-
-		String forwardedFor = httpServletRequest.getHeader("X-Forwarded-For");
-
-		if (!Validator.isBlank(forwardedFor)) {
-			int index = forwardedFor.indexOf(',');
-
-			if (index >= 0) {
-				forwardedFor = forwardedFor.substring(0, index);
-			}
-
-			forwardedFor = forwardedFor.trim();
-
-			if (!Validator.isBlank(forwardedFor)) {
-				return forwardedFor;
-			}
-		}
-
+	private String _getClientHost(HttpServletRequest httpServletRequest) {
 		return httpServletRequest.getRemoteAddr();
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/util/DynamicRegistrationAuditMessageUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/util/DynamicRegistrationAuditMessageUtil.java
@@ -1,0 +1,42 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.rest.internal.endpoint.util;
+
+import com.liferay.portal.kernel.audit.AuditException;
+import com.liferay.portal.kernel.audit.AuditMessage;
+import com.liferay.portal.kernel.audit.AuditRouterUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class DynamicRegistrationAuditMessageUtil {
+
+	public static void routeAuditMessage(AuditMessage auditMessage) {
+		if (auditMessage == null) {
+			return;
+		}
+
+		try {
+			AuditRouterUtil.route(auditMessage);
+		}
+		catch (AuditException auditException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to route audit message", auditException);
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DynamicRegistrationAuditMessageUtil.class);
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:document-library:document-library-api")
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-remote:portal-remote-cors-api")
+	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-api")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
@@ -14,9 +14,11 @@ import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.audit.AuditMessage;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
@@ -27,6 +29,7 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.test.rule.FeatureFlag;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -37,19 +40,28 @@ import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.MultivaluedHashMap;
 import jakarta.ws.rs.core.Response;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Dictionary;
+import java.util.Hashtable;
 import java.util.List;
 
 import org.apache.cxf.rs.security.oauth2.utils.OAuthConstants;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Jorge García Jiménez
@@ -62,6 +74,37 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_auditMessages = new ArrayList<>();
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			DynamicRegistrationServiceTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		Dictionary<String, Object> properties = new Hashtable<>();
+
+		properties.put("eventTypes", "*");
+
+		_serviceRegistration = bundleContext.registerService(
+			AuditMessageProcessor.class,
+			auditMessage -> _auditMessages.add(auditMessage), properties);
+	}
+
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+
+		super.tearDown();
+	}
 
 	@Test
 	public void testDeleteClientRegistration() throws Exception {
@@ -189,6 +232,80 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 
 		Assert.assertNull(
 			response.getHeaderString("Access-Control-Allow-Origin"));
+
+		AuditMessage addAuditMessage = _fetchAuditMessage(
+			"DYNAMIC_REGISTRATION_ADD");
+
+		Assert.assertEquals(
+			OAuth2Application.class.getName(), addAuditMessage.getClassName());
+		Assert.assertEquals(clientId, addAuditMessage.getClassPK());
+
+		JSONObject addAdditionalInfoJSONObject =
+			addAuditMessage.getAdditionalInfo();
+
+		Assert.assertEquals(
+			clientName, addAdditionalInfoJSONObject.getString("clientName"));
+
+		JSONArray grantTypesJSONArray =
+			addAdditionalInfoJSONObject.getJSONArray("grantTypes");
+
+		Assert.assertEquals(1, grantTypesJSONArray.length());
+		Assert.assertEquals(
+			OAuthConstants.CLIENT_CREDENTIALS_GRANT,
+			grantTypesJSONArray.getString(0));
+
+		Assert.assertEquals(
+			"authenticated", addAdditionalInfoJSONObject.getString("mode"));
+
+		String[] auditScopes = StringUtil.split(
+			addAdditionalInfoJSONObject.getString("scope"), CharPool.SPACE);
+
+		Arrays.sort(auditScopes);
+
+		Assert.assertArrayEquals(expectedScopes, auditScopes);
+
+		AuditMessage rejectAuditMessage = _fetchAuditMessage(
+			"DYNAMIC_REGISTRATION_REJECT");
+
+		Assert.assertEquals(
+			OAuth2Application.class.getName(),
+			rejectAuditMessage.getClassName());
+
+		JSONObject rejectAdditionalInfoJSONObject =
+			rejectAuditMessage.getAdditionalInfo();
+
+		Assert.assertEquals(
+			"invalid_client_metadata",
+			rejectAdditionalInfoJSONObject.getString("error"));
+	}
+
+	@Test
+	public void testRegisterWithInvalidBearerToken() throws Exception {
+		WebTarget registerWebTarget = getRegisterWebTarget();
+
+		Invocation.Builder invocationBuilder = registerWebTarget.request();
+
+		invocationBuilder.header(
+			"Authorization", "Bearer " + RandomTestUtil.randomString());
+
+		Response response = invocationBuilder.method(
+			"post",
+			Entity.json(
+				JSONUtil.put(
+					"client_name", RandomTestUtil.randomString()
+				).toString()));
+
+		Assert.assertEquals(401, response.getStatus());
+
+		AuditMessage auditMessage = _fetchAuditMessage(
+			"DYNAMIC_REGISTRATION_REJECT");
+
+		JSONObject additionalInfoJSONObject = auditMessage.getAdditionalInfo();
+
+		Assert.assertEquals(
+			"invalid_token", additionalInfoJSONObject.getString("error"));
+		Assert.assertEquals(
+			"authenticated", additionalInfoJSONObject.getString("mode"));
 	}
 
 	@Test
@@ -262,6 +379,16 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 		);
 	}
 
+	private AuditMessage _fetchAuditMessage(String eventType) {
+		for (AuditMessage auditMessage : _auditMessages) {
+			if (eventType.equals(auditMessage.getEventType())) {
+				return auditMessage;
+			}
+		}
+
+		return null;
+	}
+
 	private OAuth2Application _getDynamicRegistratorOAuth2Application()
 		throws Exception {
 
@@ -311,8 +438,12 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 		return tokenString;
 	}
 
+	private List<AuditMessage> _auditMessages;
+
 	@Inject
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
+
+	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
 
 	private class DynamicRegistrationServiceTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {

--- a/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/test/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/object/relationship/ObjectRelationshipDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/object/object-dynamic-data-mapping-form-field-type/src/test/java/com/liferay/object/dynamic/data/mapping/form/field/type/internal/object/relationship/ObjectRelationshipDDMFormFieldTemplateContextContributorTest.java
@@ -141,8 +141,7 @@ public class ObjectRelationshipDDMFormFieldTemplateContextContributorTest
 			_getAPIURL(additionalAPIURLParameters));
 
 		Assert.assertEquals(
-			_PORTAL_URL + _REST_CONTEXT_PATH,
-			_getAPIURL(StringPool.BLANK));
+			_PORTAL_URL + _REST_CONTEXT_PATH, _getAPIURL(StringPool.BLANK));
 	}
 
 	private String _getAPIURL(String additionalAPIURLParameters) {


### PR DESCRIPTION
Addresses the review feedback on PR #3060 / brianchandotcom PR #178138: the `_build*AuditMessage` helpers do not end in a call to a `build()` method (they `return new AuditMessage(...)`), so they are renamed to `_get*` per the convention. The source formatter reordered the methods alphabetically as a result.

Renamed methods:
- `LiferayDynamicRegistrationService`: `_getAddAuditMessage`, `_getRejectAuditMessage`
- `DynamicRegistrationServiceContainerRequestFilter`: `_getAuthorizationFailureAuditMessage`, `_getRejectAuditMessage`