### PR TITLE
LPD-91327 Default the scope for open registration when omitted

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/dynamic/registration/LiferayDynamicRegistrationService.java
@@ -843,11 +843,21 @@ public class LiferayDynamicRegistrationService
 		String scope = clientRegistration.getScope();
 
 		if (Validator.isBlank(scope)) {
-			OAuth2ErrorUtil.reportInvalidRequestError(
-				"An explicit scope is required for open registration",
-				OAuth2ProviderRESTEndpointConstants.
-					ERROR_INVALID_CLIENT_METADATA,
-				Response.Status.BAD_REQUEST);
+			List<String> allowedScopesList = ListUtil.fromArray(allowedScopes);
+
+			allowedScopesList.removeAll(Collections.singleton(StringPool.STAR));
+
+			if (allowedScopesList.isEmpty()) {
+				OAuth2ErrorUtil.reportInvalidRequestError(
+					"An explicit scope is required for open registration",
+					OAuth2ProviderRESTEndpointConstants.
+						ERROR_INVALID_CLIENT_METADATA,
+					Response.Status.BAD_REQUEST);
+			}
+
+			scope = StringUtil.merge(allowedScopesList, StringPool.SPACE);
+
+			clientRegistration.setScope(scope);
 		}
 
 		_validateOpenRegistrationAllowedValues(

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/dynamic/registration/test/DynamicRegistrationServiceTest.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Http;
@@ -345,6 +346,46 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 	}
 
 	@Test
+	public void testRegisterInOpenModeDefaultsMissingScope() throws Exception {
+		WebTarget registerWebTarget = getRegisterWebTarget();
+
+		JSONObject jsonObject = _createOpenRegistrationJSONObject(
+			false, _getRandomRedirectURI());
+
+		String[] expectedScopes = {
+			RandomTestUtil.randomString(), RandomTestUtil.randomString()
+		};
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					_createCompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						"oauth2.dynamic.registration.allowed.scopes",
+						ArrayUtil.append(
+							expectedScopes,
+							new String[] {StringPool.STAR, StringPool.STAR}))) {
+
+			Invocation.Builder invocationBuilder = registerWebTarget.request();
+
+			Response response = invocationBuilder.method(
+				"post", Entity.json(jsonObject.toString()));
+
+			Assert.assertEquals(201, response.getStatus());
+
+			JSONObject responseJSONObject = parseJSONObject(response);
+
+			String[] actualScopes = StringUtil.split(
+				responseJSONObject.getString("scope"), CharPool.SPACE);
+
+			Arrays.sort(actualScopes);
+
+			Arrays.sort(expectedScopes);
+
+			Assert.assertArrayEquals(expectedScopes, actualScopes);
+		}
+	}
+
+	@Test
 	public void testRegisterInOpenModeEnforcesAllowedHosts() throws Exception {
 
 		// Allow when the bracketed IPv6 host is compared with or without a port
@@ -521,15 +562,9 @@ public class DynamicRegistrationServiceTest extends BaseClientTestCase {
 			"oauth2.dynamic.registration.allowed.redirect.uri.patterns",
 			new String[] {"https://*.example.org/*"});
 
-		// Deny when the scope is missing, even when all scopes are allowed
+		// Deny when the scope is missing and only the wildcard scope is
+		// allowed, since there is no concrete scope to default to
 
-		_testRegisterInOpenModeWithInvalidRequest(
-			_createOpenRegistrationJSONObject(
-				false, _getRandomRedirectURI()
-			).toString(),
-			"invalid_client_metadata", 400,
-			"oauth2.dynamic.registration.allowed.scopes",
-			new String[] {"Liferay.Headless.Delivery.everything"});
 		_testRegisterInOpenModeWithInvalidRequest(
 			_createOpenRegistrationJSONObject(
 				false, _getRandomRedirectURI()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-91327

## What Is Being Fixed

Open (anonymous) dynamic client registration rejected any registration request that omitted the `scope` field, returning `invalid_client_metadata` with "An explicit scope is required for open registration". The `scope` parameter is optional in client registration per RFC 7591, and standard MCP clients (for example, the one used by Claude Code) register without one, so they could never complete registration and could not connect to the Liferay MCP server. MCP Inspector worked only because its SDK happens to include a scope.

## How It Is Being Fixed

When an open registration request omits the scope, `_validateOpenRegistrationScopes` now defaults it to the scopes configured as "Allowed Scopes" in the dynamic registration configuration, excluding the wildcard, and writes it back onto the client registration so the registered client carries those scopes. This mirrors the existing behavior for a missing grant type, which already defaults to `authorization_code`. When the only allowed scope is the wildcard there is no concrete scope to grant, so the request is still rejected as before.

## PR Check

**pr-check: SKIPPED** — Will be run and published on this PR after creation. Equivalent local validation already passed: the module compiled on deploy, `formatSource` and `ant format-source-current-branch` reported no changes, and DynamicRegistrationServiceTest passed 15/15.

<!-- pr-check {"reason": "Will be run and published on this PR after creation; equivalent local validation already passed", "result": "skipped", "sha": "e98fe70aa51308e4652e7db02aa4fbf29ae52660"} -->
