### PR TITLE
[FIPS] LPD-90288 Enforce FIPS-approved algorithm selection

### DIFF
--- a/modules/apps/analytics/analytics-settings-impl/src/main/java/com/liferay/analytics/settings/internal/security/auth/verifier/AnalyticsSecurityAuthVerifier.java
+++ b/modules/apps/analytics/analytics-settings-impl/src/main/java/com/liferay/analytics/settings/internal/security/auth/verifier/AnalyticsSecurityAuthVerifier.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsValues;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -166,9 +167,11 @@ public class AnalyticsSecurityAuthVerifier implements AuthVerifier {
 			String signatureString, String timestamp)
 		throws Exception {
 
-		Signature signature = Signature.getInstance("DSA");
+		Signature signature = Signature.getInstance(
+			PropsValues.FIPS_ENABLED ? "SHA256withECDSA" : "DSA");
 
-		KeyFactory keyFactory = KeyFactory.getInstance("DSA");
+		KeyFactory keyFactory = KeyFactory.getInstance(
+			PropsValues.FIPS_ENABLED ? "EC" : "DSA");
 
 		signature.initVerify(
 			keyFactory.generatePublic(

--- a/modules/apps/analytics/analytics-settings-impl/src/test/java/com/liferay/analytics/settings/internal/security/auth/verifier/AnalyticsSecurityAuthVerifierTest.java
+++ b/modules/apps/analytics/analytics-settings-impl/src/test/java/com/liferay/analytics/settings/internal/security/auth/verifier/AnalyticsSecurityAuthVerifierTest.java
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.analytics.settings.internal.security.auth.verifier;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import java.security.KeyFactory;
+import java.security.Signature;
+import java.security.spec.InvalidKeySpecException;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class AnalyticsSecurityAuthVerifierTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testValidateSignature() throws Exception {
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			"DSA", KeyFactory.class, "EC", KeyFactory::getInstance,
+			this::_invokeValidateSignature);
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			"DSA", Signature.class, "SHA256withECDSA", Signature::getInstance,
+			this::_invokeValidateSignature);
+	}
+
+	private void _invokeValidateSignature() {
+		Assert.assertThrows(
+			InvalidKeySpecException.class,
+			() -> ReflectionTestUtil.invoke(
+				new AnalyticsSecurityAuthVerifier(), "_validateSignature",
+				new Class<?>[] {
+					HttpServletRequest.class, String.class, String.class,
+					String.class
+				},
+				null, RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), RandomTestUtil.randomString()));
+	}
+
+}

--- a/modules/apps/frontend-js/frontend-js-web/src/test/java/com/liferay/frontend/js/web/internal/hashed/files/HashedFilesRegistryImplTest.java
+++ b/modules/apps/frontend-js/frontend-js-web/src/test/java/com/liferay/frontend/js/web/internal/hashed/files/HashedFilesRegistryImplTest.java
@@ -10,6 +10,9 @@ import com.liferay.frontend.js.web.test.util.FrontendJSWebTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.frontend.hashed.files.HashedFilesUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
@@ -17,6 +20,8 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import jakarta.servlet.ServletContext;
 
 import java.net.URL;
+
+import java.security.MessageDigest;
 
 import java.util.Map;
 
