### PR TITLE
LPD-95976 Require JDK 17 and bump the patched Apache CXF jars

### DIFF
--- a/modules/third-party/org-apache-cxf-core-3.6.11/bnd.bnd
+++ b/modules/third-party/org-apache-cxf-core-3.6.11/bnd.bnd
@@ -1,2 +1,2 @@
 Bundle-SymbolicName: org.apache.cxf.core
-Bundle-Version: 3.6.11.LIFERAY-PATCHED-1
+Bundle-Version: 3.6.11.LIFERAY-PATCHED-2

--- a/modules/third-party/org-apache-cxf-core-3.6.11/build.gradle
+++ b/modules/third-party/org-apache-cxf-core-3.6.11/build.gradle
@@ -2,6 +2,10 @@ import com.liferay.gradle.plugins.patcher.PatchTask
 
 apply plugin: "com.liferay.patcher"
 
+if (JavaVersion.current() != JavaVersion.VERSION_17) {
+	throw new GradleException("Project ${project.name} requires JDK 17.")
+}
+
 task patch(type: PatchTask)
 
 dependencies {

--- a/modules/third-party/org-apache-cxf-rt-rs-security-oauth2-3.6.11/bnd.bnd
+++ b/modules/third-party/org-apache-cxf-rt-rs-security-oauth2-3.6.11/bnd.bnd
@@ -1,2 +1,2 @@
 Bundle-SymbolicName: org.apache.cxf.rt.rs.security.oauth2
-Bundle-Version: 3.6.11.LIFERAY-PATCHED-1
+Bundle-Version: 3.6.11.LIFERAY-PATCHED-2

--- a/modules/third-party/org-apache-cxf-rt-rs-security-oauth2-3.6.11/build.gradle
+++ b/modules/third-party/org-apache-cxf-rt-rs-security-oauth2-3.6.11/build.gradle
@@ -2,6 +2,10 @@ import com.liferay.gradle.plugins.patcher.PatchTask
 
 apply plugin: "com.liferay.patcher"
 
+if (JavaVersion.current() != JavaVersion.VERSION_17) {
+	throw new GradleException("Project ${project.name} requires JDK 17.")
+}
+
 task patch(type: PatchTask)
 
 dependencies {


### PR DESCRIPTION
Supersedes #3126 — re-sent with a bnd version bump so the corrected build can be published as a new artifact.

Adds a JDK 17 build guard to the two Apache CXF patcher modules (`org-apache-cxf-core-3.6.11` and `org-apache-cxf-rt-rs-security-oauth2-3.6.11`), matching the precedent on `org-primefaces` and `jakarta-faces` (LPD-86469), and bumps their bnd version from `3.6.11.LIFERAY-PATCHED-1` to `3.6.11.LIFERAY-PATCHED-2`.

JDK 21's `javac` ([JDK-8292275](https://bugs.openjdk.org/browse/JDK-8292275)) emits a `MethodParameters` attribute with empty parameter names for the synthetic and mandated constructor parameters of anonymous inner classes (for example `OAuthRequestFilter$1` and `W3CMultiSchemaFactory$RecursiveAllowedXMLSchemaReader$1$1`). The Jakarta transformer (bnd 6.4.0) throws an NPE writing that nameless attribute, so those classes fail to transform and are copied through still referencing `javax.*`. JDK 17's `javac` does not emit it.

The guard fails the build up front on any non-JDK-17 JVM, and the version bump lets the corrected JDK 17 build publish as `LIFERAY-PATCHED-2` rather than overwriting the existing artifacts.

**pr-check: PASS** — tested on `6ccce4b0523d3f55c2513b44c87d0e33e98a8285`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "6ccce4b0523d3f55c2513b44c87d0e33e98a8285"} -->
