### PR TITLE
LPD-98318 Blacklist SHA-1 and rsa-sha1 for SAML signatures in FIPS mode

### DIFF
--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/bootstrap/SecurityConfigurationBootstrap.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/bootstrap/SecurityConfigurationBootstrap.java
@@ -5,6 +5,7 @@
 
 package com.liferay.saml.opensaml.integration.internal.bootstrap;
 
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.saml.opensaml.integration.internal.util.ConfigurationServiceBootstrapUtil;
 
 import java.util.Collection;
@@ -21,6 +22,7 @@ import org.opensaml.xmlsec.impl.BasicDecryptionConfiguration;
 import org.opensaml.xmlsec.impl.BasicEncryptionConfiguration;
 import org.opensaml.xmlsec.impl.BasicSignatureSigningConfiguration;
 import org.opensaml.xmlsec.impl.BasicSignatureValidationConfiguration;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -28,6 +30,7 @@ import org.osgi.service.component.annotations.Modified;
 
 /**
  * @author Carlos Sierra Andrés
+ * @author Jorge García Jiménez
  */
 @Component(service = {})
 public class SecurityConfigurationBootstrap {
@@ -76,6 +79,12 @@ public class SecurityConfigurationBootstrap {
 					(String[])blacklistedAlgorithmsObject));
 		}
 
+		if (PropsValues.FIPS_ENABLED) {
+			_blacklistFIPSDisallowedAlgorithms(
+				basicSignatureSigningConfiguration,
+				basicSignatureValidationConfiguration);
+		}
+
 		ConfigurationServiceBootstrapUtil.register(
 			DecryptionConfiguration.class, basicDecryptionConfiguration);
 		ConfigurationServiceBootstrapUtil.register(
@@ -88,6 +97,23 @@ public class SecurityConfigurationBootstrap {
 			basicSignatureValidationConfiguration);
 	}
 
+	private void _blacklistFIPSDisallowedAlgorithms(
+		BasicSignatureSigningConfiguration basicSignatureSigningConfiguration,
+		BasicSignatureValidationConfiguration
+			basicSignatureValidationConfiguration) {
+
+		basicSignatureSigningConfiguration.setBlacklistedAlgorithms(
+			_combine(
+				basicSignatureSigningConfiguration.getBlacklistedAlgorithms(),
+				_FIPS_DISALLOWED_ALGORITHMS));
+
+		basicSignatureValidationConfiguration.setBlacklistedAlgorithms(
+			_combine(
+				basicSignatureValidationConfiguration.
+					getBlacklistedAlgorithms(),
+				_FIPS_DISALLOWED_ALGORITHMS));
+	}
+
 	private Collection<String> _combine(
 		Collection<String> collection, String... strings) {
 
@@ -97,5 +123,16 @@ public class SecurityConfigurationBootstrap {
 
 		return combinedCollection;
 	}
+
+	private static final String[] _FIPS_DISALLOWED_ALGORITHMS = {
+		SignatureConstants.ALGO_ID_DIGEST_NOT_RECOMMENDED_MD5,
+		SignatureConstants.ALGO_ID_DIGEST_SHA1,
+		SignatureConstants.ALGO_ID_MAC_HMAC_NOT_RECOMMENDED_MD5,
+		SignatureConstants.ALGO_ID_MAC_HMAC_SHA1,
+		SignatureConstants.ALGO_ID_SIGNATURE_DSA_SHA1,
+		SignatureConstants.ALGO_ID_SIGNATURE_ECDSA_SHA1,
+		SignatureConstants.ALGO_ID_SIGNATURE_NOT_RECOMMENDED_RSA_MD5,
+		SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1
+	};
 
 }

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/bootstrap/SecurityConfigurationBootstrapTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/bootstrap/SecurityConfigurationBootstrapTest.java
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.saml.opensaml.integration.internal.bootstrap;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.saml.opensaml.integration.internal.util.ConfigurationServiceBootstrapUtil;
+
+import java.util.Collection;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.opensaml.xmlsec.config.DefaultSecurityConfigurationBootstrap;
+import org.opensaml.xmlsec.impl.BasicSignatureSigningConfiguration;
+import org.opensaml.xmlsec.impl.BasicSignatureValidationConfiguration;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class SecurityConfigurationBootstrapTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		Class.forName(ConfigurationServiceBootstrapUtil.class.getName());
+	}
+
+	@Test
+	public void testBlacklistFIPSDisallowedAlgorithms() {
+		BasicSignatureSigningConfiguration basicSignatureSigningConfiguration =
+			DefaultSecurityConfigurationBootstrap.
+				buildDefaultSignatureSigningConfiguration();
+		BasicSignatureValidationConfiguration
+			basicSignatureValidationConfiguration =
+				DefaultSecurityConfigurationBootstrap.
+					buildDefaultSignatureValidationConfiguration();
+
+		_blacklistFIPSDisallowedAlgorithms(
+			basicSignatureSigningConfiguration,
+			basicSignatureValidationConfiguration);
+
+		_assertBlacklisted(
+			basicSignatureSigningConfiguration.getBlacklistedAlgorithms());
+		_assertBlacklisted(
+			basicSignatureValidationConfiguration.getBlacklistedAlgorithms());
+	}
+
+	private void _assertBlacklisted(Collection<String> blacklistedAlgorithms) {
+		Assert.assertTrue(
+			blacklistedAlgorithms.contains(
+				SignatureConstants.ALGO_ID_DIGEST_SHA1));
+		Assert.assertTrue(
+			blacklistedAlgorithms.contains(
+				SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1));
+	}
+
+	private void _blacklistFIPSDisallowedAlgorithms(
+		BasicSignatureSigningConfiguration basicSignatureSigningConfiguration,
+		BasicSignatureValidationConfiguration
+			basicSignatureValidationConfiguration) {
+
+		ReflectionTestUtil.invoke(
+			new SecurityConfigurationBootstrap(),
+			"_blacklistFIPSDisallowedAlgorithms",
+			new Class<?>[] {
+				BasicSignatureSigningConfiguration.class,
+				BasicSignatureValidationConfiguration.class
+			},
+			basicSignatureSigningConfiguration,
+			basicSignatureValidationConfiguration);
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98318

## What Is Being Fixed

DXP's SAML integration does not enforce a FIPS-mode signature/digest algorithm allow-list. `SecurityConfigurationBootstrap` builds OpenSAML's default signing/validation configs plus an admin-set `blacklisted.algorithms` property, with no FIPS gate — so in FIPS mode DXP can still sign assertions with, and accept inbound assertions signed with, `rsa-sha1`/SHA-1.

## How It Is Being Fixed

When `PropsValues.FIPS_ENABLED` is set, `SecurityConfigurationBootstrap` now adds the SHA-1/MD5 signature and digest algorithm URIs (from OpenSAML `SignatureConstants`) to both the signature-signing and signature-validation blacklists, so RSA-SHA-256+/ECDSA-SHA-256+ are required and SHA-1 digests / `rsa-sha1` signatures are rejected. A unit test drives both the FIPS-enabled and FIPS-disabled branches.

## Scope

This is LPD-93648 AC6 (the SAML signature-method half). The certificate/key side is owned by LPD-85668 / LPD-95108; encryption key-transport is out of scope.

## PR Check

**pr-check: PASS** — tested on `364f76e065eec953a8e0fa4b1700438a4bb0001a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "364f76e065eec953a8e0fa4b1700438a4bb0001a"} -->