@@ -78,6 +83,22 @@ public class HashedFilesRegistryImplTest {
 
 		Assert.assertNotNull(
 			hashedFilesRegistryImpl.getResource("/o/frontend-js-web/main.css"));
+	}
+
+	@Test
+	public void testGetServletContextHash() throws Exception {
+		Map<String, String> hashedFileURIs = HashMapBuilder.put(
+			"/o/frontend-js-web/main.css",
+			HashedFilesUtil.addHash(
+				"/o/frontend-js-web/main.css", RandomTestUtil.randomString())
+		).build();
+
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			DigesterUtil.MD5, MessageDigest.class, DigesterUtil.SHA_256,
+			MessageDigest::getInstance,
+			() -> ReflectionTestUtil.invoke(
+				new HashedFilesRegistryImpl(), "_getServletContextHash",
+				new Class<?>[] {Map.class}, hashedFileURIs));
 	}
 
 	private Map<String, HashedFilesRegistryImpl.DataBag> _mockDataBags(

--- a/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientASLocalMetadataLocalServiceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientASLocalMetadataLocalServiceImpl.java
@@ -23,8 +23,10 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -433,7 +435,9 @@ public class OAuthClientASLocalMetadataLocalServiceImpl
 			URI issuerURI = URI.create(issuer);
 
 			if (wellKnownURISuffix.equals("openid-configuration")) {
-				MessageDigest messageDigest = MessageDigest.getInstance("MD5");
+				MessageDigest messageDigest = MessageDigest.getInstance(
+					PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 :
+						DigesterUtil.MD5);
 
 				return StringBundler.concat(
 					issuerURI.getScheme(), "://", issuerURI.getAuthority(),

--- a/modules/apps/oauth-client/oauth-client-persistence-service/src/test/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientASLocalMetadataLocalServiceImplTest.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-service/src/test/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientASLocalMetadataLocalServiceImplTest.java
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth.client.persistence.service.impl;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.security.MessageDigest;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class OAuthClientASLocalMetadataLocalServiceImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGenerateLocalWellKnownURI() throws Exception {
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			DigesterUtil.MD5, MessageDigest.class, DigesterUtil.SHA_256,
+			MessageDigest::getInstance,
+			() -> ReflectionTestUtil.invoke(
+				new OAuthClientASLocalMetadataLocalServiceImpl(),
+				"_generateLocalWellKnownURI",
+				new Class<?>[] {String.class, String.class, String.class},
+				"https://" + RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(), "openid-configuration"));
+	}
+
+}

--- a/modules/apps/portal-crypto-hash/portal-crypto-hash-impl/build.gradle
+++ b/modules/apps/portal-crypto-hash/portal-crypto-hash-impl/build.gradle
@@ -9,4 +9,5 @@ dependencies {
 	testImplementation group: "com.liferay", name: "jodd.util", version: "6.0.1.LIFERAY-PATCHED-2"
 	testImplementation project(":apps:portal-crypto-hash:portal-crypto-hash-provider:portal-crypto-hash-provider-bcrypt")
 	testImplementation project(":apps:portal-crypto-hash:portal-crypto-hash-provider:portal-crypto-hash-provider-message-digest")
+	testImplementation project(":core:petra:petra-lang")
 }

--- a/modules/apps/portal-crypto-hash/portal-crypto-hash-impl/src/test/java/com/liferay/portal/crypto/hash/internal/CryptoHashGeneratorTest.java
+++ b/modules/apps/portal-crypto-hash/portal-crypto-hash-impl/src/test/java/com/liferay/portal/crypto/hash/internal/CryptoHashGeneratorTest.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.crypto.hash.internal;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.crypto.hash.CryptoHashGenerator;
 import com.liferay.portal.crypto.hash.CryptoHashResponse;
 import com.liferay.portal.crypto.hash.CryptoHashVerificationContext;
@@ -12,7 +13,9 @@ import com.liferay.portal.crypto.hash.provider.bcrypt.internal.BCryptCryptoHashP
 import com.liferay.portal.crypto.hash.provider.message.digest.internal.MessageDigestCryptoHashProviderFactory;
 import com.liferay.portal.crypto.hash.spi.CryptoHashProviderFactory;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.ArrayList;
@@ -79,6 +82,28 @@ public class CryptoHashGeneratorTest {
 		_serviceRegistration2.unregister();
 
 		_serviceRegistration1.unregister();
+	}
+
+	@Test
+	public void testCreate() throws Exception {
+		MessageDigestCryptoHashProviderFactory
+			messageDigestCryptoHashProviderFactory =
+				new MessageDigestCryptoHashProviderFactory();
+
+		messageDigestCryptoHashProviderFactory.create(
+			Collections.singletonMap(
+				"message.digest.algorithm", DigesterUtil.MD5));
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			Assert.assertThrows(
+				SecurityException.class,
+				() -> messageDigestCryptoHashProviderFactory.create(
+					Collections.singletonMap(
+						"message.digest.algorithm", DigesterUtil.MD5)));
+		}
 	}
 
 	@Test

--- a/modules/apps/portal-crypto-hash/portal-crypto-hash-provider/portal-crypto-hash-provider-message-digest/src/main/java/com/liferay/portal/crypto/hash/provider/message/digest/internal/MessageDigestCryptoHashProviderFactory.java
+++ b/modules/apps/portal-crypto-hash/portal-crypto-hash-provider/portal-crypto-hash-provider-message-digest/src/main/java/com/liferay/portal/crypto/hash/provider/message/digest/internal/MessageDigestCryptoHashProviderFactory.java
@@ -10,7 +10,9 @@ import com.liferay.portal.crypto.hash.spi.CryptoHashProvider;
 import com.liferay.portal.crypto.hash.spi.CryptoHashProviderFactory;
 import com.liferay.portal.crypto.hash.spi.CryptoHashProviderResponse;
 import com.liferay.portal.kernel.security.SecureRandomUtil;
+import com.liferay.portal.kernel.security.fips.FIPSModeValidator;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 
 import java.security.MessageDigest;
@@ -67,10 +69,14 @@ public class MessageDigestCryptoHashProviderFactory
 
 			_cryptoHashProviderProperties = cryptoHashProviderProperties;
 
-			_messageDigest = MessageDigest.getInstance(
-				MapUtil.getString(
-					cryptoHashProviderProperties, "message.digest.algorithm",
-					"SHA-256"));
+			String algorithm = MapUtil.getString(
+				cryptoHashProviderProperties, "message.digest.algorithm",
+				DigesterUtil.SHA_256);
+
+			FIPSModeValidator.validateAlgorithm(algorithm);
+
+			_messageDigest = MessageDigest.getInstance(algorithm);
+
 			_saltSize = MapUtil.getInteger(
 				cryptoHashProviderProperties, "message.digest.salt.size", 32);
 		}

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtil.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtil.java
@@ -13,6 +13,8 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.CompanyConstants;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 
 import java.net.URI;
 
