### PR TITLE
LPD-98531 Include the offending URL in the invalid HTTPS resource error

### DIFF
--- a/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientPRLocalMetadataLocalServiceImpl.java
+++ b/modules/apps/oauth-client/oauth-client-persistence-service/src/main/java/com/liferay/oauth/client/persistence/service/impl/OAuthClientPRLocalMetadataLocalServiceImpl.java
@@ -18,6 +18,8 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.User;
@@ -29,6 +31,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 
 import java.util.List;
 import java.util.Objects;
@@ -77,9 +80,10 @@ public class OAuthClientPRLocalMetadataLocalServiceImpl
 			throw new OAuthClientPRLocalMetadataProtectedResourceURIException();
 		}
 
-		_validateURL(
-			OAuthClientPRLocalMetadataProtectedResourceURIException.class,
-			protectedResourceURI);
+		if (!_isValidURL(protectedResourceURI)) {
+			throw new OAuthClientPRLocalMetadataProtectedResourceURIException(
+				protectedResourceURI);
+		}
 
 		protectedResourceURI = _removeTrailingSlash(protectedResourceURI);
 
@@ -271,16 +275,17 @@ public class OAuthClientPRLocalMetadataLocalServiceImpl
 			throw new OAuthClientPRLocalMetadataProtectedResourceURIException();
 		}
 
+		if (!_isValidURL(protectedResourceURI)) {
+			throw new OAuthClientPRLocalMetadataProtectedResourceURIException(
+				protectedResourceURI);
+		}
+
 		OAuthClientPRLocalMetadata oAuthClientPRLocalMetadata =
 			oAuthClientPRLocalMetadataLocalService.
 				getOAuthClientPRLocalMetadata(oAuthClientPRLocalMetadataId);
 
 		String localWellKnownURI =
 			oAuthClientPRLocalMetadata.getLocalWellKnownURI();
-
-		_validateURL(
-			OAuthClientPRLocalMetadataProtectedResourceURIException.class,
-			protectedResourceURI);
 
 		protectedResourceURI = _removeTrailingSlash(protectedResourceURI);
 
@@ -367,6 +372,48 @@ public class OAuthClientPRLocalMetadataLocalServiceImpl
 		}
 	}
 
+	private boolean _isValidURL(String urlString) {
+		if (Validator.isNull(urlString)) {
+			return true;
+		}
+
+		try {
+			URI uri = new URI(urlString);
+
+			String scheme = uri.getScheme();
+
+			if (!Http.HTTP.equalsIgnoreCase(scheme) &&
+				!Http.HTTPS.equalsIgnoreCase(scheme)) {
+
+				return false;
+			}
+
+			String host = uri.getHost();
+
+			if (Validator.isNull(host)) {
+				return false;
+			}
+
+			if (Validator.isNotNull(uri.getFragment()) ||
+				(!Http.HTTPS.equalsIgnoreCase(scheme) &&
+				 !Objects.equals(host, "127.0.0.1") &&
+				 !Objects.equals(host, "[::1]") &&
+				 !Objects.equals(host, "localhost"))) {
+
+				return false;
+			}
+		}
+		catch (URISyntaxException uriSyntaxException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(uriSyntaxException);
+			}
+
+			return false;
+		}
+
+		return true;
+	}
+
 	private String _removeTrailingSlash(String urlString) {
 		if ((urlString == null) || !urlString.endsWith(StringPool.SLASH)) {
 			return urlString;
@@ -400,9 +447,10 @@ public class OAuthClientPRLocalMetadataLocalServiceImpl
 		}
 
 		for (String authorizationServer : authorizationServers) {
-			_validateURL(
-				OAuthClientPRLocalMetadataMetadataJSONException.class,
-				authorizationServer);
+			if (!_isValidURL(authorizationServer)) {
+				throw new OAuthClientPRLocalMetadataMetadataJSONException(
+					authorizationServer);
+			}
 		}
 
 		if (ArrayUtil.isEmpty(bearerMethodsSupported)) {
@@ -437,47 +485,8 @@ public class OAuthClientPRLocalMetadataLocalServiceImpl
 		}
 	}
 
-	private void _validateURL(
-			Class<? extends PortalException> clazz, String urlString)
-		throws PortalException {
-
-		if (Validator.isNull(urlString)) {
-			return;
-		}
-
-		try {
-			URI uri = new URI(urlString);
-
-			String scheme = uri.getScheme();
-
-			if (!Http.HTTP.equalsIgnoreCase(scheme) &&
-				!Http.HTTPS.equalsIgnoreCase(scheme)) {
-
-				throw clazz.newInstance();
-			}
-
-			String host = uri.getHost();
-
-			if (Validator.isNull(host)) {
-				throw clazz.newInstance();
-			}
-
-			if (Validator.isNotNull(uri.getFragment()) ||
-				(!Http.HTTPS.equalsIgnoreCase(scheme) &&
-				 !Objects.equals(host, "127.0.0.1") &&
-				 !Objects.equals(host, "[::1]") &&
-				 !Objects.equals(host, "localhost"))) {
-
-				throw clazz.newInstance();
-			}
-		}
-		catch (PortalException portalException) {
-			throw portalException;
-		}
-		catch (Exception exception) {
-			throw new PortalException(exception);
-		}
-	}
+	private static final Log _log = LogFactoryUtil.getLog(
+		OAuthClientPRLocalMetadataLocalServiceImpl.class);
 
 	@Reference
 	private JSONFactory _jsonFactory;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98531

## What Is Being Fixed

When saving an OAuth Protected Resource Local Metadata entry with a non-HTTPS
Resource URL, the validation error was shown with an unresolved `{0}`
placeholder (`Invalid HTTPS Resource URL: {0}`) instead of the offending URL,
so the user could not tell which value was rejected. The same applied to the
Authorization Servers field.

## How It Is Being Fixed

The URL validation in `OAuthClientPRLocalMetadataLocalServiceImpl` threw its
exceptions through a reflective `Class.newInstance()` helper, which always used
the no-argument constructor and left the message empty, so the JSP had nothing
to interpolate into the `{0}` placeholder. The reflective helper is replaced by
a plain `_isValidURL` boolean check, and each call site now throws the specific
exception with the offending URL as its message. This mirrors the pattern
already used by the sibling Authorization Server metadata service.

## Why Are There No Tests?

The rendered message is already covered end-to-end by the existing Playwright
test tagged `@LPD-91289` (`oauthClientAdministration.spec.ts`), which asserts
the full text `Invalid HTTPS Resource URL: http://example.com/o/mcp`.
Message-content assertions have no precedent at the integration/action layer in
this area, where tests assert only the exception type, so no new test is added.

The test this pr solves is 
tests/oauth-client-administration/main/oauthClientAdministration.spec.ts "Create an oauth-protected-resource and validate"


## PR Check

**pr-check: PASS** — tested on `822b8f16acca43c449eb44875394083cfb3c6e2f`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "822b8f16acca43c449eb44875394083cfb3c6e2f"} -->
