### PR TITLE
LPD-91337 Support Resource Indicators for OAuth 2.0 (RFC 8707)

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/BaseAccessTokenGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/BaseAccessTokenGrantHandler.java
@@ -94,14 +94,12 @@ public abstract class BaseAccessTokenGrantHandler
 
 		List<String> registeredAudiences = client.getRegisteredAudiences();
 
-		if (ListUtil.isNotEmpty(registeredAudiences)) {
-			for (String resource : resources) {
-				if (!registeredAudiences.contains(resource)) {
-					OAuth2ErrorUtil.reportInvalidRequestError(
-						"The resource parameter is not a registered audience",
-						"invalid_target", Response.Status.BAD_REQUEST);
-				}
-			}
+		if (ListUtil.isNotEmpty(registeredAudiences) &&
+			!registeredAudiences.containsAll(resources)) {
+
+			OAuth2ErrorUtil.reportInvalidRequestError(
+				"The resource parameter is not a registered audience",
+				"invalid_target", Response.Status.BAD_REQUEST);
 		}
 
 		try {

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/BaseAccessTokenGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/BaseAccessTokenGrantHandler.java
@@ -89,7 +89,12 @@ public abstract class BaseAccessTokenGrantHandler
 		}
 
 		for (String resource : resources) {
-			_validateResource(resource);
+			if (!_isValidResource(resource)) {
+				OAuth2ErrorUtil.reportInvalidRequestError(
+					"The resource parameter must be an absolute URI without " +
+						"a fragment",
+					"invalid_target", Response.Status.BAD_REQUEST);
+			}
 		}
 
 		List<String> registeredAudiences = client.getRegisteredAudiences();
@@ -177,25 +182,27 @@ public abstract class BaseAccessTokenGrantHandler
 	@Reference
 	protected UserLocalService userLocalService;
 
-	private void _validateResource(String resource) {
-		if (!Validator.isBlank(resource)) {
-			try {
-				URI uri = new URI(resource);
-
-				if (uri.isAbsolute() && (uri.getFragment() == null)) {
-					return;
-				}
-			}
-			catch (URISyntaxException uriSyntaxException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(uriSyntaxException);
-				}
-			}
+	private boolean _isValidResource(String resource) {
+		if (Validator.isBlank(resource)) {
+			return false;
 		}
 
-		OAuth2ErrorUtil.reportInvalidRequestError(
-			"The resource parameter must be an absolute URI without a fragment",
-			"invalid_target", Response.Status.BAD_REQUEST);
+		try {
+			URI uri = new URI(resource);
+
+			if (uri.isAbsolute() && (uri.getFragment() == null)) {
+				return true;
+			}
+
+			return false;
+		}
+		catch (URISyntaxException uriSyntaxException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(uriSyntaxException);
+			}
+
+			return false;
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/BaseAccessTokenGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/BaseAccessTokenGrantHandler.java
@@ -17,11 +17,15 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.function.Supplier;
 
 import org.apache.cxf.rs.security.oauth2.common.Client;
 import org.apache.cxf.rs.security.oauth2.common.ServerAccessToken;
@@ -66,6 +70,38 @@ public abstract class BaseAccessTokenGrantHandler
 			OAuth2ProviderRESTEndpointConstants.PROPERTY_KEY_COMPANY_ID);
 
 		return Objects.equals(companyId1, companyId2);
+	}
+
+	protected ServerAccessToken createAccessTokenWithResources(
+		Client client, MultivaluedMap<String, String> params,
+		Supplier<ServerAccessToken> supplier) {
+
+		List<String> resources = params.get("resource");
+
+		if (ListUtil.isEmpty(resources)) {
+			return supplier.get();
+		}
+
+		List<String> originalRegisteredAudiences =
+			client.getRegisteredAudiences();
+
+		try {
+			List<String> mutableAudiences = new ArrayList<>(
+				originalRegisteredAudiences);
+
+			for (String resource : resources) {
+				if (!mutableAudiences.contains(resource)) {
+					mutableAudiences.add(resource);
+				}
+			}
+
+			client.setRegisteredAudiences(mutableAudiences);
+
+			return supplier.get();
+		}
+		finally {
+			client.setRegisteredAudiences(originalRegisteredAudiences);
+		}
 	}
 
 	protected abstract ServerAccessToken doCreateAccessToken(

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/BaseAccessTokenGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/BaseAccessTokenGrantHandler.java
@@ -8,6 +8,7 @@ package com.liferay.oauth2.provider.rest.internal.endpoint.access.token.grant.ha
 import com.liferay.oauth2.provider.constants.OAuth2ProviderActionKeys;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
+import com.liferay.oauth2.provider.rest.internal.endpoint.util.OAuth2ErrorUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -19,8 +20,13 @@ import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermi
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -82,25 +88,29 @@ public abstract class BaseAccessTokenGrantHandler
 			return supplier.get();
 		}
 
-		List<String> originalRegisteredAudiences =
-			client.getRegisteredAudiences();
+		for (String resource : resources) {
+			_validateResource(resource);
+		}
 
-		try {
-			List<String> mutableAudiences = new ArrayList<>(
-				originalRegisteredAudiences);
+		List<String> registeredAudiences = client.getRegisteredAudiences();
 
+		if (ListUtil.isNotEmpty(registeredAudiences)) {
 			for (String resource : resources) {
-				if (!mutableAudiences.contains(resource)) {
-					mutableAudiences.add(resource);
+				if (!registeredAudiences.contains(resource)) {
+					OAuth2ErrorUtil.reportInvalidRequestError(
+						"The resource parameter is not a registered audience",
+						"invalid_target", Response.Status.BAD_REQUEST);
 				}
 			}
+		}
 
-			client.setRegisteredAudiences(mutableAudiences);
+		try {
+			client.setRegisteredAudiences(new ArrayList<>(resources));
 
 			return supplier.get();
 		}
 		finally {
-			client.setRegisteredAudiences(originalRegisteredAudiences);
+			client.setRegisteredAudiences(registeredAudiences);
 		}
 	}
 
@@ -168,6 +178,27 @@ public abstract class BaseAccessTokenGrantHandler
 
 	@Reference
 	protected UserLocalService userLocalService;
+
+	private void _validateResource(String resource) {
+		if (!Validator.isBlank(resource)) {
+			try {
+				URI uri = new URI(resource);
+
+				if (uri.isAbsolute() && (uri.getFragment() == null)) {
+					return;
+				}
+			}
+			catch (URISyntaxException uriSyntaxException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(uriSyntaxException);
+				}
+			}
+		}
+
+		OAuth2ErrorUtil.reportInvalidRequestError(
+			"The resource parameter must be an absolute URI without a fragment",
+			"invalid_target", Response.Status.BAD_REQUEST);
+	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		BaseAccessTokenGrantHandler.class);

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayAuthorizationAccessTokenCodeGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayAuthorizationAccessTokenCodeGrantHandler.java
@@ -13,11 +13,9 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -69,34 +67,10 @@ public class LiferayAuthorizationAccessTokenCodeGrantHandler
 	protected ServerAccessToken doCreateAccessToken(
 		Client client, MultivaluedMap<String, String> params) {
 
-		List<String> resources = params.get("resource");
-
-		if (ListUtil.isEmpty(resources)) {
-			return _authorizationCodeGrantHandler.createAccessToken(
-				client, params);
-		}
-
-		List<String> originalRegisteredAudiences =
-			client.getRegisteredAudiences();
-
-		try {
-			List<String> mutableAudiences = new ArrayList<>(
-				originalRegisteredAudiences);
-
-			for (String resource : resources) {
-				if (!mutableAudiences.contains(resource)) {
-					mutableAudiences.add(resource);
-				}
-			}
-
-			client.setRegisteredAudiences(mutableAudiences);
-
-			return _authorizationCodeGrantHandler.createAccessToken(
-				client, params);
-		}
-		finally {
-			client.setRegisteredAudiences(originalRegisteredAudiences);
-		}
+		return createAccessTokenWithResources(
+			client, params,
+			() -> _authorizationCodeGrantHandler.createAccessToken(
+				client, params));
 	}
 
 	@Override

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayAuthorizationAccessTokenCodeGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayAuthorizationAccessTokenCodeGrantHandler.java
@@ -13,9 +13,11 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -67,7 +69,32 @@ public class LiferayAuthorizationAccessTokenCodeGrantHandler
 	protected ServerAccessToken doCreateAccessToken(
 		Client client, MultivaluedMap<String, String> params) {
 
-		return _authorizationCodeGrantHandler.createAccessToken(client, params);
+		String resource = params.getFirst("resource");
+
+		if (Validator.isNull(resource)) {
+			return _authorizationCodeGrantHandler.createAccessToken(
+				client, params);
+		}
+
+		List<String> originalRegisteredAudiences =
+			client.getRegisteredAudiences();
+
+		try {
+			List<String> mutableAudiences = new ArrayList<>(
+				originalRegisteredAudiences);
+
+			if (!mutableAudiences.contains(resource)) {
+				mutableAudiences.add(resource);
+			}
+
+			client.setRegisteredAudiences(mutableAudiences);
+
+			return _authorizationCodeGrantHandler.createAccessToken(
+				client, params);
+		}
+		finally {
+			client.setRegisteredAudiences(originalRegisteredAudiences);
+		}
 	}
 
 	@Override

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayAuthorizationAccessTokenCodeGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayAuthorizationAccessTokenCodeGrantHandler.java
@@ -13,7 +13,7 @@ import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.ListUtil;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
@@ -69,9 +69,9 @@ public class LiferayAuthorizationAccessTokenCodeGrantHandler
 	protected ServerAccessToken doCreateAccessToken(
 		Client client, MultivaluedMap<String, String> params) {
 
-		String resource = params.getFirst("resource");
+		List<String> resources = params.get("resource");
 
-		if (Validator.isNull(resource)) {
+		if (ListUtil.isEmpty(resources)) {
 			return _authorizationCodeGrantHandler.createAccessToken(
 				client, params);
 		}
@@ -83,8 +83,10 @@ public class LiferayAuthorizationAccessTokenCodeGrantHandler
 			List<String> mutableAudiences = new ArrayList<>(
 				originalRegisteredAudiences);
 
-			if (!mutableAudiences.contains(resource)) {
-				mutableAudiences.add(resource);
+			for (String resource : resources) {
+				if (!mutableAudiences.contains(resource)) {
+					mutableAudiences.add(resource);
+				}
 			}
 
 			client.setRegisteredAudiences(mutableAudiences);

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayClientCredentialsAccessTokenGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayClientCredentialsAccessTokenGrantHandler.java
@@ -9,11 +9,9 @@ import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.rest.internal.endpoint.liferay.LiferayOAuthDataProvider;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -56,34 +54,10 @@ public class LiferayClientCredentialsAccessTokenGrantHandler
 	protected ServerAccessToken doCreateAccessToken(
 		Client client, MultivaluedMap<String, String> params) {
 
-		List<String> resources = params.get("resource");
-
-		if (ListUtil.isEmpty(resources)) {
-			return _clientCredentialsGrantHandler.createAccessToken(
-				client, params);
-		}
-
-		List<String> originalRegisteredAudiences =
-			client.getRegisteredAudiences();
-
-		try {
-			List<String> mutableAudiences = new ArrayList<>(
-				originalRegisteredAudiences);
-
-			for (String resource : resources) {
-				if (!mutableAudiences.contains(resource)) {
-					mutableAudiences.add(resource);
-				}
-			}
-
-			client.setRegisteredAudiences(mutableAudiences);
-
-			return _clientCredentialsGrantHandler.createAccessToken(
-				client, params);
-		}
-		finally {
-			client.setRegisteredAudiences(originalRegisteredAudiences);
-		}
+		return createAccessTokenWithResources(
+			client, params,
+			() -> _clientCredentialsGrantHandler.createAccessToken(
+				client, params));
 	}
 
 	@Override

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayClientCredentialsAccessTokenGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayClientCredentialsAccessTokenGrantHandler.java
@@ -9,9 +9,11 @@ import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.rest.internal.endpoint.liferay.LiferayOAuthDataProvider;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +56,32 @@ public class LiferayClientCredentialsAccessTokenGrantHandler
 	protected ServerAccessToken doCreateAccessToken(
 		Client client, MultivaluedMap<String, String> params) {
 
-		return _clientCredentialsGrantHandler.createAccessToken(client, params);
+		String resource = params.getFirst("resource");
+
+		if (Validator.isNull(resource)) {
+			return _clientCredentialsGrantHandler.createAccessToken(
+				client, params);
+		}
+
+		List<String> originalRegisteredAudiences =
+			client.getRegisteredAudiences();
+
+		try {
+			List<String> mutableAudiences = new ArrayList<>(
+				originalRegisteredAudiences);
+
+			if (!mutableAudiences.contains(resource)) {
+				mutableAudiences.add(resource);
+			}
+
+			client.setRegisteredAudiences(mutableAudiences);
+
+			return _clientCredentialsGrantHandler.createAccessToken(
+				client, params);
+		}
+		finally {
+			client.setRegisteredAudiences(originalRegisteredAudiences);
+		}
 	}
 
 	@Override

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayClientCredentialsAccessTokenGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayClientCredentialsAccessTokenGrantHandler.java
@@ -9,7 +9,7 @@ import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.rest.internal.endpoint.liferay.LiferayOAuthDataProvider;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
-import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.ListUtil;
 
 import jakarta.ws.rs.core.MultivaluedMap;
 
@@ -56,9 +56,9 @@ public class LiferayClientCredentialsAccessTokenGrantHandler
 	protected ServerAccessToken doCreateAccessToken(
 		Client client, MultivaluedMap<String, String> params) {
 
-		String resource = params.getFirst("resource");
+		List<String> resources = params.get("resource");
 
-		if (Validator.isNull(resource)) {
+		if (ListUtil.isEmpty(resources)) {
 			return _clientCredentialsGrantHandler.createAccessToken(
 				client, params);
 		}
@@ -70,8 +70,10 @@ public class LiferayClientCredentialsAccessTokenGrantHandler
 			List<String> mutableAudiences = new ArrayList<>(
 				originalRegisteredAudiences);
 
-			if (!mutableAudiences.contains(resource)) {
-				mutableAudiences.add(resource);
+			for (String resource : resources) {
+				if (!mutableAudiences.contains(resource)) {
+					mutableAudiences.add(resource);
+				}
 			}
 
 			client.setRegisteredAudiences(mutableAudiences);

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -1806,7 +1806,8 @@ public class LiferayOAuthDataProvider
 
 		for (String audience : audiences) {
 			if (Validator.isBlank(audience)) {
-				continue;
+				OAuth2ErrorUtil.reportInvalidRequestError(
+					audience, "invalid_target", Response.Status.BAD_REQUEST);
 			}
 
 			URI uri;

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -71,6 +71,8 @@ import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
 
 import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import java.nio.charset.StandardCharsets;
 
@@ -989,6 +991,8 @@ public class LiferayOAuthDataProvider
 	protected ServerAccessToken doCreateAccessToken(
 		AccessTokenRegistration accessTokenRegistration) {
 
+		_validateAudiences(accessTokenRegistration.getAudiences());
+
 		ServerAccessToken serverAccessToken = _createOpaqueServerAccessToken(
 			accessTokenRegistration.getAudiences(),
 			accessTokenRegistration.getClient(),
@@ -1792,6 +1796,39 @@ public class LiferayOAuthDataProvider
 
 			throw new OAuthServiceException(
 				portalException.getMessage(), portalException);
+		}
+	}
+
+	private void _validateAudiences(List<String> audiences) {
+		if (ListUtil.isEmpty(audiences)) {
+			return;
+		}
+
+		for (String audience : audiences) {
+			if (Validator.isBlank(audience)) {
+				continue;
+			}
+
+			URI uri;
+
+			try {
+				uri = new URI(audience);
+			}
+			catch (URISyntaxException uriSyntaxException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(uriSyntaxException);
+				}
+
+				OAuth2ErrorUtil.reportInvalidRequestError(
+					audience, "invalid_target", Response.Status.BAD_REQUEST);
+
+				return;
+			}
+
+			if (!uri.isAbsolute() || audience.contains(StringPool.POUND)) {
+				OAuth2ErrorUtil.reportInvalidRequestError(
+					audience, "invalid_target", Response.Status.BAD_REQUEST);
+			}
 		}
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -71,8 +71,6 @@ import jakarta.ws.rs.core.SecurityContext;
 import java.io.IOException;
 
 import java.net.HttpURLConnection;
-import java.net.URI;
-import java.net.URISyntaxException;
 
 import java.nio.charset.StandardCharsets;
 
@@ -991,8 +989,6 @@ public class LiferayOAuthDataProvider
 	protected ServerAccessToken doCreateAccessToken(
 		AccessTokenRegistration accessTokenRegistration) {
 
-		_validateAudiences(accessTokenRegistration.getAudiences());
-
 		ServerAccessToken serverAccessToken = _createOpaqueServerAccessToken(
 			accessTokenRegistration.getAudiences(),
 			accessTokenRegistration.getClient(),
@@ -1796,37 +1792,6 @@ public class LiferayOAuthDataProvider
 
 			throw new OAuthServiceException(
 				portalException.getMessage(), portalException);
-		}
-	}
-
-	private void _validateAudiences(List<String> audiences) {
-		if (ListUtil.isEmpty(audiences)) {
-			return;
-		}
-
-		for (String audience : audiences) {
-			if (Validator.isBlank(audience)) {
-				OAuth2ErrorUtil.reportInvalidRequestError(
-					audience, "invalid_target", Response.Status.BAD_REQUEST);
-			}
-
-			try {
-				URI uri = new URI(audience);
-
-				if (!uri.isAbsolute() || audience.contains(StringPool.POUND)) {
-					OAuth2ErrorUtil.reportInvalidRequestError(
-						audience, "invalid_target",
-						Response.Status.BAD_REQUEST);
-				}
-			}
-			catch (URISyntaxException uriSyntaxException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(uriSyntaxException);
-				}
-
-				OAuth2ErrorUtil.reportInvalidRequestError(
-					audience, "invalid_target", Response.Status.BAD_REQUEST);
-			}
 		}
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -1810,23 +1810,20 @@ public class LiferayOAuthDataProvider
 					audience, "invalid_target", Response.Status.BAD_REQUEST);
 			}
 
-			URI uri;
-
 			try {
-				uri = new URI(audience);
+				URI uri = new URI(audience);
+
+				if (!uri.isAbsolute() || audience.contains(StringPool.POUND)) {
+					OAuth2ErrorUtil.reportInvalidRequestError(
+						audience, "invalid_target",
+						Response.Status.BAD_REQUEST);
+				}
 			}
 			catch (URISyntaxException uriSyntaxException) {
 				if (_log.isDebugEnabled()) {
 					_log.debug(uriSyntaxException);
 				}
 
-				OAuth2ErrorUtil.reportInvalidRequestError(
-					audience, "invalid_target", Response.Status.BAD_REQUEST);
-
-				return;
-			}
-
-			if (!uri.isAbsolute() || audience.contains(StringPool.POUND)) {
 				OAuth2ErrorUtil.reportInvalidRequestError(
 					audience, "invalid_target", Response.Status.BAD_REQUEST);
 			}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
@@ -201,9 +201,9 @@ public class TokenAudienceTest extends BaseClientTestCase {
 
 		Assert.assertEquals(resources.size(), audJSONArray.length());
 
-		List<String> audiencesList = JSONUtil.toStringList(audJSONArray);
+		List<String> audiences = JSONUtil.toStringList(audJSONArray);
 
-		Assert.assertTrue(audiencesList.containsAll(resources));
+		Assert.assertTrue(audiences.containsAll(resources));
 	}
 
 	private void _testTokenRequestWithInvalidResource(String resource)

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
@@ -126,7 +126,6 @@ public class TokenAudienceTest extends BaseClientTestCase {
 
 		JSONArray audJSONArray = jsonObject.getJSONArray("aud");
 
-		Assert.assertNotNull(audJSONArray);
 		Assert.assertEquals(1, audJSONArray.length());
 		Assert.assertEquals(_RESOURCE_URI, audJSONArray.getString(0));
 	}
@@ -200,7 +199,6 @@ public class TokenAudienceTest extends BaseClientTestCase {
 
 		JSONArray audJSONArray = jsonObject.getJSONArray("aud");
 
-		Assert.assertNotNull(audJSONArray);
 		Assert.assertEquals(resources.size(), audJSONArray.length());
 
 		List<String> audiencesList = JSONUtil.toStringList(audJSONArray);

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
@@ -55,7 +55,8 @@ public class TokenAudienceTest extends BaseClientTestCase {
 		_testTokenIntrospectionAudience(
 			Collections.singletonList(_RESOURCE_URI));
 		_testTokenIntrospectionAudience(
-			Arrays.asList(_RESOURCE_URI, _RESOURCE_URI_2));
+			Arrays.asList(
+				_RESOURCE_URI, "https://" + RandomTestUtil.randomString()));
 	}
 
 	@Test
@@ -202,9 +203,9 @@ public class TokenAudienceTest extends BaseClientTestCase {
 		Assert.assertNotNull(audJSONArray);
 		Assert.assertEquals(resources.size(), audJSONArray.length());
 
-		List<String> audiences = JSONUtil.toStringList(audJSONArray);
+		List<String> audiencesList = JSONUtil.toStringList(audJSONArray);
 
-		Assert.assertTrue(audiences.containsAll(resources));
+		Assert.assertTrue(audiencesList.containsAll(resources));
 	}
 
 	private void _testTokenRequestWithInvalidResource(String resource)
@@ -235,10 +236,8 @@ public class TokenAudienceTest extends BaseClientTestCase {
 
 	private static final String _CLIENT_SECRET = RandomTestUtil.randomString();
 
-	private static final String _RESOURCE_URI = "https://mcp.example.com/o/mcp";
-
-	private static final String _RESOURCE_URI_2 =
-		"https://api.example.com/o/api";
+	private static final String _RESOURCE_URI =
+		"https://" + RandomTestUtil.randomString();
 
 	private class TokenAudienceTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
@@ -8,14 +8,17 @@ package com.liferay.oauth2.provider.client.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import jakarta.ws.rs.client.Entity;
@@ -26,6 +29,7 @@ import jakarta.ws.rs.core.Response;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -48,6 +52,30 @@ public class TokenAudienceTest extends BaseClientTestCase {
 
 	@Test
 	public void testTokenIntrospectionAudience() throws Exception {
+		_testTokenIntrospectionAudience(
+			Collections.singletonList(_RESOURCE_URI));
+		_testTokenIntrospectionAudience(
+			Arrays.asList(_RESOURCE_URI, _RESOURCE_URI_2));
+	}
+
+	@Test
+	public void testTokenIntrospectionAudienceWithAuthorizationCodeGrant()
+		throws Exception {
+
+		String authorizationCode = parseAuthorizationCodeString(
+			getCodeResponse(
+				TestPropsValues.getUser(
+				).getEmailAddress(),
+				PropsValues.DEFAULT_ADMIN_PASSWORD, null,
+				getCodeFunction(
+					webTarget -> webTarget.queryParam(
+						"client_id", _CLIENT_ID
+					).queryParam(
+						"response_type", "code"
+					))));
+
+		Assert.assertNotNull(authorizationCode);
+
 		WebTarget tokenWebTarget = getTokenWebTarget();
 
 		Invocation.Builder tokenInvocationBuilder = tokenWebTarget.request();
@@ -60,7 +88,9 @@ public class TokenAudienceTest extends BaseClientTestCase {
 					).put(
 						"client_secret", _CLIENT_SECRET
 					).put(
-						"grant_type", "client_credentials"
+						"code", authorizationCode
+					).put(
+						"grant_type", "authorization_code"
 					).put(
 						"resource", _RESOURCE_URI
 					).build())));
@@ -102,6 +132,84 @@ public class TokenAudienceTest extends BaseClientTestCase {
 
 	@Test
 	public void testTokenRequestWithInvalidResource() throws Exception {
+		_testTokenRequestWithInvalidResource(StringPool.SPACE);
+		_testTokenRequestWithInvalidResource(
+			StringBundler.concat(
+				"https://", RandomTestUtil.randomString(), "/#",
+				RandomTestUtil.randomString()));
+		_testTokenRequestWithInvalidResource(RandomTestUtil.randomString());
+	}
+
+	@Override
+	protected BundleActivator getBundleActivator() {
+		return new TokenAudienceTestPreparatorBundleActivator();
+	}
+
+	private void _testTokenIntrospectionAudience(List<String> resources)
+		throws Exception {
+
+		MultivaluedHashMap<String, String> tokenFormData =
+			new MultivaluedHashMap<>(
+				HashMapBuilder.put(
+					"client_id", _CLIENT_ID
+				).put(
+					"client_secret", _CLIENT_SECRET
+				).put(
+					"grant_type", "client_credentials"
+				).build());
+
+		for (String resource : resources) {
+			tokenFormData.add("resource", resource);
+		}
+
+		WebTarget tokenWebTarget = getTokenWebTarget();
+
+		Invocation.Builder tokenInvocationBuilder = tokenWebTarget.request();
+
+		Response tokenResponse = tokenInvocationBuilder.post(
+			Entity.form(tokenFormData));
+
+		Assert.assertEquals(200, tokenResponse.getStatus());
+
+		String accessToken = parseTokenString(tokenResponse);
+
+		Assert.assertNotNull(accessToken);
+
+		WebTarget introspectWebTarget = getIntrospectWebTarget();
+
+		Invocation.Builder introspectInvocationBuilder =
+			introspectWebTarget.request();
+
+		Response introspectResponse = introspectInvocationBuilder.post(
+			Entity.form(
+				new MultivaluedHashMap<>(
+					HashMapBuilder.put(
+						"client_id", _CLIENT_ID
+					).put(
+						"client_secret", _CLIENT_SECRET
+					).put(
+						"token", accessToken
+					).build())));
+
+		Assert.assertEquals(200, introspectResponse.getStatus());
+
+		JSONObject jsonObject = parseJSONObject(introspectResponse);
+
+		Assert.assertTrue(jsonObject.getBoolean("active"));
+
+		JSONArray audJSONArray = jsonObject.getJSONArray("aud");
+
+		Assert.assertNotNull(audJSONArray);
+		Assert.assertEquals(resources.size(), audJSONArray.length());
+
+		List<String> audiences = JSONUtil.toStringList(audJSONArray);
+
+		Assert.assertTrue(audiences.containsAll(resources));
+	}
+
+	private void _testTokenRequestWithInvalidResource(String resource)
+		throws Exception {
+
 		WebTarget tokenWebTarget = getTokenWebTarget();
 
 		Invocation.Builder invocationBuilder = tokenWebTarget.request();
@@ -116,19 +224,11 @@ public class TokenAudienceTest extends BaseClientTestCase {
 					).put(
 						"grant_type", "client_credentials"
 					).put(
-						"resource",
-						StringBundler.concat(
-							"https://", RandomTestUtil.randomString(), "/#",
-							RandomTestUtil.randomString())
+						"resource", resource
 					).build())));
 
 		Assert.assertEquals(400, response.getStatus());
 		Assert.assertEquals("invalid_target", parseError(response));
-	}
-
-	@Override
-	protected BundleActivator getBundleActivator() {
-		return new TokenAudienceTestPreparatorBundleActivator();
 	}
 
 	private static final String _CLIENT_ID = RandomTestUtil.randomString();
@@ -136,6 +236,9 @@ public class TokenAudienceTest extends BaseClientTestCase {
 	private static final String _CLIENT_SECRET = RandomTestUtil.randomString();
 
 	private static final String _RESOURCE_URI = "https://mcp.example.com/o/mcp";
+
+	private static final String _RESOURCE_URI_2 =
+		"https://api.example.com/o/api";
 
 	private class TokenAudienceTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
@@ -148,8 +251,10 @@ public class TokenAudienceTest extends BaseClientTestCase {
 
 			createOAuth2Application(
 				companyId, user, _CLIENT_ID, _CLIENT_SECRET,
-				Collections.singletonList(GrantType.CLIENT_CREDENTIALS),
-				"client_secret_post", null, Arrays.asList(), false,
+				Arrays.asList(
+					GrantType.CLIENT_CREDENTIALS, GrantType.AUTHORIZATION_CODE),
+				"client_secret_post", null,
+				Collections.singletonList("http://redirecturi:8080"), false,
 				Collections.singletonList("everything"), false);
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -56,7 +57,8 @@ public class TokenAudienceTest extends BaseClientTestCase {
 			Collections.singletonList(_RESOURCE_URI));
 		_testTokenIntrospectionAudience(
 			Arrays.asList(
-				_RESOURCE_URI, "https://" + RandomTestUtil.randomString()));
+				_RESOURCE_URI,
+				Http.HTTPS_WITH_SLASH + RandomTestUtil.randomString()));
 	}
 
 	@Test
@@ -135,7 +137,7 @@ public class TokenAudienceTest extends BaseClientTestCase {
 		_testTokenRequestWithInvalidResource(StringPool.SPACE);
 		_testTokenRequestWithInvalidResource(
 			StringBundler.concat(
-				"https://", RandomTestUtil.randomString(), "/#",
+				Http.HTTPS_WITH_SLASH, RandomTestUtil.randomString(), "/#",
 				RandomTestUtil.randomString()));
 		_testTokenRequestWithInvalidResource(RandomTestUtil.randomString());
 	}
@@ -235,7 +237,7 @@ public class TokenAudienceTest extends BaseClientTestCase {
 	private static final String _CLIENT_SECRET = RandomTestUtil.randomString();
 
 	private static final String _RESOURCE_URI =
-		"https://" + RandomTestUtil.randomString();
+		Http.HTTPS_WITH_SLASH + RandomTestUtil.randomString();
 
 	private class TokenAudienceTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
@@ -251,8 +253,9 @@ public class TokenAudienceTest extends BaseClientTestCase {
 				Arrays.asList(
 					GrantType.CLIENT_CREDENTIALS, GrantType.AUTHORIZATION_CODE),
 				"client_secret_post", null,
-				Collections.singletonList("http://redirecturi:8080"), false,
-				Collections.singletonList("everything"), false);
+				Collections.singletonList(
+					Http.HTTP_WITH_SLASH + RandomTestUtil.randomString()),
+				false, Collections.singletonList("everything"), false);
 		}
 
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenAudienceTest.java
@@ -67,9 +67,8 @@ public class TokenAudienceTest extends BaseClientTestCase {
 
 		String authorizationCode = parseAuthorizationCodeString(
 			getCodeResponse(
-				TestPropsValues.getUser(
-				).getEmailAddress(),
-				PropsValues.DEFAULT_ADMIN_PASSWORD, null,
+				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
+				null,
 				getCodeFunction(
 					webTarget -> webTarget.queryParam(
 						"client_id", _CLIENT_ID
@@ -239,6 +238,8 @@ public class TokenAudienceTest extends BaseClientTestCase {
 	private static final String _RESOURCE_URI =
 		Http.HTTPS_WITH_SLASH + RandomTestUtil.randomString();
 
+	private User _user;
+
 	private class TokenAudienceTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
 
@@ -246,10 +247,10 @@ public class TokenAudienceTest extends BaseClientTestCase {
 		protected void prepareTest() throws Exception {
 			long companyId = TestPropsValues.getCompanyId();
 
-			User user = UserTestUtil.getAdminUser(companyId);
+			_user = UserTestUtil.getAdminUser(companyId);
 
 			createOAuth2Application(
-				companyId, user, _CLIENT_ID, _CLIENT_SECRET,
+				companyId, _user, _CLIENT_ID, _CLIENT_SECRET,
 				Arrays.asList(
 					GrantType.CLIENT_CREDENTIALS, GrantType.AUTHORIZATION_CODE),
 				"client_secret_post", null,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91337

## What Is Being Done

Adds support for OAuth 2.0 Resource Indicators (RFC 8707). The `resource` request parameter on the `authorization_code` and `client_credentials` token flows is bridged to Apache CXF's legacy audience slot, so issued access tokens carry the requested resource(s) as their audience and token introspection emits them under `aud`. One or more `resource` values are supported; each is validated as an absolute URI without a fragment per RFC 8707 §2, and malformed values are rejected with `400 invalid_target`.

## Review Changes

The last five commits apply review feedback on top of the feature:

- Drop the redundant `assertNotNull` before the audience assertions.
- Rename `audiencesList` to `audiences`.
- Route the test URLs through the `Http` URL constants and randomize the redirect URI.
- Replace the audience membership loop with `containsAll`.
- Extract `_isValidResource` to flatten the resource validation behind a guard clause.

## Testing

`TokenAudienceTest` passes against a running bundle (single- and multi-resource introspection on `client_credentials`, the `authorization_code` flow, and `invalid_target` rejection for blank, fragment, and relative resources).

## PR Check

**pr-check: PASS** — tested on `76c08c6094495388b8fd856d9c4f8f3e0fb95d94`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "76c08c6094495388b8fd856d9c4f8f3e0fb95d94"} -->
