### PR TITLE
LPD-91327 Test opt-in open dynamic client registration

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
@@ -8,12 +8,14 @@ package com.liferay.oauth2.provider.dynamic.registration.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.client.test.BaseClientTestCase;
 import com.liferay.oauth2.provider.client.test.BaseTestPreparatorBundleActivator;
+import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.constants.OAuth2ApplicationConstants;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.CompanyConfigurationTemporarySwapper;
 import com.liferay.portal.kernel.audit.AuditMessage;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
@@ -22,12 +24,16 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserConstants;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -108,9 +114,11 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 
 	@Test
 	public void testDeleteClientRegistration() throws Exception {
+		long companyId = TestPropsValues.getCompanyId();
+
 		OAuth2Application oAuth2Application =
 			_oAuth2ApplicationLocalService.fetchOAuth2Application(
-				TestPropsValues.getCompanyId(), "oauthDeleteMeApplication");
+				companyId, "oauthDeleteMeApplication");
 
 		WebTarget registerWebTarget = getRegisterWebTarget(
 			oAuth2Application.getClientId());
@@ -119,8 +127,7 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 			registerWebTarget.request(),
 			_getToken(
 				_oAuth2ApplicationLocalService.fetchOAuth2Application(
-					TestPropsValues.getCompanyId(),
-					"oauthDynamicRegisterTestApplication")));
+					companyId, "oauthDynamicRegisterTestApplication")));
 
 		Response response = invocationBuilder.delete();
 
@@ -280,6 +287,369 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 	}
 
 	@Test
