### PR TITLE
LPD-96649 Add a source formatter check for non-FIPS BouncyCastle

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BouncyCastleFIPSCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/BouncyCastleFIPSCheck.java
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.check;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Christopher Kian
+ */
+public class BouncyCastleFIPSCheck extends BaseFileCheck {
+
+	@Override
+	public boolean isLiferaySourceCheck() {
+		return true;
+	}
+
+	@Override
+	protected String doProcess(
+		String fileName, String absolutePath, String content) {
+
+		if (absolutePath.contains("/modules/third-party/")) {
+			return content;
+		}
+
+		if (fileName.endsWith(".gradle")) {
+			_check(fileName, content, _artifactPattern);
+		}
+		else {
+			_check(fileName, content, _importPattern);
+		}
+
+		return content;
+	}
+
+	private void _check(String fileName, String content, Pattern pattern) {
+		Matcher matcher = pattern.matcher(content);
+
+		while (matcher.find()) {
+			addMessage(
+				fileName, "Do not use non-FIPS BouncyCastle, see LPD-90318",
+				getLineNumber(content, matcher.start(1)));
+		}
+	}
+
+	private static final Pattern _artifactPattern = Pattern.compile(
+		"name: \"(bc(?:mail|pkix|prov|util)-jdk[^\"]*)\"");
+	private static final Pattern _importPattern = Pattern.compile(
+		"\nimport (?:static )?(org\\.bouncycastle\\.(?:crypto\\.(?:engines|" +
+			"generators|macs|modes|paddings|params|prng|signers)|jce" +
+				"\\.provider|jcajce\\.provider)\\.[^;]+);");
+
+}

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -282,6 +282,10 @@
 		</check>
 	</source-processor>
 	<source-processor name="GradleSourceProcessor">
+		<check name="BouncyCastleFIPSCheck">
+			<category name="Bug Prevention" />
+			<description name="Finds non-FIPS BouncyCastle artifacts in `build.gradle` files." />
+		</check>
 		<check name="GradleBlockOrderCheck">
 			<category name="Styling" />
 			<description name="Sorts logic in gradle build files." />
@@ -471,6 +475,10 @@
 		<check name="ArrayCheck">
 			<category name="Performance" />
 			<description name="Checks if performance can be improved by using different methods that can be used by collections." />
+		</check>
+		<check name="BouncyCastleFIPSCheck">
+			<category name="Bug Prevention" />
+			<description name="Finds imports of non-FIPS BouncyCastle packages." />
 		</check>
 		<check name="EmptyCollectionCheck">
 			<category name="Styling" />

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/GradleSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/GradleSourceProcessorTest.java
@@ -13,6 +13,18 @@ import org.junit.Test;
 public class GradleSourceProcessorTest extends BaseSourceProcessorTestCase {
 
 	@Test
+	public void testBouncyCastleFIPS() throws Exception {
+		test(
+			SourceProcessorTestParameters.create(
+				"BouncyCastleFIPS.testgradle"
+			).addExpectedMessage(
+				"Do not use non-FIPS BouncyCastle, see LPD-90318", 3
+			).addExpectedMessage(
+				"Do not use non-FIPS BouncyCastle, see LPD-90318", 4
+			));
+	}
+
+	@Test
 	public void testMissingLineBreaksAroundCurlyBraces() throws Exception {
 		test("MissingLineBreaksAroundCurlyBraces.testgradle");
 	}

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
@@ -69,6 +69,18 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testBouncyCastleFIPS() throws Exception {
+		test(
+			SourceProcessorTestParameters.create(
+				"BouncyCastleFIPS.testjava"
+			).addExpectedMessage(
+				"Do not use non-FIPS BouncyCastle, see LPD-90318", 9
+			).addExpectedMessage(
+				"Do not use non-FIPS BouncyCastle, see LPD-90318", 10
+			));
+	}
+
+	@Test
 	public void testBuilder() throws Exception {
 		test(
 			SourceProcessorTestParameters.create(

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/BouncyCastleFIPS.testgradle
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/BouncyCastleFIPS.testgradle
@@ -1,0 +1,5 @@
+dependencies {
+	compileOnly group: "org.bouncycastle", name: "bcpkix-fips", version: "1.0.7"
+	compileOnly group: "org.bouncycastle", name: "bcprov-jdk18on", version: "1.70"
+	compileOnly group: "org.bouncycastle", name: "bcutil-jdk18on", version: "1.70"
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/BouncyCastleFIPS.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/BouncyCastleFIPS.testjava
@@ -1,0 +1,29 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+/**
+ * @author Christopher Kian
+ */
+public class BouncyCastleFIPS {
+
+	public BouncyCastleProvider getBouncyCastleProvider() {
+		return null;
+	}
+
+	public PKCS5S2ParametersGenerator getPKCS5S2ParametersGenerator() {
+		return null;
+	}
+
+	public X509v3CertificateBuilder getX509v3CertificateBuilder() {
+		return null;
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-96649

## What Is Being Fixed

The application-layer decoupling from non-FIPS BouncyCastle (LPD-90318) removed all non-FIPS BouncyCastle usage from deployed bundles, but nothing prevented new code from reintroducing it. This covers the parent story's acceptance criterion for a source-formatter rule that blocks new non-FIPS BouncyCastle usage.

## How It Is Being Fixed

Adds a `BouncyCastleFIPSCheck` to the source formatter, registered under the Java and Gradle source processors so it runs in CI and on formatSource. FIPS BouncyCastle (bc-fips, bcpkix-fips, bcutil-fips) shares the org.bouncycastle.* namespace with the non-FIPS jars and is legitimately used by modules such as saml-opensaml-integration, so a blanket ban would produce false positives. The check therefore targets non-FIPS usage specifically: in Java files it flags imports of the lightweight-engine packages that do not exist in bc-fips (org.bouncycastle.crypto.engines/.generators/.macs/.modes/.paddings/.params/.prng/.signers, org.bouncycastle.jce.provider, org.bouncycastle.jcajce.provider), and in build.gradle files it flags the non-FIPS Gradle coordinates (bcprov-jdk*, bcpkix-jdk*, bcutil-jdk*, bcmail*). Patched third-party modules under modules/third-party are excluded. Unit tests in JavaSourceProcessorTest and GradleSourceProcessorTest cover both the flagged and the allowed FIPS cases.

## PR Check

**pr-check: PASS** — tested on `136515dd54d5aec05353b99ebe2ee706a90afea2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "136515dd54d5aec05353b99ebe2ee706a90afea2"} -->
