### PR TITLE
LPD-93283 Add a canonical FIPS audit event timestamp formatter

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditTimestamp.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditTimestamp.java
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import java.util.Date;
+
+/**
+ * Formats FIPS audit event timestamps in a single canonical representation: UTC,
+ * ISO 8601 extended form with millisecond precision and a literal <code>Z</code>
+ * suffix (for example <code>2026-05-06T14:19:23.471Z</code>), sourced from the
+ * host clock.
+ *
+ * <p>
+ * Every FIPS audit event across §5.2 to §5.5 shares this format so the audit
+ * trail keeps a stable time ordering across cluster nodes and downstream SIEM
+ * correlation. Sub millisecond precision is truncated rather than rounded, and
+ * the format is emitted in UTC regardless of the host default time zone.
+ * </p>
+ *
+ * <p>
+ * The timestamp carries millisecond precision only; it does not by itself
+ * guarantee a unique ordering for two events emitted within the same
+ * millisecond, so the §5.4 audit log integrity chain, not the timestamp, is the
+ * authority on order.
+ * </p>
+ *
+ * @author Jorge García Jiménez
+ */
+public class FIPSAuditTimestamp {
+
+	public static String format(Instant instant) {
+		return _dateTimeFormatter.format(instant.atZone(ZoneOffset.UTC));
+	}
+
+	public static String format(long epochMillis) {
+		return format(Instant.ofEpochMilli(epochMillis));
+	}
+
+	public static String normalize(Date date) {
+		return format(date.toInstant());
+	}
+
+	public static String normalize(String timestamp) {
+		try {
+			return format(Instant.parse(timestamp));
+		}
+		catch (DateTimeParseException dateTimeParseException1) {
+			try {
+				OffsetDateTime offsetDateTime = OffsetDateTime.parse(timestamp);
+
+				return format(offsetDateTime.toInstant());
+			}
+			catch (DateTimeParseException dateTimeParseException2) {
+				throw new IllegalArgumentException(
+					"Unable to normalize timestamp \"" + timestamp + "\"",
+					dateTimeParseException2);
+			}
+		}
+	}
+
+	public static String now() {
+		return format(Instant.now());
+	}
+
+	private static final DateTimeFormatter _dateTimeFormatter =
+		DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
+}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditTimestampTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditTimestampTest.java
@@ -1,0 +1,86 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+
+import java.time.Instant;
+
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSAuditTimestampTest {
+
+	@Test
+	public void testFormat() {
+		Assert.assertEquals(
+			_TIMESTAMP,
+			FIPSAuditTimestamp.format(Instant.ofEpochMilli(_EPOCH_MILLIS)));
+		Assert.assertEquals(
+			_TIMESTAMP, FIPSAuditTimestamp.format(_EPOCH_MILLIS));
+
+		Assert.assertEquals(
+			"2025-05-06T14:19:23.000Z",
+			FIPSAuditTimestamp.format(Instant.ofEpochSecond(_EPOCH_SECONDS)));
+		Assert.assertEquals(
+			"2025-05-06T14:19:23.123Z",
+			FIPSAuditTimestamp.format(
+				Instant.ofEpochSecond(_EPOCH_SECONDS, 123_999_999)));
+	}
+
+	@Test
+	public void testFormatIsUTCIndependentOfDefaultTimeZone() {
+		TimeZone timeZone = TimeZone.getDefault();
+
+		try {
+			TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+
+			Assert.assertEquals(
+				_TIMESTAMP,
+				FIPSAuditTimestamp.format(Instant.ofEpochMilli(_EPOCH_MILLIS)));
+		}
+		finally {
+			TimeZone.setDefault(timeZone);
+		}
+	}
+
+	@Test
+	public void testNormalize() {
+		Assert.assertEquals(
+			_TIMESTAMP, FIPSAuditTimestamp.normalize(new Date(_EPOCH_MILLIS)));
+		Assert.assertEquals(
+			_TIMESTAMP, FIPSAuditTimestamp.normalize(_TIMESTAMP));
+		Assert.assertEquals(
+			_TIMESTAMP,
+			FIPSAuditTimestamp.normalize("2025-05-06T16:19:23.471+02:00"));
+
+		Assert.assertThrows(
+			IllegalArgumentException.class,
+			() -> FIPSAuditTimestamp.normalize(RandomTestUtil.randomString()));
+	}
+
+	@Test
+	public void testNow() {
+		String now = FIPSAuditTimestamp.now();
+
+		Assert.assertTrue(
+			now,
+			now.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"));
+	}
+
+	private static final long _EPOCH_MILLIS = 1746541163471L;
+
+	private static final long _EPOCH_SECONDS = 1746541163L;
+
+	private static final String _TIMESTAMP = "2025-05-06T14:19:23.471Z";
+
+}


### PR DESCRIPTION
Implements §5.1 "Universal Timestamp Formatting" of the FIPS Level 1 audit framework (story LPD-93283, impl task LPD-99060).

`FIPSAuditTimestamp` (portal-kernel, `com.liferay.portal.kernel.security.fips`) gives every FIPS audit event one canonical timestamp representation — UTC ISO 8601 with millisecond precision and a literal `Z` suffix (e.g. `2026-05-06T14:19:23.471Z`), sourced from the host clock:

- `now()` — current host-clock timestamp (primary emit path; no caller-supplied timestamps)
- `format(Instant)` / `format(long epochMillis)` — format a known instant
- `normalize(Date)` / `normalize(String)` — canonicalize a legacy `Date` or a downstream ISO-8601 (Z or offset) provider timestamp; unparseable input throws `IllegalArgumentException`

Uses an explicit `DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")` with UTC applied in the `format(Instant)` primitive — `SSS` truncates sub-millisecond rather than rounding, and it is independent of the host default time zone. Millisecond precision only; the §5.4 audit-log integrity chain, not the timestamp, is the authority on same-millisecond ordering.

`FIPSAuditTimestampTest`: 4 unit tests. No packageinfo bump — the fips package's additive changes since the last release are already covered by its current 1.1.0.

Open review point: the public methods have no in-tree consumers yet — this is the §5.1 foundation landing ahead of its §5.2–§5.5 consumers.

**pr-check: PASS** — tested on `c1907b344388a72f9f5429dff85981ae1edb5d1f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS (no consumers) |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "c1907b344388a72f9f5429dff85981ae1edb5d1f"} -->
