### PR TITLE
LPD-88886 Mask API key fields in AI provider configurations

### DIFF
--- a/modules/apps/ai-creator/ai-creator-openai-api/src/main/java/com/liferay/ai/creator/openai/configuration/AICreatorOpenAICompanyConfiguration.java
+++ b/modules/apps/ai-creator/ai-creator-openai-api/src/main/java/com/liferay/ai/creator/openai/configuration/AICreatorOpenAICompanyConfiguration.java
@@ -23,7 +23,10 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 )
 public interface AICreatorOpenAICompanyConfiguration {
 
-	@Meta.AD(deflt = "", name = "api-key", required = false)
+	@Meta.AD(
+		deflt = "", name = "api-key", required = false,
+		type = Meta.Type.Password
+	)
 	public String apiKey();
 
 	@Meta.AD(

--- a/modules/apps/ai-creator/ai-creator-openai-api/src/main/java/com/liferay/ai/creator/openai/configuration/AICreatorOpenAIGroupConfiguration.java
+++ b/modules/apps/ai-creator/ai-creator-openai-api/src/main/java/com/liferay/ai/creator/openai/configuration/AICreatorOpenAIGroupConfiguration.java
@@ -23,7 +23,10 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 )
 public interface AICreatorOpenAIGroupConfiguration {
 
-	@Meta.AD(deflt = "", name = "api-key", required = false)
+	@Meta.AD(
+		deflt = "", name = "api-key", required = false,
+		type = Meta.Type.Password
+	)
 	public String apiKey();
 
 	@Meta.AD(

--- a/modules/apps/asset/asset-auto-tagger-google-cloud-natural-language-impl/src/main/java/com/liferay/asset/auto/tagger/google/cloud/natural/language/internal/configuration/GCloudNaturalLanguageAssetAutoTaggerCompanyConfiguration.java
+++ b/modules/apps/asset/asset-auto-tagger-google-cloud-natural-language-impl/src/main/java/com/liferay/asset/auto/tagger/google/cloud/natural/language/internal/configuration/GCloudNaturalLanguageAssetAutoTaggerCompanyConfiguration.java
@@ -39,7 +39,7 @@ public interface GCloudNaturalLanguageAssetAutoTaggerCompanyConfiguration {
 	)
 	@Meta.AD(
 		description = "set-the-api-key-for-the-google-cloud-natural-language-api",
-		name = "api-key", required = false
+		name = "api-key", required = false, type = Meta.Type.Password
 	)
 	public String apiKey();
 

--- a/modules/apps/document-library/document-library-asset-auto-tagger-google-cloud-vision/src/main/java/com/liferay/document/library/asset/auto/tagger/google/cloud/vision/internal/configuration/GCloudVisionAssetAutoTagProviderCompanyConfiguration.java
+++ b/modules/apps/document-library/document-library-asset-auto-tagger-google-cloud-vision/src/main/java/com/liferay/document/library/asset/auto/tagger/google/cloud/vision/internal/configuration/GCloudVisionAssetAutoTagProviderCompanyConfiguration.java
@@ -34,7 +34,7 @@ public interface GCloudVisionAssetAutoTagProviderCompanyConfiguration {
 	)
 	@Meta.AD(
 		description = "set-the-api-key-for-the-google-cloud-vision-api",
-		name = "api-key", required = false
+		name = "api-key", required = false, type = Meta.Type.Password
 	)
 	public String apiKey();
 

--- a/modules/apps/document-library/document-library-asset-auto-tagger-microsoft-cognitive-services/src/main/java/com/liferay/document/library/asset/auto/tagger/microsoft/cognitive/services/internal/configuration/MSCognitiveServicesAssetAutoTagProviderCompanyConfiguration.java
+++ b/modules/apps/document-library/document-library-asset-auto-tagger-microsoft-cognitive-services/src/main/java/com/liferay/document/library/asset/auto/tagger/microsoft/cognitive/services/internal/configuration/MSCognitiveServicesAssetAutoTagProviderCompanyConfiguration.java
@@ -51,7 +51,7 @@ public interface MSCognitiveServicesAssetAutoTagProviderCompanyConfiguration {
 	)
 	@Meta.AD(
 		description = "set-the-api-key-for-the-computer-vision-api-v2",
-		name = "api-key", required = false
+		name = "api-key", required = false, type = Meta.Type.Password
 	)
 	public String apiKey();
 


### PR DESCRIPTION
Part of the LPD-88411 credential-hardening sweep (LPD-88886). Flags the API key fields of the OpenAI, Google Cloud Natural Language, Google Cloud Vision, and Microsoft Cognitive Services provider configurations with the masked-input metatype type so they render as masked input instead of plain text:

- `AICreatorOpenAICompanyConfiguration#apiKey`
- `AICreatorOpenAIGroupConfiguration#apiKey`
- `GCloudNaturalLanguageAssetAutoTaggerCompanyConfiguration#apiKey`
- `GCloudVisionAssetAutoTagProviderCompanyConfiguration#apiKey`
- `MSCognitiveServicesAssetAutoTagProviderCompanyConfiguration#apiKey`

This continues the pattern applied to the translator, store, and push notification configurations.

<!-- pr-check {"result":"success","sha":"fcf0bc958509abda3a214faae9024207cf38988a"} -->