+	public void testRegisterInOpenMode() throws Exception {
+		long companyId = TestPropsValues.getCompanyId();
+
+		WebTarget registerWebTarget = getRegisterWebTarget();
+
+		JSONObject jsonObject = _createOpenRegistrationJSONObject(
+			true, _getRandomRedirectURI());
+
+		String clientName = jsonObject.getString("client_name");
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					_createCompanyConfigurationTemporarySwapper(companyId)) {
+
+			Invocation.Builder invocationBuilder = registerWebTarget.request();
+
+			Response response = invocationBuilder.method(
+				"post", Entity.json(jsonObject.toString()));
+
+			Assert.assertEquals(201, response.getStatus());
+
+			JSONObject responseJSONObject = parseJSONObject(response);
+
+			Assert.assertEquals(
+				clientName, responseJSONObject.getString("client_name"));
+
+			String clientId = responseJSONObject.getString(
+				OAuthConstants.CLIENT_ID);
+
+			OAuth2Application oAuth2Application =
+				_oAuth2ApplicationLocalService.fetchOAuth2Application(
+					companyId, clientId);
+
+			User user = _userLocalService.getUserByScreenName(
+				companyId, UserConstants.SCREEN_NAME_DEFAULT_SERVICE_ACCOUNT);
+
+			Assert.assertEquals(
+				user.getUserId(), oAuth2Application.getUserId());
+
+			Assert.assertFalse(oAuth2Application.isTrustedApplication());
+
+			AuditMessage auditMessage = _fetchAuditMessage(
+				"DYNAMIC_REGISTRATION_ADD");
+
+			Assert.assertEquals(
+				OAuth2Application.class.getName(), auditMessage.getClassName());
+			Assert.assertEquals(clientId, auditMessage.getClassPK());
+
+			JSONObject additionalInfoJSONObject =
+				auditMessage.getAdditionalInfo();
+
+			Assert.assertEquals(
+				clientName, additionalInfoJSONObject.getString("clientName"));
+			Assert.assertEquals(
+				"open", additionalInfoJSONObject.getString("mode"));
+		}
+	}
+
+	@Test
+	public void testRegisterInOpenModeEnforcesAllowedHosts() throws Exception {
+		String allowedHost = RandomTestUtil.randomString();
+
+		String bracketedHostAndPort = StringBundler.concat(
+			"[", allowedHost, "]:", PortalUtil.getPortalServerPort(false));
+
+		// Allow when the bracketed IPv6 host is compared with or without a port
+
+		_testRegisterInOpenModeEnforcesAllowedHosts(
+			allowedHost, 201, bracketedHostAndPort);
+		_testRegisterInOpenModeEnforcesAllowedHosts(
+			bracketedHostAndPort, 201, allowedHost);
+
+		// Allow when the port is present on the request host
+
+		_testRegisterInOpenModeEnforcesAllowedHosts(
+			allowedHost, 201,
+			allowedHost + ":" + PortalUtil.getPortalServerPort(false));
+
+		// Allow when the request host matches exactly
+
+		_testRegisterInOpenModeEnforcesAllowedHosts(
+			allowedHost, 201, allowedHost);
+
+		// Deny when the request host does not match
+
+		_testRegisterInOpenModeEnforcesAllowedHosts(
+			allowedHost, 403, RandomTestUtil.randomString());
+	}
+
+	@Test
+	public void testRegisterInOpenModeIgnoresUntrustedProxyHeaders()
+		throws Exception {
+
+		String allowedHost = RandomTestUtil.randomString();
+
+		WebTarget registerWebTarget = getRegisterWebTarget();
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					_createCompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						"dynamic.registration.allowed.hosts",
+						new String[] {allowedHost})) {
+
+			Invocation.Builder invocationBuilder = registerWebTarget.request();
+
+			invocationBuilder.header("X-Forwarded-For", allowedHost);
+
+			Response response = invocationBuilder.method(
+				"post",
+				Entity.json(
+					_createOpenRegistrationJSONObject(
+						true, _getRandomRedirectURI()
+					).toString()));
+
+			Assert.assertEquals(403, response.getStatus());
+
+			Assert.assertEquals(
+				OAuthConstants.ACCESS_DENIED, parseError(response));
+		}
+	}
+
+	@Test
+	public void testRegisterInOpenModeIsCreateOnly() throws Exception {
+		WebTarget registerWebTarget = getRegisterWebTarget();
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					_createCompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId())) {
+
+			Invocation.Builder invocationBuilder = registerWebTarget.request();
+
+			Response response = invocationBuilder.method(
+				"post",
+				Entity.json(
+					_createOpenRegistrationJSONObject(
+						true, _getRandomRedirectURI()
+					).toString()));
+
+			Assert.assertEquals(201, response.getStatus());
+
+			JSONObject responseJSONObject = parseJSONObject(response);
+
+			Assert.assertFalse(
+				responseJSONObject.has("registration_access_token"));
+			Assert.assertFalse(
+				responseJSONObject.has("registration_client_uri"));
+
+			registerWebTarget = getRegisterWebTarget(
+				responseJSONObject.getString(OAuthConstants.CLIENT_ID));
+
+			invocationBuilder = registerWebTarget.request();
+
+			invocationBuilder.header(
+				"Authorization", "Bearer " + RandomTestUtil.randomString());
+
+			response = invocationBuilder.get();
+
+			Assert.assertEquals(401, response.getStatus());
+
+			response = invocationBuilder.delete();
+
+			Assert.assertEquals(401, response.getStatus());
+		}
+	}
+
+	@Test
+	public void testRegisterInOpenModeWithInvalidRequest() throws Exception {
+
+		// Deny when the grant type is not allowed
+
+		_testRegisterInOpenModeWithInvalidRequest(
+			_createOpenRegistrationJSONObject(
+				true, _getRandomRedirectURI()
+			).toString(),
+			"invalid_client_metadata", 400,
+			"dynamic.registration.allowed.grant.types",
+			new String[] {OAuthConstants.CLIENT_CREDENTIALS_GRANT});
+
+		// Deny when the initial access token is missing
+
+		_testRegisterInOpenModeWithInvalidRequest(
+			JSONUtil.put(
+				"client_name", RandomTestUtil.randomString()
+			).toString(),
+			null, 401, "dynamic.registration.require.initial.access.token",
+			true);
+
+		// Deny when the redirect URI does not match the allowed patterns
+
+		_testRegisterInOpenModeWithInvalidRequest(
+			_createOpenRegistrationJSONObject(
+				true, _getRandomRedirectURI()
+			).toString(),
+			"invalid_redirect_uri", 400,
+			"dynamic.registration.allowed.redirect.uri.patterns",
+			new String[] {"https://*.example.org/*"});
+
+		// Deny when the redirect URI is blank
+
+		_testRegisterInOpenModeWithInvalidRequest(
+			_createOpenRegistrationJSONObject(
+				true, StringPool.BLANK
+			).toString(),
+			"invalid_redirect_uri", 400,
+			"dynamic.registration.allowed.redirect.uri.patterns",
+			new String[] {"https://*.example.org/*"});
+
+		// Deny when the scope is missing, even when all scopes are allowed
+
+		_testRegisterInOpenModeWithInvalidRequest(
+			_createOpenRegistrationJSONObject(
+				false, _getRandomRedirectURI()
+			).toString(),
+			"invalid_client_metadata", 400,
+			"dynamic.registration.allowed.scopes",
+			new String[] {"Liferay.Headless.Delivery.everything"});
+		_testRegisterInOpenModeWithInvalidRequest(
+			_createOpenRegistrationJSONObject(
+				false, _getRandomRedirectURI()
+			).toString(),
+			"invalid_client_metadata", 400,
+			"dynamic.registration.allowed.scopes",
+			new String[] {StringPool.STAR});
+
+		// Deny when the scope is not allowed
+
+		_testRegisterInOpenModeWithInvalidRequest(
+			JSONUtil.put(
+				"client_name", RandomTestUtil.randomString()
+			).put(
+				"grant_types",
+				new String[] {OAuthConstants.CLIENT_CREDENTIALS_GRANT}
+			).put(
+				"scope", "Liferay.Headless.Admin.Site.everything"
+			).toString(),
+			"invalid_scope", 400, "dynamic.registration.allowed.scopes",
+			new String[] {"Liferay.Headless.Delivery.everything"});
+	}
+
+	@Test
+	public void testRegisterInOpenModeWithoutRedirectURIs() throws Exception {
+		WebTarget registerWebTarget = getRegisterWebTarget();
+
+		String bodyJSON = JSONUtil.put(
+			"client_name", RandomTestUtil.randomString()
+		).put(
+			"grant_types",
+			new String[] {OAuthConstants.CLIENT_CREDENTIALS_GRANT}
+		).put(
+			"scope", RandomTestUtil.randomString()
+		).toString();
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					_createCompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						"dynamic.registration.allowed.grant.types",
+						new String[] {OAuthConstants.CLIENT_CREDENTIALS_GRANT},
+						"dynamic.registration.allowed.redirect.uri.patterns",
+						new String[0])) {
+
+			Invocation.Builder invocationBuilder = registerWebTarget.request();
+
+			Response response = invocationBuilder.method(
+				"post", Entity.json(bodyJSON));
+
+			Assert.assertEquals(201, response.getStatus());
+
+			AuditMessage auditMessage = _fetchAuditMessage(
+				"DYNAMIC_REGISTRATION_ADD");
+
+			JSONObject additionalInfoJSONObject =
+				auditMessage.getAdditionalInfo();
+
+			Assert.assertEquals(
+				"open", additionalInfoJSONObject.getString("mode"));
+		}
+	}
+
+	@Test
+	public void testRegisterPromotesPublicAuthorizationCode() throws Exception {
+		long companyId = TestPropsValues.getCompanyId();
+
+		WebTarget registerWebTarget = getRegisterWebTarget();
+
+		String bodyJSON = _createOpenRegistrationJSONObject(
+			true, _getRandomRedirectURI()
+		).put(
+			"token_endpoint_auth_method",
+			OAuthConstants.TOKEN_ENDPOINT_AUTH_NONE
+		).toString();
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					_createCompanyConfigurationTemporarySwapper(companyId)) {
+
+			Invocation.Builder invocationBuilder = registerWebTarget.request();
+
+			Response response = invocationBuilder.method(
+				"post", Entity.json(bodyJSON));
+
+			Assert.assertEquals(201, response.getStatus());
+
+			JSONObject responseJSONObject = parseJSONObject(response);
+
+			Assert.assertEquals(
+				Collections.singletonList(
+					OAuthConstants.AUTHORIZATION_CODE_GRANT),
+				JSONUtil.toStringList(
+					responseJSONObject.getJSONArray("grant_types")));
+
+			OAuth2Application oAuth2Application =
+				_oAuth2ApplicationLocalService.fetchOAuth2Application(
+					companyId,
+					responseJSONObject.getString(OAuthConstants.CLIENT_ID));
+
+			Assert.assertEquals(
+				Collections.singletonList(GrantType.AUTHORIZATION_CODE_PKCE),
+				oAuth2Application.getAllowedGrantTypesList());
+		}
+	}
+
+	@Test
+	public void testRegisterWithAuthenticationInOpenMode() throws Exception {
+		WebTarget registerWebTarget = getRegisterWebTarget();
+
+		String bodyJSON = JSONUtil.put(
+			"client_name", RandomTestUtil.randomString()
+		).put(
+			"grant_types",
+			new String[] {OAuthConstants.CLIENT_CREDENTIALS_GRANT}
+		).put(
+			"redirect_uris", new String[] {_getRandomRedirectURI()}
+		).toString();
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					_createCompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId())) {
+
+			Invocation.Builder invocationBuilder = authorize(
+				registerWebTarget.request(),
+				_getToken(_getDynamicRegistratorOAuth2Application()));
+
+			Response response = invocationBuilder.method(
+				"post", Entity.json(bodyJSON));
+
+			Assert.assertEquals(201, response.getStatus());
+
+			AuditMessage auditMessage = _fetchAuditMessage(
+				"DYNAMIC_REGISTRATION_ADD");
+
+			JSONObject additionalInfoJSONObject =
+				auditMessage.getAdditionalInfo();
+
+			Assert.assertEquals(
+				"authenticated", additionalInfoJSONObject.getString("mode"));
+		}
+	}
+
+	@Test
 	public void testRegisterWithInvalidBearerToken() throws Exception {
 		WebTarget registerWebTarget = getRegisterWebTarget();
 
@@ -379,6 +749,60 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 		);
 	}
 
