### PR TITLE
LPD-97371 Preserve user roles on SCIM PATCH and PUT updates

### DIFF
--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
@@ -1291,7 +1291,7 @@ public class UserManagerImpl implements UserManager {
 			contact.getSmsSn(), contact.getFacebookSn(), contact.getJabberSn(),
 			contact.getSkypeSn(), contact.getTwitterSn(),
 			scimUser.getJobTitle(), portalUser.getGroupIds(),
-			portalUser.getOrganizationIds(), scimUser.getRoleIds(), null,
+			portalUser.getOrganizationIds(), portalUser.getRoleIds(), null,
 			portalUser.getUserGroupIds(), portalUser.getAddresses(),
 			portalUser.getEmailAddresses(), portalUser.getPhones(),
 			portalUser.getWebsites(), null, new ServiceContext());

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/UserResourceTest.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/UserResourceTest.java
@@ -19,6 +19,8 @@ import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -26,6 +28,7 @@ import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DataGuard;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -650,6 +653,11 @@ public class UserResourceTest extends BaseUserResourceTestCase {
 			_userLocalService.getUserByExternalReferenceCode(
 				user.getExternalId(), TestPropsValues.getCompanyId());
 
+		Role role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_userLocalService.addRoleUsers(
+			role.getRoleId(), new long[] {portalUser.getUserId()});
+
 		portalUser = _userLocalService.updatePortrait(
 			portalUser.getUserId(),
 			FileUtil.getBytes(
@@ -689,6 +697,8 @@ public class UserResourceTest extends BaseUserResourceTestCase {
 		portalUser = _userLocalService.getUser(portalUser.getUserId());
 
 		Assert.assertEquals(portraitId, portalUser.getPortraitId());
+		Assert.assertTrue(
+			ArrayUtil.contains(portalUser.getRoleIds(), role.getRoleId()));
 	}
 
 	private static final String _PREFIX = StringUtil.toLowerCase(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-97371
https://liferay.atlassian.net/browse/LPP-64700

## What Is Being Fixed

A SCIM PATCH or PUT request to /o/scim/v1.0/v2/Users/{id} silently removed all of the user's assigned roles, even when the request modified only a basic attribute such as the display name and contained no role or group operations. Reported through customer issue LPP-64700.

## How It Is Being Fixed

The update path in UserManagerImpl passed the reconstructed SCIM object's role IDs to UserService.updateUser, which treats that array as the authoritative set of direct role assignments. On an update the reconstructed object never carries the user's roles, so the array was empty and every assigned role was cleared. Groups, organizations, and user groups were already read back from the existing portal user on the same call; roles were the lone exception. The fix reads roles from the existing portal user as well, so they are preserved. An integration test asserts that a role assigned to the user survives a PATCH that changes an unrelated attribute.

## PR Check

**pr-check: PASS** — tested on `379a0e6`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |

<!-- pr-check {"result": "success", "sha": "379a0e6c0adeffa4335e42b0af072c83a8d5e4ac"} -->
