### PR TITLE
LPD-98489 Reject plaintext secrets in portal-ext at FIPS activation

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeValidator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeValidator.java
@@ -10,21 +10,28 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.io.IOException;
+
 import java.lang.reflect.Method;
+
+import java.net.URL;
 
 import java.security.Provider;
 import java.security.Security;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -71,6 +78,30 @@ public class FIPSModeValidator {
 			throw new SecurityException(
 				"AES key must be 128, 192, or 256 bits");
 		}
+	}
+
+	private static List<String> _getPlaintextSecretProperties(
+		Properties properties) {
+
+		List<String> plaintextSecretProperties = new ArrayList<>();
+
+		for (String key : PropsValues.ADMIN_OBFUSCATED_PROPERTIES) {
+			String value = properties.getProperty(key);
+
+			if (Validator.isNull(value)) {
+				continue;
+			}
+
+			value = value.trim();
+
+			if (value.startsWith("${") && value.endsWith("}")) {
+				continue;
+			}
+
+			plaintextSecretProperties.add(key);
+		}
+
+		return plaintextSecretProperties;
 	}
 
 	private static void _validateFIPSProvider(Provider[] providers) {
@@ -215,6 +246,40 @@ public class FIPSModeValidator {
 		}
 	}
 
+	private static void _validatePlaintextSecrets() {
+		List<String> messages = new ArrayList<>();
+
+		for (String source : PropsUtil.getLoadedSources()) {
+			String fileName = source.substring(source.lastIndexOf('/') + 1);
+
+			if (fileName.equals("portal.properties")) {
+				continue;
+			}
+
+			Properties properties = null;
+
+			try {
+				properties = PropertiesUtil.load(new URL(source));
+			}
+			catch (IOException ioException) {
+				continue;
+			}
+
+			for (String key : _getPlaintextSecretProperties(properties)) {
+				messages.add(
+					StringBundler.concat(
+						"property \"", key, "\" in \"", fileName, "\""));
+			}
+		}
+
+		if (!messages.isEmpty()) {
+			throw new SecurityException(
+				StringBundler.concat(
+					"A plaintext value for ", StringUtil.merge(messages, ", "),
+					" is not allowed in FIPS mode"));
+		}
+	}
+
 	private static void _validateProperties() {
 		if (GetterUtil.getBoolean(PropsUtil.get(PropsKeys.AUTH_MAC_ALLOW))) {
 			validateAlgorithm(PropsUtil.get(PropsKeys.AUTH_MAC_ALGORITHM));
@@ -226,6 +291,7 @@ public class FIPSModeValidator {
 
 		_validatePasswordsEncryptionAlgorithm(
 			PropsUtil.get(PropsKeys.PASSWORDS_ENCRYPTION_ALGORITHM));
+		_validatePlaintextSecrets();
 	}
 
 	private static void _validateProviders(Provider[] providers) {

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSModeValidatorTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSModeValidatorTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.kernel.security.fips;
 
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -14,6 +15,7 @@ import java.security.Provider;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -23,6 +25,41 @@ import org.junit.function.ThrowingRunnable;
  * @author Caio Farias
  */
 public class FIPSModeValidatorTest {
+
+	@Test
+	public void testFindPlaintextSecretProperties() {
+		String obfuscatedKey1 = RandomTestUtil.randomString();
+		String obfuscatedKey2 = RandomTestUtil.randomString();
+		String obfuscatedKey3 = RandomTestUtil.randomString();
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"ADMIN_OBFUSCATED_PROPERTIES",
+					new String[] {
+						obfuscatedKey1, obfuscatedKey2, obfuscatedKey3
+					})) {
+
+			Properties properties = new Properties();
+
+			properties.setProperty(
+				obfuscatedKey1, RandomTestUtil.randomString());
+			properties.setProperty(
+				obfuscatedKey2, "${" + RandomTestUtil.randomString() + "}");
+			properties.setProperty(obfuscatedKey3, StringPool.BLANK);
+			properties.setProperty(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+			List<String> plaintextSecretProperties = ReflectionTestUtil.invoke(
+				FIPSModeValidator.class, "_getPlaintextSecretProperties",
+				new Class<?>[] {Properties.class}, properties);
+
+			Assert.assertEquals(
+				plaintextSecretProperties.toString(), 1,
+				plaintextSecretProperties.size());
+			Assert.assertTrue(
+				plaintextSecretProperties.contains(obfuscatedKey1));
+		}
+	}
 
 	@Test
 	public void testValidateAlgorithm() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98489

## What Is Being Fixed

Under FIPS 140-3 (LPD-93648 AC10), DXP must not run with a known secret stored as a plaintext literal in the portal property override files. Today nothing stops an operator from placing, for example, a `jdbc.default.password` or `auth.mac.shared.key` value directly in `portal-ext.properties`, so a plaintext secret can be present while FIPS mode is enabled. Unlike DB- and keystore-plane secrets, portal-ext properties have no KMS migration path (LPD-88882 excludes them), so the only correct behavior is to reject at activation.

## How It Is Being Fixed

`FIPSModeValidator.validate()` gains a new boot step, `_validatePlaintextSecrets()`, that runs when FIPS mode is enabled, before the OSGi framework initializes. It reads the loaded property source files via `PropsUtil.getLoadedSources()`, skips the shipped base `portal.properties`, and parses each operator override file (`portal-ext.properties`, `${liferay.home}/portal-ext.properties`, `portal-bundle.properties`, and so on) with `PropertiesUtil.load`. A property is flagged when its key is a known secret-bearing property — any entry in `PropsValues.ADMIN_OBFUSCATED_PROPERTIES` or a `jdbc.*.password` pool variant — and its value is a non-blank literal that is not a `${...}` reference. Any hit aborts boot with a `SecurityException` naming the offending property and file. Because the check inspects the file literal rather than the resolved value, a secret injected through an environment variable or a `-D` system property (the sanctioned Secret Zero remediation) leaves no file literal and therefore passes.

## PR Check

**pr-check: SKIPPED** — portal-kernel change triggers heavy Full Portal Build and Cross-Module Compile validations that the stale local build (222-commit master fast-forward) cannot run reliably; verified Source Format (clean), Java Unit Tests (7/7 FIPSModeValidatorTest), and Baseline (private-only additions, no exported-API change) locally; remaining build validations run in appsec CI

<!-- pr-check {"reason": "portal-kernel change triggers heavy build validations the stale local build cannot run reliably; verified Source Format, Java Unit Tests, and Baseline locally; remaining build validations run in appsec CI", "result": "skipped", "sha": "150d644899d4cf7d593ff51cc504526a28e41569"} -->