+	private CompanyConfigurationTemporarySwapper
+			_createCompanyConfigurationTemporarySwapper(
+				long companyId, Object... keysAndValues)
+		throws Exception {
+
+		Dictionary<String, Object> properties =
+			HashMapDictionaryBuilder.<String, Object>put(
+				"dynamic.registration.allowed.grant.types",
+				new String[] {StringPool.STAR}
+			).put(
+				"dynamic.registration.allowed.hosts",
+				new String[] {StringPool.STAR}
+			).put(
+				"dynamic.registration.allowed.redirect.uri.patterns",
+				new String[] {StringPool.STAR}
+			).put(
+				"dynamic.registration.allowed.scopes",
+				new String[] {StringPool.STAR}
+			).put(
+				"dynamic.registration.require.initial.access.token", false
+			).build();
+
+		for (int i = 0; i < keysAndValues.length; i += 2) {
+			properties.put((String)keysAndValues[i], keysAndValues[i + 1]);
+		}
+
+		return new CompanyConfigurationTemporarySwapper(
+			companyId,
+			"com.liferay.oauth2.provider.rest.internal.configuration." +
+				"OAuth2DynamicRegistrationConfiguration",
+			properties);
+	}
+
+	private JSONObject _createOpenRegistrationJSONObject(
+		boolean includeScope, String redirectURI) {
+
+		JSONObject jsonObject = JSONUtil.put(
+			"client_name", RandomTestUtil.randomString()
+		).put(
+			"grant_types",
+			new String[] {OAuthConstants.AUTHORIZATION_CODE_GRANT}
+		).put(
+			"redirect_uris", new String[] {redirectURI}
+		).put(
+			"response_types", new String[] {OAuthConstants.CODE_RESPONSE_TYPE}
+		);
+
+		if (includeScope) {
+			jsonObject.put("scope", RandomTestUtil.randomString());
+		}
+
+		return jsonObject;
+	}
+
 	private AuditMessage _fetchAuditMessage(String eventType) {
 		for (AuditMessage auditMessage : _auditMessages) {
 			if (eventType.equals(auditMessage.getEventType())) {
@@ -413,6 +837,12 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 		return oAuth2Applications.get(0);
 	}
 
+	private String _getRandomRedirectURI() {
+		return StringBundler.concat(
+			Http.HTTPS_WITH_SLASH, RandomTestUtil.randomString(),
+			".com/callback");
+	}
+
 	private String _getToken(OAuth2Application oAuth2Application) {
 		WebTarget tokenWebTarget = getTokenWebTarget();
 
@@ -438,12 +868,86 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 		return tokenString;
 	}
 
+	private void _testRegisterInOpenModeEnforcesAllowedHosts(
+			String allowedHost, int expectedStatus, String requestHost)
+		throws Exception {
+
+		WebTarget registerWebTarget = getRegisterWebTarget();
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					_createCompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						"dynamic.registration.allowed.hosts",
+						new String[] {allowedHost},
+						"dynamic.registration.trust.proxy.headers", true)) {
+
+			Invocation.Builder invocationBuilder = registerWebTarget.request();
+
+			invocationBuilder.header("X-Forwarded-For", requestHost);
+
+			Response response = invocationBuilder.method(
+				"post",
+				Entity.json(
+					_createOpenRegistrationJSONObject(
+						true, _getRandomRedirectURI()
+					).toString()));
+
+			Assert.assertEquals(expectedStatus, response.getStatus());
+
+			if (expectedStatus == 403) {
+				Assert.assertEquals(
+					OAuthConstants.ACCESS_DENIED, parseError(response));
+
+				AuditMessage auditMessage = _fetchAuditMessage(
+					"DYNAMIC_REGISTRATION_REJECT");
+
+				JSONObject additionalInfoJSONObject =
+					auditMessage.getAdditionalInfo();
+
+				Assert.assertEquals(
+					OAuthConstants.ACCESS_DENIED,
+					additionalInfoJSONObject.getString("error"));
+				Assert.assertEquals(
+					"open", additionalInfoJSONObject.getString("mode"));
+			}
+		}
+	}
+
+	private void _testRegisterInOpenModeWithInvalidRequest(
+			String bodyJSON, String expectedError, int expectedStatus,
+			Object... keysAndValues)
+		throws Exception {
+
+		WebTarget registerWebTarget = getRegisterWebTarget();
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					_createCompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(), keysAndValues)) {
+
+			Invocation.Builder invocationBuilder = registerWebTarget.request();
+
+			Response response = invocationBuilder.method(
+				"post", Entity.json(bodyJSON));
+
+			Assert.assertEquals(expectedStatus, response.getStatus());
+
+			if (expectedError != null) {
+				Assert.assertEquals(expectedError, parseError(response));
+			}
+		}
+	}
+
 	private List<AuditMessage> _auditMessages;
 
 	@Inject
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 	private class DynamicRegistrationServiceTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
@@ -388,7 +388,7 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 				companyConfigurationTemporarySwapper =
 					_createCompanyConfigurationTemporarySwapper(
 						TestPropsValues.getCompanyId(),
-						"dynamic.registration.allowed.hosts",
+						"oauth2.dynamic.registration.allowed.hosts",
 						new String[] {allowedHost})) {
 
 			Invocation.Builder invocationBuilder = registerWebTarget.request();
@@ -464,7 +464,7 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 				true, _getRandomRedirectURI()
 			).toString(),
 			"invalid_client_metadata", 400,
-			"dynamic.registration.allowed.grant.types",
+			"oauth2.dynamic.registration.allowed.grant.types",
 			new String[] {OAuthConstants.CLIENT_CREDENTIALS_GRANT});
 
 		// Deny when the initial access token is missing
@@ -473,8 +473,8 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 			JSONUtil.put(
 				"client_name", RandomTestUtil.randomString()
 			).toString(),
-			null, 401, "dynamic.registration.require.initial.access.token",
-			true);
+			null, 401,
+			"oauth2.dynamic.registration.require.initial.access.token", true);
 
 		// Deny when the redirect URI does not match the allowed patterns
 
@@ -483,7 +483,7 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 				true, _getRandomRedirectURI()
 			).toString(),
 			"invalid_redirect_uri", 400,
-			"dynamic.registration.allowed.redirect.uri.patterns",
+			"oauth2.dynamic.registration.allowed.redirect.uri.patterns",
 			new String[] {"https://*.example.org/*"});
 
 		// Deny when the redirect URI is blank
@@ -493,7 +493,7 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 				true, StringPool.BLANK
 			).toString(),
 			"invalid_redirect_uri", 400,
-			"dynamic.registration.allowed.redirect.uri.patterns",
+			"oauth2.dynamic.registration.allowed.redirect.uri.patterns",
 			new String[] {"https://*.example.org/*"});
 
 		// Deny when the scope is missing, even when all scopes are allowed
@@ -503,14 +503,14 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 				false, _getRandomRedirectURI()
 			).toString(),
 			"invalid_client_metadata", 400,
-			"dynamic.registration.allowed.scopes",
+			"oauth2.dynamic.registration.allowed.scopes",
 			new String[] {"Liferay.Headless.Delivery.everything"});
 		_testRegisterInOpenModeWithInvalidRequest(
 			_createOpenRegistrationJSONObject(
 				false, _getRandomRedirectURI()
 			).toString(),
 			"invalid_client_metadata", 400,
-			"dynamic.registration.allowed.scopes",
+			"oauth2.dynamic.registration.allowed.scopes",
 			new String[] {StringPool.STAR});
 
 		// Deny when the scope is not allowed
@@ -524,7 +524,7 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 			).put(
 				"scope", "Liferay.Headless.Admin.Site.everything"
 			).toString(),
-			"invalid_scope", 400, "dynamic.registration.allowed.scopes",
+			"invalid_scope", 400, "oauth2.dynamic.registration.allowed.scopes",
 			new String[] {"Liferay.Headless.Delivery.everything"});
 	}
 
@@ -545,9 +545,10 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 				companyConfigurationTemporarySwapper =
 					_createCompanyConfigurationTemporarySwapper(
 						TestPropsValues.getCompanyId(),
-						"dynamic.registration.allowed.grant.types",
+						"oauth2.dynamic.registration.allowed.grant.types",
 						new String[] {OAuthConstants.CLIENT_CREDENTIALS_GRANT},
-						"dynamic.registration.allowed.redirect.uri.patterns",
+						"oauth2.dynamic.registration.allowed.redirect.uri." +
+							"patterns",
 						new String[0])) {
 
 			Invocation.Builder invocationBuilder = registerWebTarget.request();
@@ -756,19 +757,20 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 
 		Dictionary<String, Object> properties =
 			HashMapDictionaryBuilder.<String, Object>put(
-				"dynamic.registration.allowed.grant.types",
+				"oauth2.dynamic.registration.allowed.grant.types",
 				new String[] {StringPool.STAR}
 			).put(
-				"dynamic.registration.allowed.hosts",
+				"oauth2.dynamic.registration.allowed.hosts",
 				new String[] {StringPool.STAR}
 			).put(
-				"dynamic.registration.allowed.redirect.uri.patterns",
+				"oauth2.dynamic.registration.allowed.redirect.uri.patterns",
 				new String[] {StringPool.STAR}
 			).put(
-				"dynamic.registration.allowed.scopes",
+				"oauth2.dynamic.registration.allowed.scopes",
 				new String[] {StringPool.STAR}
 			).put(
-				"dynamic.registration.require.initial.access.token", false
+				"oauth2.dynamic.registration.require.initial.access.token",
+				false
 			).build();
 
 		for (int i = 0; i < keysAndValues.length; i += 2) {
@@ -878,9 +880,10 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 				companyConfigurationTemporarySwapper =
 					_createCompanyConfigurationTemporarySwapper(
 						TestPropsValues.getCompanyId(),
-						"dynamic.registration.allowed.hosts",
+						"oauth2.dynamic.registration.allowed.hosts",
 						new String[] {allowedHost},
-						"dynamic.registration.trust.proxy.headers", true)) {
+						"oauth2.dynamic.registration.trust.proxy.headers",
+						true)) {
 
 			Invocation.Builder invocationBuilder = registerWebTarget.request();
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Http;
-import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.test.rule.FeatureFlag;
@@ -349,8 +348,10 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 	public void testRegisterInOpenModeEnforcesAllowedHosts() throws Exception {
 		String allowedHost = RandomTestUtil.randomString();
 
+		int port = RandomTestUtil.randomInt(1025, 65535);
+
 		String bracketedHostAndPort = StringBundler.concat(
-			"[", allowedHost, "]:", PortalUtil.getPortalServerPort(false));
+			"[", allowedHost, "]:", port);
 
 		// Allow when the bracketed IPv6 host is compared with or without a port
 
@@ -362,8 +363,7 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 		// Allow when the port is present on the request host
 
 		_testRegisterInOpenModeEnforcesAllowedHosts(
-			allowedHost, 201,
-			allowedHost + ":" + PortalUtil.getPortalServerPort(false));
+			allowedHost, 201, allowedHost + ":" + port);
 
 		// Allow when the request host matches exactly
 


### PR DESCRIPTION
Test half of the opt-in open dynamic client registration feature — companion to the implementation PR #3078. Adds six open-mode integration test methods (`testRegisterInOpenMode`, `…EnforcesAllowedHosts`, `…IsCreateOnly`, `…WithInvalidRequest`, `testRegisterPromotesPublicAuthorizationCode`, `testRegisterWithAuthenticationInOpenMode`) plus their helpers to the existing `DynamicRegistrationServiceTest`.

These exercise the open mode at runtime, so they pass only once the implementation is deployed — **this PR will be forwarded after #3078 merges.** It compiles standalone: the configuration is referenced by PID string, not import.

**pr-check: PASS** — tested on `647c164beba5df00826707c2653b9a7e23e0a996`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |

Notes: baselined against the branch base `c78b64d0`; only the test file changes. Source Format (`gradlew formatSource` on oauth2-provider-test) clean, no autocommit. Integration Test Compile (`oauth2-provider-test:compileTestIntegrationJava`) BUILD SUCCESSFUL on the base master — the open-mode tests reference the configuration by PID string, so they compile without the implementation present, and require #3078 deployed to pass at runtime.

<!-- pr-check {"result": "success", "sha": "647c164beba5df00826707c2653b9a7e23e0a996"} -->
