### PR TITLE
LPD-98315 Harden the FIPS JWS algorithm and JWK key-type allow-list

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/util/OAuth2JWKValidatorUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/util/OAuth2JWKValidatorUtil.java
@@ -122,23 +122,11 @@ public class OAuth2JWKValidatorUtil {
 						" bits is not allowed in FIPS mode"));
 			}
 		}
-		else if (keyType.equals("oct")) {
-			int bits = _decodeBase64URLBitLength(jsonObject.getString("k"));
-
-			if (bits < _MIN_HMAC_KEY_BITS) {
-				throw new SecurityException(
-					StringBundler.concat(
-						"HMAC key of ", bits,
-						" bits is not allowed in FIPS mode"));
-			}
-		}
 		else {
 			throw new SecurityException(
 				"JWK key type \"" + keyType + "\" is not allowed in FIPS mode");
 		}
 	}
-
-	private static final int _MIN_HMAC_KEY_BITS = 112;
 
 	private static final int _MIN_RSA_KEY_BITS = 2048;
 
@@ -148,7 +136,7 @@ public class OAuth2JWKValidatorUtil {
 	private static final Set<String> _allowedECCurves = Set.of(
 		"P-256", "P-384", "P-521");
 	private static final Set<String> _allowedJWSAlgorithms = Set.of(
-		"ES256", "ES384", "ES512", "HS256", "HS384", "HS512", "PS256", "PS384",
-		"PS512", "RS256", "RS384", "RS512");
+		"ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "RS256", "RS384",
+		"RS512");
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/util/OAuth2JWKValidatorUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/util/OAuth2JWKValidatorUtil.java
@@ -112,6 +112,14 @@ public class OAuth2JWKValidatorUtil {
 					"EC curve \"" + curve + "\" is not allowed in FIPS mode");
 			}
 		}
+		else if (keyType.equals("OKP")) {
+			String curve = jsonObject.getString("crv");
+
+			if (!_allowedOKPCurves.contains(curve)) {
+				throw new SecurityException(
+					"OKP curve \"" + curve + "\" is not allowed in FIPS mode");
+			}
+		}
 		else if (keyType.equals("RSA")) {
 			int bits = _decodeBase64URLBitLength(jsonObject.getString("n"));
 
@@ -136,7 +144,9 @@ public class OAuth2JWKValidatorUtil {
 	private static final Set<String> _allowedECCurves = Set.of(
 		"P-256", "P-384", "P-521");
 	private static final Set<String> _allowedJWSAlgorithms = Set.of(
-		"ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "RS256", "RS384",
-		"RS512");
+		"ES256", "ES384", "ES512", "EdDSA", "PS256", "PS384", "PS512", "RS256",
+		"RS384", "RS512");
+	private static final Set<String> _allowedOKPCurves = Set.of(
+		"Ed25519", "Ed448");
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/test/java/com/liferay/oauth2/provider/util/OAuth2JWKValidatorUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/test/java/com/liferay/oauth2/provider/util/OAuth2JWKValidatorUtilTest.java
@@ -104,27 +104,30 @@ public class OAuth2JWKValidatorUtilTest {
 	}
 
 	@Test
+	public void testValidateJWKWithOKPKey() {
+		OAuth2JWKValidatorUtil.validateJWK(_generateOKPJWK("EdDSA", "Ed25519"));
+		OAuth2JWKValidatorUtil.validateJWK(_generateOKPJWK("EdDSA", "Ed448"));
+
+		Assert.assertThrows(
+			SecurityException.class,
+			() -> OAuth2JWKValidatorUtil.validateJWK(
+				_generateOKPJWK("EdDSA", "X25519")));
+	}
+
+	@Test
 	public void testValidateJWKWithUnsupportedKeyType() {
-		for (String keyType : new String[] {"OKP", "oct"}) {
-			Assert.assertThrows(
-				SecurityException.class,
-				() -> OAuth2JWKValidatorUtil.validateJWK(
-					JSONUtil.put(
-						"alg", "RS256"
-					).put(
-						"kty", keyType
-					).toString()));
-		}
+		_testValidateJWKWithUnsupportedKeyType("oct");
+		_testValidateJWKWithUnsupportedKeyType(RandomTestUtil.randomString());
 	}
 
 	@Test
 	public void testValidateJWSAlgorithm() {
 		_testValidateJWSAlgorithm(
-			false, null, StringPool.BLANK, "ES256K", "EdDSA", "HS1", "HS256",
-			"HS384", "HS512", "RS1", "RSA1_5", "garbage", "none", "rs256");
+			false, null, StringPool.BLANK, "ES256K", "HS1", "HS256", "HS384",
+			"HS512", "RS1", "RSA1_5", "garbage", "none", "rs256");
 		_testValidateJWSAlgorithm(
-			true, "ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "RS256",
-			"RS384", "RS512");
+			true, "ES256", "ES384", "ES512", "EdDSA", "PS256", "PS384", "PS512",
+			"RS256", "RS384", "RS512");
 	}
 
 	private String _generateECJWK(String algorithm, String curve) {
@@ -136,6 +139,18 @@ public class OAuth2JWKValidatorUtilTest {
 			"kid", RandomTestUtil.randomString()
 		).put(
 			"kty", "EC"
+		).toString();
+	}
+
+	private String _generateOKPJWK(String algorithm, String curve) {
+		return JSONUtil.put(
+			"alg", algorithm
+		).put(
+			"crv", curve
+		).put(
+			"kid", RandomTestUtil.randomString()
+		).put(
+			"kty", "OKP"
 		).toString();
 	}
 
