### PR TITLE
LPD-91327 Use the last X-Forwarded-For entry for allowed hosts check

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/container/request/filter/DynamicRegistrationServiceContainerRequestFilter.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/container/request/filter/DynamicRegistrationServiceContainerRequestFilter.java
@@ -352,10 +352,10 @@ public class DynamicRegistrationServiceContainerRequestFilter
 			return _normalizeHost(httpServletRequest.getRemoteAddr());
 		}
 
-		int index = forwardedFor.indexOf(',');
+		int index = forwardedFor.lastIndexOf(',');
 
 		if (index >= 0) {
-			forwardedFor = forwardedFor.substring(0, index);
+			forwardedFor = forwardedFor.substring(index + 1);
 		}
 
 		forwardedFor = forwardedFor.trim();

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
@@ -371,6 +371,18 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 		_testRegisterInOpenModeEnforcesAllowedHosts(
 			allowedHost, 201, allowedHost);
 
+		// Allow when the rightmost forwarded host matches
+
+		_testRegisterInOpenModeEnforcesAllowedHosts(
+			allowedHost, 201,
+			RandomTestUtil.randomString() + ", " + allowedHost);
+
+		// Deny when only the leftmost forwarded host matches
+
+		_testRegisterInOpenModeEnforcesAllowedHosts(
+			allowedHost, 403,
+			allowedHost + ", " + RandomTestUtil.randomString());
+
 		// Deny when the request host does not match
 
 		_testRegisterInOpenModeEnforcesAllowedHosts(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91327

## What Is Being Fixed

Open registration's allowed-hosts check derived the client host from the leftmost X-Forwarded-For entry. When the fronting proxy appends to the header rather than overwriting it (a common default), that entry is caller-provided: a request can present an allowed host as the first entry and pass the check, even though the proxy appends the real source afterward. Raised by @cdbm in review.

## How It Is Being Fixed

`_getClientHost` now reads the rightmost X-Forwarded-For entry — the one the fronting proxy actually sets — instead of the leftmost, so the allowed-hosts check compares against the proxy-provided value.

`testRegisterInOpenModeEnforcesAllowedHosts` gains two cases: with a two-entry header, a match on the rightmost entry is allowed and a match only on the leftmost entry is denied.

## PR Check

**pr-check: PASS** — tested on `7b92c95f21cc6bf729c249486ebeb62cbc025a7c`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "7b92c95f21cc6bf729c249486ebeb62cbc025a7c"} -->
