### PR TITLE
LPD-88886 Mask credential fields in push notification configurations

### DIFF
--- a/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-apple/src/main/java/com/liferay/push/notifications/sender/apple/internal/configuration/ApplePushNotificationsSenderConfiguration.java
+++ b/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-apple/src/main/java/com/liferay/push/notifications/sender/apple/internal/configuration/ApplePushNotificationsSenderConfiguration.java
@@ -27,7 +27,8 @@ public interface ApplePushNotificationsSenderConfiguration {
 
 	@Meta.AD(
 		description = "certificate-password-description",
-		name = "certificate-password-name", required = false
+		name = "certificate-password-name", required = false,
+		type = Meta.Type.Password
 	)
 	public String certificatePassword();
 

--- a/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-firebase/src/main/java/com/liferay/push/notifications/sender/firebase/internal/configuration/FirebasePushNotificationsSenderConfiguration.java
+++ b/modules/apps/push-notifications/push-notifications-sender/push-notifications-sender-firebase/src/main/java/com/liferay/push/notifications/sender/firebase/internal/configuration/FirebasePushNotificationsSenderConfiguration.java
@@ -41,7 +41,7 @@ public interface FirebasePushNotificationsSenderConfiguration {
 	)
 	@Meta.AD(
 		description = "service-account-key-help", name = "service-account-key",
-		required = false
+		required = false, type = Meta.Type.Password
 	)
 	public String serviceAccountKey();
 


### PR DESCRIPTION
Part of the LPD-88411 credential-hardening sweep (LPD-88886). Flags the credential fields of the Apple and Firebase push notification sender configurations with the masked-input metatype type so they render as masked input instead of plain text:

- `ApplePushNotificationsSenderConfiguration#certificatePassword`
- `FirebasePushNotificationsSenderConfiguration#serviceAccountKey`

The SMS sender's `authToken` is an equivalent credential but is deferred to a follow-up: its `name` value is a legacy dot-delimited key (`authentication.token.name`), and touching the annotation trips `JavaMetaAnnotationsCheck`, which requires the dash-delimited form — a language-key migration best kept out of this annotation-only change.

This continues the pattern applied to the translator and store configurations.

<!-- pr-check {"result":"success","sha":"32711e9252a292c045cd94ad59da222f3215f235"} -->
