### PR TITLE
LPD-88886 Mask secret-bearing translator configuration fields

### DIFF
--- a/modules/apps/translation/translation-translator-aws/src/main/java/com/liferay/translation/translator/aws/internal/configuration/AWSTranslatorConfiguration.java
+++ b/modules/apps/translation/translation-translator-aws/src/main/java/com/liferay/translation/translator/aws/internal/configuration/AWSTranslatorConfiguration.java
@@ -35,7 +35,10 @@ public interface AWSTranslatorConfiguration {
 	@Meta.AD(deflt = "us-west-1", name = "region", required = false)
 	public String region();
 
-	@Meta.AD(deflt = "", name = "secret-key", required = false)
+	@Meta.AD(
+		deflt = "", name = "secret-key", required = false,
+		type = Meta.Type.Password
+	)
 	public String secretKey();
 
 }

--- a/modules/apps/translation/translation-translator-azure/src/main/java/com/liferay/translation/translator/azure/internal/configuration/AzureTranslatorConfiguration.java
+++ b/modules/apps/translation/translation-translator-azure/src/main/java/com/liferay/translation/translator/azure/internal/configuration/AzureTranslatorConfiguration.java
@@ -32,7 +32,10 @@ public interface AzureTranslatorConfiguration {
 	@Meta.AD(deflt = "", name = "resource-location-name", required = false)
 	public String resourceLocation();
 
-	@Meta.AD(deflt = "", name = "subscription-key-name", required = false)
+	@Meta.AD(
+		deflt = "", name = "subscription-key-name", required = false,
+		type = Meta.Type.Password
+	)
 	public String subscriptionKey();
 
 }

--- a/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/configuration/DeepLTranslatorConfiguration.java
+++ b/modules/apps/translation/translation-translator-deepl/src/main/java/com/liferay/translation/translator/deepl/internal/configuration/DeepLTranslatorConfiguration.java
@@ -23,7 +23,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 )
 public interface DeepLTranslatorConfiguration {
 
-	@Meta.AD(name = "token", required = false)
+	@Meta.AD(name = "token", required = false, type = Meta.Type.Password)
 	public String authKey();
 
 	@Meta.AD(

--- a/modules/apps/translation/translation-translator-google-cloud/src/main/java/com/liferay/translation/translator/google/cloud/internal/configuration/GoogleCloudTranslatorConfiguration.java
+++ b/modules/apps/translation/translation-translator-google-cloud/src/main/java/com/liferay/translation/translator/google/cloud/internal/configuration/GoogleCloudTranslatorConfiguration.java
@@ -32,7 +32,8 @@ public interface GoogleCloudTranslatorConfiguration {
 
 	@Meta.AD(
 		deflt = "", description = "service-account-private-key-description",
-		name = "service-account-private-key", required = false
+		name = "service-account-private-key", required = false,
+		type = Meta.Type.Password
 	)
 	public String serviceAccountPrivateKey();
 


### PR DESCRIPTION
Part of the LPD-88411 credential-hardening sweep (LPD-88886). Flags the credential fields of the AWS, Azure, DeepL, and Google Cloud translator configurations with the masked-input metatype type so they render as masked input instead of plain text:

- `AWSTranslatorConfiguration#secretKey`
- `AzureTranslatorConfiguration#subscriptionKey`
- `DeepLTranslatorConfiguration#authKey`
- `GoogleCloudTranslatorConfiguration#serviceAccountPrivateKey`

`AWSTranslatorConfiguration#accessKey` is intentionally left as plain text: an AWS access key ID is not confidential (AwsBasicCredentials.toString prints it while redacting the secretAccessKey).

This mirrors the pattern already applied to the search connection configurations (e.g. OpenSearchConnectionConfiguration).

<!-- pr-check {"result":"success","sha":"34695a7403809292c2241b17b7221b9ad061dd31"} -->