### PR TITLE
LPD-98644 Fix unresponsive CAPTCHA refresh on JSF portlets

### DIFF
--- a/modules/apps/captcha/captcha-jsf-sample-test/bnd.bnd
+++ b/modules/apps/captcha/captcha-jsf-sample-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay CAPTCHA JSF Sample Test
+Bundle-SymbolicName: com.liferay.captcha.jsf.sample.test
+Bundle-Version: 1.0.0

--- a/modules/apps/captcha/captcha-jsf-sample-test/build.gradle
+++ b/modules/apps/captcha/captcha-jsf-sample-test/build.gradle
@@ -1,0 +1,23 @@
+apply plugin: "war"
+
+dependencies {
+	compileOnly group: "com.liferay.jakarta.portlet", name: "com.liferay.jakarta.portlet-api", version: "4.0.0"
+	implementation group: "com.liferay", name: "com.liferay.faces.bridge.api", version: "7.0.0"
+	implementation group: "com.liferay", name: "com.liferay.faces.bridge.ext", version: "9.0.1"
+	implementation group: "com.liferay", name: "com.liferay.faces.bridge.impl", version: "7.0.1"
+	implementation group: "com.liferay", name: "com.liferay.faces.portal", version: "7.0.1"
+	implementation group: "com.liferay", name: "com.liferay.faces.util", version: "5.0.0"
+	implementation group: "com.liferay", name: "jakarta.faces", version: "2.3.21.LIFERAY-PATCHED-4.JAKARTA-LIFERAY-PATCHED-1"
+}
+
+deploy {
+	from war
+
+	rename {
+		"captcha-jsf-sample-test.war"
+	}
+}
+
+liferay {
+	deployDir = file("${liferayHome}/osgi/war")
+}

--- a/modules/apps/captcha/captcha-jsf-sample-test/source-formatter-suppressions.xml
+++ b/modules/apps/captcha/captcha-jsf-sample-test/source-formatter-suppressions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+
+<suppressions>
+	<source-check>
+		<suppress checks="GradleDependencyArtifactsCheck" files=".*" />
+	</source-check>
+</suppressions>

--- a/modules/apps/captcha/captcha-jsf-sample-test/src/main/java/com/liferay/captcha/jsf/sample/test/portlet/CaptchaFacesPortlet.java
+++ b/modules/apps/captcha/captcha-jsf-sample-test/src/main/java/com/liferay/captcha/jsf/sample/test/portlet/CaptchaFacesPortlet.java
@@ -1,0 +1,14 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.captcha.jsf.sample.test.portlet;
+
+import com.liferay.faces.GenericFacesPortlet;
+
+/**
+ * @author Manuele Castro
+ */
+public class CaptchaFacesPortlet extends GenericFacesPortlet {
+}

--- a/modules/apps/captcha/captcha-jsf-sample-test/src/main/webapp/WEB-INF/liferay-display.xml
+++ b/modules/apps/captcha/captcha-jsf-sample-test/src/main/webapp/WEB-INF/liferay-display.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<!DOCTYPE display PUBLIC "-//Liferay//DTD Display 7.4.0//EN" "http://www.liferay.com/dtd/liferay-display_7_4_0.dtd">
+
+<display>
+	<category name="category.sample">
+		<portlet id="1" />
+	</category>
+</display>

--- a/modules/apps/captcha/captcha-jsf-sample-test/src/main/webapp/WEB-INF/liferay-plugin-package.properties
+++ b/modules/apps/captcha/captcha-jsf-sample-test/src/main/webapp/WEB-INF/liferay-plugin-package.properties
@@ -1,0 +1,8 @@
+author=Liferay, Inc.
+change-log=
+licenses=LGPL
+module-group-id=liferay
+module-version=1.0.0
+name=Sample CAPTCHA JSF Portlet
+page-url=http://www.liferay.com
+tags=sample

