### PR TITLE
LPD-88886 Mask credential fields in commerce and CRM configurations

### DIFF
--- a/modules/apps/commerce/commerce-geocoder-bing/src/main/java/com/liferay/commerce/geocoder/bing/internal/configuration/BingCommerceGeocoderConfiguration.java
+++ b/modules/apps/commerce/commerce-geocoder-bing/src/main/java/com/liferay/commerce/geocoder/bing/internal/configuration/BingCommerceGeocoderConfiguration.java
@@ -22,7 +22,7 @@ public interface BingCommerceGeocoderConfiguration {
 
 	@Meta.AD(
 		description = "set-the-key-for-the-bing-maps-api-integration",
-		name = "api-key", required = false
+		name = "api-key", required = false, type = Meta.Type.Password
 	)
 	public String apiKey();
 

--- a/modules/apps/commerce/commerce-google-merchant/src/main/java/com/liferay/commerce/google/merchant/internal/sftp/SftpConfiguration.java
+++ b/modules/apps/commerce/commerce-google-merchant/src/main/java/com/liferay/commerce/google/merchant/internal/sftp/SftpConfiguration.java
@@ -29,7 +29,9 @@ public interface SftpConfiguration {
 	)
 	public String host();
 
-	@Meta.AD(name = "feed-password", required = false)
+	@Meta.AD(
+		name = "feed-password", required = false, type = Meta.Type.Password
+	)
 	public String password();
 
 	@Meta.AD(deflt = "19321", name = "port", required = false)

--- a/modules/apps/commerce/commerce-payment-method-authorize-net/src/main/java/com/liferay/commerce/payment/method/authorize/net/internal/configuration/AuthorizeNetGroupServiceConfiguration.java
+++ b/modules/apps/commerce/commerce-payment-method-authorize-net/src/main/java/com/liferay/commerce/payment/method/authorize/net/internal/configuration/AuthorizeNetGroupServiceConfiguration.java
@@ -50,10 +50,14 @@ public interface AuthorizeNetGroupServiceConfiguration {
 	)
 	public boolean showStoreName();
 
-	@Meta.AD(name = "signature-key", required = false)
+	@Meta.AD(
+		name = "signature-key", required = false, type = Meta.Type.Password
+	)
 	public String signatureKey();
 
-	@Meta.AD(name = "transaction-key", required = false)
+	@Meta.AD(
+		name = "transaction-key", required = false, type = Meta.Type.Password
+	)
 	public String transactionKey();
 
 }

--- a/modules/apps/commerce/commerce-tax-engine-remote/src/main/java/com/liferay/commerce/tax/engine/remote/internal/configuration/RemoteCommerceTaxConfiguration.java
+++ b/modules/apps/commerce/commerce-tax-engine-remote/src/main/java/com/liferay/commerce/tax/engine/remote/internal/configuration/RemoteCommerceTaxConfiguration.java
@@ -22,7 +22,10 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 )
 public interface RemoteCommerceTaxConfiguration {
 
-	@Meta.AD(name = "tax-value-endpoint-authorization-token", required = false)
+	@Meta.AD(
+		name = "tax-value-endpoint-authorization-token", required = false,
+		type = Meta.Type.Password
+	)
 	public String taxValueEndpointAuthorizationToken();
 
 	@Meta.AD(name = "tax-value-endpoint-url", required = false)

--- a/modules/apps/object/object-storage-salesforce-api/src/main/java/com/liferay/object/storage/salesforce/configuration/SalesforceConfiguration.java
+++ b/modules/apps/object/object-storage-salesforce-api/src/main/java/com/liferay/object/storage/salesforce/configuration/SalesforceConfiguration.java
@@ -24,7 +24,9 @@ public interface SalesforceConfiguration {
 	@Meta.AD(name = "consumer-key", required = false)
 	public String consumerKey();
 
-	@Meta.AD(name = "consumer-secret", required = false)
+	@Meta.AD(
+		name = "consumer-secret", required = false, type = Meta.Type.Password
+	)
 	public String consumerSecret();
 
 	@Meta.AD(name = "login-url", required = false)


### PR DESCRIPTION
Part of the LPD-88411 credential-hardening sweep (LPD-88886). Flags the credential fields of the Bing geocoder, Google Merchant SFTP, Authorize.Net payment, remote tax engine, and Salesforce object storage configurations with the masked-input metatype type so they render as masked input instead of plain text:

- `BingCommerceGeocoderConfiguration#apiKey`
- `SftpConfiguration#password`
- `AuthorizeNetGroupServiceConfiguration#signatureKey`
- `AuthorizeNetGroupServiceConfiguration#transactionKey`
- `RemoteCommerceTaxConfiguration#taxValueEndpointAuthorizationToken`
- `SalesforceConfiguration#consumerSecret`

The paired public identifiers (Authorize.Net `apiLoginId`, Salesforce `consumerKey`) are left as plain text.

<!-- pr-check {"result":"success","sha":"e8a0b3d941872f197360ca423e355b1f2c74bee8"} -->
