### PR TITLE
LPD-92681 Add the SecretManager implementation

### DIFF
--- a/modules/apps/portal-security/portal-security-key-impl/build.gradle
+++ b/modules/apps/portal-security/portal-security-key-impl/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
+	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")
 	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.test", version: "default"
 	testImplementation group: "junit", name: "junit", version: "4.13.1"

--- a/modules/apps/portal-security/portal-security-key-impl/src/main/java/com/liferay/portal/security/key/internal/secret/SecretManagerImpl.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/main/java/com/liferay/portal/security/key/internal/secret/SecretManagerImpl.java
@@ -228,8 +228,8 @@ public class SecretManagerImpl implements SecretManager {
 
 		throw new SecretException(
 			StringBundler.concat(
-				"No secret provider found for ID ", secretProviderId,
-				" and company ID ", companyId));
+				"No secret provider found for secret provider ID ",
+				secretProviderId, " and company ID ", companyId));
 	}
 
 	private String _getSecretProviderId(long companyId, String secretProviderId)
@@ -243,10 +243,10 @@ public class SecretManagerImpl implements SecretManager {
 			return secretProviderId;
 		}
 
-		KeyManagerProfile activeProfile =
+		KeyManagerProfile activeKeyManagerProfile =
 			_keyManagerProfileRegistry.getActiveKeyManagerProfile();
 