--- a/modules/apps/captcha/captcha-jsf-sample-test/src/main/webapp/WEB-INF/liferay-portlet.xml
+++ b/modules/apps/captcha/captcha-jsf-sample-test/src/main/webapp/WEB-INF/liferay-portlet.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<!DOCTYPE liferay-portlet-app PUBLIC "-//Liferay//DTD Portlet Application 7.4.0//EN" "http://www.liferay.com/dtd/liferay-portlet-app_7_4_0.dtd">
+
+<liferay-portlet-app>
+	<portlet>
+		<portlet-name>1</portlet-name>
+		<requires-namespaced-parameters>false</requires-namespaced-parameters>
+		<ajaxable>false</ajaxable>
+	</portlet>
+	<role-mapper>
+		<role-name>administrator</role-name>
+		<role-link>Administrator</role-link>
+	</role-mapper>
+	<role-mapper>
+		<role-name>guest</role-name>
+		<role-link>Guest</role-link>
+	</role-mapper>
+	<role-mapper>
+		<role-name>power-user</role-name>
+		<role-link>Power User</role-link>
+	</role-mapper>
+	<role-mapper>
+		<role-name>user</role-name>
+		<role-link>User</role-link>
+	</role-mapper>
+</liferay-portlet-app>

--- a/modules/apps/captcha/captcha-jsf-sample-test/src/main/webapp/WEB-INF/portlet.xml
+++ b/modules/apps/captcha/captcha-jsf-sample-test/src/main/webapp/WEB-INF/portlet.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<portlet-app version="3.0" xmlns="http://xmlns.jcp.org/xml/ns/portlet" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/portlet http://xmlns.jcp.org/xml/ns/portlet/portlet-app_3_0.xsd">
+	<portlet>
+		<portlet-name>1</portlet-name>
+		<display-name>Sample CAPTCHA JSF Portlet</display-name>
+		<portlet-class>com.liferay.captcha.jsf.sample.test.portlet.CaptchaFacesPortlet</portlet-class>
+		<init-param>
+			<name>com.liferay.faces.defaultViewId.view</name>
+			<value>/WEB-INF/views/captcha.xhtml</value>
+		</init-param>
+		<expiration-cache>0</expiration-cache>
+		<supports>
+			<mime-type>text/html</mime-type>
+		</supports>
+		<portlet-info>
+			<title>Sample CAPTCHA JSF Portlet</title>
+			<short-title>Sample CAPTCHA JSF Portlet</short-title>
+			<keywords>Sample CAPTCHA JSF Portlet</keywords>
+		</portlet-info>
+	</portlet>
+</portlet-app>

--- a/modules/apps/captcha/captcha-jsf-sample-test/src/main/webapp/WEB-INF/views/captcha.xhtml
+++ b/modules/apps/captcha/captcha-jsf-sample-test/src/main/webapp/WEB-INF/views/captcha.xhtml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<f:view
+	xmlns="http://www.w3.org/1999/xhtml"
+	xmlns:f="http://xmlns.jcp.org/jsf/core"
+	xmlns:h="http://xmlns.jcp.org/jsf/html"
+	xmlns:portal="http://liferay.com/faces/portal"
+>
+	<h:body>
+		<h:form id="form">
+			<portal:captcha
+				required="true"
+				requiredMessage="CAPTCHA is required"
+				validatorMessage="Incorrect CAPTCHA"
+			/>
+
+			<br /><br />
+
+			<h:commandButton value="Submit" />
+		</h:form>
+	</h:body>
+</f:view>

--- a/modules/apps/captcha/captcha-jsf-sample-test/src/main/webapp/WEB-INF/web.xml
+++ b/modules/apps/captcha/captcha-jsf-sample-test/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+
+<web-app version="6.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd">
+	<context-param>
+		<param-name>jakarta.faces.PROJECT_STAGE</param-name>
+		<param-value>Development</param-value>
+	</context-param>
+	<servlet>
+		<servlet-name>Faces Servlet</servlet-name>
+		<servlet-class>jakarta.faces.webapp.FacesServlet</servlet-class>
+		<load-on-startup>1</load-on-startup>
+	</servlet>
+	<security-constraint>
+		<web-resource-collection>
+			<web-resource-name>Facelet XHTML</web-resource-name>
+			<url-pattern>*.xhtml</url-pattern>
+		</web-resource-collection>
+		<auth-constraint />
+	</security-constraint>
+</web-app>

--- a/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
+++ b/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
@@ -9,7 +9,6 @@
 
 <%
 String captchaId = PortalUtil.generateRandomKey(request, "captchaId");
