### PR TITLE
LPD-88886 Mask credential fields in the S3 and GCS store configurations

### DIFF
--- a/modules/apps/portal-store/portal-store-gcs/src/main/java/com/liferay/portal/store/gcs/configuration/GCSStoreConfiguration.java
+++ b/modules/apps/portal-store/portal-store-gcs/src/main/java/com/liferay/portal/store/gcs/configuration/GCSStoreConfiguration.java
@@ -22,7 +22,7 @@ public interface GCSStoreConfiguration {
 
 	@Meta.AD(
 		deflt = "", description = "aes256-key-help", name = "aes256-key",
-		required = false
+		required = false, type = Meta.Type.Password
 	)
 	public String aes256Key();
 
@@ -82,7 +82,7 @@ public interface GCSStoreConfiguration {
 	)
 	@Meta.AD(
 		description = "service-account-key-help", name = "service-account-key",
-		required = false
+		required = false, type = Meta.Type.Password
 	)
 	public String serviceAccountKey();
 

--- a/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/configuration/S3StoreConfiguration.java
+++ b/modules/apps/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/configuration/S3StoreConfiguration.java
@@ -148,7 +148,8 @@ public interface S3StoreConfiguration {
 	public String s3StorageClass();
 
 	@Meta.AD(
-		description = "secret-key-help", name = "secret-key", required = false
+		description = "secret-key-help", name = "secret-key", required = false,
+		type = Meta.Type.Password
 	)
 	public String secretKey();
 


### PR DESCRIPTION
Part of the LPD-88411 credential-hardening sweep (LPD-88886). Flags the credential fields of the S3 and Google Cloud Storage store configurations with the masked-input metatype type so they render as masked input instead of plain text:

- `S3StoreConfiguration#secretKey`
- `GCSStoreConfiguration#aes256Key`
- `GCSStoreConfiguration#serviceAccountKey`

`S3StoreConfiguration#accessKey` is intentionally left as plain text: an access key ID is not confidential (mirroring the adjacent `proxyPassword`, already masked, versus `proxyUsername`, which is not).

This continues the pattern applied to the translator configurations (PR pending forward) and the search connection configurations.

<!-- pr-check {"result":"success","sha":"a9f73e4e6107a21fdf0e134c7293e9e8da6efdd4"} -->