-		if (activeProfile == null) {
+		if (activeKeyManagerProfile == null) {
 			throw new SecretException(
 				StringBundler.concat(
 					"No active key manager profile found to resolve the ",
@@ -254,10 +254,12 @@ public class SecretManagerImpl implements SecretManager {
 		}
 
 		if (companyId == CompanyConstants.SYSTEM) {
-			secretProviderId = activeProfile.getSystemSecretProviderId();
+			secretProviderId =
+				activeKeyManagerProfile.getSystemSecretProviderId();
 		}
 		else {
-			secretProviderId = activeProfile.getCompanySecretProviderId();
+			secretProviderId =
+				activeKeyManagerProfile.getCompanySecretProviderId();
 		}
 
 		if (Validator.isNull(secretProviderId)) {

--- a/modules/apps/portal-security/portal-security-key-impl/src/main/java/com/liferay/portal/security/key/internal/secret/SecretManagerImpl.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/main/java/com/liferay/portal/security/key/internal/secret/SecretManagerImpl.java
@@ -1,0 +1,292 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.internal.secret;
+
+import com.liferay.osgi.service.tracker.collections.map.PropertyServiceReferenceMapper;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.security.key.KeyReference;
+import com.liferay.portal.security.key.secret.Secret;
+import com.liferay.portal.security.key.secret.SecretManager;
+import com.liferay.portal.security.key.secret.exception.SecretException;
+import com.liferay.portal.security.key.spi.ProviderStatus;
+import com.liferay.portal.security.key.spi.profile.KeyManagerProfile;
+import com.liferay.portal.security.key.spi.profile.KeyManagerProfileRegistry;
+import com.liferay.portal.security.key.spi.secret.SecretProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Tomas Polesovsky
+ * @author Christopher Kian
+ */
+@Component(service = SecretManager.class)
+public class SecretManagerImpl implements SecretManager {
+
+	@Override
+	public void deleteSecret(long companyId, KeyReference keyReference)
+		throws SecretException {
+
+		if (keyReference == null) {
+			throw new IllegalArgumentException("Key reference is null");
+		}
+
+		try {
+			SecretProvider secretProvider = _getSecretProvider(
+				companyId,
+				_getSecretProviderId(companyId, keyReference.getProviderId()));
+
+			secretProvider.deleteSecret(
+				companyId, keyReference.getIdentifier());
+		}
+		catch (SecretException secretException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to delete secret", secretException);
+			}
+
+			throw secretException;
+		}
+	}
+
+	@Override
+	public List<KeyReference> getKeyReferences(
+			long companyId, String secretProviderId)
+		throws SecretException {
+
+		if (Validator.isNull(secretProviderId)) {
+			throw new IllegalArgumentException("Secret provider ID is null");
+		}
+
+		try {
+			secretProviderId = _getSecretProviderId(
+				companyId, secretProviderId);
+
+			SecretProvider secretProvider = _getSecretProvider(
+				companyId, secretProviderId);
+
+			return _toKeyReferences(
+				secretProvider.getSecretIdentifiers(companyId),
+				secretProviderId);
+		}
+		catch (SecretException secretException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to get secret identifiers", secretException);
+			}
+
+			throw secretException;
+		}
+	}
+
+	@Override
+	public Secret getSecret(long companyId, KeyReference keyReference)
+		throws SecretException {
+
+		if (keyReference == null) {
+			throw new IllegalArgumentException("Key reference is null");
+		}
+
+		try {
+			SecretProvider secretProvider = _getSecretProvider(
+				companyId,
+				_getSecretProviderId(companyId, keyReference.getProviderId()));
+
+			return secretProvider.getSecret(
+				companyId, keyReference.getIdentifier());
+		}
+		catch (SecretException secretException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to get secret", secretException);
+			}
+
+			throw secretException;
+		}
+	}
+
+	@Override
+	public List<String> getSecretProviderIds(long companyId) {
+		List<String> secretProviderIds = new ArrayList<>();
+
+		ServiceTrackerMap<String, List<SecretProvider>> serviceTrackerMap =
+			_serviceTrackerMap;
+
+		if (serviceTrackerMap == null) {
+			return secretProviderIds;
+		}
+
+		for (String secretProviderId : serviceTrackerMap.keySet()) {
+			List<SecretProvider> secretProviders = serviceTrackerMap.getService(
+				secretProviderId);
+
+			if (secretProviders == null) {
+				continue;
+			}
+
+			for (SecretProvider secretProvider : secretProviders) {
+				if (secretProvider.isAllowedCompany(companyId)) {
+					secretProviderIds.add(secretProviderId);
+
+					break;
+				}
+			}
+		}
+
+		return secretProviderIds;
+	}
+
+	@Override
+	public KeyReference putSecret(long companyId, Secret secret)
+		throws SecretException {
+
+		if (secret == null) {
+			throw new IllegalArgumentException("Secret is null");
+		}
+
+		try {
+			KeyReference keyReference = secret.getKeyReference();
+
+			String secretProviderId = _getSecretProviderId(
+				companyId, keyReference.getProviderId());
+
+			SecretProvider secretProvider = _getSecretProvider(
+				companyId, secretProviderId);
+
+			secretProvider.putSecret(companyId, secret);
+
+			return new KeyReference(
+				keyReference.getIdentifier(), secretProviderId,
+				KeyReference.Type.SECRET);
+		}
+		catch (SecretException secretException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to put secret", secretException);
+			}
+
+			throw secretException;
+		}
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceTrackerMap = ServiceTrackerMapFactory.openMultiValueMap(
+			bundleContext, SecretProvider.class, "(secret.provider.id=*)",
+			new PropertyServiceReferenceMapper<>("secret.provider.id"));
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		if (_serviceTrackerMap != null) {
+			_serviceTrackerMap.close();
+
+			_serviceTrackerMap = null;
+		}
+	}
+
+	private SecretProvider _getSecretProvider(
+			long companyId, String secretProviderId)
+		throws SecretException {
+
+		List<SecretProvider> secretProviders = _serviceTrackerMap.getService(
+			secretProviderId);
+
+		if (secretProviders != null) {
+			for (SecretProvider secretProvider : secretProviders) {
+				if (!secretProvider.isAllowedCompany(companyId)) {
+					continue;
+				}
+
+				if (secretProvider.getProviderStatus() ==
+						ProviderStatus.ERROR) {
+
+					throw new SecretException(
+						StringBundler.concat(
+							"Secret provider ", secretProviderId,
+							" is in an error state for company ID ",
+							companyId));
+				}
+
+				return secretProvider;
+			}
+		}
+
+		throw new SecretException(
+			StringBundler.concat(
+				"No secret provider found for ID ", secretProviderId,
+				" and company ID ", companyId));
+	}
+
+	private String _getSecretProviderId(long companyId, String secretProviderId)
+		throws SecretException {
+
+		if (Validator.isNull(secretProviderId)) {
+			throw new IllegalArgumentException("Secret provider ID is null");
+		}
+
+		if (!Objects.equals(secretProviderId, StringPool.STAR)) {
+			return secretProviderId;
+		}
+
+		KeyManagerProfile activeProfile =
+			_keyManagerProfileRegistry.getActiveKeyManagerProfile();
+
+		if (activeProfile == null) {
+			throw new SecretException(
+				StringBundler.concat(
+					"No active key manager profile found to resolve the ",
+					"provider wildcard for company ID ", companyId));
+		}
+
+		if (companyId == CompanyConstants.SYSTEM) {
+			secretProviderId = activeProfile.getSystemSecretProviderId();
+		}
+		else {
+			secretProviderId = activeProfile.getCompanySecretProviderId();
+		}
+
+		if (Validator.isNull(secretProviderId)) {
+			throw new SecretException(
+				StringBundler.concat(
+					"The active key manager profile does not configure a ",
+					(companyId == CompanyConstants.SYSTEM) ? "system" :
+						"company",
+					" secret provider ID"));
+		}
+
+		return secretProviderId;
+	}
+
+	private List<KeyReference> _toKeyReferences(
+		List<String> secretIdentifiers, String secretProviderId) {
+
+		return TransformUtil.transform(
+			secretIdentifiers,
+			secretIdentifier -> new KeyReference(
+				secretIdentifier, secretProviderId, KeyReference.Type.SECRET));
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SecretManagerImpl.class);
+
+	@Reference
+	private KeyManagerProfileRegistry _keyManagerProfileRegistry;
+
+	private ServiceTrackerMap<String, List<SecretProvider>> _serviceTrackerMap;
+
+}

--- a/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/secret/SecretManagerImplTest.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/secret/SecretManagerImplTest.java
@@ -123,15 +123,15 @@ public class SecretManagerImplTest {
 		// Delegates to the provider
 
 		long companyId = RandomTestUtil.randomLong();
-		String identifier = RandomTestUtil.randomString();
+		String secretIdentifier = RandomTestUtil.randomString();
 		String secretProviderId = RandomTestUtil.randomString();
 
 		Mockito.when(
-			_secretProvider.getSecret(companyId, identifier)
+			_secretProvider.getSecret(companyId, secretIdentifier)
 		).thenReturn(
 			new Secret(
 				RandomTestUtil.randomBytes(),
-				_keyReference(secretProviderId, identifier))
+				_keyReference(secretProviderId, secretIdentifier))
 		);
 
 		Mockito.when(
@@ -147,12 +147,12 @@ public class SecretManagerImplTest {
 		);
 
 		_secretManagerImpl.getSecret(
-			companyId, _keyReference(secretProviderId, identifier));
+			companyId, _keyReference(secretProviderId, secretIdentifier));
 
 		Mockito.verify(
 			_secretProvider
 		).getSecret(
-			companyId, identifier
+			companyId, secretIdentifier
 		);
 
 		// Throws when the provider is in an error state
@@ -232,10 +232,10 @@ public class SecretManagerImplTest {
 		);
 
 		long companyId = RandomTestUtil.randomLong();
-		String identifier = RandomTestUtil.randomString();
+		String secretIdentifier = RandomTestUtil.randomString();
 
 		try (Secret secret = new Secret(
-				_keyReference(secretProviderId, identifier),
+				_keyReference(secretProviderId, secretIdentifier),
 				RandomTestUtil.randomString())) {
 
 			_secretManagerImpl.putSecret(companyId, secret);
@@ -258,10 +258,10 @@ public class SecretManagerImplTest {
 	}
 
 	private KeyReference _keyReference(
-		String secretProviderId, String identifier) {
+		String secretProviderId, String secretIdentifier) {
 
 		return new KeyReference(
-			identifier, secretProviderId, KeyReference.Type.SECRET);
+			secretIdentifier, secretProviderId, KeyReference.Type.SECRET);
 	}
 
 	private void _testPutSecretResolvesProviderWildcard(long companyId)

--- a/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/secret/SecretManagerImplTest.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/secret/SecretManagerImplTest.java
@@ -54,14 +54,42 @@ public class SecretManagerImplTest {
 	}
 
 	@Test
-	public void testDeleteSecret() {
+	public void testDeleteSecret() throws Exception {
+
+		// Delegates to the provider
+
+		long companyId = RandomTestUtil.randomLong();
+		String secretIdentifier = RandomTestUtil.randomString();
 		String secretProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_secretProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_serviceTrackerMap.getService(secretProviderId)
+		).thenReturn(
+			Collections.singletonList(_secretProvider)
+		);
+
+		_secretManagerImpl.deleteSecret(
+			companyId, _createKeyReference(secretIdentifier, secretProviderId));
+
+		Mockito.verify(
+			_secretProvider
+		).deleteSecret(
+			companyId, secretIdentifier
+		);
+
+		// Throws when the provider is not found
 
 		Assert.assertThrows(
 			SecretException.class,
 			() -> _secretManagerImpl.deleteSecret(
 				RandomTestUtil.randomLong(),
-				_createKeyReference(secretProviderId)));
+				_createKeyReference(RandomTestUtil.randomString())));
 	}
 
 	@Test

--- a/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/secret/SecretManagerImplTest.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/secret/SecretManagerImplTest.java
@@ -128,7 +128,7 @@ public class SecretManagerImplTest {
 		).thenReturn(
 			new Secret(
 				RandomTestUtil.randomBytes(),
-				_keyReference(secretProviderId, secretIdentifier))
+				_keyReference(secretIdentifier, secretProviderId))
 		);
 
 		Mockito.when(
@@ -144,7 +144,7 @@ public class SecretManagerImplTest {
 		);
 
 		_secretManagerImpl.getSecret(
-			companyId, _keyReference(secretProviderId, secretIdentifier));
+			companyId, _keyReference(secretIdentifier, secretProviderId));
 
 		Mockito.verify(
 			_secretProvider
@@ -223,7 +223,7 @@ public class SecretManagerImplTest {
 		String secretIdentifier = RandomTestUtil.randomString();
 
 		try (Secret secret = new Secret(
-				_keyReference(secretProviderId, secretIdentifier),
+				_keyReference(secretIdentifier, secretProviderId),
 				RandomTestUtil.randomString())) {
 
 			_secretManagerImpl.putSecret(companyId, secret);
@@ -240,11 +240,11 @@ public class SecretManagerImplTest {
 	}
 
 	private KeyReference _keyReference(String secretProviderId) {
-		return _keyReference(secretProviderId, RandomTestUtil.randomString());
+		return _keyReference(RandomTestUtil.randomString(), secretProviderId);
 	}
 
 	private KeyReference _keyReference(
-		String secretProviderId, String secretIdentifier) {
+		String secretIdentifier, String secretProviderId) {
 
 		return new KeyReference(
 			secretIdentifier, secretProviderId, KeyReference.Type.SECRET);
@@ -289,7 +289,7 @@ public class SecretManagerImplTest {
 		);
 
 		try (Secret secret = new Secret(
-				_keyReference(StringPool.STAR, RandomTestUtil.randomString()),
+				_keyReference(RandomTestUtil.randomString(), StringPool.STAR),
 				RandomTestUtil.randomString())) {
 
 			_secretManagerImpl.putSecret(companyId, secret);

--- a/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/secret/SecretManagerImplTest.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/secret/SecretManagerImplTest.java
@@ -85,12 +85,12 @@ public class SecretManagerImplTest {
 			_keyManagerProfile
 		);
 
-		String identifier = RandomTestUtil.randomString();
+		String secretIdentifier = RandomTestUtil.randomString();
 
 		Mockito.when(
 			_secretProvider.getSecretIdentifiers(Mockito.anyLong())
 		).thenReturn(
-			Collections.singletonList(identifier)
+			Collections.singletonList(secretIdentifier)
 		);
 
 		Mockito.when(
@@ -113,7 +113,7 @@ public class SecretManagerImplTest {
 		KeyReference keyReference = keyReferences.get(0);
 
 		Assert.assertEquals(KeyReference.Type.SECRET, keyReference.getType());
-		Assert.assertEquals(identifier, keyReference.getIdentifier());
+		Assert.assertEquals(secretIdentifier, keyReference.getIdentifier());
 		Assert.assertEquals(secretProviderId, keyReference.getProviderId());
 	}
 

--- a/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/secret/SecretManagerImplTest.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/secret/SecretManagerImplTest.java
@@ -119,9 +119,6 @@ public class SecretManagerImplTest {
 
 	@Test
 	public void testGetSecret() throws Exception {
-
-		// Delegates to the provider
-
 		long companyId = RandomTestUtil.randomLong();
 		String secretIdentifier = RandomTestUtil.randomString();
 		String secretProviderId = RandomTestUtil.randomString();
@@ -155,8 +152,6 @@ public class SecretManagerImplTest {
 			companyId, secretIdentifier
 		);
 
-		// Throws when the provider is in an error state
-
 		Mockito.when(
 			_secretProvider.getProviderStatus()
 		).thenReturn(
@@ -171,6 +166,14 @@ public class SecretManagerImplTest {
 
 	@Test
 	public void testGetSecretProviderIds() {
+		long companyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_secretProvider.isAllowedCompany(companyId)
+		).thenReturn(
+			true
+		);
+
 		String secretProviderId = RandomTestUtil.randomString();
 
 		Mockito.when(
@@ -185,21 +188,9 @@ public class SecretManagerImplTest {
 			Collections.singleton(secretProviderId)
 		);
 
-		// Includes a provider that allows the company
-
-		long companyId = RandomTestUtil.randomLong();
-
-		Mockito.when(
-			_secretProvider.isAllowedCompany(companyId)
-		).thenReturn(
-			true
-		);
-
 		Assert.assertEquals(
 			Collections.singletonList(secretProviderId),
 			_secretManagerImpl.getSecretProviderIds(companyId));
-
-		// Excludes a provider that does not allow the company
 
 		Mockito.when(
 			_secretProvider.isAllowedCompany(companyId)
@@ -214,9 +205,6 @@ public class SecretManagerImplTest {
 
 	@Test
 	public void testPutSecret() throws Exception {
-
-		// Routes to the resolved provider
-
 		Mockito.when(
 			_secretProvider.isAllowedCompany(Mockito.anyLong())
 		).thenReturn(
@@ -246,8 +234,6 @@ public class SecretManagerImplTest {
 		).putSecret(
 			Mockito.eq(companyId), Mockito.any(Secret.class)
 		);
-
-		// Resolves the provider wildcard through the active profile
 
 		_testPutSecretResolvesProviderWildcard(CompanyConstants.SYSTEM);
 		_testPutSecretResolvesProviderWildcard(RandomTestUtil.randomLong());

--- a/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/secret/SecretManagerImplTest.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/secret/SecretManagerImplTest.java
@@ -112,9 +112,9 @@ public class SecretManagerImplTest {
 
 		KeyReference keyReference = keyReferences.get(0);
 
-		Assert.assertEquals(KeyReference.Type.SECRET, keyReference.getType());
 		Assert.assertEquals(secretIdentifier, keyReference.getIdentifier());
 		Assert.assertEquals(secretProviderId, keyReference.getProviderId());
+		Assert.assertEquals(KeyReference.Type.SECRET, keyReference.getType());
 	}
 
 	@Test

--- a/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/secret/SecretManagerImplTest.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/secret/SecretManagerImplTest.java
@@ -1,0 +1,339 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.internal.secret;
+
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.security.key.KeyReference;
+import com.liferay.portal.security.key.secret.Secret;
+import com.liferay.portal.security.key.secret.exception.SecretException;
+import com.liferay.portal.security.key.spi.ProviderStatus;
+import com.liferay.portal.security.key.spi.profile.KeyManagerProfile;
+import com.liferay.portal.security.key.spi.profile.KeyManagerProfileRegistry;
+import com.liferay.portal.security.key.spi.secret.SecretProvider;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Christopher Kian
+ */
+public class SecretManagerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.openMocks(this);
+
+		ReflectionTestUtil.setFieldValue(
+			_secretManagerImpl, "_keyManagerProfileRegistry",
+			_keyManagerProfileRegistry);
+		ReflectionTestUtil.setFieldValue(
+			_secretManagerImpl, "_serviceTrackerMap", _serviceTrackerMap);
+	}
+
+	@Test
+	public void testDeleteSecret() {
+		String secretProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_serviceTrackerMap.getService(secretProviderId)
+		).thenReturn(
+			null
+		);
+
+		Assert.assertThrows(
+			SecretException.class,
+			() -> _secretManagerImpl.deleteSecret(
+				RandomTestUtil.randomLong(), _keyReference(secretProviderId)));
+	}
+
+	@Test
+	public void testGetKeyReferences() throws Exception {
+		String secretProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_keyManagerProfile.getCompanySecretProviderId()
+		).thenReturn(
+			secretProviderId
+		);
+
+		Mockito.when(
+			_keyManagerProfileRegistry.getActiveKeyManagerProfile()
+		).thenReturn(
+			_keyManagerProfile
+		);
+
+		String identifier = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_secretProvider.getSecretIdentifiers(Mockito.anyLong())
+		).thenReturn(
+			Collections.singletonList(identifier)
+		);
+
+		Mockito.when(
+			_secretProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_serviceTrackerMap.getService(secretProviderId)
+		).thenReturn(
+			Collections.singletonList(_secretProvider)
+		);
+
+		List<KeyReference> keyReferences = _secretManagerImpl.getKeyReferences(
+			RandomTestUtil.randomLong(), StringPool.STAR);
+
+		Assert.assertEquals(keyReferences.toString(), 1, keyReferences.size());
+
+		KeyReference keyReference = keyReferences.get(0);
+
+		Assert.assertEquals(KeyReference.Type.SECRET, keyReference.getType());
+		Assert.assertEquals(identifier, keyReference.getIdentifier());
+		Assert.assertEquals(secretProviderId, keyReference.getProviderId());
+	}
+
+	@Test
+	public void testGetSecret() throws Exception {
+
+		// Delegates to the provider
+
+		long companyId = RandomTestUtil.randomLong();
+		String identifier = RandomTestUtil.randomString();
+		String secretProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_secretProvider.getSecret(companyId, identifier)
+		).thenReturn(
+			new Secret(
+				RandomTestUtil.randomBytes(),
+				_keyReference(secretProviderId, identifier))
+		);
+
+		Mockito.when(
+			_secretProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_serviceTrackerMap.getService(secretProviderId)
+		).thenReturn(
+			Collections.singletonList(_secretProvider)
+		);
+
+		_secretManagerImpl.getSecret(
+			companyId, _keyReference(secretProviderId, identifier));
+
+		Mockito.verify(
+			_secretProvider
+		).getSecret(
+			companyId, identifier
+		);
+
+		// Throws when the provider is in an error state
+
+		Mockito.when(
+			_secretProvider.getProviderStatus()
+		).thenReturn(
+			ProviderStatus.ERROR
+		);
+
+		Assert.assertThrows(
+			SecretException.class,
+			() -> _secretManagerImpl.getSecret(
+				RandomTestUtil.randomLong(), _keyReference(secretProviderId)));
+	}
+
+	@Test
+	public void testGetSecretProviderIds() {
+		String secretProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_serviceTrackerMap.getService(secretProviderId)
+		).thenReturn(
+			Collections.singletonList(_secretProvider)
+		);
+
+		Mockito.when(
+			_serviceTrackerMap.keySet()
+		).thenReturn(
+			Collections.singleton(secretProviderId)
+		);
+
+		// Includes a provider that allows the company
+
+		long companyId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_secretProvider.isAllowedCompany(companyId)
+		).thenReturn(
+			true
+		);
+
+		Assert.assertEquals(
+			Collections.singletonList(secretProviderId),
+			_secretManagerImpl.getSecretProviderIds(companyId));
+
+		// Excludes a provider that does not allow the company
+
+		Mockito.when(
+			_secretProvider.isAllowedCompany(companyId)
+		).thenReturn(
+			false
+		);
+
+		Assert.assertEquals(
+			Collections.emptyList(),
+			_secretManagerImpl.getSecretProviderIds(companyId));
+	}
+
+	@Test
+	public void testPutSecret() throws Exception {
+
+		// Routes to the resolved provider
+
+		Mockito.when(
+			_secretProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		String secretProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_serviceTrackerMap.getService(secretProviderId)
+		).thenReturn(
+			Collections.singletonList(_secretProvider)
+		);
+
+		long companyId = RandomTestUtil.randomLong();
+		String identifier = RandomTestUtil.randomString();
+
+		try (Secret secret = new Secret(
+				_keyReference(secretProviderId, identifier),
+				RandomTestUtil.randomString())) {
+
+			_secretManagerImpl.putSecret(companyId, secret);
+		}
+
+		Mockito.verify(
+			_secretProvider
+		).putSecret(
+			Mockito.eq(companyId), Mockito.any(Secret.class)
+		);
+
+		// Resolves the provider wildcard through the active profile
+
+		_testPutSecretResolvesProviderWildcard(CompanyConstants.SYSTEM);
+		_testPutSecretResolvesProviderWildcard(RandomTestUtil.randomLong());
+	}
+
+	private KeyReference _keyReference(String secretProviderId) {
+		return _keyReference(secretProviderId, RandomTestUtil.randomString());
+	}
+
+	private KeyReference _keyReference(
+		String secretProviderId, String identifier) {
+
+		return new KeyReference(
+			identifier, secretProviderId, KeyReference.Type.SECRET);
+	}
+
+	private void _testPutSecretResolvesProviderWildcard(long companyId)
+		throws Exception {
+
+		String secretProviderId = RandomTestUtil.randomString();
+
+		if (companyId == CompanyConstants.SYSTEM) {
+			Mockito.when(
+				_keyManagerProfile.getSystemSecretProviderId()
+			).thenReturn(
+				secretProviderId
+			);
+		}
+		else {
+			Mockito.when(
+				_keyManagerProfile.getCompanySecretProviderId()
+			).thenReturn(
+				secretProviderId
+			);
+		}
+
+		Mockito.when(
+			_keyManagerProfileRegistry.getActiveKeyManagerProfile()
+		).thenReturn(
+			_keyManagerProfile
+		);
+
+		Mockito.when(
+			_secretProvider.isAllowedCompany(companyId)
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_serviceTrackerMap.getService(secretProviderId)
+		).thenReturn(
+			Collections.singletonList(_secretProvider)
+		);
+
+		try (Secret secret = new Secret(
+				_keyReference(StringPool.STAR, RandomTestUtil.randomString()),
+				RandomTestUtil.randomString())) {
+
+			_secretManagerImpl.putSecret(companyId, secret);
+		}
+
+		if (companyId == CompanyConstants.SYSTEM) {
+			Mockito.verify(
+				_keyManagerProfile
+			).getSystemSecretProviderId();
+		}
+		else {
+			Mockito.verify(
+				_keyManagerProfile
+			).getCompanySecretProviderId();
+		}
+	}
+
+	@Mock
+	private KeyManagerProfile _keyManagerProfile;
+
+	@Mock
+	private KeyManagerProfileRegistry _keyManagerProfileRegistry;
+
+	private final SecretManagerImpl _secretManagerImpl =
+		new SecretManagerImpl();
+
+	@Mock
+	private SecretProvider _secretProvider;
+
+	@Mock
+	private ServiceTrackerMap<String, List<SecretProvider>> _serviceTrackerMap;
+
+}

--- a/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/secret/SecretManagerImplTest.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/secret/SecretManagerImplTest.java
@@ -57,16 +57,11 @@ public class SecretManagerImplTest {
 	public void testDeleteSecret() {
 		String secretProviderId = RandomTestUtil.randomString();
 
-		Mockito.when(
-			_serviceTrackerMap.getService(secretProviderId)
-		).thenReturn(
-			null
-		);
-
 		Assert.assertThrows(
 			SecretException.class,
 			() -> _secretManagerImpl.deleteSecret(
-				RandomTestUtil.randomLong(), _keyReference(secretProviderId)));
+				RandomTestUtil.randomLong(),
+				_createKeyReference(secretProviderId)));
 	}
 
 	@Test
@@ -119,6 +114,9 @@ public class SecretManagerImplTest {
 
 	@Test
 	public void testGetSecret() throws Exception {
+
+		// Delegates to the provider
+
 		long companyId = RandomTestUtil.randomLong();
 		String secretIdentifier = RandomTestUtil.randomString();
 		String secretProviderId = RandomTestUtil.randomString();
@@ -128,7 +126,7 @@ public class SecretManagerImplTest {
 		).thenReturn(
 			new Secret(
 				RandomTestUtil.randomBytes(),
-				_keyReference(secretIdentifier, secretProviderId))
+				_createKeyReference(secretIdentifier, secretProviderId))
 		);
 
 		Mockito.when(
@@ -144,13 +142,15 @@ public class SecretManagerImplTest {
 		);
 
 		_secretManagerImpl.getSecret(
-			companyId, _keyReference(secretIdentifier, secretProviderId));
+			companyId, _createKeyReference(secretIdentifier, secretProviderId));
 
 		Mockito.verify(
 			_secretProvider
 		).getSecret(
 			companyId, secretIdentifier
 		);
+
+		// Throws when the provider is in an error state
 
 		Mockito.when(
 			_secretProvider.getProviderStatus()
@@ -161,12 +161,15 @@ public class SecretManagerImplTest {
 		Assert.assertThrows(
 			SecretException.class,
 			() -> _secretManagerImpl.getSecret(
-				RandomTestUtil.randomLong(), _keyReference(secretProviderId)));
+				RandomTestUtil.randomLong(),
+				_createKeyReference(secretProviderId)));
 	}
 
 	@Test
 	public void testGetSecretProviderIds() {
 		long companyId = RandomTestUtil.randomLong();
+
+		// Includes a provider that allows the company
 
 		Mockito.when(
 			_secretProvider.isAllowedCompany(companyId)
@@ -191,6 +194,8 @@ public class SecretManagerImplTest {
 		Assert.assertEquals(
 			Collections.singletonList(secretProviderId),
 			_secretManagerImpl.getSecretProviderIds(companyId));
+
+		// Excludes a provider that does not allow the company
 
 		Mockito.when(
 			_secretProvider.isAllowedCompany(companyId)
@@ -223,7 +228,7 @@ public class SecretManagerImplTest {
 		String secretIdentifier = RandomTestUtil.randomString();
 
 		try (Secret secret = new Secret(
-				_keyReference(secretIdentifier, secretProviderId),
+				_createKeyReference(secretIdentifier, secretProviderId),
 				RandomTestUtil.randomString())) {
 
 			_secretManagerImpl.putSecret(companyId, secret);
@@ -239,11 +244,12 @@ public class SecretManagerImplTest {
 		_testPutSecretResolvesProviderWildcard(RandomTestUtil.randomLong());
 	}
 
-	private KeyReference _keyReference(String secretProviderId) {
-		return _keyReference(RandomTestUtil.randomString(), secretProviderId);
+	private KeyReference _createKeyReference(String secretProviderId) {
+		return _createKeyReference(
+			RandomTestUtil.randomString(), secretProviderId);
 	}
 
-	private KeyReference _keyReference(
+	private KeyReference _createKeyReference(
 		String secretIdentifier, String secretProviderId) {
 
 		return new KeyReference(
@@ -289,7 +295,8 @@ public class SecretManagerImplTest {
 		);
 
 		try (Secret secret = new Secret(
-				_keyReference(RandomTestUtil.randomString(), StringPool.STAR),
+				_createKeyReference(
+					RandomTestUtil.randomString(), StringPool.STAR),
 				RandomTestUtil.randomString())) {
 
 			_secretManagerImpl.putSecret(companyId, secret);


### PR DESCRIPTION
`SecretManagerImpl` (final layer of the SecretManager split), rebased on the latest master. Carries Brian's earlier review commits plus follow-ups; latest commit refines the test per his review on #178836 (`_createKeyReference` rename, dropped a redundant stub in testDeleteSecret, and one-line valid/invalid scenario comments).