### PR TITLE
LPD-88886 Mask credential fields in cloud file connector configurations

### DIFF
--- a/modules/apps/document-library/document-library-google-drive-api/src/main/java/com/liferay/document/library/google/drive/configuration/DLGoogleDriveCompanyConfiguration.java
+++ b/modules/apps/document-library/document-library-google-drive-api/src/main/java/com/liferay/document/library/google/drive/configuration/DLGoogleDriveCompanyConfiguration.java
@@ -53,7 +53,7 @@ public interface DLGoogleDriveCompanyConfiguration {
 	)
 	@Meta.AD(
 		description = "client-secret-description", name = "client-secret",
-		required = false
+		required = false, type = Meta.Type.Password
 	)
 	public String clientSecret();
 
@@ -68,7 +68,7 @@ public interface DLGoogleDriveCompanyConfiguration {
 	)
 	@Meta.AD(
 		description = "picker-api-key-description", name = "picker-api-key",
-		required = false
+		required = false, type = Meta.Type.Password
 	)
 	public String pickerAPIKey();
 

--- a/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/configuration/DLOneDriveCompanyConfiguration.java
+++ b/modules/dxp/apps/document-library-opener/document-library-opener-onedrive-web/src/main/java/com/liferay/document/library/opener/onedrive/web/internal/configuration/DLOneDriveCompanyConfiguration.java
@@ -55,7 +55,7 @@ public interface DLOneDriveCompanyConfiguration {
 	)
 	@Meta.AD(
 		description = "onedrive-client-secret-description",
-		name = "client-secret", required = false
+		name = "client-secret", required = false, type = Meta.Type.Password
 	)
 	public String clientSecret();
 


### PR DESCRIPTION
Part of the LPD-88411 credential-hardening sweep (LPD-88886). Flags the credential fields of the Google Drive and OneDrive document repository connectors with the masked-input metatype type so they render as masked input instead of plain text:

- `DLGoogleDriveCompanyConfiguration#clientSecret`
- `DLGoogleDriveCompanyConfiguration#pickerAPIKey`
- `DLOneDriveCompanyConfiguration#clientSecret`

<!-- pr-check {"result":"success","sha":"4c8fdf959a33d280cea7cc4a27d8e16449173d76"} -->
