### PR TITLE
LPD-6722 Audit segment role assignments and unassignments

### DIFF
--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/build.gradle
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
 	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-api")
 	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-event-generators-api")
+	testIntegrationImplementation project(":apps:segments:segments-api")
+	testIntegrationImplementation project(":apps:segments:segments-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/SegmentsEntryRoleModelListenerTest.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/test/SegmentsEntryRoleModelListenerTest.java
@@ -1,0 +1,107 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.audit.event.generators.internal.model.listener.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.audit.AuditMessage;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.RoleConstants;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.segments.model.SegmentsEntry;
+import com.liferay.segments.service.SegmentsEntryRoleLocalService;
+import com.liferay.segments.test.util.SegmentsTestUtil;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Rafael Praxedes
+ */
+@RunWith(Arquillian.class)
+public class SegmentsEntryRoleModelListenerTest
+	extends BaseModelListenerTestCase {
+
+	@Test
+	public void testOnBeforeCreate() throws Exception {
+		_group = GroupTestUtil.addGroup();
+		_role = RoleTestUtil.addRole(RoleConstants.TYPE_SITE);
+		_segmentsEntry = SegmentsTestUtil.addSegmentsEntry(_group.getGroupId());
+
+		auditMessages.clear();
+
+		_segmentsEntryRoleLocalService.addSegmentsEntryRole(
+			_segmentsEntry.getSegmentsEntryId(), _role.getRoleId(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		AuditMessage auditMessage = fetchAuditMessage(
+			Role.class.getName(), EventTypes.ASSIGN);
+
+		Assert.assertNotNull(auditMessage);
+
+		Assert.assertEquals(_role.getCompanyId(), auditMessage.getCompanyId());
+
+		JSONObject additionalInfoJSONObject = auditMessage.getAdditionalInfo();
+
+		Assert.assertEquals(
+			_role.getName(), additionalInfoJSONObject.getString("roleName"));
+		Assert.assertEquals(
+			_segmentsEntry.getSegmentsEntryId(),
+			additionalInfoJSONObject.getLong("segmentsEntryId"));
+		Assert.assertEquals(
+			_segmentsEntry.getNameCurrentValue(),
+			additionalInfoJSONObject.getString("segmentsEntryName"));
+	}
+
+	@Test
+	public void testOnBeforeRemove() throws Exception {
+		_group = GroupTestUtil.addGroup();
+		_role = RoleTestUtil.addRole(RoleConstants.TYPE_SITE);
+		_segmentsEntry = SegmentsTestUtil.addSegmentsEntry(_group.getGroupId());
+
+		_segmentsEntryRoleLocalService.addSegmentsEntryRole(
+			_segmentsEntry.getSegmentsEntryId(), _role.getRoleId(),
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		auditMessages.clear();
+
+		_segmentsEntryRoleLocalService.deleteSegmentsEntryRole(
+			_segmentsEntry.getSegmentsEntryId(), _role.getRoleId());
+
+		AuditMessage auditMessage = fetchAuditMessage(
+			Role.class.getName(), EventTypes.UNASSIGN);
+
+		Assert.assertNotNull(auditMessage);
+
+		JSONObject additionalInfoJSONObject = auditMessage.getAdditionalInfo();
+
+		Assert.assertEquals(
+			_role.getName(), additionalInfoJSONObject.getString("roleName"));
+		Assert.assertEquals(
+			_segmentsEntry.getNameCurrentValue(),
+			additionalInfoJSONObject.getString("segmentsEntryName"));
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@DeleteAfterTestRun
+	private Role _role;
+
+	@DeleteAfterTestRun
+	private SegmentsEntry _segmentsEntry;
+
+	@Inject
+	private SegmentsEntryRoleLocalService _segmentsEntryRoleLocalService;
+
+}

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/SegmentsEntryRoleModelListener.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/model/listener/SegmentsEntryRoleModelListener.java
@@ -1,0 +1,95 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.audit.event.generators.internal.model.listener;
+
+import com.liferay.portal.kernel.audit.AuditMessage;
+import com.liferay.portal.kernel.audit.AuditRouter;
+import com.liferay.portal.kernel.exception.ModelListenerException;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
+import com.liferay.portal.security.audit.event.generators.util.AuditMessageBuilder;
+import com.liferay.segments.model.SegmentsEntry;
+import com.liferay.segments.model.SegmentsEntryRole;
+import com.liferay.segments.service.SegmentsEntryLocalService;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Rafael Praxedes
+ */
+@Component(service = ModelListener.class)
+public class SegmentsEntryRoleModelListener
+	extends BaseModelListener<SegmentsEntryRole> {
+
+	@Override
+	public void onBeforeCreate(SegmentsEntryRole segmentsEntryRole)
+		throws ModelListenerException {
+
+		auditOnCreateOrRemove(EventTypes.ASSIGN, segmentsEntryRole);
+	}
+
+	@Override
+	public void onBeforeRemove(SegmentsEntryRole segmentsEntryRole)
+		throws ModelListenerException {
+
+		auditOnCreateOrRemove(EventTypes.UNASSIGN, segmentsEntryRole);
+	}
+
+	protected void auditOnCreateOrRemove(
+			String eventType, SegmentsEntryRole segmentsEntryRole)
+		throws ModelListenerException {
+
+		try {
+			AuditMessage auditMessage = AuditMessageBuilder.buildAuditMessage(
+				Role.class.getName(), segmentsEntryRole.getRoleId(), eventType,
+				null);
+
+			JSONObject additionalInfoJSONObject =
+				auditMessage.getAdditionalInfo();
+
+			Role role = _roleLocalService.fetchRole(
+				segmentsEntryRole.getRoleId());
+
+			if (role != null) {
+				additionalInfoJSONObject.put("roleName", role.getName());
+			}
+
+			long segmentsEntryId = segmentsEntryRole.getSegmentsEntryId();
+
+			additionalInfoJSONObject.put("segmentsEntryId", segmentsEntryId);
+
+			SegmentsEntry segmentsEntry =
+				_segmentsEntryLocalService.fetchSegmentsEntry(segmentsEntryId);
+
+			if (segmentsEntry != null) {
+				additionalInfoJSONObject.put(
+					"segmentsEntryName", segmentsEntry.getNameCurrentValue());
+			}
+
+			auditMessage.setCompanyId(segmentsEntryRole.getCompanyId());
+
+			_auditRouter.route(auditMessage);
+		}
+		catch (Exception exception) {
+			throw new ModelListenerException(exception);
+		}
+	}
+
+	@Reference
+	private AuditRouter _auditRouter;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
+	private SegmentsEntryLocalService _segmentsEntryLocalService;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-6722

## What Is Being Fixed

Assigning a segment to a role, or unassigning it, produced no audit trail. A security administrator reviewing the audit log had no record of who changed a role's segment membership or which segment was involved.

## How It Is Being Fixed

A new `SegmentsEntryRoleModelListener` in `portal-security-audit-event-generators` listens on the `SegmentsEntryRole` association entity. Its `onBeforeCreate` and `onBeforeRemove` callbacks route an `ASSIGN` / `UNASSIGN` audit message, so every service path that adds or removes a segment-role — including the cascades triggered by deleting a role or a segment — is covered by a single listener. Each event is anchored on the `Role` (`className` / `classPK`) and carries `roleName`, `segmentsEntryId`, and `segmentsEntryName` in `additionalInfo`. Both the role and segment names are resolved null-safely (`fetchRole`, `fetchSegmentsEntry`), so the segment-deletion cascade — which removes the segment row before its roles — cannot break the delete. An integration test verifies the payload for both the assign and unassign events.

## PR Check

**pr-check: SKIPPED** — Draft PR opened for early visibility; local verification done (formatSource clean, both modules compile, integration test passes). pr-check will run before marking ready for review.

<!-- pr-check {"reason": "Draft PR opened for early visibility; local verification done (formatSource clean, both modules compile, integration test passes). pr-check will run before marking ready for review.", "result": "skipped", "sha": "c35e82b10ae7f1cc60e221d9002deb33920fde9e"} -->
