### PR TITLE
LPD-88886 Mask credential fields in miscellaneous configurations

### DIFF
--- a/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/configuration/CaptchaConfiguration.java
+++ b/modules/apps/captcha/captcha-api/src/main/java/com/liferay/captcha/configuration/CaptchaConfiguration.java
@@ -59,7 +59,10 @@ public interface CaptchaConfiguration {
 	)
 	public String reCaptchaNoScriptURL();
 
-	@Meta.AD(name = "recaptcha-private-key", required = false)
+	@Meta.AD(
+		name = "recaptcha-private-key", required = false,
+		type = Meta.Type.Password
+	)
 	public String reCaptchaPrivateKey();
 
 	@Meta.AD(name = "recaptcha-public-key", required = false)

--- a/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/configuration/CTSettingsConfiguration.java
+++ b/modules/apps/change-tracking/change-tracking-api/src/main/java/com/liferay/change/tracking/configuration/CTSettingsConfiguration.java
@@ -68,7 +68,10 @@ public interface CTSettingsConfiguration {
 	public String remoteClientId();
 
 	@ExtendedAttributeDefinition(featureFlagKey = "LPS-186360")
-	@Meta.AD(name = "remote-client-secret", required = false)
+	@Meta.AD(
+		name = "remote-client-secret", required = false,
+		type = Meta.Type.Password
+	)
 	public String remoteClientSecret();
 
 	@ExtendedAttributeDefinition(featureFlagKey = "LPS-186360")

--- a/modules/apps/iframe/iframe-web/src/main/java/com/liferay/iframe/web/internal/configuration/IFramePortletInstanceConfiguration.java
+++ b/modules/apps/iframe/iframe-web/src/main/java/com/liferay/iframe/web/internal/configuration/IFramePortletInstanceConfiguration.java
@@ -32,7 +32,7 @@ public interface IFramePortletInstanceConfiguration {
 	@Meta.AD(deflt = "basic", name = "authentication-type", required = false)
 	public String authType();
 
-	@Meta.AD(name = "password", required = false)
+	@Meta.AD(name = "password", required = false, type = Meta.Type.Password)
 	public String basicPassword();
 
 	@Meta.AD(name = "user-name", required = false)
@@ -50,7 +50,7 @@ public interface IFramePortletInstanceConfiguration {
 	@Meta.AD(deflt = "post", name = "form-method", required = false)
 	public String formMethod();
 
-	@Meta.AD(name = "password", required = false)
+	@Meta.AD(name = "password", required = false, type = Meta.Type.Password)
 	public String formPassword();
 
 	@Meta.AD(name = "user-name", required = false)

--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/configuration/LayoutReportsGooglePageSpeedGroupConfiguration.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/configuration/LayoutReportsGooglePageSpeedGroupConfiguration.java
@@ -29,7 +29,7 @@ public interface LayoutReportsGooglePageSpeedGroupConfiguration {
 	)
 	@Meta.AD(
 		description = "get-your-api-key-at-x", name = "api-key",
-		required = false
+		required = false, type = Meta.Type.Password
 	)
 	public String apiKey();
 

--- a/modules/apps/microsoft-translator/microsoft-translator/src/main/java/com/liferay/microsoft/translator/internal/configuration/MicrosoftTranslatorConfiguration.java
+++ b/modules/apps/microsoft-translator/microsoft-translator/src/main/java/com/liferay/microsoft/translator/internal/configuration/MicrosoftTranslatorConfiguration.java
@@ -22,7 +22,8 @@ public interface MicrosoftTranslatorConfiguration {
 
 	@Meta.AD(
 		description = "subscription-key-description",
-		name = "subscription-key-name", required = false
+		name = "subscription-key-name", required = false,
+		type = Meta.Type.Password
 	)
 	public String subscriptionKey();
 

--- a/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/internal/configuration/PortalInstancesConfiguration.java
+++ b/modules/apps/portal-instances/portal-instances-service/src/main/java/com/liferay/portal/instances/internal/configuration/PortalInstancesConfiguration.java
@@ -37,7 +37,7 @@ public interface PortalInstancesConfiguration {
 	@Meta.AD(required = false, type = Meta.Type.String)
 	public String adminMiddleName();
 
-	@Meta.AD(required = false, type = Meta.Type.String)
+	@Meta.AD(required = false, type = Meta.Type.Password)
 	public String adminPassword();
 
 	@Meta.AD(required = false, type = Meta.Type.String)

--- a/modules/apps/static/portal-k8s-agent/portal-k8s-agent-api/src/main/java/com/liferay/portal/k8s/agent/configuration/PortalK8sAgentConfiguration.java
+++ b/modules/apps/static/portal-k8s-agent/portal-k8s-agent-api/src/main/java/com/liferay/portal/k8s/agent/configuration/PortalK8sAgentConfiguration.java
@@ -46,7 +46,7 @@ public interface PortalK8sAgentConfiguration {
 	@Meta.AD(type = Meta.Type.String)
 	public String namespace();
 
-	@Meta.AD(type = Meta.Type.String)
+	@Meta.AD(type = Meta.Type.Password)
 	public String saToken();
 
 }


### PR DESCRIPTION
Part of the LPD-88411 credential-hardening sweep (LPD-88886). Flags credential fields across several miscellaneous configurations with the masked-input metatype type so they render as masked input instead of plain text:

- `CaptchaConfiguration#reCaptchaPrivateKey`
- `LayoutReportsGooglePageSpeedGroupConfiguration#apiKey`
- `CTSettingsConfiguration#remoteClientSecret`
- `MicrosoftTranslatorConfiguration#subscriptionKey`
- `PortalInstancesConfiguration#adminPassword` (was Meta.Type.String)
- `IFramePortletInstanceConfiguration#basicPassword`
- `IFramePortletInstanceConfiguration#formPassword`
- `PortalK8sAgentConfiguration#saToken` (was Meta.Type.String)

<!-- pr-check {"result":"success","sha":"8744341040c2550e02e345276d04821a97de7445"} -->