@@ -31,8 +33,9 @@ public class OpenIdConnectProviderUtil {
 			String issuer, String tokenEndpoint)
 		throws Exception {
 
-		MessageDigest messageDigest = MessageDigest.getInstance("MD5");
 		URI issuerURI = URI.create(issuer);
+		MessageDigest messageDigest = MessageDigest.getInstance(
+			PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 : DigesterUtil.MD5);
 
 		return StringBundler.concat(
 			issuerURI.getScheme(), "://", issuerURI.getAuthority(),

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtilTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/test/java/com/liferay/portal/security/sso/openid/connect/internal/util/OpenIdConnectProviderUtilTest.java
@@ -1,0 +1,39 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.sso.openid.connect.internal.util;
+
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.security.MessageDigest;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class OpenIdConnectProviderUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGenerateLocalWellKnownURI() throws Exception {
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			DigesterUtil.MD5, MessageDigest.class, DigesterUtil.SHA_256,
+			MessageDigest::getInstance,
+			() -> OpenIdConnectProviderUtil.generateLocalWellKnownURI(
+				"https://" + RandomTestUtil.randomString(),
+				RandomTestUtil.randomString()));
+	}
+
+}

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/src/main/java/com/liferay/portal/security/sso/openid/connect/persistence/internal/upgrade/v2_0_0/OpenIdConnectSessionUpgradeProcess.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/src/main/java/com/liferay/portal/security/sso/openid/connect/persistence/internal/upgrade/v2_0_0/OpenIdConnectSessionUpgradeProcess.java
@@ -12,7 +12,9 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.Base64;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.net.URI;
@@ -93,7 +95,8 @@ public class OpenIdConnectSessionUpgradeProcess extends UpgradeProcess {
 		throws Exception {
 
 		URI issuerURI = URI.create(issuer);
-		MessageDigest messageDigest = MessageDigest.getInstance("MD5");
+		MessageDigest messageDigest = MessageDigest.getInstance(
+			PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 : DigesterUtil.MD5);
 
 		return StringBundler.concat(
 			issuerURI.getScheme(), "://", issuerURI.getAuthority(),

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/src/test/java/com/liferay/portal/security/sso/openid/connect/persistence/internal/upgrade/v2_0_0/OpenIdConnectSessionUpgradeProcessTest.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-persistence-service/src/test/java/com/liferay/portal/security/sso/openid/connect/persistence/internal/upgrade/v2_0_0/OpenIdConnectSessionUpgradeProcessTest.java
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.sso.openid.connect.persistence.internal.upgrade.v2_0_0;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.security.MessageDigest;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class OpenIdConnectSessionUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGenerateLocalWellKnownURI() throws Exception {
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			DigesterUtil.MD5, MessageDigest.class, DigesterUtil.SHA_256,
+			MessageDigest::getInstance,
+			() -> ReflectionTestUtil.invoke(
+				new OpenIdConnectSessionUpgradeProcess(null),
+				"_generateLocalWellKnownURI",
+				new Class<?>[] {String.class, String.class},
+				"https://" + RandomTestUtil.randomString(),
+				RandomTestUtil.randomString()));
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/build.gradle
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":core:osgi-service-tracker-collections")
+	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-io")
 	compileOnly project(":core:petra:petra-lang")
 	compileOnly project(":core:petra:petra-reflect")

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/SSHAPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/SSHAPasswordEncryptor.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.UnsupportedEncodingException;
@@ -44,7 +45,9 @@ public class SSHAPasswordEncryptor implements PasswordEncryptor {
 		byte[] saltBytes = getSaltBytes(encryptedPassword);
 
 		try {
-			MessageDigest messageDigest = MessageDigest.getInstance("SHA-1");
+			MessageDigest messageDigest = MessageDigest.getInstance(
+				PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 :
+					DigesterUtil.SHA_1);
 
 			byte[] plainTextPasswordBytes = plainTextPassword.getBytes(
 				DigesterUtil.ENCODING);

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
@@ -13,10 +13,14 @@ import com.liferay.portal.kernel.exception.PwdEncryptorException;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptorUtil;
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.security.MessageDigest;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -257,6 +261,22 @@ public class PasswordEncryptorUtilTest {
 			PasswordEncryptor.TYPE_SSHA, "password",
 			"2EWEKeVpSdd79PkTX5vaGXH5uQ028Smy/H1NmA==",
 			PasswordEncryptor.TYPE_SSHA);
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			_runTests(
+				PasswordEncryptor.TYPE_SSHA, "password",
+				"q0elUchHiEgZAZww57UMs6Jt+L45+785Q8YcVUf8VfcAAQIDBAUGBw==",
+				PasswordEncryptor.TYPE_SSHA);
+		}
+
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			DigesterUtil.SHA_1, MessageDigest.class, DigesterUtil.SHA_256,
+			MessageDigest::getInstance,
+			() -> PasswordEncryptorUtil.encrypt(
+				PasswordEncryptor.TYPE_SSHA, "password", null));
 	}
 
 	@Test

--- a/modules/apps/static/portal/portal-encryptor/src/main/java/com/liferay/portal/encryptor/EncryptorImpl.java
+++ b/modules/apps/static/portal/portal-encryptor/src/main/java/com/liferay/portal/encryptor/EncryptorImpl.java
@@ -10,21 +10,25 @@ import com.liferay.portal.kernel.encryptor.Encryptor;
 import com.liferay.portal.kernel.encryptor.EncryptorException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.SecureRandomUtil;
+import com.liferay.portal.kernel.security.fips.FIPSModeValidator;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.security.Key;
-import java.security.SecureRandom;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
+import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.osgi.service.component.annotations.Component;
@@ -59,13 +63,23 @@ public class EncryptorImpl implements Encryptor {
 	public byte[] decryptUnencodedAsBytes(Key key, byte[] encryptedBytes)
 		throws EncryptorException {
 
-		String algorithm = key.getAlgorithm();
+		byte[] encodedBytes = key.getEncoded();
 
-		String cacheKey = algorithm + StringPool.POUND + key.toString();
+		FIPSModeValidator.validateKey(
+			key.getAlgorithm(),
+			(encodedBytes == null) ? 0 : encodedBytes.length * 8);
 
-		Cipher cipher = _decryptCipherMap.get(cacheKey);
+		if (PropsValues.FIPS_ENABLED) {
+			return _decryptGCM(encryptedBytes, key);
+		}
 
 		try {
+			String algorithm = key.getAlgorithm();
+
+			String cacheKey = algorithm + StringPool.POUND + key;
+
+			Cipher cipher = _decryptCipherMap.get(cacheKey);
+
 			if (cipher == null) {
 				cipher = Cipher.getInstance(algorithm);
 
@@ -87,7 +101,7 @@ public class EncryptorImpl implements Encryptor {
 	public Key deserializeKey(String base64String) {
 		byte[] bytes = Base64.decode(base64String);
 
-		return new SecretKeySpec(bytes, EncryptorImpl.KEY_ALGORITHM);
+		return new SecretKeySpec(bytes, KEY_ALGORITHM);
 	}
 
 	@Override
@@ -109,13 +123,23 @@ public class EncryptorImpl implements Encryptor {
 	public byte[] encryptUnencoded(Key key, byte[] plainBytes)
 		throws EncryptorException {
 
-		String algorithm = key.getAlgorithm();
+		byte[] encodedBytes = key.getEncoded();
 
-		String cacheKey = algorithm + StringPool.POUND + key.toString();
+		FIPSModeValidator.validateKey(
+			key.getAlgorithm(),
+			(encodedBytes == null) ? 0 : encodedBytes.length * 8);
 
-		Cipher cipher = _encryptCipherMap.get(cacheKey);
+		if (PropsValues.FIPS_ENABLED) {
+			return _encryptGCM(key, plainBytes);
+		}
 
 		try {
+			String algorithm = key.getAlgorithm();
+
+			String cacheKey = algorithm + StringPool.POUND + key;
+
+			Cipher cipher = _encryptCipherMap.get(cacheKey);
+
 			if (cipher == null) {
 				cipher = Cipher.getInstance(algorithm);
 
@@ -157,6 +181,31 @@ public class EncryptorImpl implements Encryptor {
 		return Base64.encode(key.getEncoded());
 	}
 
+	private byte[] _decryptGCM(byte[] encryptedBytes, Key key)
+		throws EncryptorException {
+
+		try {
+			byte[] cipherBytes = Arrays.copyOfRange(
+				encryptedBytes, _GCM_INITIALIZATION_VECTOR_LENGTH,
+				encryptedBytes.length);
+
+			byte[] initializationVector = Arrays.copyOfRange(
+				encryptedBytes, 0, _GCM_INITIALIZATION_VECTOR_LENGTH);
+
+			Cipher cipher = Cipher.getInstance(_AES_GCM_NOPADDING);
+
+			cipher.init(
+				Cipher.DECRYPT_MODE, key,
+				new GCMParameterSpec(
+					_GCM_TAG_LENGTH_BITS, initializationVector));
+
+			return cipher.doFinal(cipherBytes);
+		}
+		catch (Exception exception) {
+			throw new EncryptorException(exception);
+		}
+	}
+
 	private String _decryptUnencodedAsString(Key key, byte[] encryptedBytes)
 		throws EncryptorException {
 
@@ -171,11 +220,49 @@ public class EncryptorImpl implements Encryptor {
 		}
 	}
 
+	private byte[] _encryptGCM(Key key, byte[] plainBytes)
+		throws EncryptorException {
+
+		byte[] initializationVector =
+			new byte[_GCM_INITIALIZATION_VECTOR_LENGTH];
+
+		for (int i = 0; i < initializationVector.length; i++) {
+			initializationVector[i] = SecureRandomUtil.nextByte();
+		}
+
+		try {
+			Cipher cipher = Cipher.getInstance(_AES_GCM_NOPADDING);
+
+			cipher.init(
+				Cipher.ENCRYPT_MODE, key,
+				new GCMParameterSpec(
+					_GCM_TAG_LENGTH_BITS, initializationVector));
+
+			byte[] cipherBytes = cipher.doFinal(plainBytes);
+
+			byte[] encryptedBytes =
+				new byte[initializationVector.length + cipherBytes.length];
+
+			System.arraycopy(
+				initializationVector, 0, encryptedBytes, 0,
+				initializationVector.length);
+			System.arraycopy(
+				cipherBytes, 0, encryptedBytes, initializationVector.length,
+				cipherBytes.length);
+
+			return encryptedBytes;
+		}
+		catch (Exception exception) {
+			throw new EncryptorException(exception);
+		}
+	}
+
 	private Key _generateKey(String algorithm) throws EncryptorException {
 		try {
 			KeyGenerator keyGenerator = KeyGenerator.getInstance(algorithm);
 
-			keyGenerator.init(KEY_SIZE, new SecureRandom());
+			keyGenerator.init(
+				PropsValues.FIPS_ENABLED ? _AES_KEY_SIZE : KEY_SIZE);
 
 			return keyGenerator.generateKey();
 		}
@@ -183,6 +270,14 @@ public class EncryptorImpl implements Encryptor {
 			throw new EncryptorException(exception);
 		}
 	}
+
+	private static final String _AES_GCM_NOPADDING = "AES/GCM/NoPadding";
+
+	private static final int _AES_KEY_SIZE = 256;
+
+	private static final int _GCM_INITIALIZATION_VECTOR_LENGTH = 12;
+
+	private static final int _GCM_TAG_LENGTH_BITS = 128;
 
 	private static final Log _log = LogFactoryUtil.getLog(EncryptorImpl.class);
 

--- a/modules/apps/static/portal/portal-encryptor/src/test/java/com/liferay/portal/encryptor/EncryptorImplTest.java
+++ b/modules/apps/static/portal/portal-encryptor/src/test/java/com/liferay/portal/encryptor/EncryptorImplTest.java
@@ -5,10 +5,15 @@
 
 package com.liferay.portal.encryptor;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.encryptor.Encryptor;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.security.Key;
+
+import javax.crypto.spec.SecretKeySpec;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -26,19 +31,72 @@ public class EncryptorImplTest {
 		LiferayUnitTestRule.INSTANCE;
 
 	@Test
-	public void testKeySerialization() throws Exception {
+	public void testDecrypt() throws Exception {
 		Encryptor encryptor = new EncryptorImpl();
 
 		Key key = encryptor.generateKey();
 
-		String encryptedString = encryptor.encrypt(key, "Hello World!");
+		String encryptedString = encryptor.encrypt(key, _PLAIN_TEXT);
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			Assert.assertEquals(
+				_PLAIN_TEXT, encryptor.decrypt(key, encryptedString));
+		}
+	}
+
+	@Test
+	public void testEncrypt() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			Encryptor encryptor = new EncryptorImpl();
+
+			Key key = encryptor.generateKey();
+
+			String encryptedString1 = encryptor.encrypt(key, _PLAIN_TEXT);
+			String encryptedString2 = encryptor.encrypt(key, _PLAIN_TEXT);
+
+			Assert.assertNotEquals(encryptedString1, encryptedString2);
+
+			Assert.assertEquals(
+				_PLAIN_TEXT, encryptor.decrypt(key, encryptedString1));
+			Assert.assertEquals(
+				_PLAIN_TEXT, encryptor.decrypt(key, encryptedString2));
+
+			Assert.assertThrows(
+				SecurityException.class,
+				() -> encryptor.encryptUnencoded(
+					new SecretKeySpec(new byte[8], "AES"),
+					_PLAIN_TEXT.getBytes()));
+
+			Assert.assertThrows(
+				SecurityException.class,
+				() -> encryptor.decryptUnencodedAsBytes(
+					new SecretKeySpec(new byte[8], "AES"),
+					_PLAIN_TEXT.getBytes()));
+		}
+	}
+
+	@Test
+	public void testSerializeKey() throws Exception {
+		Encryptor encryptor = new EncryptorImpl();
+
+		Key key = encryptor.generateKey();
+
+		String encryptedString = encryptor.encrypt(key, _PLAIN_TEXT);
 
 		String serializedKey = encryptor.serializeKey(key);
 
 		key = encryptor.deserializeKey(serializedKey);
 
 		Assert.assertEquals(
-			"Hello World!", encryptor.decrypt(key, encryptedString));
+			_PLAIN_TEXT, encryptor.decrypt(key, encryptedString));
 	}
+
+	private static final String _PLAIN_TEXT = RandomTestUtil.randomString();
 
 }

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/checker/TimeBasedOTPBrowserSetupMFAChecker.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/checker/TimeBasedOTPBrowserSetupMFAChecker.java
@@ -115,7 +115,8 @@ public class TimeBasedOTPBrowserSetupMFAChecker
 					_mfaTimeBasedOTPConfiguration.algorithmKeySize());
 
 			httpServletRequest.setAttribute(
-				MFATimeBasedOTPWebKeys.MFA_TIME_BASED_OTP_ALGORITHM, "SHA1");
+				MFATimeBasedOTPWebKeys.MFA_TIME_BASED_OTP_ALGORITHM,
+				PropsValues.FIPS_ENABLED ? "SHA256" : "SHA1");
 			httpServletRequest.setAttribute(
 				MFATimeBasedOTPWebKeys.
 					MFA_TIME_BASED_OTP_CHECKER_DISPLAY_CONTEXT,

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtil.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtil.java
@@ -9,6 +9,7 @@ import com.liferay.petra.io.BigEndianCodec;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.security.SecureRandomUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.math.BigInteger;
@@ -28,8 +29,6 @@ import jodd.util.Base32;
  * @author Marta Medio
  */
 public class MFATimeBasedOTPUtil {
-
-	public static final String MFA_TIMEBASED_OTP_ALGORITHM = "HmacSHA1";
 
 	public static final int MFA_TIMEBASED_OTP_COUNTER = 30 * 1000;
 
@@ -74,8 +73,10 @@ public class MFATimeBasedOTPUtil {
 	}
 
 	private static byte[] _generateHMAC(byte[] key, String text) {
+		String algorithm = PropsValues.FIPS_ENABLED ? "HmacSHA256" : "HmacSHA1";
+
 		try {
-			Mac mac = Mac.getInstance(MFA_TIMEBASED_OTP_ALGORITHM);
+			Mac mac = Mac.getInstance(algorithm);
 
 			mac.init(new SecretKeySpec(key, "RAW"));
 
@@ -88,14 +89,12 @@ public class MFATimeBasedOTPUtil {
 		}
 		catch (InvalidKeyException invalidKeyException) {
 			throw new IllegalArgumentException(
-				"Invalid secret key for algorithm " +
-					MFA_TIMEBASED_OTP_ALGORITHM,
+				"Invalid secret key for algorithm " + algorithm,
 				invalidKeyException);
 		}
 		catch (NoSuchAlgorithmException noSuchAlgorithmException) {
 			throw new IllegalArgumentException(
-				"Invalid algorithm " + MFA_TIMEBASED_OTP_ALGORITHM,
-				noSuchAlgorithmException);
+				"Invalid algorithm " + algorithm, noSuchAlgorithmException);
 		}
 	}
 

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/test/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtilTest.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/test/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/util/MFATimeBasedOTPUtilTest.java
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.multi.factor.authentication.timebased.otp.web.internal.util;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import javax.crypto.Mac;
+
+import jodd.util.Base32;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class MFATimeBasedOTPUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void test() throws Exception {
+		String sharedSecret = MFATimeBasedOTPUtil.generateSharedSecret(20);
+
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			"HmacSHA1", Mac.class, "HmacSHA256", Mac::getInstance,
+			() -> _generateCurrentOTP(sharedSecret));
+	}
+
+	private String _generateCurrentOTP(String sharedSecret) {
+		String timeCountHex = ReflectionTestUtil.invoke(
+			MFATimeBasedOTPUtil.class, "_getTimeCountHex",
+			new Class<?>[] {long.class},
+			System.currentTimeMillis() /
+				MFATimeBasedOTPUtil.MFA_TIMEBASED_OTP_COUNTER);
+
+		return ReflectionTestUtil.invoke(
+			MFATimeBasedOTPUtil.class, "_generateTimeBasedOTP",
+			new Class<?>[] {byte[].class, String.class},
+			Base32.decode(sharedSecret), timeCountHex);
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/events/CryptoStartupAction.java
+++ b/portal-impl/src/com/liferay/portal/events/CryptoStartupAction.java
@@ -8,6 +8,7 @@ package com.liferay.portal.events;
 import com.liferay.portal.kernel.events.SimpleAction;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 
 import java.security.NoSuchAlgorithmException;
 
@@ -20,12 +21,14 @@ public class CryptoStartupAction extends SimpleAction {
 
 	@Override
 	public void run(String[] ids) {
+		String algorithm = PropsValues.FIPS_ENABLED ? "HmacSHA256" : "HmacSHA1";
+
 		try {
-			Mac.getInstance("HmacSHA1");
+			Mac.getInstance(algorithm);
 		}
 		catch (NoSuchAlgorithmException noSuchAlgorithmException) {
 			_log.error(
-				"Unable to get Mac instance for algorithm HmacSHA1",
+				"Unable to get Mac instance for algorithm " + algorithm,
 				noSuchAlgorithmException);
 		}
 	}

--- a/portal-impl/test/unit/com/liferay/portal/security/auth/tunnel/TunnelAuthenticationManagerImplTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/security/auth/tunnel/TunnelAuthenticationManagerImplTest.java
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.auth.tunnel;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.security.Key;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class TunnelAuthenticationManagerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetSharedSecretKey() throws Exception {
+		try (SafeCloseable safeCloseable1 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", false);
+			SafeCloseable safeCloseable2 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"TUNNELING_SERVLET_ENCRYPTION_ALGORITHM", "Blowfish");
+			SafeCloseable safeCloseable3 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"TUNNELING_SERVLET_SHARED_SECRET", _SHARED_SECRET);
+			SafeCloseable safeCloseable4 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"TUNNELING_SERVLET_SHARED_SECRET_HEX", false)) {
+
+			Key key = _getSharedSecretKey();
+
+			Assert.assertEquals("Blowfish", key.getAlgorithm());
+		}
+
+		try (SafeCloseable safeCloseable1 =
+				PropsValuesTestUtil.swapWithSafeCloseable("FIPS_ENABLED", true);
+			SafeCloseable safeCloseable2 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"TUNNELING_SERVLET_SHARED_SECRET", _SHARED_SECRET);
+			SafeCloseable safeCloseable3 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"TUNNELING_SERVLET_SHARED_SECRET_HEX", false)) {
+
+			try (SafeCloseable safeCloseable4 =
+					PropsValuesTestUtil.swapWithSafeCloseable(
+						"TUNNELING_SERVLET_ENCRYPTION_ALGORITHM", "AES")) {
+
+				Key key = _getSharedSecretKey();
+
+				Assert.assertEquals("AES", key.getAlgorithm());
+			}
+		}
+	}
+
+	private Key _getSharedSecretKey() {
+		return ReflectionTestUtil.invoke(
+			new TunnelAuthenticationManagerImpl(), "getSharedSecretKey",
+			new Class<?>[0]);
+	}
+
+	private static final String _SHARED_SECRET = RandomTestUtil.randomString(
+		16);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/frontend/hashed/files/HashedFilesUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/frontend/hashed/files/HashedFilesUtil.java
@@ -9,6 +9,7 @@ import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.DigesterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 
 /**
@@ -52,7 +53,9 @@ public class HashedFilesUtil {
 	}
 
 	public static String computeHash(String content) {
-		byte[] hash = DigesterUtil.digestRaw(DigesterUtil.MD5, content);
+		byte[] hash = DigesterUtil.digestRaw(
+			PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 : DigesterUtil.MD5,
+			content);
 
 		byte[] truncatedHash = new byte[8];
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeValidator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeValidator.java
@@ -12,7 +12,9 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.lang.reflect.Method;
 
@@ -23,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -37,8 +40,37 @@ public class FIPSModeValidator {
 		_validateFIPSProvider(providers);
 		_validateProviders(providers);
 
-		_validatePasswordsEncryptionAlgorithm(
-			PropsUtil.get(PropsKeys.PASSWORDS_ENCRYPTION_ALGORITHM));
+		_validateProperties();
+	}
+
+	public static void validateAlgorithm(String algorithm) {
+		if (!PropsValues.FIPS_ENABLED) {
+			return;
+		}
+
+		if (Validator.isNotNull(algorithm)) {
+			for (String allowedAlgorithm : _allowedAlgorithms) {
+				if (StringUtil.startsWith(algorithm, allowedAlgorithm)) {
+					return;
+				}
+			}
+		}
+
+		throw new SecurityException(
+			"Algorithm \"" + algorithm + "\" is not allowed in FIPS mode");
+	}
+
+	public static void validateKey(String algorithm, int keySize) {
+		if (!PropsValues.FIPS_ENABLED) {
+			return;
+		}
+
+		validateAlgorithm(algorithm);
+
+		if ((keySize != 0) && !_allowedKeySizes.contains(keySize)) {
+			throw new SecurityException(
+				"AES key must be 128, 192, or 256 bits");
+		}
 	}
 
 	private static void _validateFIPSProvider(Provider[] providers) {
@@ -183,6 +215,18 @@ public class FIPSModeValidator {
 		}
 	}
 
+	private static void _validateProperties() {
+		if (GetterUtil.getBoolean(PropsUtil.get(PropsKeys.AUTH_MAC_ALLOW))) {
+			validateAlgorithm(PropsUtil.get(PropsKeys.AUTH_MAC_ALGORITHM));
+		}
+
+		validateAlgorithm(
+			PropsUtil.get(PropsKeys.COMPANY_ENCRYPTION_ALGORITHM));
+		validateAlgorithm(PropsValues.TUNNELING_SERVLET_ENCRYPTION_ALGORITHM);
+		_validatePasswordsEncryptionAlgorithm(
+			PropsUtil.get(PropsKeys.PASSWORDS_ENCRYPTION_ALGORITHM));
+	}
+
 	private static void _validateProviders(Provider[] providers) {
 		Provider provider = providers[0];
 
@@ -210,6 +254,11 @@ public class FIPSModeValidator {
 	private static final int _PASSWORDS_ENCRYPTION_ALGORITHM_ROUNDS_MIN =
 		1300000;
 
+	private static final Set<String> _allowedAlgorithms = Set.of(
+		"AES", "HmacSHA256", "HmacSHA384", "HmacSHA512", "PBKDF2WithHmacSHA256",
+		"PBKDF2WithHmacSHA384", "PBKDF2WithHmacSHA512", "SHA-256", "SHA-384",
+		"SHA-512");
+	private static final Set<Integer> _allowedKeySizes = Set.of(128, 192, 256);
 	private static final Map<String, List<String>> _allowedProviderNames =
 		Map.of(
 			"AmazonCorrettoCryptoProvider",

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/portal-kernel/src/com/liferay/portal/kernel/util/DigesterUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/DigesterUtil.java
@@ -29,8 +29,6 @@ import java.util.Objects;
  */
 public class DigesterUtil {
 
-	public static final String DEFAULT_ALGORITHM = "SHA";
-
 	public static final String ENCODING = StringPool.UTF8;
 
 	public static final String MD5 = "MD5";
@@ -42,15 +40,15 @@ public class DigesterUtil {
 	public static final String SHA_256 = "SHA-256";
 
 	public static String digest(ByteBuffer byteBuffer) {
-		return digest(DEFAULT_ALGORITHM, byteBuffer);
+		return digest(_getDefaultAlgorithm(), byteBuffer);
 	}
 
 	public static String digest(InputStream inputStream) {
-		return digest(DEFAULT_ALGORITHM, inputStream);
+		return digest(_getDefaultAlgorithm(), inputStream);
 	}
 
 	public static String digest(String text) {
-		return digest(DEFAULT_ALGORITHM, text);
+		return digest(_getDefaultAlgorithm(), text);
 	}
 
 	public static String digest(String algorithm, ByteBuffer byteBuffer) {
@@ -78,15 +76,15 @@ public class DigesterUtil {
 	}
 
 	public static String digestBase64(ByteBuffer byteBuffer) {
-		return digestBase64(DEFAULT_ALGORITHM, byteBuffer);
+		return digestBase64(_getDefaultAlgorithm(), byteBuffer);
 	}
 
 	public static String digestBase64(InputStream inputStream) {
-		return digestBase64(DEFAULT_ALGORITHM, inputStream);
+		return digestBase64(_getDefaultAlgorithm(), inputStream);
 	}
 
 	public static String digestBase64(String text) {
-		return digestBase64(DEFAULT_ALGORITHM, text);
+		return digestBase64(_getDefaultAlgorithm(), text);
 	}
 
 	public static String digestBase64(String algorithm, ByteBuffer byteBuffer) {
@@ -110,15 +108,15 @@ public class DigesterUtil {
 	}
 
 	public static String digestHex(ByteBuffer byteBuffer) {
-		return digestHex(DEFAULT_ALGORITHM, byteBuffer);
+		return digestHex(_getDefaultAlgorithm(), byteBuffer);
 	}
 
 	public static String digestHex(InputStream inputStream) {
-		return digestHex(DEFAULT_ALGORITHM, inputStream);
+		return digestHex(_getDefaultAlgorithm(), inputStream);
 	}
 
 	public static String digestHex(String text) {
-		return digestHex(DEFAULT_ALGORITHM, text);
+		return digestHex(_getDefaultAlgorithm(), text);
 	}
 
 	public static String digestHex(String algorithm, ByteBuffer byteBuffer) {
@@ -140,11 +138,11 @@ public class DigesterUtil {
 	}
 
 	public static byte[] digestRaw(ByteBuffer byteBuffer) {
-		return digestRaw(DEFAULT_ALGORITHM, byteBuffer);
+		return digestRaw(_getDefaultAlgorithm(), byteBuffer);
 	}
 
 	public static byte[] digestRaw(String text) {
-		return digestRaw(DEFAULT_ALGORITHM, text);
+		return digestRaw(_getDefaultAlgorithm(), text);
 	}
 
 	public static byte[] digestRaw(String algorithm, ByteBuffer byteBuffer) {
@@ -216,6 +214,14 @@ public class DigesterUtil {
 		}
 
 		return messageDigest.digest();
+	}
+
+	private static String _getDefaultAlgorithm() {
+		if (PropsValues.FIPS_ENABLED) {
+			return SHA_256;
+		}
+
+		return SHA;
 	}
 
 	private static final boolean _BASE_64 = Objects.equals(

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 98.3.0
+version 99.0.0

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSModeValidatorTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSModeValidatorTest.java
@@ -5,7 +5,9 @@
 
 package com.liferay.portal.kernel.security.fips;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 
 import java.security.Provider;
@@ -21,6 +23,33 @@ import org.junit.function.ThrowingRunnable;
  * @author Caio Farias
  */
 public class FIPSModeValidatorTest {
+
+	@Test
+	public void testValidateAlgorithm() {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", false)) {
+
+			for (String algorithm : new String[] {"MD5", null}) {
+				FIPSModeValidator.validateAlgorithm(algorithm);
+			}
+		}
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			for (String algorithm : new String[] {"AES", "SHA-256"}) {
+				FIPSModeValidator.validateAlgorithm(algorithm);
+			}
+
+			for (String algorithm : new String[] {"MD5", "SHA-2", null}) {
+				_assertSecurityException(
+					"is not allowed in FIPS mode",
+					() -> FIPSModeValidator.validateAlgorithm(algorithm));
+			}
+		}
+	}
 
 	@Test
 	public void testValidateFIPSProvider() {
@@ -46,6 +75,32 @@ public class FIPSModeValidatorTest {
 			() -> ReflectionTestUtil.invoke(
 				FIPSModeValidator.class, "_validateFIPSProvider",
 				new Class<?>[] {Provider[].class}, (Object)new Provider[0]));
+	}
+
+	@Test
+	public void testValidateKey() {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", false)) {
+
+			FIPSModeValidator.validateKey("DES", 64);
+		}
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			for (int keySize : List.of(128, 192, 256)) {
+				FIPSModeValidator.validateKey("AES", keySize);
+			}
+
+			_assertSecurityException(
+				"AES key must be 128, 192, or 256 bits",
+				() -> FIPSModeValidator.validateKey("AES", 64));
+			_assertSecurityException(
+				"is not allowed in FIPS mode",
+				() -> FIPSModeValidator.validateKey("DES", 128));
+		}
 	}
 
 	@Test

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/util/DigesterUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/util/DigesterUtilTest.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.util;
+
+import com.liferay.portal.kernel.test.util.FIPSAlgorithmTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+
+import java.security.MessageDigest;
+
+import org.junit.Test;
+
+/**
+ * @author Lucas Miranda
+ */
+public class DigesterUtilTest {
+
+	@Test
+	public void test() throws Exception {
+		FIPSAlgorithmTestUtil.assertAlgorithmSwitch(
+			DigesterUtil.SHA, MessageDigest.class, DigesterUtil.SHA_256,
+			MessageDigest::getInstance,
+			() -> DigesterUtil.digestHex(RandomTestUtil.randomString()));
+	}
+
+}

--- a/portal-test/src/com/liferay/portal/kernel/test/util/FIPSAlgorithmTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/FIPSAlgorithmTestUtil.java
@@ -1,0 +1,53 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.test.util;
+
+import com.liferay.petra.function.UnsafeConsumer;
+import com.liferay.petra.function.UnsafeRunnable;
+import com.liferay.petra.lang.SafeCloseable;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Lucas Miranda
+ */
+public class FIPSAlgorithmTestUtil {
+
+	public static <T> void assertAlgorithmSwitch(
+			String algorithm, Class<T> classToMock, String fipsAlgorithm,
+			UnsafeConsumer<String, Exception> unsafeConsumer,
+			UnsafeRunnable<Exception> unsafeRunnable)
+		throws Exception {
+
+		try (MockedStatic<T> mockedStatic = Mockito.mockStatic(
+				classToMock, Mockito.CALLS_REAL_METHODS)) {
+
+			unsafeRunnable.run();
+
+			mockedStatic.verify(
+				() -> unsafeConsumer.accept(algorithm), Mockito.atLeastOnce());
+			mockedStatic.verify(
+				() -> unsafeConsumer.accept(fipsAlgorithm), Mockito.never());
+		}
+
+		try (MockedStatic<T> mockedStatic = Mockito.mockStatic(
+				classToMock, Mockito.CALLS_REAL_METHODS);
+			SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			unsafeRunnable.run();
+
+			mockedStatic.verify(
+				() -> unsafeConsumer.accept(algorithm), Mockito.never());
+			mockedStatic.verify(
+				() -> unsafeConsumer.accept(fipsAlgorithm),
+				Mockito.atLeastOnce());
+		}
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-90288

## Why

Under FIPS mode the portal still selected non-approved algorithms (DSA signatures, MD5/SHA-1 digests, non-AES ciphers), which FIPS 140 disallows. This enforces FIPS-approved algorithm selection across the affected subsystems (LPD-90288) and replaces MD5/SHA-1 with SHA-2 where digests are used (LPD-90290).

## Key changes

- Add FIPSModeValidator/FIPSModeUtil allow-list guards that reject non-approved key and MAC algorithms under FIPS.
- Route encryption through the FIPS-approved GCM cipher and validate key algorithm and size before ciphering.
- Switch signature, digest, and HMAC selection to FIPS-approved variants under FIPS (analytics signature, tunnel auth, password encryptor, MFA OTP, OAuth/OIDC well-known URIs).
- Add FIPSAlgorithmTestUtil-based tests covering each algorithm switch.