### PR TITLE
LPD-97358 Decouple the email OTP send button from the submit lockout

### DIFF
--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-email-otp-web/src/main/resources/META-INF/resources/mfa_email_otp_checker/verify_browser.jsp
@@ -90,12 +90,6 @@ if ((mfaEmailOTPResendEmailTimeout > 0) && (mfaEmailOTPSetAtTime > 0)) {
 				maximumAllowedAttemptsError.remove();
 			}
 
-			if (!resendCountdown) {
-				sendEmailButton.removeAttribute('disabled');
-
-				sendEmailButton.removeClass('disabled');
-			}
-
 			submitEmailButton.text(originalSubmitButtonText);
 
 			submitEmailButton.removeAttribute('disabled');
@@ -113,11 +107,9 @@ if ((mfaEmailOTPResendEmailTimeout > 0) && (mfaEmailOTPSetAtTime > 0)) {
 		if (resendDuration < 1) {
 			sendEmailButton.text(originalSendButtonText);
 
-			if (!failedAttemptsRetryCountdown) {
-				sendEmailButton.removeAttribute('disabled');
+			sendEmailButton.removeAttribute('disabled');
 
-				sendEmailButton.removeClass('disabled');
-			}
+			sendEmailButton.removeClass('disabled');
 
 			clearInterval(resendCountdown);
 
@@ -143,7 +135,6 @@ if ((mfaEmailOTPResendEmailTimeout > 0) && (mfaEmailOTPSetAtTime > 0)) {
 	}
 
 	if (failedAttemptsRetryTimeout > 0) {
-		sendEmailButton.setAttribute('disabled', 'disabled');
 		submitEmailButton.setAttribute('disabled', 'disabled');
 
 		failedAttemptsRetryCountdown = <portlet:namespace />createCountdown(

--- a/modules/test/playwright/tests/multi-factor-authentication-email-otp-web/main/multi-factor-authentication-email-otp.spec.ts
+++ b/modules/test/playwright/tests/multi-factor-authentication-email-otp-web/main/multi-factor-authentication-email-otp.spec.ts
@@ -10,6 +10,7 @@ import {loginTest} from '../../../fixtures/loginTest';
 import {multiFactorAuthenticationPagesTest} from '../../../fixtures/multiFactorAuthenticationPagesTest';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
+import signInAndReachMFAChallenge from '../../../utils/signInAndReachMFAChallenge';
 
 export const test = mergeTests(
 	dataApiHelpersTest,
@@ -37,26 +38,15 @@ test(
 
 		const user = await apiHelpers.headlessAdminUser.postUserAccount();
 
-		// Reach the MFA stage in a clean context, leaving the admin signed in
+		// Reach the email OTP challenge in a clean context, leaving the admin
+		// signed in
 
-		const userContext = await browser.newContext();
-		const userPage = await userContext.newPage();
+		const {userContext, userPage} = await signInAndReachMFAChallenge(
+			browser,
+			user.emailAddress
+		);
 
 		try {
-			await userPage.goto('/');
-
-			await userPage
-				.getByRole('button', {name: 'Sign In'})
-				.last()
-				.click();
-
-			await userPage.getByLabel('Email Address').fill(user.emailAddress);
-			await userPage.getByLabel('Password').fill('test');
-
-			await userPage
-				.getByRole('button', {name: 'Sign In'})
-				.last()
-				.click();
 
 			// Request a one-time password so the send button starts its cooldown
 
@@ -132,26 +122,15 @@ test(
 
 		const user = await apiHelpers.headlessAdminUser.postUserAccount();
 
-		// Reach the MFA stage in a clean context, leaving the admin signed in
+		// Reach the email OTP challenge in a clean context, leaving the admin
+		// signed in
 
-		const userContext = await browser.newContext();
-		const userPage = await userContext.newPage();
+		const {userContext, userPage} = await signInAndReachMFAChallenge(
+			browser,
+			user.emailAddress
+		);
 
 		try {
-			await userPage.goto('/');
-
-			await userPage
-				.getByRole('button', {name: 'Sign In'})
-				.last()
-				.click();
-
-			await userPage.getByLabel('Email Address').fill(user.emailAddress);
-			await userPage.getByLabel('Password').fill('test');
-
-			await userPage
-				.getByRole('button', {name: 'Sign In'})
-				.last()
-				.click();
 
 			// Request a one-time password so the send button starts its cooldown
 
@@ -222,6 +201,99 @@ test(
 );
 
 test(
+	'LPD-97358 keeps the send button independent from the failed-attempts lockout',
+	{tag: ['@LPD-97358', '@LPP-64662']},
+	async ({
+		apiHelpers,
+		browser,
+		multiFactorAuthenticationConfigurationPage,
+	}) => {
+
+		// Enable email OTP with a resend cooldown that is much shorter than the
+		// failed-attempts retry lockout, so the resend cooldown elapses before
+		// the OTP is submitted. A single failed attempt triggers the lockout.
+
+		await multiFactorAuthenticationConfigurationPage.goto();
+
+		await multiFactorAuthenticationConfigurationPage.enable({
+			failedAttemptsAllowed: 1,
+			resendEmailTimeout: 2,
+			retryTimeout: 30,
+		});
+
+		// Create a user that will be challenged with email OTP when signing in
+
+		const user = await apiHelpers.headlessAdminUser.postUserAccount();
+
+		// Reach the email OTP challenge in a clean context, leaving the admin
+		// signed in
+
+		const {userContext, userPage} = await signInAndReachMFAChallenge(
+			browser,
+			user.emailAddress
+		);
+
+		try {
+			const sendEmailButton = userPage.locator('[id$="sendEmailButton"]');
+
+			const submitEmailButton = userPage.locator(
+				'[id$="submitEmailButton"]'
+			);
+
+			// Request a one-time password so the send button starts its cooldown,
+			// then wait for that short cooldown to elapse so the resend timer is
+			// no longer the reason the button could be disabled.
+
+			await expect(sendEmailButton).toHaveText('Send');
+
+			await clickAndExpectToBeVisible({
+				target: userPage.getByText(
+					'Your one-time password has been sent by email.'
+				),
+				trigger: sendEmailButton,
+			});
+
+			await expect(sendEmailButton).toBeEnabled({timeout: 15000});
+
+			// Submit an incorrect OTP to exhaust the single allowed attempt. The
+			// full-page re-render brings back the challenge with the retry
+			// lockout active on the submit button.
+
+			await userPage
+				.getByLabel('Enter the one-time password from the email')
+				.fill(getRandomString());
+
+			await submitEmailButton.click();
+
+			await expect(
+				userPage.getByText('Multi-factor authentication has failed.')
+			).toBeVisible();
+
+			// LPD-97358: the lockout governs only the submit button. With the
+			// resend cooldown already elapsed, the send button must stay usable
+			// so a new OTP can be requested while the submit lockout runs.
+
+			await expect(submitEmailButton).toBeDisabled();
+
+			await expect(submitEmailButton).toHaveText(/^\s*\d+\s*$/);
+
+			await expect(sendEmailButton).toBeEnabled();
+
+			await expect(sendEmailButton).toHaveText('Send');
+
+			await expect(sendEmailButton).not.toHaveClass(/\bdisabled\b/);
+		}
+		finally {
+			await userContext.close();
+
+			await multiFactorAuthenticationConfigurationPage.goto();
+
+			await multiFactorAuthenticationConfigurationPage.resetConfiguration();
+		}
+	}
+);
+
+test(
 	'LPD-96858 removes the sent-by-email message once the resend countdown finishes',
 	{tag: '@LPD-96858'},
 	async ({
@@ -244,27 +316,15 @@ test(
 
 		const user = await apiHelpers.headlessAdminUser.postUserAccount();
 
-		// Reach the MFA stage in a clean context, leaving the admin signed in
+		// Reach the email OTP challenge in a clean context, leaving the admin
+		// signed in
 
-		const userContext = await browser.newContext();
-		const userPage = await userContext.newPage();
+		const {userContext, userPage} = await signInAndReachMFAChallenge(
+			browser,
+			user.emailAddress
+		);
 
 		try {
-			await userPage.goto('/');
-
-			await userPage
-				.getByRole('button', {name: 'Sign In'})
-				.last()
-				.click();
-
-			await userPage.getByLabel('Email Address').fill(user.emailAddress);
-			await userPage.getByLabel('Password').fill('test');
-
-			await userPage
-				.getByRole('button', {name: 'Sign In'})
-				.last()
-				.click();
-
 			const sendEmailButton = userPage.locator('[id$="sendEmailButton"]');
 
 			const sentMessage = userPage.getByText(

--- a/modules/test/playwright/utils/signInAndReachMFAChallenge.ts
+++ b/modules/test/playwright/utils/signInAndReachMFAChallenge.ts
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Browser, BrowserContext, Page} from '@playwright/test';
+
+interface MFAChallengeSession {
+	userContext: BrowserContext;
+	userPage: Page;
+}
+
+/**
+ * Signs in as the given user in a fresh browser context and stops on the
+ * multi-factor authentication challenge, leaving any session on the caller's
+ * page (typically the admin) untouched. Sign-in does not complete because the
+ * challenge interrupts it, so the shared performLogin helper does not apply.
+ */
+export default async function signInAndReachMFAChallenge(
+	browser: Browser,
+	emailAddress: string,
+	password = 'test'
+): Promise<MFAChallengeSession> {
+	const userContext = await browser.newContext();
+	const userPage = await userContext.newPage();
+
+	await userPage.goto('/');
+
+	await userPage.getByRole('button', {name: 'Sign In'}).last().click();
+
+	await userPage.getByLabel('Email Address').fill(emailAddress);
+	await userPage.getByLabel('Password').fill(password);
+
+	await userPage.getByRole('button', {name: 'Sign In'}).last().click();
+
+	return {userContext, userPage};
+}


### PR DESCRIPTION
Resolves the email OTP verification bug tracked in LPD-97358 (reported as LPP-64662).

## Problem

On the email OTP verification screen the *Send* (resend) button and the *Submit* button shared their disabled state. While the failed-attempts retry lockout was running on the *Submit* button, the *Send* button stayed disabled too, and it only became usable once the *Submit* countdown finished — even when its own resend cooldown had already elapsed. This coupling was introduced by LPD-95283.

## Fix

Each countdown now governs only its own button:

- The failed-attempts countdown no longer disables or re-enables the *Send* button.
- The resend countdown re-enables the *Send* button unconditionally.
- On page load a failed-attempts lockout disables only the *Submit* button.

So the *Send* button is disabled solely while its own resend cooldown runs, independently from the *Submit* lockout.

## Tests

Added a Playwright test (`@LPD-97358`) covering the case where the failed-attempts lockout is active while the resend cooldown has already elapsed: the *Submit* button stays locked with its countdown while the *Send* button remains usable. The existing `@LPD-95294`, `@LPD-95735`, and `@LPD-96858` tests still pass.

**pr-check: PASS** — tested on `89cfc76db4995`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |
