### PR TITLE
LPD-98318 Blacklist SHA-1 and rsa-sha1 for SAML signatures in FIPS mode

### DIFF
--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/bootstrap/SecurityConfigurationBootstrap.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/bootstrap/SecurityConfigurationBootstrap.java
@@ -5,6 +5,7 @@
 
 package com.liferay.saml.opensaml.integration.internal.bootstrap;
 
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.saml.opensaml.integration.internal.util.ConfigurationServiceBootstrapUtil;
 
 import java.util.Collection;
@@ -21,6 +22,8 @@ import org.opensaml.xmlsec.impl.BasicDecryptionConfiguration;
 import org.opensaml.xmlsec.impl.BasicEncryptionConfiguration;
 import org.opensaml.xmlsec.impl.BasicSignatureSigningConfiguration;
 import org.opensaml.xmlsec.impl.BasicSignatureValidationConfiguration;
+import org.opensaml.xmlsec.impl.BasicWhitelistBlacklistConfiguration;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -28,6 +31,7 @@ import org.osgi.service.component.annotations.Modified;
 
 /**
  * @author Carlos Sierra Andrés
+ * @author Jorge García Jiménez
  */
 @Component(service = {})
 public class SecurityConfigurationBootstrap {
@@ -49,32 +53,29 @@ public class SecurityConfigurationBootstrap {
 				DefaultSecurityConfigurationBootstrap.
 					buildDefaultSignatureValidationConfiguration();
 
+		String[] blacklistedAlgorithms = new String[0];
+
 		Object blacklistedAlgorithmsObject = properties.get(
 			"blacklisted.algorithms");
 
 		if (blacklistedAlgorithmsObject instanceof String[]) {
-			basicDecryptionConfiguration.setBlacklistedAlgorithms(
-				_combine(
-					basicDecryptionConfiguration.getBlacklistedAlgorithms(),
-					(String[])blacklistedAlgorithmsObject));
-
-			basicEncryptionConfiguration.setBlacklistedAlgorithms(
-				_combine(
-					basicEncryptionConfiguration.getBlacklistedAlgorithms(),
-					(String[])blacklistedAlgorithmsObject));
-
-			basicSignatureSigningConfiguration.setBlacklistedAlgorithms(
-				_combine(
-					basicSignatureSigningConfiguration.
-						getBlacklistedAlgorithms(),
-					(String[])blacklistedAlgorithmsObject));
-
-			basicSignatureValidationConfiguration.setBlacklistedAlgorithms(
-				_combine(
-					basicSignatureValidationConfiguration.
-						getBlacklistedAlgorithms(),
-					(String[])blacklistedAlgorithmsObject));
+			blacklistedAlgorithms = (String[])blacklistedAlgorithmsObject;
 		}
+
+		String[] fipsDisallowedAlgorithms = new String[0];
+
+		if (PropsValues.FIPS_ENABLED) {
+			fipsDisallowedAlgorithms = _FIPS_DISALLOWED_ALGORITHMS;
+		}
+
+		_blacklist(basicDecryptionConfiguration, blacklistedAlgorithms);
+		_blacklist(basicEncryptionConfiguration, blacklistedAlgorithms);
+		_blacklist(
+			basicSignatureSigningConfiguration, blacklistedAlgorithms,
+			fipsDisallowedAlgorithms);
+		_blacklist(
+			basicSignatureValidationConfiguration, blacklistedAlgorithms,
+			fipsDisallowedAlgorithms);
 
 		ConfigurationServiceBootstrapUtil.register(
 			DecryptionConfiguration.class, basicDecryptionConfiguration);
@@ -88,14 +89,31 @@ public class SecurityConfigurationBootstrap {
 			basicSignatureValidationConfiguration);
 	}
 
-	private Collection<String> _combine(
-		Collection<String> collection, String... strings) {
+	private void _blacklist(
+		BasicWhitelistBlacklistConfiguration
+			basicWhitelistBlacklistConfiguration,
+		String[]... stringsArrays) {
 
-		Collection<String> combinedCollection = new HashSet<>(collection);
+		Collection<String> blacklistedAlgorithms = new HashSet<>(
+			basicWhitelistBlacklistConfiguration.getBlacklistedAlgorithms());
 
-		Collections.addAll(combinedCollection, strings);
+		for (String[] strings : stringsArrays) {
+			Collections.addAll(blacklistedAlgorithms, strings);
+		}
 
-		return combinedCollection;
+		basicWhitelistBlacklistConfiguration.setBlacklistedAlgorithms(
+			blacklistedAlgorithms);
 	}
+
+	private static final String[] _FIPS_DISALLOWED_ALGORITHMS = {
+		SignatureConstants.ALGO_ID_DIGEST_NOT_RECOMMENDED_MD5,
+		SignatureConstants.ALGO_ID_DIGEST_SHA1,
+		SignatureConstants.ALGO_ID_MAC_HMAC_NOT_RECOMMENDED_MD5,
+		SignatureConstants.ALGO_ID_MAC_HMAC_SHA1,
+		SignatureConstants.ALGO_ID_SIGNATURE_DSA_SHA1,
+		SignatureConstants.ALGO_ID_SIGNATURE_ECDSA_SHA1,
+		SignatureConstants.ALGO_ID_SIGNATURE_NOT_RECOMMENDED_RSA_MD5,
+		SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1
+	};
 
 }

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/bootstrap/SecurityConfigurationBootstrapTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/bootstrap/SecurityConfigurationBootstrapTest.java
@@ -1,0 +1,76 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.saml.opensaml.integration.internal.bootstrap;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.saml.opensaml.integration.internal.util.ConfigurationServiceBootstrapUtil;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.opensaml.xmlsec.SignatureSigningConfiguration;
+import org.opensaml.xmlsec.SignatureValidationConfiguration;
+import org.opensaml.xmlsec.signature.support.SignatureConstants;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class SecurityConfigurationBootstrapTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		Class.forName(ConfigurationServiceBootstrapUtil.class.getName());
+	}
+
+	@Test
+	public void testActivate() {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			ReflectionTestUtil.invoke(
+				new SecurityConfigurationBootstrap(), "activate",
+				new Class<?>[] {Map.class}, Collections.emptyMap());
+
+			SignatureSigningConfiguration signatureSigningConfiguration =
+				ConfigurationServiceBootstrapUtil.get(
+					SignatureSigningConfiguration.class);
+			SignatureValidationConfiguration signatureValidationConfiguration =
+				ConfigurationServiceBootstrapUtil.get(
+					SignatureValidationConfiguration.class);
+
+			_assertBlacklisted(
+				signatureSigningConfiguration.getBlacklistedAlgorithms());
+			_assertBlacklisted(
+				signatureValidationConfiguration.getBlacklistedAlgorithms());
+		}
+	}
+
+	private void _assertBlacklisted(Collection<String> blacklistedAlgorithms) {
+		Assert.assertTrue(
+			blacklistedAlgorithms.contains(
+				SignatureConstants.ALGO_ID_DIGEST_SHA1));
+		Assert.assertTrue(
+			blacklistedAlgorithms.contains(
+				SignatureConstants.ALGO_ID_SIGNATURE_RSA_SHA1));
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98318

## What Is Being Fixed

When FIPS mode is enabled, the SAML signing and validation configurations must reject the SHA-1 and MD5 based signature, digest, and MAC algorithms that are not permitted under FIPS 140-3. Nothing blacklisted them before, so the OpenSAML defaults left them available.

## How It Is Being Fixed

`SecurityConfigurationBootstrap.activate()` computes the operator-configured blacklist (the `blacklisted.algorithms` property) and, when `PropsValues.FIPS_ENABLED` is set, the FIPS-disallowed algorithms. It then applies them to each configuration through a single `_blacklist(configuration, arrays...)` helper that merges the configuration's existing blacklist with the given arrays (varargs of arrays) and sets it back, so each configuration is blacklisted in one call. The signing and validation configurations receive both the operator blacklist and the FIPS-disallowed algorithms.

This is a fresh PR for the work previously in #3104 (closed); the FIPS-only helper was reworked per review into the varargs `_blacklist` form.
