### PR TITLE
LPD-96787 Stamp audit events with the audited entity's companyId

### DIFF
--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/AddressModelListenerTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/AddressModelListenerTest.java
@@ -8,15 +8,16 @@ package com.liferay.portal.security.audit.event.generators.user.management.inter
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.audit.AuditMessage;
-import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.AddressLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
@@ -44,10 +45,10 @@ import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
 
 /**
- * @author Ivica Cardic
+ * @author Christian Moura
  */
 @RunWith(Arquillian.class)
-public class UserModelListenerTest {
+public class AddressModelListenerTest {
 
 	@ClassRule
 	@Rule
@@ -60,7 +61,7 @@ public class UserModelListenerTest {
 	public void setUp() throws Exception {
 		_auditMessages = new ArrayList<>();
 
-		Bundle bundle = FrameworkUtil.getBundle(UserModelListenerTest.class);
+		Bundle bundle = FrameworkUtil.getBundle(AddressModelListenerTest.class);
 
 		BundleContext bundleContext = bundle.getBundleContext();
 
@@ -86,59 +87,47 @@ public class UserModelListenerTest {
 
 		_company = CompanyTestUtil.addCompany();
 
-		Assert.assertFalse(_user.isAgreedToTermsOfUse());
+		_address = _addressLocalService.addAddress(
+			null, _user.getUserId(), User.class.getName(), _user.getUserId(), 0,
+			0, 0, RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			false, RandomTestUtil.randomString(), false,
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), null, RandomTestUtil.randomString(),
+			null, ServiceContextTestUtil.getServiceContext());
 
 		_auditMessages.clear();
+
+		_address.setStreet1(RandomTestUtil.randomString());
 
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_company.getCompanyId())) {
 
-			_userLocalService.updateAgreedToTermsOfUse(_user.getUserId(), true);
+			_addressLocalService.updateAddress(_address);
 		}
 
-		AuditMessage agreedToTermsOfUseAuditMessage = null;
+		AuditMessage updateAuditMessage = null;
 
 		for (AuditMessage auditMessage : _auditMessages) {
-			if (EventTypes.AGREED_TO_TERMS_OF_USE.equals(
-					auditMessage.getEventType()) &&
+			if (EventTypes.UPDATE.equals(auditMessage.getEventType()) &&
 				Objects.equals(
 					User.class.getName(), auditMessage.getClassName())) {
 
-				agreedToTermsOfUseAuditMessage = auditMessage;
+				updateAuditMessage = auditMessage;
 
 				break;
 			}
 		}
 
-		JSONObject additionalInfoJSONObject =
-			agreedToTermsOfUseAuditMessage.getAdditionalInfo();
-
-		Assert.assertTrue(
-			additionalInfoJSONObject.has("termsOfUseJournalArticleGroupId"));
-		Assert.assertTrue(
-			additionalInfoJSONObject.has("termsOfUseJournalArticleId"));
-
 		Assert.assertEquals(
-			String.valueOf(_user.getUserId()),
-			agreedToTermsOfUseAuditMessage.getClassPK());
-		Assert.assertEquals(
-			_user.getCompanyId(),
-			agreedToTermsOfUseAuditMessage.getCompanyId());
-
-		_auditMessages.clear();
-
-		_user = _userLocalService.getUser(_user.getUserId());
-
-		_user.setComments(RandomTestUtil.randomString());
-
-		_user = _userLocalService.updateUser(_user);
-
-		for (AuditMessage auditMessage : _auditMessages) {
-			Assert.assertNotEquals(
-				EventTypes.AGREED_TO_TERMS_OF_USE, auditMessage.getEventType());
-		}
+			_user.getCompanyId(), updateAuditMessage.getCompanyId());
 	}
+
+	@DeleteAfterTestRun
+	private Address _address;
+
+	@Inject
+	private AddressLocalService _addressLocalService;
 
 	private List<AuditMessage> _auditMessages;
 
@@ -149,8 +138,5 @@ public class UserModelListenerTest {
 
 	@DeleteAfterTestRun
 	private User _user;
-
-	@Inject
-	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/AddressModelListenerTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/AddressModelListenerTest.java
@@ -109,9 +109,10 @@ public class AddressModelListenerTest {
 		AuditMessage updateAuditMessage = null;
 
 		for (AuditMessage auditMessage : _auditMessages) {
-			if (EventTypes.UPDATE.equals(auditMessage.getEventType()) &&
+			if (Objects.equals(
+					auditMessage.getClassName(), User.class.getName()) &&
 				Objects.equals(
-					User.class.getName(), auditMessage.getClassName())) {
+					auditMessage.getEventType(), EventTypes.UPDATE)) {
 
 				updateAuditMessage = auditMessage;
 

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/AddressModelListenerTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/AddressModelListenerTest.java
@@ -13,73 +13,23 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.AddressLocalService;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import java.util.ArrayList;
-import java.util.Dictionary;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Objects;
-
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Christian Moura
  */
 @RunWith(Arquillian.class)
-public class AddressModelListenerTest {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE);
-
-	@Before
-	public void setUp() throws Exception {
-		_auditMessages = new ArrayList<>();
-
-		Bundle bundle = FrameworkUtil.getBundle(AddressModelListenerTest.class);
-
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Dictionary<String, Object> properties = new Hashtable<>();
-
-		properties.put("eventTypes", "*");
-
-		_serviceRegistration = bundleContext.registerService(
-			AuditMessageProcessor.class,
-			auditMessage -> _auditMessages.add(auditMessage), properties);
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		if (_serviceRegistration != null) {
-			_serviceRegistration.unregister();
-		}
-	}
+public class AddressModelListenerTest extends BaseModelListenerTestCase {
 
 	@Test
 	public void testOnBeforeUpdate() throws Exception {
@@ -95,7 +45,7 @@ public class AddressModelListenerTest {
 			RandomTestUtil.randomString(), null, RandomTestUtil.randomString(),
 			null, ServiceContextTestUtil.getServiceContext());
 
-		_auditMessages.clear();
+		auditMessages.clear();
 
 		_address.setStreet1(RandomTestUtil.randomString());
 
@@ -106,22 +56,10 @@ public class AddressModelListenerTest {
 			_addressLocalService.updateAddress(_address);
 		}
 
-		AuditMessage updateAuditMessage = null;
+		AuditMessage auditMessage = fetchAuditMessage(
+			User.class.getName(), EventTypes.UPDATE);
 
-		for (AuditMessage auditMessage : _auditMessages) {
-			if (Objects.equals(
-					auditMessage.getClassName(), User.class.getName()) &&
-				Objects.equals(
-					auditMessage.getEventType(), EventTypes.UPDATE)) {
-
-				updateAuditMessage = auditMessage;
-
-				break;
-			}
-		}
-
-		Assert.assertEquals(
-			_user.getCompanyId(), updateAuditMessage.getCompanyId());
+		Assert.assertEquals(_user.getCompanyId(), auditMessage.getCompanyId());
 	}
 
 	@DeleteAfterTestRun
@@ -130,12 +68,8 @@ public class AddressModelListenerTest {
 	@Inject
 	private AddressLocalService _addressLocalService;
 
-	private List<AuditMessage> _auditMessages;
-
 	@DeleteAfterTestRun
 	private Company _company;
-
-	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
 
 	@DeleteAfterTestRun
 	private User _user;

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/BaseModelListenerTestCase.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/BaseModelListenerTestCase.java
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.audit.event.generators.user.management.internal.model.listener.test;
+
+import com.liferay.portal.kernel.audit.AuditMessage;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.security.audit.AuditMessageProcessor;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Christian Moura
+ */
+public abstract class BaseModelListenerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		auditMessages = new ArrayList<>();
+
+		Bundle bundle = FrameworkUtil.getBundle(getClass());
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		Dictionary<String, Object> properties = new Hashtable<>();
+
+		properties.put("eventTypes", "*");
+
+		_serviceRegistration = bundleContext.registerService(
+			AuditMessageProcessor.class,
+			auditMessage -> auditMessages.add(auditMessage), properties);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
+	protected AuditMessage fetchAuditMessage(
+		String className, String eventType) {
+
+		for (AuditMessage auditMessage : auditMessages) {
+			if (Objects.equals(auditMessage.getClassName(), className) &&
+				Objects.equals(auditMessage.getEventType(), eventType)) {
+
+				return auditMessage;
+			}
+		}
+
+		return null;
+	}
+
+	protected List<AuditMessage> auditMessages;
+
+	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
+
+}

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/BaseModelListenerTestCase.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/BaseModelListenerTestCase.java
@@ -41,8 +41,6 @@ public abstract class BaseModelListenerTestCase {
 
 	@Before
 	public void setUp() throws Exception {
-		auditMessages = new ArrayList<>();
-
 		Bundle bundle = FrameworkUtil.getBundle(getClass());
 
 		BundleContext bundleContext = bundle.getBundleContext();
@@ -77,7 +75,7 @@ public abstract class BaseModelListenerTestCase {
 		return null;
 	}
 
-	protected List<AuditMessage> auditMessages;
+	protected final List<AuditMessage> auditMessages = new ArrayList<>();
 
 	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
 

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/ContactModelListenerTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/ContactModelListenerTest.java
@@ -102,9 +102,10 @@ public class ContactModelListenerTest {
 		AuditMessage updateAuditMessage = null;
 
 		for (AuditMessage auditMessage : _auditMessages) {
-			if (EventTypes.UPDATE.equals(auditMessage.getEventType()) &&
+			if (Objects.equals(
+					auditMessage.getClassName(), User.class.getName()) &&
 				Objects.equals(
-					User.class.getName(), auditMessage.getClassName())) {
+					auditMessage.getEventType(), EventTypes.UPDATE)) {
 
 				updateAuditMessage = auditMessage;
 

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/ContactModelListenerTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/ContactModelListenerTest.java
@@ -8,11 +8,11 @@ package com.liferay.portal.security.audit.event.generators.user.management.inter
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.audit.AuditMessage;
-import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.ContactLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
@@ -44,10 +44,10 @@ import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
 
 /**
- * @author Ivica Cardic
+ * @author Christian Moura
  */
 @RunWith(Arquillian.class)
-public class UserModelListenerTest {
+public class ContactModelListenerTest {
 
 	@ClassRule
 	@Rule
@@ -60,7 +60,7 @@ public class UserModelListenerTest {
 	public void setUp() throws Exception {
 		_auditMessages = new ArrayList<>();
 
-		Bundle bundle = FrameworkUtil.getBundle(UserModelListenerTest.class);
+		Bundle bundle = FrameworkUtil.getBundle(ContactModelListenerTest.class);
 
 		BundleContext bundleContext = bundle.getBundleContext();
 
@@ -86,58 +86,34 @@ public class UserModelListenerTest {
 
 		_company = CompanyTestUtil.addCompany();
 
-		Assert.assertFalse(_user.isAgreedToTermsOfUse());
-
 		_auditMessages.clear();
+
+		Contact contact = _user.getContact();
+
+		contact.setFirstName(RandomTestUtil.randomString());
 
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_company.getCompanyId())) {
 
-			_userLocalService.updateAgreedToTermsOfUse(_user.getUserId(), true);
+			_contactLocalService.updateContact(contact);
 		}
 
-		AuditMessage agreedToTermsOfUseAuditMessage = null;
+		AuditMessage updateAuditMessage = null;
 
 		for (AuditMessage auditMessage : _auditMessages) {
-			if (EventTypes.AGREED_TO_TERMS_OF_USE.equals(
-					auditMessage.getEventType()) &&
+			if (EventTypes.UPDATE.equals(auditMessage.getEventType()) &&
 				Objects.equals(
 					User.class.getName(), auditMessage.getClassName())) {
 
-				agreedToTermsOfUseAuditMessage = auditMessage;
+				updateAuditMessage = auditMessage;
 
 				break;
 			}
 		}
 
-		JSONObject additionalInfoJSONObject =
-			agreedToTermsOfUseAuditMessage.getAdditionalInfo();
-
-		Assert.assertTrue(
-			additionalInfoJSONObject.has("termsOfUseJournalArticleGroupId"));
-		Assert.assertTrue(
-			additionalInfoJSONObject.has("termsOfUseJournalArticleId"));
-
 		Assert.assertEquals(
-			String.valueOf(_user.getUserId()),
-			agreedToTermsOfUseAuditMessage.getClassPK());
-		Assert.assertEquals(
-			_user.getCompanyId(),
-			agreedToTermsOfUseAuditMessage.getCompanyId());
-
-		_auditMessages.clear();
-
-		_user = _userLocalService.getUser(_user.getUserId());
-
-		_user.setComments(RandomTestUtil.randomString());
-
-		_user = _userLocalService.updateUser(_user);
-
-		for (AuditMessage auditMessage : _auditMessages) {
-			Assert.assertNotEquals(
-				EventTypes.AGREED_TO_TERMS_OF_USE, auditMessage.getEventType());
-		}
+			_user.getCompanyId(), updateAuditMessage.getCompanyId());
 	}
 
 	private List<AuditMessage> _auditMessages;
@@ -145,12 +121,12 @@ public class UserModelListenerTest {
 	@DeleteAfterTestRun
 	private Company _company;
 
+	@Inject
+	private ContactLocalService _contactLocalService;
+
 	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
 
 	@DeleteAfterTestRun
 	private User _user;
-
-	@Inject
-	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/ContactModelListenerTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/ContactModelListenerTest.java
@@ -13,72 +13,22 @@ import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ContactLocalService;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import java.util.ArrayList;
-import java.util.Dictionary;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Objects;
-
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Christian Moura
  */
 @RunWith(Arquillian.class)
-public class ContactModelListenerTest {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE);
-
-	@Before
-	public void setUp() throws Exception {
-		_auditMessages = new ArrayList<>();
-
-		Bundle bundle = FrameworkUtil.getBundle(ContactModelListenerTest.class);
-
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Dictionary<String, Object> properties = new Hashtable<>();
-
-		properties.put("eventTypes", "*");
-
-		_serviceRegistration = bundleContext.registerService(
-			AuditMessageProcessor.class,
-			auditMessage -> _auditMessages.add(auditMessage), properties);
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		if (_serviceRegistration != null) {
-			_serviceRegistration.unregister();
-		}
-	}
+public class ContactModelListenerTest extends BaseModelListenerTestCase {
 
 	@Test
 	public void testOnBeforeUpdate() throws Exception {
@@ -86,7 +36,7 @@ public class ContactModelListenerTest {
 
 		_company = CompanyTestUtil.addCompany();
 
-		_auditMessages.clear();
+		auditMessages.clear();
 
 		Contact contact = _user.getContact();
 
@@ -99,33 +49,17 @@ public class ContactModelListenerTest {
 			_contactLocalService.updateContact(contact);
 		}
 
-		AuditMessage updateAuditMessage = null;
+		AuditMessage auditMessage = fetchAuditMessage(
+			User.class.getName(), EventTypes.UPDATE);
 
-		for (AuditMessage auditMessage : _auditMessages) {
-			if (Objects.equals(
-					auditMessage.getClassName(), User.class.getName()) &&
-				Objects.equals(
-					auditMessage.getEventType(), EventTypes.UPDATE)) {
-
-				updateAuditMessage = auditMessage;
-
-				break;
-			}
-		}
-
-		Assert.assertEquals(
-			_user.getCompanyId(), updateAuditMessage.getCompanyId());
+		Assert.assertEquals(_user.getCompanyId(), auditMessage.getCompanyId());
 	}
-
-	private List<AuditMessage> _auditMessages;
 
 	@DeleteAfterTestRun
 	private Company _company;
 
 	@Inject
 	private ContactLocalService _contactLocalService;
-
-	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
 
 	@DeleteAfterTestRun
 	private User _user;

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/OrganizationModelListenerTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/OrganizationModelListenerTest.java
@@ -102,21 +102,10 @@ public class OrganizationModelListenerTest {
 				new long[] {_user.getUserId()});
 		}
 
-		AuditMessage assignAuditMessage = null;
+		AuditMessage auditMessage = _fetchAuditMessage(
+			User.class.getName(), EventTypes.ASSIGN);
 
-		for (AuditMessage auditMessage : _auditMessages) {
-			if (EventTypes.ASSIGN.equals(auditMessage.getEventType()) &&
-				Objects.equals(
-					User.class.getName(), auditMessage.getClassName())) {
-
-				assignAuditMessage = auditMessage;
-
-				break;
-			}
-		}
-
-		Assert.assertEquals(
-			_user.getCompanyId(), assignAuditMessage.getCompanyId());
+		Assert.assertEquals(_user.getCompanyId(), auditMessage.getCompanyId());
 	}
 
 	@Test
@@ -137,22 +126,25 @@ public class OrganizationModelListenerTest {
 				_organization);
 		}
 
-		AuditMessage updateAuditMessage = null;
+		AuditMessage auditMessage = _fetchAuditMessage(
+			Organization.class.getName(), EventTypes.UPDATE);
+
+		Assert.assertEquals(
+			_organization.getCompanyId(), auditMessage.getCompanyId());
+	}
+
+	private AuditMessage _fetchAuditMessage(
+		String className, String eventType) {
 
 		for (AuditMessage auditMessage : _auditMessages) {
-			if (EventTypes.UPDATE.equals(auditMessage.getEventType()) &&
-				Objects.equals(
-					Organization.class.getName(),
-					auditMessage.getClassName())) {
+			if (Objects.equals(auditMessage.getClassName(), className) &&
+				Objects.equals(auditMessage.getEventType(), eventType)) {
 
-				updateAuditMessage = auditMessage;
-
-				break;
+				return auditMessage;
 			}
 		}
 
-		Assert.assertEquals(
-			_organization.getCompanyId(), updateAuditMessage.getCompanyId());
+		return null;
 	}
 
 	private List<AuditMessage> _auditMessages;

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/OrganizationModelListenerTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/OrganizationModelListenerTest.java
@@ -14,74 +14,23 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import java.util.ArrayList;
-import java.util.Dictionary;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Objects;
-
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Christian Moura
  */
 @RunWith(Arquillian.class)
-public class OrganizationModelListenerTest {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE);
-
-	@Before
-	public void setUp() throws Exception {
-		_auditMessages = new ArrayList<>();
-
-		Bundle bundle = FrameworkUtil.getBundle(
-			OrganizationModelListenerTest.class);
-
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Dictionary<String, Object> properties = new Hashtable<>();
-
-		properties.put("eventTypes", "*");
-
-		_serviceRegistration = bundleContext.registerService(
-			AuditMessageProcessor.class,
-			auditMessage -> _auditMessages.add(auditMessage), properties);
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		if (_serviceRegistration != null) {
-			_serviceRegistration.unregister();
-		}
-	}
+public class OrganizationModelListenerTest extends BaseModelListenerTestCase {
 
 	@Test
 	public void testOnBeforeAddAssociation() throws Exception {
@@ -91,7 +40,7 @@ public class OrganizationModelListenerTest {
 
 		_company = CompanyTestUtil.addCompany();
 
-		_auditMessages.clear();
+		auditMessages.clear();
 
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
@@ -102,7 +51,7 @@ public class OrganizationModelListenerTest {
 				new long[] {_user.getUserId()});
 		}
 
-		AuditMessage auditMessage = _fetchAuditMessage(
+		AuditMessage auditMessage = fetchAuditMessage(
 			User.class.getName(), EventTypes.ASSIGN);
 
 		Assert.assertEquals(_user.getCompanyId(), auditMessage.getCompanyId());
@@ -114,7 +63,7 @@ public class OrganizationModelListenerTest {
 
 		_company = CompanyTestUtil.addCompany();
 
-		_auditMessages.clear();
+		auditMessages.clear();
 
 		_organization.setName(RandomTestUtil.randomString());
 
@@ -126,28 +75,12 @@ public class OrganizationModelListenerTest {
 				_organization);
 		}
 
-		AuditMessage auditMessage = _fetchAuditMessage(
+		AuditMessage auditMessage = fetchAuditMessage(
 			Organization.class.getName(), EventTypes.UPDATE);
 
 		Assert.assertEquals(
 			_organization.getCompanyId(), auditMessage.getCompanyId());
 	}
-
-	private AuditMessage _fetchAuditMessage(
-		String className, String eventType) {
-
-		for (AuditMessage auditMessage : _auditMessages) {
-			if (Objects.equals(auditMessage.getClassName(), className) &&
-				Objects.equals(auditMessage.getEventType(), eventType)) {
-
-				return auditMessage;
-			}
-		}
-
-		return null;
-	}
-
-	private List<AuditMessage> _auditMessages;
 
 	@DeleteAfterTestRun
 	private Company _company;
@@ -157,8 +90,6 @@ public class OrganizationModelListenerTest {
 
 	@Inject
 	private OrganizationLocalService _organizationLocalService;
-
-	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
 
 	@DeleteAfterTestRun
 	private User _user;

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/OrganizationModelListenerTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/OrganizationModelListenerTest.java
@@ -8,14 +8,16 @@ package com.liferay.portal.security.audit.event.generators.user.management.inter
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.audit.AuditMessage;
-import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
+import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.security.audit.AuditMessageProcessor;
@@ -44,10 +46,10 @@ import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
 
 /**
- * @author Ivica Cardic
+ * @author Christian Moura
  */
 @RunWith(Arquillian.class)
-public class UserModelListenerTest {
+public class OrganizationModelListenerTest {
 
 	@ClassRule
 	@Rule
@@ -60,7 +62,8 @@ public class UserModelListenerTest {
 	public void setUp() throws Exception {
 		_auditMessages = new ArrayList<>();
 
-		Bundle bundle = FrameworkUtil.getBundle(UserModelListenerTest.class);
+		Bundle bundle = FrameworkUtil.getBundle(
+			OrganizationModelListenerTest.class);
 
 		BundleContext bundleContext = bundle.getBundleContext();
 
@@ -81,12 +84,12 @@ public class UserModelListenerTest {
 	}
 
 	@Test
-	public void testOnBeforeUpdate() throws Exception {
+	public void testOnBeforeAddAssociation() throws Exception {
 		_user = UserTestUtil.addUser();
 
-		_company = CompanyTestUtil.addCompany();
+		_organization = OrganizationTestUtil.addOrganization();
 
-		Assert.assertFalse(_user.isAgreedToTermsOfUse());
+		_company = CompanyTestUtil.addCompany();
 
 		_auditMessages.clear();
 
@@ -94,56 +97,74 @@ public class UserModelListenerTest {
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_company.getCompanyId())) {
 
-			_userLocalService.updateAgreedToTermsOfUse(_user.getUserId(), true);
+			_userLocalService.addOrganizationUsers(
+				_organization.getOrganizationId(),
+				new long[] {_user.getUserId()});
 		}
 
-		AuditMessage agreedToTermsOfUseAuditMessage = null;
+		AuditMessage assignAuditMessage = null;
 
 		for (AuditMessage auditMessage : _auditMessages) {
-			if (EventTypes.AGREED_TO_TERMS_OF_USE.equals(
-					auditMessage.getEventType()) &&
+			if (EventTypes.ASSIGN.equals(auditMessage.getEventType()) &&
 				Objects.equals(
 					User.class.getName(), auditMessage.getClassName())) {
 
-				agreedToTermsOfUseAuditMessage = auditMessage;
+				assignAuditMessage = auditMessage;
 
 				break;
 			}
 		}
 
-		JSONObject additionalInfoJSONObject =
-			agreedToTermsOfUseAuditMessage.getAdditionalInfo();
-
-		Assert.assertTrue(
-			additionalInfoJSONObject.has("termsOfUseJournalArticleGroupId"));
-		Assert.assertTrue(
-			additionalInfoJSONObject.has("termsOfUseJournalArticleId"));
-
 		Assert.assertEquals(
-			String.valueOf(_user.getUserId()),
-			agreedToTermsOfUseAuditMessage.getClassPK());
-		Assert.assertEquals(
-			_user.getCompanyId(),
-			agreedToTermsOfUseAuditMessage.getCompanyId());
+			_user.getCompanyId(), assignAuditMessage.getCompanyId());
+	}
+
+	@Test
+	public void testOnBeforeUpdate() throws Exception {
+		_organization = OrganizationTestUtil.addOrganization();
+
+		_company = CompanyTestUtil.addCompany();
 
 		_auditMessages.clear();
 
-		_user = _userLocalService.getUser(_user.getUserId());
+		_organization.setName(RandomTestUtil.randomString());
 
-		_user.setComments(RandomTestUtil.randomString());
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					_company.getCompanyId())) {
 
-		_user = _userLocalService.updateUser(_user);
+			_organization = _organizationLocalService.updateOrganization(
+				_organization);
+		}
+
+		AuditMessage updateAuditMessage = null;
 
 		for (AuditMessage auditMessage : _auditMessages) {
-			Assert.assertNotEquals(
-				EventTypes.AGREED_TO_TERMS_OF_USE, auditMessage.getEventType());
+			if (EventTypes.UPDATE.equals(auditMessage.getEventType()) &&
+				Objects.equals(
+					Organization.class.getName(),
+					auditMessage.getClassName())) {
+
+				updateAuditMessage = auditMessage;
+
+				break;
+			}
 		}
+
+		Assert.assertEquals(
+			_organization.getCompanyId(), updateAuditMessage.getCompanyId());
 	}
 
 	private List<AuditMessage> _auditMessages;
 
 	@DeleteAfterTestRun
 	private Company _company;
+
+	@DeleteAfterTestRun
+	private Organization _organization;
+
+	@Inject
+	private OrganizationLocalService _organizationLocalService;
 
 	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
 

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/UserGroupModelListenerTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/UserGroupModelListenerTest.java
@@ -14,74 +14,23 @@ import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import java.util.ArrayList;
-import java.util.Dictionary;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Objects;
-
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Christian Moura
  */
 @RunWith(Arquillian.class)
-public class UserGroupModelListenerTest {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE);
-
-	@Before
-	public void setUp() throws Exception {
-		_auditMessages = new ArrayList<>();
-
-		Bundle bundle = FrameworkUtil.getBundle(
-			UserGroupModelListenerTest.class);
-
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Dictionary<String, Object> properties = new Hashtable<>();
-
-		properties.put("eventTypes", "*");
-
-		_serviceRegistration = bundleContext.registerService(
-			AuditMessageProcessor.class,
-			auditMessage -> _auditMessages.add(auditMessage), properties);
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		if (_serviceRegistration != null) {
-			_serviceRegistration.unregister();
-		}
-	}
+public class UserGroupModelListenerTest extends BaseModelListenerTestCase {
 
 	@Test
 	public void testOnBeforeAddAssociation() throws Exception {
@@ -91,7 +40,7 @@ public class UserGroupModelListenerTest {
 
 		_company = CompanyTestUtil.addCompany();
 
-		_auditMessages.clear();
+		auditMessages.clear();
 
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
@@ -101,7 +50,7 @@ public class UserGroupModelListenerTest {
 				_userGroup.getUserGroupId(), new long[] {_user.getUserId()});
 		}
 
-		AuditMessage auditMessage = _fetchAuditMessage(
+		AuditMessage auditMessage = fetchAuditMessage(
 			User.class.getName(), EventTypes.ASSIGN);
 
 		Assert.assertEquals(_user.getCompanyId(), auditMessage.getCompanyId());
@@ -113,7 +62,7 @@ public class UserGroupModelListenerTest {
 
 		_company = CompanyTestUtil.addCompany();
 
-		_auditMessages.clear();
+		auditMessages.clear();
 
 		_userGroup.setName(RandomTestUtil.randomString());
 
@@ -124,33 +73,15 @@ public class UserGroupModelListenerTest {
 			_userGroup = _userGroupLocalService.updateUserGroup(_userGroup);
 		}
 
-		AuditMessage auditMessage = _fetchAuditMessage(
+		AuditMessage auditMessage = fetchAuditMessage(
 			UserGroup.class.getName(), EventTypes.UPDATE);
 
 		Assert.assertEquals(
 			_userGroup.getCompanyId(), auditMessage.getCompanyId());
 	}
 
-	private AuditMessage _fetchAuditMessage(
-		String className, String eventType) {
-
-		for (AuditMessage auditMessage : _auditMessages) {
-			if (Objects.equals(auditMessage.getClassName(), className) &&
-				Objects.equals(auditMessage.getEventType(), eventType)) {
-
-				return auditMessage;
-			}
-		}
-
-		return null;
-	}
-
-	private List<AuditMessage> _auditMessages;
-
 	@DeleteAfterTestRun
 	private Company _company;
-
-	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
 
 	@DeleteAfterTestRun
 	private User _user;

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/UserGroupModelListenerTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/UserGroupModelListenerTest.java
@@ -8,15 +8,17 @@ package com.liferay.portal.security.audit.event.generators.user.management.inter
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.audit.AuditMessage;
-import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.UserGroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
@@ -44,10 +46,10 @@ import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
 
 /**
- * @author Ivica Cardic
+ * @author Christian Moura
  */
 @RunWith(Arquillian.class)
-public class UserModelListenerTest {
+public class UserGroupModelListenerTest {
 
 	@ClassRule
 	@Rule
@@ -60,7 +62,8 @@ public class UserModelListenerTest {
 	public void setUp() throws Exception {
 		_auditMessages = new ArrayList<>();
 
-		Bundle bundle = FrameworkUtil.getBundle(UserModelListenerTest.class);
+		Bundle bundle = FrameworkUtil.getBundle(
+			UserGroupModelListenerTest.class);
 
 		BundleContext bundleContext = bundle.getBundleContext();
 
@@ -81,12 +84,12 @@ public class UserModelListenerTest {
 	}
 
 	@Test
-	public void testOnBeforeUpdate() throws Exception {
+	public void testOnBeforeAddAssociation() throws Exception {
 		_user = UserTestUtil.addUser();
 
-		_company = CompanyTestUtil.addCompany();
+		_userGroup = UserGroupTestUtil.addUserGroup();
 
-		Assert.assertFalse(_user.isAgreedToTermsOfUse());
+		_company = CompanyTestUtil.addCompany();
 
 		_auditMessages.clear();
 
@@ -94,50 +97,59 @@ public class UserModelListenerTest {
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_company.getCompanyId())) {
 
-			_userLocalService.updateAgreedToTermsOfUse(_user.getUserId(), true);
+			_userLocalService.addUserGroupUsers(
+				_userGroup.getUserGroupId(), new long[] {_user.getUserId()});
 		}
 
-		AuditMessage agreedToTermsOfUseAuditMessage = null;
+		AuditMessage assignAuditMessage = null;
 
 		for (AuditMessage auditMessage : _auditMessages) {
-			if (EventTypes.AGREED_TO_TERMS_OF_USE.equals(
-					auditMessage.getEventType()) &&
+			if (EventTypes.ASSIGN.equals(auditMessage.getEventType()) &&
 				Objects.equals(
 					User.class.getName(), auditMessage.getClassName())) {
 
-				agreedToTermsOfUseAuditMessage = auditMessage;
+				assignAuditMessage = auditMessage;
 
 				break;
 			}
 		}
 
-		JSONObject additionalInfoJSONObject =
-			agreedToTermsOfUseAuditMessage.getAdditionalInfo();
-
-		Assert.assertTrue(
-			additionalInfoJSONObject.has("termsOfUseJournalArticleGroupId"));
-		Assert.assertTrue(
-			additionalInfoJSONObject.has("termsOfUseJournalArticleId"));
-
 		Assert.assertEquals(
-			String.valueOf(_user.getUserId()),
-			agreedToTermsOfUseAuditMessage.getClassPK());
-		Assert.assertEquals(
-			_user.getCompanyId(),
-			agreedToTermsOfUseAuditMessage.getCompanyId());
+			_user.getCompanyId(), assignAuditMessage.getCompanyId());
+	}
+
+	@Test
+	public void testOnBeforeUpdate() throws Exception {
+		_userGroup = UserGroupTestUtil.addUserGroup();
+
+		_company = CompanyTestUtil.addCompany();
 
 		_auditMessages.clear();
 
-		_user = _userLocalService.getUser(_user.getUserId());
+		_userGroup.setName(RandomTestUtil.randomString());
 
-		_user.setComments(RandomTestUtil.randomString());
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					_company.getCompanyId())) {
 
-		_user = _userLocalService.updateUser(_user);
+			_userGroup = _userGroupLocalService.updateUserGroup(_userGroup);
+		}
+
+		AuditMessage updateAuditMessage = null;
 
 		for (AuditMessage auditMessage : _auditMessages) {
-			Assert.assertNotEquals(
-				EventTypes.AGREED_TO_TERMS_OF_USE, auditMessage.getEventType());
+			if (EventTypes.UPDATE.equals(auditMessage.getEventType()) &&
+				Objects.equals(
+					UserGroup.class.getName(), auditMessage.getClassName())) {
+
+				updateAuditMessage = auditMessage;
+
+				break;
+			}
 		}
+
+		Assert.assertEquals(
+			_userGroup.getCompanyId(), updateAuditMessage.getCompanyId());
 	}
 
 	private List<AuditMessage> _auditMessages;
@@ -149,6 +161,12 @@ public class UserModelListenerTest {
 
 	@DeleteAfterTestRun
 	private User _user;
+
+	@DeleteAfterTestRun
+	private UserGroup _userGroup;
+
+	@Inject
+	private UserGroupLocalService _userGroupLocalService;
 
 	@Inject
 	private UserLocalService _userLocalService;

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/UserGroupModelListenerTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/UserGroupModelListenerTest.java
@@ -101,21 +101,10 @@ public class UserGroupModelListenerTest {
 				_userGroup.getUserGroupId(), new long[] {_user.getUserId()});
 		}
 
-		AuditMessage assignAuditMessage = null;
+		AuditMessage auditMessage = _fetchAuditMessage(
+			User.class.getName(), EventTypes.ASSIGN);
 
-		for (AuditMessage auditMessage : _auditMessages) {
-			if (EventTypes.ASSIGN.equals(auditMessage.getEventType()) &&
-				Objects.equals(
-					User.class.getName(), auditMessage.getClassName())) {
-
-				assignAuditMessage = auditMessage;
-
-				break;
-			}
-		}
-
-		Assert.assertEquals(
-			_user.getCompanyId(), assignAuditMessage.getCompanyId());
+		Assert.assertEquals(_user.getCompanyId(), auditMessage.getCompanyId());
 	}
 
 	@Test
@@ -135,21 +124,25 @@ public class UserGroupModelListenerTest {
 			_userGroup = _userGroupLocalService.updateUserGroup(_userGroup);
 		}
 
-		AuditMessage updateAuditMessage = null;
+		AuditMessage auditMessage = _fetchAuditMessage(
+			UserGroup.class.getName(), EventTypes.UPDATE);
+
+		Assert.assertEquals(
+			_userGroup.getCompanyId(), auditMessage.getCompanyId());
+	}
+
+	private AuditMessage _fetchAuditMessage(
+		String className, String eventType) {
 
 		for (AuditMessage auditMessage : _auditMessages) {
-			if (EventTypes.UPDATE.equals(auditMessage.getEventType()) &&
-				Objects.equals(
-					UserGroup.class.getName(), auditMessage.getClassName())) {
+			if (Objects.equals(auditMessage.getClassName(), className) &&
+				Objects.equals(auditMessage.getEventType(), eventType)) {
 
-				updateAuditMessage = auditMessage;
-
-				break;
+				return auditMessage;
 			}
 		}
 
-		Assert.assertEquals(
-			_userGroup.getCompanyId(), updateAuditMessage.getCompanyId());
+		return null;
 	}
 
 	private List<AuditMessage> _auditMessages;

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/UserModelListenerTest.java
@@ -100,10 +100,11 @@ public class UserModelListenerTest {
 		AuditMessage agreedToTermsOfUseAuditMessage = null;
 
 		for (AuditMessage auditMessage : _auditMessages) {
-			if (EventTypes.AGREED_TO_TERMS_OF_USE.equals(
-					auditMessage.getEventType()) &&
+			if (Objects.equals(
+					auditMessage.getClassName(), User.class.getName()) &&
 				Objects.equals(
-					User.class.getName(), auditMessage.getClassName())) {
+					auditMessage.getEventType(),
+					EventTypes.AGREED_TO_TERMS_OF_USE)) {
 
 				agreedToTermsOfUseAuditMessage = auditMessage;
 

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/UserModelListenerTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/test/UserModelListenerTest.java
@@ -13,72 +13,22 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import java.util.ArrayList;
-import java.util.Dictionary;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Objects;
-
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Ivica Cardic
  */
 @RunWith(Arquillian.class)
-public class UserModelListenerTest {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE);
-
-	@Before
-	public void setUp() throws Exception {
-		_auditMessages = new ArrayList<>();
-
-		Bundle bundle = FrameworkUtil.getBundle(UserModelListenerTest.class);
-
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Dictionary<String, Object> properties = new Hashtable<>();
-
-		properties.put("eventTypes", "*");
-
-		_serviceRegistration = bundleContext.registerService(
-			AuditMessageProcessor.class,
-			auditMessage -> _auditMessages.add(auditMessage), properties);
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		if (_serviceRegistration != null) {
-			_serviceRegistration.unregister();
-		}
-	}
+public class UserModelListenerTest extends BaseModelListenerTestCase {
 
 	@Test
 	public void testOnBeforeUpdate() throws Exception {
@@ -88,7 +38,7 @@ public class UserModelListenerTest {
 
 		Assert.assertFalse(_user.isAgreedToTermsOfUse());
 
-		_auditMessages.clear();
+		auditMessages.clear();
 
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
@@ -97,20 +47,8 @@ public class UserModelListenerTest {
 			_userLocalService.updateAgreedToTermsOfUse(_user.getUserId(), true);
 		}
 
-		AuditMessage agreedToTermsOfUseAuditMessage = null;
-
-		for (AuditMessage auditMessage : _auditMessages) {
-			if (Objects.equals(
-					auditMessage.getClassName(), User.class.getName()) &&
-				Objects.equals(
-					auditMessage.getEventType(),
-					EventTypes.AGREED_TO_TERMS_OF_USE)) {
-
-				agreedToTermsOfUseAuditMessage = auditMessage;
-
-				break;
-			}
-		}
+		AuditMessage agreedToTermsOfUseAuditMessage = fetchAuditMessage(
+			User.class.getName(), EventTypes.AGREED_TO_TERMS_OF_USE);
 
 		JSONObject additionalInfoJSONObject =
 			agreedToTermsOfUseAuditMessage.getAdditionalInfo();
@@ -127,7 +65,7 @@ public class UserModelListenerTest {
 			_user.getCompanyId(),
 			agreedToTermsOfUseAuditMessage.getCompanyId());
 
-		_auditMessages.clear();
+		auditMessages.clear();
 
 		_user = _userLocalService.getUser(_user.getUserId());
 
@@ -135,18 +73,14 @@ public class UserModelListenerTest {
 
 		_user = _userLocalService.updateUser(_user);
 
-		for (AuditMessage auditMessage : _auditMessages) {
+		for (AuditMessage auditMessage : auditMessages) {
 			Assert.assertNotEquals(
 				EventTypes.AGREED_TO_TERMS_OF_USE, auditMessage.getEventType());
 		}
 	}
 
-	private List<AuditMessage> _auditMessages;
-
 	@DeleteAfterTestRun
 	private Company _company;
-
-	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
 
 	@DeleteAfterTestRun
 	private User _user;

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management/src/main/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/AddressModelListener.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management/src/main/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/AddressModelListener.java
@@ -48,6 +48,8 @@ public class AddressModelListener extends BaseModelListener<Address> {
 						User.class.getName(), address.getClassPK(),
 						EventTypes.UPDATE, attributes);
 
+				auditMessage.setCompanyId(address.getCompanyId());
+
 				_auditRouter.route(auditMessage);
 			}
 		}

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management/src/main/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/ContactModelListener.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management/src/main/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/ContactModelListener.java
@@ -42,6 +42,8 @@ public class ContactModelListener extends BaseModelListener<Contact> {
 						User.class.getName(), contact.getClassPK(),
 						EventTypes.UPDATE, attributes);
 
+				auditMessage.setCompanyId(contact.getCompanyId());
+
 				_auditRouter.route(auditMessage);
 			}
 		}

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management/src/main/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/OrganizationModelListener.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management/src/main/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/OrganizationModelListener.java
@@ -79,6 +79,8 @@ public class OrganizationModelListener extends BaseModelListener<Organization> {
 						organization.getOrganizationId(), EventTypes.UPDATE,
 						attributes);
 
+				auditMessage.setCompanyId(organization.getCompanyId());
+
 				_auditRouter.route(auditMessage);
 			}
 		}
@@ -114,6 +116,8 @@ public class OrganizationModelListener extends BaseModelListener<Organization> {
 			additionalInfoJSONObject.put(
 				"organizationName", organization.getName());
 
+			auditMessage.setCompanyId(organization.getCompanyId());
+
 			_auditRouter.route(auditMessage);
 		}
 		catch (Exception exception) {
@@ -129,6 +133,8 @@ public class OrganizationModelListener extends BaseModelListener<Organization> {
 			AuditMessage auditMessage = AuditMessageBuilder.buildAuditMessage(
 				Organization.class.getName(), organization.getOrganizationId(),
 				eventType, null);
+
+			auditMessage.setCompanyId(organization.getCompanyId());
 
 			_auditRouter.route(auditMessage);
 		}

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management/src/main/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/UserGroupModelListener.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management/src/main/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/UserGroupModelListener.java
@@ -81,6 +81,8 @@ public class UserGroupModelListener extends BaseModelListener<UserGroup> {
 						UserGroup.class.getName(), userGroup.getUserGroupId(),
 						EventTypes.UPDATE, attributes);
 
+				auditMessage.setCompanyId(userGroup.getCompanyId());
+
 				_auditRouter.route(auditMessage);
 			}
 		}
@@ -129,6 +131,8 @@ public class UserGroupModelListener extends BaseModelListener<UserGroup> {
 
 			additionalInfoJSONObject.put("userGroupName", userGroup.getName());
 
+			auditMessage.setCompanyId(userGroup.getCompanyId());
+
 			_auditRouter.route(auditMessage);
 		}
 		catch (Exception exception) {
@@ -143,6 +147,8 @@ public class UserGroupModelListener extends BaseModelListener<UserGroup> {
 			AuditMessage auditMessage = AuditMessageBuilder.buildAuditMessage(
 				UserGroup.class.getName(), userGroup.getUserGroupId(),
 				eventType, null);
+
+			auditMessage.setCompanyId(userGroup.getCompanyId());
 
 			_auditRouter.route(auditMessage);
 		}

--- a/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management/src/main/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/UserModelListener.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-event-generators-user-management/src/main/java/com/liferay/portal/security/audit/event/generators/user/management/internal/model/listener/UserModelListener.java
@@ -66,6 +66,8 @@ public class UserModelListener extends BaseModelListener<User> {
 						User.class.getName(), user.getUserId(),
 						EventTypes.UPDATE, attributes);
 
+				auditMessage.setCompanyId(user.getCompanyId());
+
 				_auditRouter.route(auditMessage);
 			}
 		}
@@ -80,6 +82,8 @@ public class UserModelListener extends BaseModelListener<User> {
 		try {
 			AuditMessage auditMessage = AuditMessageBuilder.buildAuditMessage(
 				User.class.getName(), user.getUserId(), eventType, null);
+
+			auditMessage.setCompanyId(user.getCompanyId());
 
 			JSONObject additionalInfoJSONObject =
 				auditMessage.getAdditionalInfo();
@@ -140,6 +144,8 @@ public class UserModelListener extends BaseModelListener<User> {
 			AuditMessage auditMessage = AuditMessageBuilder.buildAuditMessage(
 				User.class.getName(), user.getUserId(),
 				EventTypes.AGREED_TO_TERMS_OF_USE, null);
+
+			auditMessage.setCompanyId(user.getCompanyId());
 
 			JSONObject additionalInfoJSONObject =
 				auditMessage.getAdditionalInfo();

--- a/modules/apps/portal-security-audit/portal-security-audit-storage-test/src/testIntegration/java/com/liferay/portal/security/audit/storage/service/test/AuditEventLocalServiceTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-test/src/testIntegration/java/com/liferay/portal/security/audit/storage/service/test/AuditEventLocalServiceTest.java
@@ -41,6 +41,10 @@ public class AuditEventLocalServiceTest {
 			RandomTestUtil.randomLong(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), new ArrayList<>());
 
+		long companyId = RandomTestUtil.randomLong();
+
+		auditMessage.setCompanyId(companyId);
+
 		AuditEvent auditEvent = _auditEventLocalService.addAuditEvent(
 			auditMessage);
 
@@ -48,6 +52,12 @@ public class AuditEventLocalServiceTest {
 			auditEvent.getAccountEntryId(), auditMessage.getAccountEntryId());
 		Assert.assertEquals(
 			auditEvent.getContextName(), auditMessage.getContextName());
+
+		AuditEvent persistedAuditEvent =
+			_auditEventLocalService.fetchAuditEvent(
+				auditEvent.getAuditEventId());
+
+		Assert.assertEquals(companyId, persistedAuditEvent.getCompanyId());
 	}
 
 	@Inject

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/bnd.bnd
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Portal Security Audit Event Generators Test
+Bundle-SymbolicName: com.liferay.portal.security.audit.event.generators.test
+Bundle-Version: 1.0.0

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/build.gradle
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/build.gradle
@@ -1,0 +1,5 @@
+dependencies {
+	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-api")
+	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-event-generators-api")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/BaseModelListenerTestCase.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/BaseModelListenerTestCase.java
@@ -41,8 +41,6 @@ public abstract class BaseModelListenerTestCase {
 
 	@Before
 	public void setUp() throws Exception {
-		auditMessages = new ArrayList<>();
-
 		Bundle bundle = FrameworkUtil.getBundle(getClass());
 
 		BundleContext bundleContext = bundle.getBundleContext();
@@ -77,7 +75,7 @@ public abstract class BaseModelListenerTestCase {
 		return null;
 	}
 
-	protected List<AuditMessage> auditMessages;
+	protected final List<AuditMessage> auditMessages = new ArrayList<>();
 
 	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
 

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/BaseModelListenerTestCase.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/BaseModelListenerTestCase.java
@@ -1,0 +1,84 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.audit.event.generators.internal.model.listener.test;
+
+import com.liferay.portal.kernel.audit.AuditMessage;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.security.audit.AuditMessageProcessor;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Christian Moura
+ */
+public abstract class BaseModelListenerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		auditMessages = new ArrayList<>();
+
+		Bundle bundle = FrameworkUtil.getBundle(getClass());
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		Dictionary<String, Object> properties = new Hashtable<>();
+
+		properties.put("eventTypes", "*");
+
+		_serviceRegistration = bundleContext.registerService(
+			AuditMessageProcessor.class,
+			auditMessage -> auditMessages.add(auditMessage), properties);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
+	protected AuditMessage fetchAuditMessage(
+		String className, String eventType) {
+
+		for (AuditMessage auditMessage : auditMessages) {
+			if (Objects.equals(auditMessage.getClassName(), className) &&
+				Objects.equals(auditMessage.getEventType(), eventType)) {
+
+				return auditMessage;
+			}
+		}
+
+		return null;
+	}
+
+	protected List<AuditMessage> auditMessages;
+
+	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
+
+}

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/RoleModelListenerTest.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/RoleModelListenerTest.java
@@ -3,20 +3,23 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.portal.security.audit.event.generators.user.management.internal.model.listener.test;
+package com.liferay.portal.security.audit.event.generators.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.audit.AuditMessage;
-import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
@@ -44,10 +47,10 @@ import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
 
 /**
- * @author Ivica Cardic
+ * @author Christian Moura
  */
 @RunWith(Arquillian.class)
-public class UserModelListenerTest {
+public class RoleModelListenerTest {
 
 	@ClassRule
 	@Rule
@@ -60,7 +63,7 @@ public class UserModelListenerTest {
 	public void setUp() throws Exception {
 		_auditMessages = new ArrayList<>();
 
-		Bundle bundle = FrameworkUtil.getBundle(UserModelListenerTest.class);
+		Bundle bundle = FrameworkUtil.getBundle(RoleModelListenerTest.class);
 
 		BundleContext bundleContext = bundle.getBundleContext();
 
@@ -81,12 +84,12 @@ public class UserModelListenerTest {
 	}
 
 	@Test
-	public void testOnBeforeUpdate() throws Exception {
+	public void testOnBeforeAddAssociation() throws Exception {
 		_user = UserTestUtil.addUser();
 
-		_company = CompanyTestUtil.addCompany();
+		_role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
 
-		Assert.assertFalse(_user.isAgreedToTermsOfUse());
+		_company = CompanyTestUtil.addCompany();
 
 		_auditMessages.clear();
 
@@ -94,56 +97,71 @@ public class UserModelListenerTest {
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_company.getCompanyId())) {
 
-			_userLocalService.updateAgreedToTermsOfUse(_user.getUserId(), true);
+			_userLocalService.addRoleUsers(
+				_role.getRoleId(), new long[] {_user.getUserId()});
 		}
 
-		AuditMessage agreedToTermsOfUseAuditMessage = null;
+		AuditMessage assignAuditMessage = null;
 
 		for (AuditMessage auditMessage : _auditMessages) {
-			if (EventTypes.AGREED_TO_TERMS_OF_USE.equals(
-					auditMessage.getEventType()) &&
+			if (EventTypes.ASSIGN.equals(auditMessage.getEventType()) &&
 				Objects.equals(
 					User.class.getName(), auditMessage.getClassName())) {
 
-				agreedToTermsOfUseAuditMessage = auditMessage;
+				assignAuditMessage = auditMessage;
 
 				break;
 			}
 		}
 
-		JSONObject additionalInfoJSONObject =
-			agreedToTermsOfUseAuditMessage.getAdditionalInfo();
-
-		Assert.assertTrue(
-			additionalInfoJSONObject.has("termsOfUseJournalArticleGroupId"));
-		Assert.assertTrue(
-			additionalInfoJSONObject.has("termsOfUseJournalArticleId"));
-
 		Assert.assertEquals(
-			String.valueOf(_user.getUserId()),
-			agreedToTermsOfUseAuditMessage.getClassPK());
-		Assert.assertEquals(
-			_user.getCompanyId(),
-			agreedToTermsOfUseAuditMessage.getCompanyId());
+			_user.getCompanyId(), assignAuditMessage.getCompanyId());
+	}
+
+	@Test
+	public void testOnBeforeUpdate() throws Exception {
+		_role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		_company = CompanyTestUtil.addCompany();
 
 		_auditMessages.clear();
 
-		_user = _userLocalService.getUser(_user.getUserId());
+		_role.setName(RandomTestUtil.randomString());
 
-		_user.setComments(RandomTestUtil.randomString());
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					_company.getCompanyId())) {
 
-		_user = _userLocalService.updateUser(_user);
+			_role = _roleLocalService.updateRole(_role);
+		}
+
+		AuditMessage updateAuditMessage = null;
 
 		for (AuditMessage auditMessage : _auditMessages) {
-			Assert.assertNotEquals(
-				EventTypes.AGREED_TO_TERMS_OF_USE, auditMessage.getEventType());
+			if (EventTypes.UPDATE.equals(auditMessage.getEventType()) &&
+				Objects.equals(
+					Role.class.getName(), auditMessage.getClassName())) {
+
+				updateAuditMessage = auditMessage;
+
+				break;
+			}
 		}
+
+		Assert.assertEquals(
+			_role.getCompanyId(), updateAuditMessage.getCompanyId());
 	}
 
 	private List<AuditMessage> _auditMessages;
 
 	@DeleteAfterTestRun
 	private Company _company;
+
+	@DeleteAfterTestRun
+	private Role _role;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
 
 	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
 

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/RoleModelListenerTest.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/RoleModelListenerTest.java
@@ -101,21 +101,10 @@ public class RoleModelListenerTest {
 				_role.getRoleId(), new long[] {_user.getUserId()});
 		}
 
-		AuditMessage assignAuditMessage = null;
+		AuditMessage auditMessage = _fetchAuditMessage(
+			User.class.getName(), EventTypes.ASSIGN);
 
-		for (AuditMessage auditMessage : _auditMessages) {
-			if (EventTypes.ASSIGN.equals(auditMessage.getEventType()) &&
-				Objects.equals(
-					User.class.getName(), auditMessage.getClassName())) {
-
-				assignAuditMessage = auditMessage;
-
-				break;
-			}
-		}
-
-		Assert.assertEquals(
-			_user.getCompanyId(), assignAuditMessage.getCompanyId());
+		Assert.assertEquals(_user.getCompanyId(), auditMessage.getCompanyId());
 	}
 
 	@Test
@@ -135,21 +124,24 @@ public class RoleModelListenerTest {
 			_role = _roleLocalService.updateRole(_role);
 		}
 
-		AuditMessage updateAuditMessage = null;
+		AuditMessage auditMessage = _fetchAuditMessage(
+			Role.class.getName(), EventTypes.UPDATE);
+
+		Assert.assertEquals(_role.getCompanyId(), auditMessage.getCompanyId());
+	}
+
+	private AuditMessage _fetchAuditMessage(
+		String className, String eventType) {
 
 		for (AuditMessage auditMessage : _auditMessages) {
-			if (EventTypes.UPDATE.equals(auditMessage.getEventType()) &&
-				Objects.equals(
-					Role.class.getName(), auditMessage.getClassName())) {
+			if (Objects.equals(auditMessage.getClassName(), className) &&
+				Objects.equals(auditMessage.getEventType(), eventType)) {
 
-				updateAuditMessage = auditMessage;
-
-				break;
+				return auditMessage;
 			}
 		}
 
-		Assert.assertEquals(
-			_role.getCompanyId(), updateAuditMessage.getCompanyId());
+		return null;
 	}
 
 	private List<AuditMessage> _auditMessages;

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/RoleModelListenerTest.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/RoleModelListenerTest.java
@@ -15,73 +15,23 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import java.util.ArrayList;
-import java.util.Dictionary;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Objects;
-
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Christian Moura
  */
 @RunWith(Arquillian.class)
-public class RoleModelListenerTest {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE);
-
-	@Before
-	public void setUp() throws Exception {
-		_auditMessages = new ArrayList<>();
-
-		Bundle bundle = FrameworkUtil.getBundle(RoleModelListenerTest.class);
-
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Dictionary<String, Object> properties = new Hashtable<>();
-
-		properties.put("eventTypes", "*");
-
-		_serviceRegistration = bundleContext.registerService(
-			AuditMessageProcessor.class,
-			auditMessage -> _auditMessages.add(auditMessage), properties);
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		if (_serviceRegistration != null) {
-			_serviceRegistration.unregister();
-		}
-	}
+public class RoleModelListenerTest extends BaseModelListenerTestCase {
 
 	@Test
 	public void testOnBeforeAddAssociation() throws Exception {
@@ -91,7 +41,7 @@ public class RoleModelListenerTest {
 
 		_company = CompanyTestUtil.addCompany();
 
-		_auditMessages.clear();
+		auditMessages.clear();
 
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
@@ -101,7 +51,7 @@ public class RoleModelListenerTest {
 				_role.getRoleId(), new long[] {_user.getUserId()});
 		}
 
-		AuditMessage auditMessage = _fetchAuditMessage(
+		AuditMessage auditMessage = fetchAuditMessage(
 			User.class.getName(), EventTypes.ASSIGN);
 
 		Assert.assertEquals(_user.getCompanyId(), auditMessage.getCompanyId());
@@ -113,7 +63,7 @@ public class RoleModelListenerTest {
 
 		_company = CompanyTestUtil.addCompany();
 
-		_auditMessages.clear();
+		auditMessages.clear();
 
 		_role.setName(RandomTestUtil.randomString());
 
@@ -124,27 +74,11 @@ public class RoleModelListenerTest {
 			_role = _roleLocalService.updateRole(_role);
 		}
 
-		AuditMessage auditMessage = _fetchAuditMessage(
+		AuditMessage auditMessage = fetchAuditMessage(
 			Role.class.getName(), EventTypes.UPDATE);
 
 		Assert.assertEquals(_role.getCompanyId(), auditMessage.getCompanyId());
 	}
-
-	private AuditMessage _fetchAuditMessage(
-		String className, String eventType) {
-
-		for (AuditMessage auditMessage : _auditMessages) {
-			if (Objects.equals(auditMessage.getClassName(), className) &&
-				Objects.equals(auditMessage.getEventType(), eventType)) {
-
-				return auditMessage;
-			}
-		}
-
-		return null;
-	}
-
-	private List<AuditMessage> _auditMessages;
 
 	@DeleteAfterTestRun
 	private Company _company;
@@ -154,8 +88,6 @@ public class RoleModelListenerTest {
 
 	@Inject
 	private RoleLocalService _roleLocalService;
-
-	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
 
 	@DeleteAfterTestRun
 	private User _user;

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/UserGroupRoleModelListenerTest.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/UserGroupRoleModelListenerTest.java
@@ -15,74 +15,23 @@ import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
-import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
-import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
 import com.liferay.portal.test.rule.Inject;
-import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
-import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 
-import java.util.ArrayList;
-import java.util.Dictionary;
-import java.util.Hashtable;
-import java.util.List;
-import java.util.Objects;
-
-import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
-import org.osgi.framework.FrameworkUtil;
-import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Christian Moura
  */
 @RunWith(Arquillian.class)
-public class UserGroupRoleModelListenerTest {
-
-	@ClassRule
-	@Rule
-	public static final AggregateTestRule aggregateTestRule =
-		new AggregateTestRule(
-			new LiferayIntegrationTestRule(),
-			PermissionCheckerMethodTestRule.INSTANCE);
-
-	@Before
-	public void setUp() throws Exception {
-		_auditMessages = new ArrayList<>();
-
-		Bundle bundle = FrameworkUtil.getBundle(
-			UserGroupRoleModelListenerTest.class);
-
-		BundleContext bundleContext = bundle.getBundleContext();
-
-		Dictionary<String, Object> properties = new Hashtable<>();
-
-		properties.put("eventTypes", "*");
-
-		_serviceRegistration = bundleContext.registerService(
-			AuditMessageProcessor.class,
-			auditMessage -> _auditMessages.add(auditMessage), properties);
-	}
-
-	@After
-	public void tearDown() throws Exception {
-		if (_serviceRegistration != null) {
-			_serviceRegistration.unregister();
-		}
-	}
+public class UserGroupRoleModelListenerTest extends BaseModelListenerTestCase {
 
 	@Test
 	public void testOnBeforeCreate() throws Exception {
@@ -94,7 +43,7 @@ public class UserGroupRoleModelListenerTest {
 
 		_company = CompanyTestUtil.addCompany();
 
-		_auditMessages.clear();
+		auditMessages.clear();
 
 		try (SafeCloseable safeCloseable =
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
@@ -105,25 +54,11 @@ public class UserGroupRoleModelListenerTest {
 				new long[] {_role.getRoleId()});
 		}
 
-		AuditMessage assignAuditMessage = null;
+		AuditMessage auditMessage = fetchAuditMessage(
+			User.class.getName(), EventTypes.ASSIGN);
 
-		for (AuditMessage auditMessage : _auditMessages) {
-			if (Objects.equals(
-					auditMessage.getClassName(), User.class.getName()) &&
-				Objects.equals(
-					auditMessage.getEventType(), EventTypes.ASSIGN)) {
-
-				assignAuditMessage = auditMessage;
-
-				break;
-			}
-		}
-
-		Assert.assertEquals(
-			_user.getCompanyId(), assignAuditMessage.getCompanyId());
+		Assert.assertEquals(_user.getCompanyId(), auditMessage.getCompanyId());
 	}
-
-	private List<AuditMessage> _auditMessages;
 
 	@DeleteAfterTestRun
 	private Company _company;
@@ -133,8 +68,6 @@ public class UserGroupRoleModelListenerTest {
 
 	@DeleteAfterTestRun
 	private Role _role;
-
-	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
 
 	@DeleteAfterTestRun
 	private User _user;

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/UserGroupRoleModelListenerTest.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/UserGroupRoleModelListenerTest.java
@@ -3,20 +3,23 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.portal.security.audit.event.generators.user.management.internal.model.listener.test;
+package com.liferay.portal.security.audit.event.generators.internal.model.listener.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.audit.AuditMessage;
-import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.RoleConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
-import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.UserGroupRoleLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.security.audit.AuditMessageProcessor;
 import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
@@ -44,10 +47,10 @@ import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.ServiceRegistration;
 
 /**
- * @author Ivica Cardic
+ * @author Christian Moura
  */
 @RunWith(Arquillian.class)
-public class UserModelListenerTest {
+public class UserGroupRoleModelListenerTest {
 
 	@ClassRule
 	@Rule
@@ -60,7 +63,8 @@ public class UserModelListenerTest {
 	public void setUp() throws Exception {
 		_auditMessages = new ArrayList<>();
 
-		Bundle bundle = FrameworkUtil.getBundle(UserModelListenerTest.class);
+		Bundle bundle = FrameworkUtil.getBundle(
+			UserGroupRoleModelListenerTest.class);
 
 		BundleContext bundleContext = bundle.getBundleContext();
 
@@ -81,12 +85,14 @@ public class UserModelListenerTest {
 	}
 
 	@Test
-	public void testOnBeforeUpdate() throws Exception {
+	public void testOnBeforeCreate() throws Exception {
 		_user = UserTestUtil.addUser();
 
-		_company = CompanyTestUtil.addCompany();
+		_group = GroupTestUtil.addGroup();
 
-		Assert.assertFalse(_user.isAgreedToTermsOfUse());
+		_role = RoleTestUtil.addRole(RoleConstants.TYPE_SITE);
+
+		_company = CompanyTestUtil.addCompany();
 
 		_auditMessages.clear();
 
@@ -94,50 +100,26 @@ public class UserModelListenerTest {
 				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
 					_company.getCompanyId())) {
 
-			_userLocalService.updateAgreedToTermsOfUse(_user.getUserId(), true);
+			_userGroupRoleLocalService.addUserGroupRoles(
+				_user.getUserId(), _group.getGroupId(),
+				new long[] {_role.getRoleId()});
 		}
 
-		AuditMessage agreedToTermsOfUseAuditMessage = null;
+		AuditMessage assignAuditMessage = null;
 
 		for (AuditMessage auditMessage : _auditMessages) {
-			if (EventTypes.AGREED_TO_TERMS_OF_USE.equals(
-					auditMessage.getEventType()) &&
+			if (EventTypes.ASSIGN.equals(auditMessage.getEventType()) &&
 				Objects.equals(
 					User.class.getName(), auditMessage.getClassName())) {
 
-				agreedToTermsOfUseAuditMessage = auditMessage;
+				assignAuditMessage = auditMessage;
 
 				break;
 			}
 		}
 
-		JSONObject additionalInfoJSONObject =
-			agreedToTermsOfUseAuditMessage.getAdditionalInfo();
-
-		Assert.assertTrue(
-			additionalInfoJSONObject.has("termsOfUseJournalArticleGroupId"));
-		Assert.assertTrue(
-			additionalInfoJSONObject.has("termsOfUseJournalArticleId"));
-
 		Assert.assertEquals(
-			String.valueOf(_user.getUserId()),
-			agreedToTermsOfUseAuditMessage.getClassPK());
-		Assert.assertEquals(
-			_user.getCompanyId(),
-			agreedToTermsOfUseAuditMessage.getCompanyId());
-
-		_auditMessages.clear();
-
-		_user = _userLocalService.getUser(_user.getUserId());
-
-		_user.setComments(RandomTestUtil.randomString());
-
-		_user = _userLocalService.updateUser(_user);
-
-		for (AuditMessage auditMessage : _auditMessages) {
-			Assert.assertNotEquals(
-				EventTypes.AGREED_TO_TERMS_OF_USE, auditMessage.getEventType());
-		}
+			_user.getCompanyId(), assignAuditMessage.getCompanyId());
 	}
 
 	private List<AuditMessage> _auditMessages;
@@ -145,12 +127,18 @@ public class UserModelListenerTest {
 	@DeleteAfterTestRun
 	private Company _company;
 
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@DeleteAfterTestRun
+	private Role _role;
+
 	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
 
 	@DeleteAfterTestRun
 	private User _user;
 
 	@Inject
-	private UserLocalService _userLocalService;
+	private UserGroupRoleLocalService _userGroupRoleLocalService;
 
 }

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/UserGroupRoleModelListenerTest.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/UserGroupRoleModelListenerTest.java
@@ -108,9 +108,10 @@ public class UserGroupRoleModelListenerTest {
 		AuditMessage assignAuditMessage = null;
 
 		for (AuditMessage auditMessage : _auditMessages) {
-			if (EventTypes.ASSIGN.equals(auditMessage.getEventType()) &&
+			if (Objects.equals(
+					auditMessage.getClassName(), User.class.getName()) &&
 				Objects.equals(
-					User.class.getName(), auditMessage.getClassName())) {
+					auditMessage.getEventType(), EventTypes.ASSIGN)) {
 
 				assignAuditMessage = auditMessage;
 

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/RoleModelListener.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/RoleModelListener.java
@@ -82,6 +82,8 @@ public class RoleModelListener extends BaseModelListener<Role> {
 						Role.class.getName(), role.getRoleId(),
 						EventTypes.UPDATE, attributes);
 
+				auditMessage.setCompanyId(role.getCompanyId());
+
 				_auditRouter.route(auditMessage);
 			}
 		}
@@ -96,6 +98,8 @@ public class RoleModelListener extends BaseModelListener<Role> {
 		try {
 			AuditMessage auditMessage = AuditMessageBuilder.buildAuditMessage(
 				Role.class.getName(), role.getRoleId(), eventType, null);
+
+			auditMessage.setCompanyId(role.getCompanyId());
 
 			_auditRouter.route(auditMessage);
 		}
@@ -182,6 +186,8 @@ public class RoleModelListener extends BaseModelListener<Role> {
 					"userId", userId
 				);
 			}
+
+			auditMessage.setCompanyId(role.getCompanyId());
 
 			_auditRouter.route(auditMessage);
 		}

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/UserGroupRoleModelListener.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/UserGroupRoleModelListener.java
@@ -67,6 +67,8 @@ public class UserGroupRoleModelListener
 				"scopeClassPK", group.getClassPK()
 			);
 
+			auditMessage.setCompanyId(role.getCompanyId());
+
 			_auditRouter.route(auditMessage);
 		}
 		catch (Exception exception) {


### PR DESCRIPTION
Re-opens the LPD-96787 audit `companyId` work after #3077 was closed during review.

### What

The model listeners in the user management and event generators modules now stamp audit events with the audited entity's `companyId` instead of the acting company's, with integration tests asserting it across the Address, Contact, Organization, User, UserGroup, Role, and UserGroupRole listeners.

### Review feedback addressed

The earlier revision duplicated the same audit-message capture harness (`@Before`/`@After`, the message list and service registration fields, and the lookup loop) in every `*ModelListenerTest`. That harness is now extracted into an abstract `BaseModelListenerTestCase` per test module; each concrete test extends it and keeps only the scenarios specific to its model listener (net −507/+204 across the test files).

### pr-check

**pr-check: PASS** — tested on `c8a100c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Integration Test Compile | PASS |
| Per-Module Compile | PASS |

Run in a provisioned checkout on today's master (`284f105`). Running the integration tests themselves is out of pr-check scope.
