### PR TITLE
LPD-98558 Unify the supported scopes delimiter to a comma

### DIFF
--- a/modules/apps/oauth-client/oauth-client-admin-web/src/main/java/com/liferay/oauth/client/admin/web/internal/portlet/action/UpdateOAuthClientASLocalMetadataMVCRenderCommand.java
+++ b/modules/apps/oauth-client/oauth-client-admin-web/src/main/java/com/liferay/oauth/client/admin/web/internal/portlet/action/UpdateOAuthClientASLocalMetadataMVCRenderCommand.java
@@ -128,7 +128,7 @@ public class UpdateOAuthClientASLocalMetadataMVCRenderCommand
 		if (supportedScopes != null) {
 			renderRequest.setAttribute(
 				OAuthClientWebKeys.SUPPORTED_SCOPES,
-				supportedScopes.toString());
+				StringUtil.merge(supportedScopes));
 		}
 
 		OIDCProviderMetadata oidcProviderMetadata = OIDCProviderMetadata.parse(

--- a/modules/test/playwright/pages/oauth-client-administration-web/AuthServerLocalMetadatasPage.ts
+++ b/modules/test/playwright/pages/oauth-client-administration-web/AuthServerLocalMetadatasPage.ts
@@ -10,7 +10,6 @@ import {GlobalMenuPage} from '../product-navigation-applications-menu/GlobalMenu
 
 export class AuthServerLocalMetadatasPage {
 	readonly addOAuthAuthorizationServerButton: Locator;
-	readonly allowedScopes: Locator;
 	readonly globalMenuPage: GlobalMenuPage;
 	readonly authServerLocalMetadataTab: Locator;
 	readonly authorizationEndpoint: Locator;
@@ -24,6 +23,7 @@ export class AuthServerLocalMetadatasPage {
 	readonly page: Page;
 	readonly saveButton: Locator;
 	readonly subjectTypesSupported: Locator;
+	readonly supportedScopes: Locator;
 	readonly successMessage: Locator;
 	readonly tokenEndpoint: Locator;
 	readonly userinfoEnpoint: Locator;
@@ -33,7 +33,6 @@ export class AuthServerLocalMetadatasPage {
 		this.addOAuthAuthorizationServerButton = page.getByRole('link', {
 			name: 'Add OAuth Authorization',
 		});
-		this.allowedScopes = page.getByLabel('Allowed Scopes');
 		this.globalMenuPage = new GlobalMenuPage(page);
 		this.authServerLocalMetadataTab = page.getByRole('link', {
 			name: 'Auth Server Local Metadata',
@@ -60,15 +59,26 @@ export class AuthServerLocalMetadatasPage {
 		this.successMessage = page.getByText(
 			'Your request completed successfully'
 		);
+		this.supportedScopes = page.getByLabel('Supported Scopes');
 		this.tokenEndpoint = page.getByLabel('Token Endpoint');
 		this.userinfoEnpoint = page.getByLabel('Userinfo enpoint');
 		this.urlErrorMessage = page.getByText('Close Error: The URL is not a');
 	}
 
-	async addAuthServerLocalMetadata(issuer: string, expectedMessage?: string) {
+	async addAuthServerLocalMetadata(
+		issuer: string,
+		{
+			expectedMessage,
+			supportedScopes,
+		}: {expectedMessage?: string; supportedScopes?: string} = {}
+	) {
 		await this.addOAuthAuthorizationServerButton.click();
 
 		await this.issuer.fill(issuer);
+
+		if (supportedScopes !== undefined) {
+			await this.supportedScopes.fill(supportedScopes);
+		}
 
 		await this.saveButton.click();
 
@@ -135,5 +145,12 @@ export class AuthServerLocalMetadatasPage {
 		await expect(
 			await this.addOAuthAuthorizationServerButton
 		).toBeVisible();
+	}
+
+	async openAuthServerLocalMetadata(wellKnownURI: string) {
+		await clickAndExpectToBeVisible({
+			target: this.supportedScopes,
+			trigger: this.page.getByRole('link', {name: wellKnownURI}),
+		});
 	}
 }

--- a/modules/test/playwright/tests/oauth-client-administration/main/oauthClientAdministration.spec.ts
+++ b/modules/test/playwright/tests/oauth-client-administration/main/oauthClientAdministration.spec.ts
@@ -69,22 +69,30 @@ test.describe('Enable Configuration of oauth-authorization-server Well-Known URI
 		'Create an oauth-authorization-server and validate',
 		{tag: '@LPD-67473'},
 		async ({authServerLocalMetadatasPage}) => {
+			const issuer = 'https://localhost.com';
+			const supportedScopes = `${getRandomString()},${getRandomString()}`;
+			const wellKnownURI = `${issuer}/o/.well-known/oauth-authorization-server`;
+
 			await authServerLocalMetadatasPage.goTo();
 
-			await authServerLocalMetadatasPage.addAuthServerLocalMetadata(
-				'',
-				'The Issuer field is required.'
-			);
+			await authServerLocalMetadatasPage.addAuthServerLocalMetadata('', {
+				expectedMessage: 'The Issuer field is required.',
+			});
 
 			await authServerLocalMetadatasPage.addAuthServerLocalMetadata(
-				'https://localhost.com'
+				issuer,
+				{
+					supportedScopes,
+				}
 			);
 
 			authServerLocalMetadataCreated = true;
 
 			await authServerLocalMetadatasPage.addAuthServerLocalMetadata(
-				'https://localhost.com',
-				'Duplicate'
+				issuer,
+				{
+					expectedMessage: 'Duplicate',
+				}
 			);
 
 			if (
@@ -99,7 +107,7 @@ test.describe('Enable Configuration of oauth-authorization-server Well-Known URI
 			await authServerLocalMetadatasPage.oAuthAuthorizatoinServerTab.click();
 			await expect(
 				await authServerLocalMetadatasPage.page.getByRole('link', {
-					name: 'https://localhost.com/o/.well-known/oauth-authorization-server',
+					name: wellKnownURI,
 				})
 			).toBeVisible();
 
@@ -107,11 +115,22 @@ test.describe('Enable Configuration of oauth-authorization-server Well-Known URI
 
 			await expect(
 				await authServerLocalMetadatasPage.page.getByRole('link', {
-					name: 'https://localhost.com/.well-known/openid-configuration/1B2M2Y8AsgTpgAmY7PhCfg**/local',
+					name: `${issuer}/.well-known/openid-configuration/1B2M2Y8AsgTpgAmY7PhCfg**/local`,
 				})
 			).toBeVisible();
 
 			await authServerLocalMetadatasPage.oAuthAuthorizatoinServerTab.click();
+
+			// Reopen the entry and verify the supported scopes round-trip with
+			// the same comma delimiter they were saved with
+
+			await authServerLocalMetadatasPage.openAuthServerLocalMetadata(
+				wellKnownURI
+			);
+
+			await expect(
+				authServerLocalMetadatasPage.supportedScopes
+			).toHaveValue(supportedScopes);
 		}
 	);
 });


### PR DESCRIPTION
[LPD-98558](https://liferay.atlassian.net/browse/LPD-98558)

The "Supported Scopes" field on the OAuth Authorization Server Local Metadata screen displayed the scopes separated by a space while the action that saves them split on a comma, so reopening and saving an entry collapsed the list into a single scope. It now renders the scopes comma-delimited, matching the Protected Resource Local Metadata screen and the delimiter used to parse them.

## Tests

Extended the `@LPD-67473` Playwright test to save two comma-delimited scopes, reopen the entry, and assert the field keeps the same value. Also fixed the stale page object locator that pointed at a nonexistent "Allowed Scopes" field.