### PR TITLE
LPD-98654 Fix the protected resource metadata delete test helper

### DIFF
--- a/modules/test/playwright/pages/oauth-client-administration-web/ProtectedResourceLocalMetadatasPage.ts
+++ b/modules/test/playwright/pages/oauth-client-administration-web/ProtectedResourceLocalMetadatasPage.ts
@@ -86,16 +86,15 @@ export class ProtectedResourceLocalMetadatasPage {
 			.last();
 
 		while (await row.isVisible()) {
-			await clickAndExpectToBeVisible({
-				autoClick: true,
-				target: this.page.getByRole('link', {name: 'Delete'}),
-				trigger: row.locator('.dropdown-toggle'),
+			this.page.once('dialog', (dialog) => {
+				dialog.accept();
 			});
 
-			await this.page
-				.getByRole('alertdialog')
-				.getByRole('button', {name: 'OK'})
-				.click();
+			await clickAndExpectToBeVisible({
+				autoClick: true,
+				target: this.page.getByRole('menuitem', {name: 'Delete'}),
+				trigger: row.locator('.dropdown-toggle'),
+			});
 
 			await expect(this.successMessage).toBeVisible();
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98654

## What Is Being Fixed

Running the OAuth client administration Playwright spec left OAuth protected
resource local metadata rows behind: the cleanup step never deleted the entry
it created, so the test timed out and rows accumulated across runs, making
later runs fail with a duplicate resource error.

## How It Is Being Fixed

The protected resource list renders its row actions in a data-set dropdown
whose Delete control is a menuitem, and the delete confirmation is a native
browser dialog because custom dialogs are disabled in this environment. The
page object looked for the action as a link and confirmed through a Clay modal,
so it never matched the control and the delete never happened. The helper now
targets the menuitem and accepts the native confirm dialog, matching the
pattern already used by the other administration page objects.

## Why Are There No Tests?

This change is itself test code (a Playwright page object). Its verification is
that the oauthClientAdministration spec now passes end to end (3 passed) and
leaves no OAuth protected resource or authorization server metadata rows behind.

## PR Check

**pr-check: PASS** — tested on `59ff583254891168b04df148e109ee19e09e4f94`

| Validation | Result |
| --- | --- |
| Source Format | PASS |

<!-- pr-check {"result": "success", "sha": "59ff583254891168b04df148e109ee19e09e4f94"} -->
