### PR TITLE
LPD-95976 Require JDK 17 to build the patched Apache CXF jars

### DIFF
--- a/modules/third-party/org-apache-cxf-core-3.6.11/build.gradle
+++ b/modules/third-party/org-apache-cxf-core-3.6.11/build.gradle
@@ -2,6 +2,10 @@ import com.liferay.gradle.plugins.patcher.PatchTask
 
 apply plugin: "com.liferay.patcher"
 
+if (JavaVersion.current() != JavaVersion.VERSION_17) {
+	throw new GradleException("Project ${project.name} requires JDK 17.")
+}
+
 task patch(type: PatchTask)
 
 dependencies {

--- a/modules/third-party/org-apache-cxf-rt-rs-security-oauth2-3.6.11/build.gradle
+++ b/modules/third-party/org-apache-cxf-rt-rs-security-oauth2-3.6.11/build.gradle
@@ -2,6 +2,10 @@ import com.liferay.gradle.plugins.patcher.PatchTask
 
 apply plugin: "com.liferay.patcher"
 
+if (JavaVersion.current() != JavaVersion.VERSION_17) {
+	throw new GradleException("Project ${project.name} requires JDK 17.")
+}
+
 task patch(type: PatchTask)
 
 dependencies {


### PR DESCRIPTION
Adds a JDK 17 build guard to the two Apache CXF patcher modules (`org-apache-cxf-core-3.6.11` and `org-apache-cxf-rt-rs-security-oauth2-3.6.11`), matching the existing precedent on `org-primefaces` and `jakarta-faces` (LPD-86469).

JDK 21's `javac` ([JDK-8292275](https://bugs.openjdk.org/browse/JDK-8292275)) emits a `MethodParameters` attribute with empty parameter names for the synthetic and mandated constructor parameters of anonymous inner classes (for example `OAuthRequestFilter$1` and `W3CMultiSchemaFactory$RecursiveAllowedXMLSchemaReader$1$1`). The Jakarta transformer (bnd 6.4.0) throws an NPE writing that nameless attribute, so those classes fail to transform and are copied through still referencing `javax.*` — the Jakarta jars come out silently broken. JDK 17's `javac` does not emit the attribute.

The guard fails the build up front on any non-JDK-17 JVM, so these artifacts can only be produced with the correct compiler.

Note: the currently published `3.6.11.LIFERAY-PATCHED-1` javax jars were built with JDK 21 and carry the attribute, so they must be re-published from a JDK 17 build before the Jakarta transform can consume them cleanly.
