### PR TITLE
LPD-88886 Mask credential fields in SSO and OAuth configurations

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/configuration/OAuth2AuthorizationServerConfiguration.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/configuration/OAuth2AuthorizationServerConfiguration.java
@@ -36,7 +36,7 @@ public interface OAuth2AuthorizationServerConfiguration {
 		description = "oauth2-authorization-server-jwt-access-token-signing-json-web-key-description",
 		id = "oauth2.authorization.server.jwt.access.token.signing.json.web.key",
 		name = "oauth2-authorization-server-jwt-access-token-signing-json-web-key",
-		required = false
+		required = false, type = Meta.Type.Password
 	)
 	public String jwtAccessTokenSigningJSONWebKey();
 

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/configuration/OAuth2InAssertionConfiguration.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/configuration/OAuth2InAssertionConfiguration.java
@@ -34,7 +34,8 @@ public interface OAuth2InAssertionConfiguration {
 	@Meta.AD(
 		description = "oauth2-in-assertion-signature-json-web-key-set-help",
 		id = "oauth2.in.assertion.signature.json.web.key.set",
-		name = "oauth2-in-assertion-signature-json-web-key-set"
+		name = "oauth2-in-assertion-signature-json-web-key-set",
+		type = Meta.Type.Password
 	)
 	public String signatureJSONWebKeySet();
 

--- a/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/configuration/FacebookConnectConfiguration.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-facebook-connect-api/src/main/java/com/liferay/portal/security/sso/facebook/connect/configuration/FacebookConnectConfiguration.java
@@ -23,7 +23,9 @@ public interface FacebookConnectConfiguration {
 	@Meta.AD(name = "application-id", required = false)
 	public String appId();
 
-	@Meta.AD(name = "application-secret", required = false)
+	@Meta.AD(
+		name = "application-secret", required = false, type = Meta.Type.Password
+	)
 	public String appSecret();
 
 	@Meta.AD(deflt = "false", name = "enabled", required = false)

--- a/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/configuration/OpenIdConnectProviderConfiguration.java
+++ b/modules/apps/portal-security-sso/portal-security-sso-openid-connect-impl/src/main/java/com/liferay/portal/security/sso/openid/connect/internal/configuration/OpenIdConnectProviderConfiguration.java
@@ -93,7 +93,7 @@ public interface OpenIdConnectProviderConfiguration {
 
 	@Meta.AD(
 		deflt = "", description = "open-id-connect-client-secret-help",
-		name = "open-id-connect-client-secret"
+		name = "open-id-connect-client-secret", type = Meta.Type.Password
 	)
 	public String openIdConnectClientSecret();
 


### PR DESCRIPTION
Part of the LPD-88411 credential-hardening sweep (LPD-88886). Flags the credential fields of the Facebook Connect, OpenID Connect, and OAuth 2.0 provider configurations with the masked-input metatype type so they render as masked input instead of plain text:

- `FacebookConnectConfiguration#appSecret`
- `OpenIdConnectProviderConfiguration#openIdConnectClientSecret`
- `OAuth2AuthorizationServerConfiguration#jwtAccessTokenSigningJSONWebKey`
- `OAuth2InAssertionConfiguration#signatureJSONWebKeySet`

<!-- pr-check {"result":"success","sha":"acaf49eab3fdf7e63162851ecfe5f26680eb4d3f"} -->
