### PR TITLE
LPD-88886 Mask credential fields in miscellaneous DXP configurations

### DIFF
--- a/modules/dxp/apps/akismet/akismet-service/src/main/java/com/liferay/akismet/internal/configuration/AkismetServiceConfiguration.java
+++ b/modules/dxp/apps/akismet/akismet-service/src/main/java/com/liferay/akismet/internal/configuration/AkismetServiceConfiguration.java
@@ -19,7 +19,7 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 )
 public interface AkismetServiceConfiguration {
 
-	@Meta.AD(name = "api-key", required = false)
+	@Meta.AD(name = "api-key", required = false, type = Meta.Type.Password)
 	public String akismetApiKey();
 
 	@Meta.AD(deflt = "50", name = "check-threshold", required = false)

--- a/modules/dxp/apps/osb/osb-patcher/osb-patcher-api/src/main/java/com/liferay/osb/patcher/configuration/PatcherConfiguration.java
+++ b/modules/dxp/apps/osb/osb-patcher/osb-patcher-api/src/main/java/com/liferay/osb/patcher/configuration/PatcherConfiguration.java
@@ -39,7 +39,7 @@ public interface PatcherConfiguration {
 	@Meta.AD(deflt = "", required = false)
 	public String jenkinsAdminUserName();
 
-	@Meta.AD(deflt = "", required = false)
+	@Meta.AD(deflt = "", required = false, type = Meta.Type.Password)
 	public String jenkinsAdminUserToken();
 
 	@Meta.AD(deflt = "", required = false)
@@ -51,7 +51,7 @@ public interface PatcherConfiguration {
 	@Meta.AD(deflt = "", required = false)
 	public boolean jenkinsLoadBalancerEnabled();
 
-	@Meta.AD(deflt = "", required = false)
+	@Meta.AD(deflt = "", required = false, type = Meta.Type.Password)
 	public String jenkinsToken();
 
 	@Meta.AD(deflt = "", required = false)
@@ -123,7 +123,7 @@ public interface PatcherConfiguration {
 	@Meta.AD(deflt = "", required = false)
 	public String supportLiferayAPIClientId();
 
-	@Meta.AD(deflt = "", required = false)
+	@Meta.AD(deflt = "", required = false, type = Meta.Type.Password)
 	public String supportLiferayAPIClientSecret();
 
 	@Meta.AD(deflt = "", required = false)

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/configuration/IpstackConfiguration.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/configuration/IpstackConfiguration.java
@@ -22,7 +22,10 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 )
 public interface IpstackConfiguration {
 
-	@Meta.AD(deflt = "", name = "api-key", required = false)
+	@Meta.AD(
+		deflt = "", name = "api-key", required = false,
+		type = Meta.Type.Password
+	)
 	public String apiKey();
 
 	@Meta.AD(

--- a/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/configuration/OpenWeatherMapConfiguration.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-service/src/main/java/com/liferay/search/experiences/internal/configuration/OpenWeatherMapConfiguration.java
@@ -23,7 +23,10 @@ import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClass
 )
 public interface OpenWeatherMapConfiguration {
 
-	@Meta.AD(deflt = "", name = "api-key", required = false)
+	@Meta.AD(
+		deflt = "", name = "api-key", required = false,
+		type = Meta.Type.Password
+	)
 	public String apiKey();
 
 	@Meta.AD(

--- a/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/configuration/SharepointRepositoryConfiguration.java
+++ b/modules/dxp/apps/sharepoint-rest/sharepoint-rest-repository/src/main/java/com/liferay/sharepoint/rest/repository/internal/configuration/SharepointRepositoryConfiguration.java
@@ -27,7 +27,9 @@ public interface SharepointRepositoryConfiguration {
 	@Meta.AD(name = "client-id", required = false)
 	public String clientId();
 
-	@Meta.AD(name = "client-secret", required = false)
+	@Meta.AD(
+		name = "client-secret", required = false, type = Meta.Type.Password
+	)
 	public String clientSecret();
 
 	@Meta.AD(name = "name", required = false)


### PR DESCRIPTION
Part of the LPD-88411 credential-hardening sweep (LPD-88886). Flags credential fields across several miscellaneous DXP configurations with the masked-input metatype type so they render as masked input instead of plain text:

- `AkismetServiceConfiguration#akismetApiKey`
- `PatcherConfiguration#supportLiferayAPIClientSecret`
- `PatcherConfiguration#jenkinsAdminUserToken`
- `PatcherConfiguration#jenkinsToken`
- `IpstackConfiguration#apiKey`
- `OpenWeatherMapConfiguration#apiKey`
- `SharepointRepositoryConfiguration#clientSecret`

<!-- pr-check {"result":"success","sha":"fa5a44315826baa2a2d61c5195d3f52334f762d7"} -->