@@ -183,6 +198,17 @@ public class OAuth2JWKValidatorUtilTest {
 				return encoder.encodeToString(modulus.toByteArray());
 			}
 		).toString();
+	}
+
+	private void _testValidateJWKWithUnsupportedKeyType(String keyType) {
+		Assert.assertThrows(
+			SecurityException.class,
+			() -> OAuth2JWKValidatorUtil.validateJWK(
+				JSONUtil.put(
+					"alg", "RS256"
+				).put(
+					"kty", keyType
+				).toString()));
 	}
 
 	private void _testValidateJWSAlgorithm(

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/test/java/com/liferay/oauth2/provider/util/OAuth2JWKValidatorUtilTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/test/java/com/liferay/oauth2/provider/util/OAuth2JWKValidatorUtilTest.java
@@ -104,25 +104,27 @@ public class OAuth2JWKValidatorUtilTest {
 	}
 
 	@Test
-	public void testValidateJWKWithUnknownKeyType() {
-		Assert.assertThrows(
-			SecurityException.class,
-			() -> OAuth2JWKValidatorUtil.validateJWK(
-				JSONUtil.put(
-					"alg", "RS256"
-				).put(
-					"kty", "OKP"
-				).toString()));
+	public void testValidateJWKWithUnsupportedKeyType() {
+		for (String keyType : new String[] {"OKP", "oct"}) {
+			Assert.assertThrows(
+				SecurityException.class,
+				() -> OAuth2JWKValidatorUtil.validateJWK(
+					JSONUtil.put(
+						"alg", "RS256"
+					).put(
+						"kty", keyType
+					).toString()));
+		}
 	}
 
 	@Test
 	public void testValidateJWSAlgorithm() {
 		_testValidateJWSAlgorithm(
-			false, null, StringPool.BLANK, "ES256K", "EdDSA", "HS1", "RS1",
-			"RSA1_5", "garbage", "none", "rs256");
+			false, null, StringPool.BLANK, "ES256K", "EdDSA", "HS1", "HS256",
+			"HS384", "HS512", "RS1", "RSA1_5", "garbage", "none", "rs256");
 		_testValidateJWSAlgorithm(
-			true, "ES256", "ES384", "ES512", "HS256", "HS384", "HS512", "PS256",
-			"PS384", "PS512", "RS256", "RS384", "RS512");
+			true, "ES256", "ES384", "ES512", "PS256", "PS384", "PS512", "RS256",
+			"RS384", "RS512");
 	}
 
 	private String _generateECJWK(String algorithm, String curve) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98315
https://liferay.atlassian.net/browse/LPD-98433

## What Is Being Fixed

The FIPS JWS/JWK allow-list in `OAuth2JWKValidatorUtil` permitted HMAC algorithms (`HS256`/`HS384`/`HS512`) and the `oct` symmetric key type — the "HS256-with-shared-secret-from-config" case FIPS disallows (in this module the only HMAC source is a shared secret configured on the OAuth2 client) — while omitting `EdDSA`, which FIPS 186-5 approves.

## How It Is Being Fixed

**LPD-98315** — `validateJWSAlgorithm` no longer accepts `HS256`/`HS384`/`HS512`, and `_validateJWK` no longer accepts the `oct` key type (the now-unused HMAC key-size floor is removed). `none` and RSA keys under 2048 bits were already rejected.

**LPD-98433** — `EdDSA` is added to the JWS allow-list, and `_validateJWK` accepts the `OKP` key type with the `Ed25519` and `Ed448` signing curves (rejecting the `X25519`/`X448` key-agreement curves). The downstream verifier (Apache CXF JOSE, `JwsUtils.getSignatureVerifier`) supports EdDSA at the API level since CXF 3.4.0 (this branch is on 3.6.11); end-to-end EdDSA verification in FIPS mode depends on the BCFIPS provider and is validated in the FIPS CI environment (LPD-80674).

Net result: only asymmetric signature algorithms (`RS`/`PS`/`ES` 256/384/512 and `EdDSA`) remain allowed. Unit tests cover the allowed/rejected JWS algorithms and the EC / OKP / RSA / unsupported key types.

## PR Check

**pr-check: PASS** — tested on `12eb18acf539cf611987eefaf955f90251b5ce54`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "12eb18acf539cf611987eefaf955f90251b5ce54"} -->
