### PR TITLE
LPD-99039 Narrow the MCP protected resource metadata servlet to an MCP-specific URL

### DIFF
--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerProtectedResourceMetadataServlet.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/MCPServerProtectedResourceMetadataServlet.java
@@ -32,8 +32,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"osgi.http.whiteboard.servlet.name=com.liferay.mcp.server.rest.internal.servlet.MCPServerProtectedResourceMetadataServlet",
-		"osgi.http.whiteboard.servlet.pattern=/.well-known/oauth-protected-resource",
-		"osgi.http.whiteboard.servlet.pattern=/.well-known/oauth-protected-resource/*"
+		"osgi.http.whiteboard.servlet.pattern=/.well-known/oauth-protected-resource/mcp"
 	},
 	service = Servlet.class
 )

--- a/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/filter/MCPServerAuthVerifierFilter.java
+++ b/modules/apps/mcp/mcp-server-rest-impl/src/main/java/com/liferay/mcp/server/rest/internal/servlet/filter/MCPServerAuthVerifierFilter.java
@@ -164,7 +164,8 @@ public class MCPServerAuthVerifierFilter extends AuthVerifierFilter {
 			"Bearer realm=\"mcp\", resource_metadata=\"",
 			_portal.getPortalURL(httpServletRequest), _portal.getPathContext(),
 			Portal.PATH_MODULE,
-			MCPServerConstants.PATH_WELL_KNOWN_PROTECTED_RESOURCE, "\"");
+			MCPServerConstants.PATH_WELL_KNOWN_PROTECTED_RESOURCE,
+			MCPServerConstants.PATH_MCP, "\"");
 	}
 
 	private boolean _isEnabled(long companyId) {

--- a/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerProtectedResourceMetadataServletTest.java
+++ b/modules/apps/mcp/mcp-server-rest-test/src/testIntegration/java/com/liferay/mcp/server/rest/internal/servlet/test/MCPServerProtectedResourceMetadataServletTest.java
@@ -130,7 +130,7 @@ public class MCPServerProtectedResourceMetadataServletTest {
 				URI.create(
 					"http://localhost:" +
 						PortalUtil.getPortalServerPort(false) +
-							"/o/.well-known/oauth-protected-resource")
+							"/o/.well-known/oauth-protected-resource/mcp")
 			).method(
 				method, HttpRequest.BodyPublishers.noBody()
 			).build(),


### PR DESCRIPTION
Addresses [LPD-99039](https://liferay.atlassian.net/browse/LPD-99039), from [this Slack thread](https://liferay.slack.com/archives/C0B3N1ZVDM1/p1782896817243849) (raised by  Alejandro Tardín).

## Problem

`MCPServerProtectedResourceMetadataServlet` registered the OSGi whiteboard patterns `/.well-known/oauth-protected-resource` **and** `/.well-known/oauth-protected-resource/*`, served under the `/o` context — so it claimed the entire `/o/.well-known/oauth-protected-resource/*` subtree for MCP-only static metadata. A future non-MCP protected resource that wants to publish metadata under the `/o` well-known space would have nowhere to go.

This does **not** collide with `OAuth2WellKnownProtectedResourceMetadataFilter`, which is a separate root-space (`/.well-known/oauth-protected-resource`), DB-backed, per-issuer filter.

## Change

Narrow the servlet to the MCP-specific path `/.well-known/oauth-protected-resource/mcp` (served at `/o/.well-known/oauth-protected-resource/mcp`), drop the unused `/*` wildcard (the servlet ignores the path suffix), and update `MCPServerAuthVerifierFilter._getChallenge` so the advertised `resource_metadata` matches. Two commits: the logic change, then the test update.

## Open question (for discussion)

Per RFC 9728 §3.1, the metadata for resource `/o/mcp` would live at the root `/.well-known/oauth-protected-resource/o/mcp` — which `OAuth2WellKnownProtectedResourceMetadataFilter` already serves. So a broader alternative is to drop the dedicated `/o` servlet entirely and route MCP through that filter. This PR takes the smaller, lower-risk step of narrowing the servlet; happy to go the other way if we prefer consolidating on the filter.

## Verification (local)

- `mcp-server-rest-impl` + `mcp-server-rest-test` compile; Source Formatter clean.
- Integration test `MCPServerProtectedResourceMetadataServletTest.testService` — **PASS** against the narrowed URL.
- Regression check — `OAuth2WellKnownProtectedResourceMetadataFilterTest.testProcessFilter` (the root `/.well-known/oauth-protected-resource` endpoint) — **PASS** on the same bundle, confirming the root filter is unaffected.
- Runtime probe: `/o/.well-known/oauth-protected-resource/mcp` → 200, bare `/o/.well-known/oauth-protected-resource` → 404.

Both components are behind feature flag `LPD-63415` (not GA), so the URL change carries no released-client risk.
