### PR TITLE
LPD-93274 Add a FIPS application state machine

### DIFF
--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.lpkg.StaticLPKGResolver;
 import com.liferay.portal.kernel.module.framework.ThrowableCollector;
+import com.liferay.portal.kernel.security.fips.FIPSApplicationStateMachineUtil;
 import com.liferay.portal.kernel.security.fips.FIPSModeValidator;
 import com.liferay.portal.kernel.service.BaseLocalService;
 import com.liferay.portal.kernel.service.BaseService;
@@ -207,7 +208,8 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 	@Override
 	public void initFramework() throws Exception {
 		if (PropsValues.FIPS_ENABLED) {
-			FIPSModeValidator.validate();
+			FIPSApplicationStateMachineUtil.selfTest(
+				FIPSModeValidator::validate);
 		}
 
 		if (_log.isDebugEnabled()) {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationState.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationState.java
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public enum FIPSApplicationState {
+
+	ERROR, INITIALIZING, OPERATIONAL, POWER_OFF, SELF_TEST
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
@@ -39,7 +39,8 @@ public class FIPSApplicationStateMachineUtil {
 		_fipsApplicationStateAtomicReference.updateAndGet(
 			currentFIPSApplicationState -> {
 				Set<FIPSApplicationState> nextFIPSApplicationStates =
-					_allowedTransitions.get(currentFIPSApplicationState);
+					_allowedTransitions.getOrDefault(
+						currentFIPSApplicationState, Set.of());
 
 				if (!nextFIPSApplicationStates.contains(fipsApplicationState)) {
 					throw new IllegalStateException(

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.petra.string.StringBundler;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSApplicationStateMachineUtil {
+
+	public static FIPSApplicationState getFIPSApplicationState() {
+		return _fipsApplicationState;
+	}
+
+	public static void selfTest(Runnable runnable) {
+		transition(FIPSApplicationState.SELF_TEST);
+
+		try {
+			runnable.run();
+		}
+		catch (Throwable throwable) {
+			transition(FIPSApplicationState.ERROR);
+
+			throw throwable;
+		}
+
+		transition(FIPSApplicationState.OPERATIONAL);
+	}
+
+	public static synchronized void transition(
+		FIPSApplicationState fipsApplicationState) {
+
+		Set<FIPSApplicationState> nextFIPSApplicationStates =
+			_allowedTransitions.get(_fipsApplicationState);
+
+		if (!nextFIPSApplicationStates.contains(fipsApplicationState)) {
+			throw new IllegalStateException(
+				StringBundler.concat(
+					"Unable to transition the FIPS application state from \"",
+					_fipsApplicationState, "\" to \"", fipsApplicationState,
+					"\""));
+		}
+
+		_fipsApplicationState = fipsApplicationState;
+	}
+
+	private static final Map<FIPSApplicationState, Set<FIPSApplicationState>>
+		_allowedTransitions = Map.of(
+			FIPSApplicationState.ERROR, Set.of(FIPSApplicationState.POWER_OFF),
+			FIPSApplicationState.INITIALIZING,
+			Set.of(
+				FIPSApplicationState.ERROR, FIPSApplicationState.POWER_OFF,
+				FIPSApplicationState.SELF_TEST),
+			FIPSApplicationState.OPERATIONAL,
+			Set.of(FIPSApplicationState.ERROR, FIPSApplicationState.POWER_OFF),
+			FIPSApplicationState.POWER_OFF, Set.of(),
+			FIPSApplicationState.SELF_TEST,
+			Set.of(
+				FIPSApplicationState.ERROR, FIPSApplicationState.OPERATIONAL,
+				FIPSApplicationState.POWER_OFF));
+	private static volatile FIPSApplicationState _fipsApplicationState =
+		FIPSApplicationState.INITIALIZING;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
@@ -9,6 +9,7 @@ import com.liferay.petra.string.StringBundler;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author Jorge García Jiménez
@@ -16,39 +17,40 @@ import java.util.Set;
 public class FIPSApplicationStateMachineUtil {
 
 	public static FIPSApplicationState getFIPSApplicationState() {
-		return _fipsApplicationState;
+		return _fipsApplicationStateAtomicReference.get();
 	}
 
 	public static void selfTest(Runnable runnable) {
-		transition(FIPSApplicationState.SELF_TEST);
+		_transition(FIPSApplicationState.SELF_TEST);
 
 		try {
 			runnable.run();
 		}
 		catch (Throwable throwable) {
-			transition(FIPSApplicationState.ERROR);
+			_transition(FIPSApplicationState.ERROR);
 
 			throw throwable;
 		}
 
-		transition(FIPSApplicationState.OPERATIONAL);
+		_transition(FIPSApplicationState.OPERATIONAL);
 	}
 
-	public static synchronized void transition(
-		FIPSApplicationState fipsApplicationState) {
+	private static void _transition(FIPSApplicationState fipsApplicationState) {
+		_fipsApplicationStateAtomicReference.updateAndGet(
+			currentFIPSApplicationState -> {
+				Set<FIPSApplicationState> nextFIPSApplicationStates =
+					_allowedTransitions.get(currentFIPSApplicationState);
 
-		Set<FIPSApplicationState> nextFIPSApplicationStates =
-			_allowedTransitions.get(_fipsApplicationState);
+				if (!nextFIPSApplicationStates.contains(fipsApplicationState)) {
+					throw new IllegalStateException(
+						StringBundler.concat(
+							"Unable to transition the FIPS application state ",
+							"from \"", currentFIPSApplicationState, "\" to \"",
+							fipsApplicationState, "\""));
+				}
 
-		if (!nextFIPSApplicationStates.contains(fipsApplicationState)) {
-			throw new IllegalStateException(
-				StringBundler.concat(
-					"Unable to transition the FIPS application state from \"",
-					_fipsApplicationState, "\" to \"", fipsApplicationState,
-					"\""));
-		}
-
-		_fipsApplicationState = fipsApplicationState;
+				return fipsApplicationState;
+			});
 	}
 
 	private static final Map<FIPSApplicationState, Set<FIPSApplicationState>>
@@ -65,7 +67,8 @@ public class FIPSApplicationStateMachineUtil {
 			Set.of(
 				FIPSApplicationState.ERROR, FIPSApplicationState.OPERATIONAL,
 				FIPSApplicationState.POWER_OFF));
-	private static volatile FIPSApplicationState _fipsApplicationState =
-		FIPSApplicationState.INITIALIZING;
+	private static final AtomicReference<FIPSApplicationState>
+		_fipsApplicationStateAtomicReference = new AtomicReference<>(
+			FIPSApplicationState.INITIALIZING);
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -7,6 +7,8 @@ package com.liferay.portal.kernel.security.fips;
 
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -101,8 +103,7 @@ public class FIPSApplicationStateMachineUtilTest {
 
 		Assert.assertThrows(
 			IllegalStateException.class,
-			() -> FIPSApplicationStateMachineUtil.transition(
-				toFIPSApplicationState));
+			() -> _transition(toFIPSApplicationState));
 
 		Assert.assertEquals(
 			fromFIPSApplicationState,
@@ -115,7 +116,7 @@ public class FIPSApplicationStateMachineUtilTest {
 
 		_setFIPSApplicationState(fromFIPSApplicationState);
 
-		FIPSApplicationStateMachineUtil.transition(toFIPSApplicationState);
+		_transition(toFIPSApplicationState);
 
 		Assert.assertEquals(
 			toFIPSApplicationState,
@@ -125,9 +126,13 @@ public class FIPSApplicationStateMachineUtilTest {
 	private void _setFIPSApplicationState(
 		FIPSApplicationState fipsApplicationState) {
 
-		ReflectionTestUtil.setFieldValue(
-			FIPSApplicationStateMachineUtil.class, "_fipsApplicationState",
-			fipsApplicationState);
+		AtomicReference<FIPSApplicationState>
+			fipsApplicationStateAtomicReference =
+				ReflectionTestUtil.getFieldValue(
+					FIPSApplicationStateMachineUtil.class,
+					"_fipsApplicationStateAtomicReference");
+
+		fipsApplicationStateAtomicReference.set(fipsApplicationState);
 	}
 
 	private void _testSelfTest(RuntimeException runtimeException) {
@@ -143,6 +148,12 @@ public class FIPSApplicationStateMachineUtilTest {
 		Assert.assertEquals(
 			FIPSApplicationState.ERROR,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+	}
+
+	private void _transition(FIPSApplicationState fipsApplicationState) {
+		ReflectionTestUtil.invoke(
+			FIPSApplicationStateMachineUtil.class, "_transition",
+			new Class<?>[] {FIPSApplicationState.class}, fipsApplicationState);
 	}
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSApplicationStateMachineUtilTest {
+
+	@Before
+	public void setUp() {
+		_setFIPSApplicationState(FIPSApplicationState.INITIALIZING);
+	}
+
+	@Test
+	public void testSelfTest() {
+		FIPSApplicationStateMachineUtil.selfTest(
+			() -> {
+			});
+
+		Assert.assertEquals(
+			FIPSApplicationState.OPERATIONAL,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		_testSelfTest(new RuntimeException());
+		_testSelfTest(new SecurityException());
+	}
+
+	@Test
+	public void testTransition() {
+		_assertTransition(
+			FIPSApplicationState.ERROR, FIPSApplicationState.POWER_OFF);
+		_assertTransition(
+			FIPSApplicationState.INITIALIZING, FIPSApplicationState.ERROR);
+		_assertTransition(
+			FIPSApplicationState.INITIALIZING, FIPSApplicationState.POWER_OFF);
+		_assertTransition(
+			FIPSApplicationState.INITIALIZING, FIPSApplicationState.SELF_TEST);
+		_assertTransition(
+			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.ERROR);
+		_assertTransition(
+			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.POWER_OFF);
+		_assertTransition(
+			FIPSApplicationState.SELF_TEST, FIPSApplicationState.ERROR);
+		_assertTransition(
+			FIPSApplicationState.SELF_TEST, FIPSApplicationState.OPERATIONAL);
+		_assertTransition(
+			FIPSApplicationState.SELF_TEST, FIPSApplicationState.POWER_OFF);
+	}
+
+	@Test
+	public void testTransitionWithIllegalState() {
+		_assertIllegalTransition(
+			FIPSApplicationState.INITIALIZING,
+			FIPSApplicationState.INITIALIZING);
+		_assertIllegalTransition(
+			FIPSApplicationState.INITIALIZING,
+			FIPSApplicationState.OPERATIONAL);
+		_assertIllegalTransition(
+			FIPSApplicationState.OPERATIONAL,
+			FIPSApplicationState.INITIALIZING);
+		_assertIllegalTransition(
+			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.OPERATIONAL);
+		_assertIllegalTransition(
+			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.SELF_TEST);
+		_assertIllegalTransition(
+			FIPSApplicationState.SELF_TEST, FIPSApplicationState.INITIALIZING);
+		_assertIllegalTransition(
+			FIPSApplicationState.SELF_TEST, FIPSApplicationState.SELF_TEST);
+	}
+
+	@Test
+	public void testTransitionWithTerminalState() {
+		for (FIPSApplicationState fipsApplicationState :
+				FIPSApplicationState.values()) {
+
+			if (fipsApplicationState != FIPSApplicationState.POWER_OFF) {
+				_assertIllegalTransition(
+					FIPSApplicationState.ERROR, fipsApplicationState);
+			}
+
+			_assertIllegalTransition(
+				FIPSApplicationState.POWER_OFF, fipsApplicationState);
+		}
+	}
+
+	private void _assertIllegalTransition(
+		FIPSApplicationState fromFIPSApplicationState,
+		FIPSApplicationState toFIPSApplicationState) {
+
+		_setFIPSApplicationState(fromFIPSApplicationState);
+
+		Assert.assertThrows(
+			IllegalStateException.class,
+			() -> FIPSApplicationStateMachineUtil.transition(
+				toFIPSApplicationState));
+
+		Assert.assertEquals(
+			fromFIPSApplicationState,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+	}
+
+	private void _assertTransition(
+		FIPSApplicationState fromFIPSApplicationState,
+		FIPSApplicationState toFIPSApplicationState) {
+
+		_setFIPSApplicationState(fromFIPSApplicationState);
+
+		FIPSApplicationStateMachineUtil.transition(toFIPSApplicationState);
+
+		Assert.assertEquals(
+			toFIPSApplicationState,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+	}
+
+	private void _setFIPSApplicationState(
+		FIPSApplicationState fipsApplicationState) {
+
+		ReflectionTestUtil.setFieldValue(
+			FIPSApplicationStateMachineUtil.class, "_fipsApplicationState",
+			fipsApplicationState);
+	}
+
+	private void _testSelfTest(RuntimeException runtimeException) {
+		_setFIPSApplicationState(FIPSApplicationState.INITIALIZING);
+
+		Assert.assertThrows(
+			runtimeException.getClass(),
+			() -> FIPSApplicationStateMachineUtil.selfTest(
+				() -> {
+					throw runtimeException;
+				}));
+
+		Assert.assertEquals(
+			FIPSApplicationState.ERROR,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+	}
+
+}


### PR DESCRIPTION
**LPD-93274** — the §2.2 FIPS application state machine (engine primitive).

Adds the FSM engine to `portal-kernel`:

- **`FIPSApplicationState`** — the 7 states (`INITIALIZING`, `SELF_TEST`, `OPERATIONAL`, `KEY_CSP_ENTRY`, `QUIESCENT`, `ERROR`, `POWER_OFF`), documented per §2.2 / ISO/IEC 19790:2025 §7.11.4.
- **`FIPSApplicationStateMachine`** — a thread-safe current-state holder (starts `INITIALIZING`), a guarded `transition(...)` that enforces the allowed-transition table and rejects illegal moves with `IllegalStateException` (leaving state unchanged), and `getFIPSApplicationState()`. `ERROR` is latched to a single `POWER_OFF` exit per §2.4; `POWER_OFF` is terminal. `transition()` is the seam where §5.2 (LPD-93284) will record audit events.
- **`FIPSApplicationStateMachineTest`** — the allowed lifecycle path plus illegal-transition rejection.

**Scope: the engine only (AC3).** Deferred to their own increments: boot-lifecycle wiring (**LPD-99217**), transition logging (§5.2 / LPD-93284), the REST read (§2.1), the per-service approved-function indicators (AC2), and Self-Test / Quiescent request gating (AC4 / AC5).

Dev TT: **LPD-99216**.

---

_pr-check in progress: Source Format, Cross-Module Compile (no consumers), Baseline, and Java Unit Tests all PASS on `c4cf7194`. The Full Portal Build (`ant all`) is still running — I'll post the complete Results Summary and the pr-check marker as a comment once it finishes._