-String refreshCaptchaId = PortalUtil.generateRandomKey(request, "refreshCaptchaId");
 
 String errorMessage = (String)request.getAttribute("liferay-captcha:captcha:errorMessage");
 String url = (String)request.getAttribute("liferay-captcha:captcha:url");
@@ -30,13 +29,12 @@ String namespace = portletDisplay.getNamespace();
 	url = HttpComponentsUtil.addParameter(url, "t", String.valueOf(System.currentTimeMillis()));
 	%>
 
-	<div class="<%= cssClass %>">
-		<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="text-to-identify" />" class="captcha d-inline-block mb-2" id="<portlet:namespace /><%= captchaId %>" src="<%= HtmlUtil.escapeAttribute(url) %>" />
+	<div class="<%= cssClass %>" data-captcha-id="<%= HtmlUtil.escapeAttribute(captchaId) %>">
+		<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="text-to-identify" />" class="captcha d-inline-block mb-2" src="<%= HtmlUtil.escapeAttribute(url) %>" />
 
 		<liferay-ui:icon
 			cssClass="align-top d-inline-block refresh"
 			icon="reload"
-			id="<%= refreshCaptchaId %>"
 			label="<%= false %>"
 			localizeMessage="<%= true %>"
 			markupView="lexicon"
@@ -60,9 +58,15 @@ String namespace = portletDisplay.getNamespace();
 
 	<aui:script>
 		function <%= captchaId %>attachEvent() {
-			var refreshCaptcha = document.getElementById(
-				'<portlet:namespace /><%= refreshCaptchaId %>'
+			var container = document.querySelector(
+				'[data-captcha-id="<%= HtmlUtil.escapeJS(captchaId) %>"]'
 			);
+
+			if (!container) {
+				return;
+			}
+
+			var refreshCaptcha = container.querySelector('.refresh');
 
 			if (refreshCaptcha && !refreshCaptcha.hasEventAttached) {
 				refreshCaptcha.hasEventAttached = true;
@@ -72,9 +76,7 @@ String namespace = portletDisplay.getNamespace();
 						'<%= HtmlUtil.escapeJS(url) %>'
 					);
 
-					var captcha = document.getElementById(
-						'<portlet:namespace /><%= captchaId %>'
-					);
+					var captcha = container.querySelector('.captcha');
 
 					if (captcha) {
 						captcha.setAttribute('src', url);

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -28,6 +28,7 @@ import {config as batchPlannerConfig} from './tests/batch-planner/main/config';
 import {config as blogsWebConfig} from './tests/blogs-web/main/config';
 import {config as calendarWebConfig} from './tests/calendar-web/main/config';
 import {config as captchaWebClientExtensionConfig} from './tests/captcha-web/client-extension/config';
+import {config as captchaWebJsfConfig} from './tests/captcha-web/jsf/config';
 import {config as captchaWebConfig} from './tests/captcha-web/main/config';
 import {config as changeTrackingWebLocalePrependConfig} from './tests/change-tracking-web/main-locale-prepend/config';
 import {config as changeTrackingWebConfig} from './tests/change-tracking-web/main/config';
@@ -274,6 +275,7 @@ export default defineConfig({
 		calendarWebConfig,
 		captchaWebClientExtensionConfig,
 		captchaWebConfig,
+		captchaWebJsfConfig,
 		changeTrackingWebConfig,
 		changeTrackingWebLocalePrependConfig,
 		clientExtensionWebConfig,

--- a/modules/test/playwright/tests/captcha-web/jsf/config.ts
+++ b/modules/test/playwright/tests/captcha-web/jsf/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'captcha-web.jsf',
+	testDir: 'tests/captcha-web/jsf',
+};

--- a/modules/test/playwright/tests/captcha-web/jsf/env/osgi-modules.list
+++ b/modules/test/playwright/tests/captcha-web/jsf/env/osgi-modules.list
@@ -1,0 +1,1 @@
+captcha-jsf-sample-test

--- a/modules/test/playwright/tests/captcha-web/jsf/env/portal-ext.properties
+++ b/modules/test/playwright/tests/captcha-web/jsf/env/portal-ext.properties
@@ -1,0 +1,3 @@
+captcha.enforce.disabled=false
+
+configuration.override.com.liferay.captcha.configuration.CaptchaConfiguration_maxChallenges=I"1"

--- a/modules/test/playwright/tests/captcha-web/jsf/simplecaptchaJSF.spec.ts
+++ b/modules/test/playwright/tests/captcha-web/jsf/simplecaptchaJSF.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {captchaConfigPageTest} from '../../../fixtures/captchaConfigPageTest';
+import {isolatedLayoutTest} from '../../../fixtures/isolatedLayoutTest';
+import {loginTest} from '../../../fixtures/loginTest';
+import {pageViewModePagesTest} from '../../../fixtures/pageViewModePagesTest';
+
+const test = mergeTests(
+	captchaConfigPageTest,
+	isolatedLayoutTest({type: 'portlet'}),
+	loginTest(),
+	pageViewModePagesTest
+);
+
+test(
+	'LPD-98644 check that the CAPTCHA refresh button works on a JSF portlet rendered through the Liferay Faces portal:captcha component',
+	{tag: '@LPD-98644'},
+	async ({captchaConfigPage, layout, page, widgetPagePage}) => {
+		await captchaConfigPage.goTo();
+
+		await captchaConfigPage.resetCaptchaConfiguration();
+
+		await page.goto(`/web/guest/${layout.friendlyURL}`);
+
+		await widgetPagePage.addPortlet('Sample CAPTCHA JSF Portlet', 'Sample');
+
+		await page.waitForLoadState();
+
+		await page.reload();
+
+		const captchaImgSource = await page
+			.getByAltText('Text to Identify')
+			.getAttribute('src');
+
+		await page.getByTitle('Refresh CAPTCHA').click();
+
+		const refreshedCaptchaImgSource = await page
+			.getByAltText('Text to Identify')
+			.getAttribute('src');
+
+		await expect(captchaImgSource).not.toEqual(refreshedCaptchaImgSource);
+	}
+);

--- a/modules/test/playwright/tests/captcha-web/jsf/test.properties
+++ b/modules/test/playwright/tests/captcha-web/jsf/test.properties
@@ -1,0 +1,1 @@
+testray.main.component.name=CAPTCHA

--- a/test.properties
+++ b/test.properties
@@ -6444,6 +6444,7 @@
 
     security.playwright.projects=\
         captcha-web.client-extension,\
+        captcha-web.jsf,\
         captcha-web.main,\
         login-web.main,\
         login-web.main-captcha-enable,\


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98644

## What Is Being Fixed

On a JSF portlet using the Liferay Faces `<portal:captcha>` component, the CAPTCHA refresh button silently does nothing — no console or server errors. LPD-66742 replaced the refresh icon's static id (`refreshCaptcha`) with a randomly generated one to support multiple CAPTCHAs per page. The external `com.liferay.faces.portal` library renders through the same JSP, but injects the portlet namespace into the icon's id via a literal string replace that assumes the id is exactly `id="refreshCaptcha"` — a workaround for Liferay's own namespace auto-injection not reliably firing in that JSF-bridge rendering context. Once the id became random, that replace silently became a no-op, leaving the icon un-namespaced and its click handler's element lookup never matching.

## How It Is Being Fixed

`simplecaptcha.jsp` now scopes the refresh-icon and captcha-image DOM lookups via a `data-captcha-id` attribute on their shared container plus CSS class selectors, instead of `getElementById` with a namespace-constructed id. This removes the dependency on id/namespace matching entirely, so it no longer matters whether Liferay's auto-namespacing or the external library's string-replace workaround fires correctly. To verify and guard against regressions on the actual mechanism, a new JSF portlet fixture (`captcha-jsf-sample-test`) was added, using the real `com.liferay.faces.portal:7.0.1` `<portal:captcha>` component — the same one the reporting customer's portlet uses — along with a Playwright test that deploys it and exercises the refresh button. The test was confirmed to fail against the pre-fix JSP and pass against the fix.

## PR Check

**pr-check: PASS** — tested on `a9452f91bc09c3387af2b995f942b9fb52327ccb`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Portlet Title | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| JSP Compile | PASS |
| Structural Smoke | PASS |
| PQL Validation | PASS |

<!-- pr-check {"result": "success", "sha": "a9452f91bc09c3387af2b995f942b9fb52327ccb"} -->
