### PR TITLE
LPD-98474 Allow HTTP in the MCP Server OAuth flow when in test mode

### DIFF
--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerServletTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerServletTest.java
@@ -10,7 +10,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.mcp.server.rest.test.util.MCPServerTestUtil;
 import com.liferay.oauth.client.persistence.model.OAuthClientASLocalMetadata;
+import com.liferay.oauth.client.persistence.model.OAuthClientPRLocalMetadata;
 import com.liferay.oauth.client.persistence.service.OAuthClientASLocalMetadataLocalService;
+import com.liferay.oauth.client.persistence.service.OAuthClientPRLocalMetadataLocalService;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
 import com.liferay.object.constants.ObjectEntryFolderConstants;
@@ -326,6 +328,23 @@ public class MCPServerServletTest {
 			new String[] {"everything"}, new String[] {"public"},
 			portalURL + "/o/oauth2/token", null);
 
+		String mcpResourceURI = _getMCPURL();
+
+		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata =
+			_oAuthClientPRLocalMetadataLocalService.
+				fetchOAuthClientPRLocalMetadata(
+					TestPropsValues.getCompanyId(), mcpResourceURI);
+
+		if (oAuthClientPRLocalMetadata != null) {
+			_oAuthClientPRLocalMetadataLocalService.
+				deleteOAuthClientPRLocalMetadata(oAuthClientPRLocalMetadata);
+		}
+
+		_oAuthClientPRLocalMetadataLocalService.addOAuthClientPRLocalMetadata(
+			RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+			new String[] {portalURL}, new String[] {"header"}, true,
+			mcpResourceURI, "Liferay MCP Server", new String[] {"everything"});
+
 		Http.Options options = new Http.Options();
 
 		options.setFollowRedirects(false);
@@ -343,7 +362,9 @@ public class MCPServerServletTest {
 		Assert.assertTrue(matcher.find());
 
 		JSONObject protectedResourceMetadataJSONObject =
-			JSONFactoryUtil.createJSONObject(_get(matcher.group(1)));
+			JSONFactoryUtil.createJSONObject(
+				_get(
+					portalURL + "/.well-known/oauth-protected-resource/o/mcp"));
 
 		String authorizationServerURL = JSONUtil.getValueAsString(
 			protectedResourceMetadataJSONObject,
@@ -1063,6 +1084,10 @@ public class MCPServerServletTest {
 	@Inject
 	private OAuthClientASLocalMetadataLocalService
 		_oAuthClientASLocalMetadataLocalService;
+
+	@Inject
+	private OAuthClientPRLocalMetadataLocalService
+		_oAuthClientPRLocalMetadataLocalService;
 
 	@Inject
 	private ObjectDefinitionLocalService _objectDefinitionLocalService;

--- a/modules/apps/oauth-client/oauth-client-admin-web/src/main/java/com/liferay/oauth/client/admin/web/internal/servlet/OAuth2WellKnownAuthorizationServerServlet.java
+++ b/modules/apps/oauth-client/oauth-client-admin-web/src/main/java/com/liferay/oauth/client/admin/web/internal/servlet/OAuth2WellKnownAuthorizationServerServlet.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -94,10 +95,15 @@ public class OAuth2WellKnownAuthorizationServerServlet extends HttpServlet {
 				_log.debug("Issuer is not null");
 			}
 
+			String scheme = Http.HTTPS_WITH_SLASH;
+
+			if (PortalRunMode.isTestMode() && !httpServletRequest.isSecure()) {
+				scheme = Http.HTTP_WITH_SLASH;
+			}
+
 			OAuthClientASLocalMetadata oAuthClientASLocalMetadata =
 				_oAuthClientASLocalMetadataLocalService.
-					fetchOAuthClientASLocalMetadata(
-						companyId, Http.HTTPS_WITH_SLASH + issuer);
+					fetchOAuthClientASLocalMetadata(companyId, scheme + issuer);
 
 			if ((oAuthClientASLocalMetadata != null) &&
 				oAuthClientASLocalMetadata.isLocalWellKnownEnabled()) {

--- a/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientASLocalMetadataLocalServiceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientASLocalMetadataLocalServiceImpl.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.util.Base64;
 import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -634,7 +635,9 @@ public class OAuthClientASLocalMetadataLocalServiceImpl
 		try {
 			URL url = new URL(urlString);
 
-			if (!Http.HTTPS.equalsIgnoreCase(url.getProtocol())) {
+			if (!Http.HTTPS.equalsIgnoreCase(url.getProtocol()) &&
+				!PortalRunMode.isTestMode()) {
+
 				throw new OAuthClientASLocalMetadataLocalWellKnownURIException(
 					urlString);
 			}

--- a/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientPRLocalMetadataLocalServiceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientPRLocalMetadataLocalServiceImpl.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.PortalRunMode;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.net.URI;
@@ -450,23 +451,16 @@ public class OAuthClientPRLocalMetadataLocalServiceImpl
 
 			String scheme = uri.getScheme();
 
-			if (!Http.HTTP.equalsIgnoreCase(scheme) &&
-				!Http.HTTPS.equalsIgnoreCase(scheme)) {
+			if (Validator.isNull(uri.getHost()) ||
+				(!Http.HTTP.equalsIgnoreCase(scheme) &&
+				 !Http.HTTPS.equalsIgnoreCase(scheme))) {
 
-				throw clazz.newInstance();
-			}
-
-			String host = uri.getHost();
-
-			if (Validator.isNull(host)) {
 				throw clazz.newInstance();
 			}
 
 			if (Validator.isNotNull(uri.getFragment()) ||
 				(!Http.HTTPS.equalsIgnoreCase(scheme) &&
-				 !Objects.equals(host, "127.0.0.1") &&
-				 !Objects.equals(host, "[::1]") &&
-				 !Objects.equals(host, "localhost"))) {
+				 !PortalRunMode.isTestMode())) {
 
 				throw clazz.newInstance();
 			}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98474

## What Is Being Fixed

The MCP Server OAuth 2 flow enforces the HTTPS scheme across its metadata and registration surface: the OAuth client authorization server (AS) and protected resource (PR) local metadata validation, the well-known authorization server servlet, and the JWKS URI check during dynamic client registration all reject non-HTTPS URLs. Integration tests exercise the portal over HTTP on localhost, so the complete flow could not be driven end to end against the running bundle.

## How It Is Being Fixed

The HTTPS-only checks now also accept HTTP when the portal runs in test mode, keeping HTTPS as the only allowed scheme otherwise, so production behavior is unchanged. The MCP Server servlet integration test was updated to drive the flow over HTTP: it registers and consumes the protected resource local metadata and registers a client with a JWKS URI over HTTP, exercising the validation paths that are relaxed under test mode.

## PR Check

**pr-check: PASS** — tested on `8a0ad4077e1b0c700557ec6c0f1ba57768056305`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "8a0ad4077e1b0c700557ec6c0f1ba57768056305"} -->
