### PR TITLE
LPD-93284 Add the shared FIPS audit-event emitter Part I, along  LPD-93283 Universal Timestamp Formatting

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7691,6 +7691,26 @@
 ##
 
     #
+    # Set the deployment instance ID recorded in the common envelope of every
+    # FIPS audit event. Leave blank to derive a stable per-install identifier.
+    # In a cluster, set a distinct value per node so that downstream SIEM
+    # correlation can attribute each event to the node that emitted it.
+    #
+    # Env: LIFERAY_FIPS_PERIOD_AUDIT_PERIOD_DEPLOYMENT_PERIOD_INSTANCE_PERIOD_ID
+    #
+    fips.audit.deployment.instance.id=
+
+    #
+    # Set the CMVP certificate ID of the validated cryptographic module,
+    # recorded in the common envelope of every FIPS audit event. This is
+    # deployment metadata that the JCE provider does not expose. Leave blank if
+    # it is unset.
+    #
+    # Env: LIFERAY_FIPS_PERIOD_AUDIT_PERIOD_PROVIDER_PERIOD_CMVP_PERIOD_CERTIFICATE_PERIOD_ID
+    #
+    fips.audit.provider.cmvp.certificate.id=
+
+    #
     # Set this to true to operate the portal in FIPS mode. When enabled, the
     # portal validates that the security providers configured in the JVM's
     # java.security file are registered in the order required to route

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A single FIPS audit event: its type, its {@link FIPSAuditSeverity}, and an
+ * insertion-ordered set of event-specific fields. The shared envelope fields
+ * (schema version, timestamp, provider identity, and deployment instance) are
+ * added by {@link FIPSAuditEventEmitter} at emission time, so callers only
+ * supply what is specific to the event.
+ *
+ * @author Jorge García Jiménez
+ */
+public class FIPSAuditEvent {
+
+	public FIPSAuditEvent(
+		String eventType, FIPSAuditSeverity fipsAuditSeverity) {
+
+		_eventType = eventType;
+		_fipsAuditSeverity = fipsAuditSeverity;
+	}
+
+	public String getEventType() {
+		return _eventType;
+	}
+
+	public Map<String, Object> getFields() {
+		return Collections.unmodifiableMap(_fields);
+	}
+
+	public FIPSAuditSeverity getFIPSAuditSeverity() {
+		return _fipsAuditSeverity;
+	}
+
+	public FIPSAuditEvent put(String key, Object value) {
+		_fields.put(key, value);
+
+		return this;
+	}
+
+	private final String _eventType;
+	private final Map<String, Object> _fields = new LinkedHashMap<>();
+	private final FIPSAuditSeverity _fipsAuditSeverity;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitter.java
@@ -1,0 +1,160 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+
+import java.io.Flushable;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * Writes FIPS audit events as NDJSON records, one per line, each sharing a
+ * common envelope: event schema version, the §5.1 timestamp, severity, event
+ * type, deployment instance ID, and the validated provider name and CMVP
+ * certificate ID active at emission. Every record is flushed synchronously, so
+ * an Error State entry reaches disk before the process continues; nothing is
+ * buffered in memory.
+ *
+ * <p>
+ * The emitter is intentionally free of OSGi and framework dependencies. FIPS
+ * finite-state-model transitions are emitted during boot, before the audit
+ * router is available, so the envelope sources are injected as suppliers and
+ * records are written straight to the supplied {@link Appendable}. The NDJSON
+ * key order is stable, keeping the trail forward-compatible with §5.4
+ * audit-log-integrity chaining.
+ * </p>
+ *
+ * @author Jorge García Jiménez
+ */
+public class FIPSAuditEventEmitter {
+
+	public FIPSAuditEventEmitter(
+		Appendable appendable, Supplier<String> cmvpCertificateIdSupplier,
+		Supplier<String> deploymentInstanceIdSupplier,
+		Supplier<String> providerNameSupplier) {
+
+		_appendable = appendable;
+		_cmvpCertificateIdSupplier = cmvpCertificateIdSupplier;
+		_deploymentInstanceIdSupplier = deploymentInstanceIdSupplier;
+		_providerNameSupplier = providerNameSupplier;
+	}
+
+	public void emit(FIPSAuditEvent fipsAuditEvent) {
+		Map<String, Object> record = LinkedHashMapBuilder.<String, Object>put(
+			"event-schema-version", "1.0"
+		).put(
+			"timestamp", FIPSAuditTimestamp.now()
+		).put(
+			"severity",
+			fipsAuditEvent.getFIPSAuditSeverity(
+			).getValue()
+		).put(
+			"event-type", fipsAuditEvent.getEventType()
+		).put(
+			"deployment-instance-id", _deploymentInstanceIdSupplier.get()
+		).put(
+			"provider-name", _providerNameSupplier.get()
+		).put(
+			"cmvp-certificate-id", _cmvpCertificateIdSupplier.get()
+		).putAll(
+			fipsAuditEvent.getFields()
+		).build();
+
+		try {
+			_appendable.append(_toNDJSON(record));
+
+			if (_appendable instanceof Flushable) {
+				Flushable flushable = (Flushable)_appendable;
+
+				flushable.flush();
+			}
+		}
+		catch (IOException ioException) {
+			throw new UncheckedIOException(
+				"Unable to write FIPS audit event", ioException);
+		}
+	}
+
+	private String _escape(String value) {
+		StringBuilder sb = new StringBuilder();
+
+		for (int i = 0; i < value.length(); i++) {
+			char c = value.charAt(i);
+
+			if (c == '\\') {
+				sb.append("\\\\");
+			}
+			else if (c == '\"') {
+				sb.append("\\\"");
+			}
+			else if (c == '\n') {
+				sb.append("\\n");
+			}
+			else if (c == '\r') {
+				sb.append("\\r");
+			}
+			else if (c == '\t') {
+				sb.append("\\t");
+			}
+			else if (c < 0x20) {
+				sb.append(String.format("\\u%04x", (int)c));
+			}
+			else {
+				sb.append(c);
+			}
+		}
+
+		return sb.toString();
+	}
+
+	private String _toJSONValue(Object value) {
+		if (value == null) {
+			return "null";
+		}
+
+		if (value instanceof Boolean || value instanceof Number) {
+			return value.toString();
+		}
+
+		return "\"" + _escape(value.toString()) + "\"";
+	}
+
+	private String _toNDJSON(Map<String, Object> record) {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		boolean first = true;
+
+		for (Map.Entry<String, Object> entry : record.entrySet()) {
+			if (!first) {
+				sb.append(",");
+			}
+
+			first = false;
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\":");
+			sb.append(_toJSONValue(entry.getValue()));
+		}
+
+		sb.append("}\n");
+
+		return sb.toString();
+	}
+
+	private final Appendable _appendable;
+	private final Supplier<String> _cmvpCertificateIdSupplier;
+	private final Supplier<String> _deploymentInstanceIdSupplier;
+	private final Supplier<String> _providerNameSupplier;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitter.java
@@ -17,11 +17,11 @@ import java.util.function.Supplier;
 
 /**
  * Writes FIPS audit events as NDJSON records, one per line, each sharing a
- * common envelope: event schema version, the §5.1 timestamp, severity, event
- * type, deployment instance ID, and the validated provider name, provider
- * version, and CMVP certificate ID active at emission. Every record is flushed
- * synchronously, so an Error State entry reaches disk before the process
- * continues; nothing is buffered in memory.
+ * common envelope, in key order: the CMVP certificate ID and deployment
+ * instance ID, event schema version, event type, the validated provider name
+ * and version active at emission, severity, and the §5.1 timestamp. Every
+ * record is flushed synchronously, so an Error State entry reaches disk before
+ * the process continues; nothing is buffered in memory.
  *
  * <p>
  * Event specific fields are nested under a single {@code fields} object rather
@@ -33,9 +33,7 @@ import java.util.function.Supplier;
  * The emitter is intentionally free of OSGi and framework dependencies. FIPS
  * finite-state-model transitions are emitted during boot, before the audit
  * router is available, so the envelope sources are injected as suppliers and
- * records are written straight to the supplied {@link Appendable}. The NDJSON
- * key order is stable, keeping the trail forward-compatible with §5.4
- * audit-log-integrity chaining.
+ * records are written straight to the supplied {@link Appendable}.
  * </p>
  *
  * @author Jorge García Jiménez
@@ -57,25 +55,25 @@ public class FIPSAuditEventEmitter {
 
 	public void emit(FIPSAuditEvent fipsAuditEvent) {
 		Map<String, Object> record = LinkedHashMapBuilder.<String, Object>put(
+			"cmvp-certificate-id", _cmvpCertificateIdSupplier.get()
+		).put(
+			"deployment-instance-id", _deploymentInstanceIdSupplier.get()
+		).put(
 			"event-schema-version", "1.0"
-		).put(
-			"timestamp", FIPSAuditTimestamp.now()
-		).put(
-			"severity",
-			fipsAuditEvent.getFIPSAuditSeverity(
-			).getValue()
 		).put(
 			"event-type", fipsAuditEvent.getEventType()
 		).put(
-			"deployment-instance-id", _deploymentInstanceIdSupplier.get()
+			"fields", fipsAuditEvent.getFields()
 		).put(
 			"provider-name", _providerNameSupplier.get()
 		).put(
 			"provider-version", _providerVersionSupplier.get()
 		).put(
-			"cmvp-certificate-id", _cmvpCertificateIdSupplier.get()
+			"severity",
+			fipsAuditEvent.getFIPSAuditSeverity(
+			).getValue()
 		).put(
-			"fields", fipsAuditEvent.getFields()
+			"timestamp", FIPSAuditTimestamp.now()
 		).build();
 
 		try {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitter.java
@@ -18,10 +18,16 @@ import java.util.function.Supplier;
 /**
  * Writes FIPS audit events as NDJSON records, one per line, each sharing a
  * common envelope: event schema version, the §5.1 timestamp, severity, event
- * type, deployment instance ID, and the validated provider name and CMVP
- * certificate ID active at emission. Every record is flushed synchronously, so
- * an Error State entry reaches disk before the process continues; nothing is
- * buffered in memory.
+ * type, deployment instance ID, and the validated provider name, provider
+ * version, and CMVP certificate ID active at emission. Every record is flushed
+ * synchronously, so an Error State entry reaches disk before the process
+ * continues; nothing is buffered in memory.
+ *
+ * <p>
+ * Event specific fields are nested under a single {@code fields} object rather
+ * than merged into the envelope, so an event can never overwrite an envelope
+ * key and misattribute the record.
+ * </p>
  *
  * <p>
  * The emitter is intentionally free of OSGi and framework dependencies. FIPS
@@ -39,12 +45,14 @@ public class FIPSAuditEventEmitter {
 	public FIPSAuditEventEmitter(
 		Appendable appendable, Supplier<String> cmvpCertificateIdSupplier,
 		Supplier<String> deploymentInstanceIdSupplier,
-		Supplier<String> providerNameSupplier) {
+		Supplier<String> providerNameSupplier,
+		Supplier<String> providerVersionSupplier) {
 
 		_appendable = appendable;
 		_cmvpCertificateIdSupplier = cmvpCertificateIdSupplier;
 		_deploymentInstanceIdSupplier = deploymentInstanceIdSupplier;
 		_providerNameSupplier = providerNameSupplier;
+		_providerVersionSupplier = providerVersionSupplier;
 	}
 
 	public void emit(FIPSAuditEvent fipsAuditEvent) {
@@ -63,9 +71,11 @@ public class FIPSAuditEventEmitter {
 		).put(
 			"provider-name", _providerNameSupplier.get()
 		).put(
+			"provider-version", _providerVersionSupplier.get()
+		).put(
 			"cmvp-certificate-id", _cmvpCertificateIdSupplier.get()
-		).putAll(
-			fipsAuditEvent.getFields()
+		).put(
+			"fields", fipsAuditEvent.getFields()
 		).build();
 
 		try {
@@ -115,6 +125,31 @@ public class FIPSAuditEventEmitter {
 		return sb.toString();
 	}
 
+	private String _toJSONObject(Map<?, ?> map) {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		boolean first = true;
+
+		for (Map.Entry<?, ?> entry : map.entrySet()) {
+			if (!first) {
+				sb.append(",");
+			}
+
+			first = false;
+
+			sb.append("\"");
+			sb.append(_escape(String.valueOf(entry.getKey())));
+			sb.append("\":");
+			sb.append(_toJSONValue(entry.getValue()));
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
 	private String _toJSONValue(Object value) {
 		if (value == null) {
 			return "null";
@@ -124,37 +159,21 @@ public class FIPSAuditEventEmitter {
 			return value.toString();
 		}
 
+		if (value instanceof Map) {
+			return _toJSONObject((Map<?, ?>)value);
+		}
+
 		return "\"" + _escape(value.toString()) + "\"";
 	}
 
 	private String _toNDJSON(Map<String, Object> record) {
-		StringBundler sb = new StringBundler();
-
-		sb.append("{");
-
-		boolean first = true;
-
-		for (Map.Entry<String, Object> entry : record.entrySet()) {
-			if (!first) {
-				sb.append(",");
-			}
-
-			first = false;
-
-			sb.append("\"");
-			sb.append(_escape(entry.getKey()));
-			sb.append("\":");
-			sb.append(_toJSONValue(entry.getValue()));
-		}
-
-		sb.append("}\n");
-
-		return sb.toString();
+		return _toJSONObject(record) + "\n";
 	}
 
 	private final Appendable _appendable;
 	private final Supplier<String> _cmvpCertificateIdSupplier;
 	private final Supplier<String> _deploymentInstanceIdSupplier;
 	private final Supplier<String> _providerNameSupplier;
+	private final Supplier<String> _providerVersionSupplier;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterUtil.java
@@ -1,0 +1,184 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
+import java.io.Flushable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.security.Provider;
+import java.security.Security;
+
+import java.util.UUID;
+
+/**
+ * Process-wide static entry point for emitting FIPS audit events to the
+ * canonical NDJSON audit log at
+ * <code>${liferay.home}/logs/fips-audit.ndjson</code>.
+ *
+ * <p>
+ * The FIPS application state machine drives events during boot, before the OSGi
+ * runtime exists, so the sink and envelope sources are wired without any
+ * framework dependency: the CMVP certificate ID and deployment instance ID come
+ * from deployment configuration (a {@link PropsKeys} property), the provider
+ * name from the validated JCE provider, and each record is appended and
+ * {@code fsync}ed to disk so a critical Error State entry survives a crash.
+ * </p>
+ *
+ * @author Jorge García Jiménez
+ */
+public class FIPSAuditEventEmitterUtil {
+
+	public static synchronized void emit(FIPSAuditEvent fipsAuditEvent) {
+		_fipsAuditEventEmitter.emit(fipsAuditEvent);
+	}
+
+	private static String _getCMVPCertificateId() {
+		return PropsValues.FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID;
+	}
+
+	private static String _getDeploymentInstanceId() {
+		String deploymentInstanceId =
+			PropsValues.FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID;
+
+		if (Validator.isNotNull(deploymentInstanceId)) {
+			return deploymentInstanceId;
+		}
+
+		Path path = Paths.get(
+			PropsValues.LIFERAY_HOME, "data",
+			"fips-audit-deployment-instance-id");
+
+		try {
+			if (Files.exists(path)) {
+				String persistedId = new String(
+					Files.readAllBytes(path), StandardCharsets.UTF_8);
+
+				return persistedId.trim();
+			}
+
+			String deploymentInstanceUUID = UUID.randomUUID(
+			).toString();
+
+			Files.createDirectories(path.getParent());
+
+			Files.write(
+				path, deploymentInstanceUUID.getBytes(StandardCharsets.UTF_8));
+
+			return deploymentInstanceUUID;
+		}
+		catch (IOException ioException) {
+			throw new UncheckedIOException(
+				"Unable to resolve the FIPS deployment instance ID",
+				ioException);
+		}
+	}
+
+	private static String _getProviderName() {
+		Provider[] providers = Security.getProviders();
+
+		if (ArrayUtil.isEmpty(providers)) {
+			return "";
+		}
+
+		Provider provider = providers[0];
+
+		return provider.getName();
+	}
+
+	private static final FIPSAuditEventEmitter _fipsAuditEventEmitter =
+		new FIPSAuditEventEmitter(
+			new FileSink(), FIPSAuditEventEmitterUtil::_getCMVPCertificateId,
+			FIPSAuditEventEmitterUtil::_getDeploymentInstanceId,
+			FIPSAuditEventEmitterUtil::_getProviderName);
+
+	private static class FileSink implements Appendable, Flushable {
+
+		@Override
+		public Appendable append(char c) {
+			return append(String.valueOf(c));
+		}
+
+		@Override
+		public Appendable append(CharSequence charSequence) {
+			try {
+				OutputStream outputStream = _getOutputStream();
+
+				outputStream.write(
+					charSequence.toString(
+					).getBytes(
+						StandardCharsets.UTF_8
+					));
+
+				return this;
+			}
+			catch (IOException ioException) {
+				throw new UncheckedIOException(
+					"Unable to write the FIPS audit log", ioException);
+			}
+		}
+
+		@Override
+		public Appendable append(
+			CharSequence charSequence, int start, int end) {
+
+			return append(charSequence.subSequence(start, end));
+		}
+
+		@Override
+		public void flush() {
+			if (_fileOutputStream == null) {
+				return;
+			}
+
+			try {
+				_fileOutputStream.flush();
+
+				FileDescriptor fileDescriptor = _fileOutputStream.getFD();
+
+				fileDescriptor.sync();
+
+				_fileOutputStream.close();
+			}
+			catch (IOException ioException) {
+				throw new UncheckedIOException(
+					"Unable to flush the FIPS audit log", ioException);
+			}
+			finally {
+				_fileOutputStream = null;
+			}
+		}
+
+		private OutputStream _getOutputStream() throws IOException {
+			if (_fileOutputStream == null) {
+				Path path = Paths.get(
+					PropsValues.LIFERAY_HOME, "logs", "fips-audit.ndjson");
+
+				Files.createDirectories(path.getParent());
+
+				_fileOutputStream = new FileOutputStream(path.toFile(), true);
+			}
+
+			return _fileOutputStream;
+		}
+
+		private FileOutputStream _fileOutputStream;
+
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterUtil.java
@@ -36,8 +36,8 @@ import java.util.UUID;
  * runtime exists, so the sink and envelope sources are wired without any
  * framework dependency: the CMVP certificate ID and deployment instance ID come
  * from deployment configuration (a {@link PropsKeys} property), the provider
- * name from the validated JCE provider, and each record is appended and
- * {@code fsync}ed to disk so a critical Error State entry survives a crash.
+ * name and version from the validated JCE provider, and each record is appended
+ * and {@code fsync}ed to disk so a critical Error State entry survives a crash.
  * </p>
  *
  * @author Jorge García Jiménez
@@ -46,6 +46,16 @@ public class FIPSAuditEventEmitterUtil {
 
 	public static synchronized void emit(FIPSAuditEvent fipsAuditEvent) {
 		_fipsAuditEventEmitter.emit(fipsAuditEvent);
+	}
+
+	private static Provider _fetchProvider() {
+		Provider[] providers = Security.getProviders();
+
+		if (ArrayUtil.isEmpty(providers)) {
+			return null;
+		}
+
+		return providers[0];
 	}
 
 	private static String _getCMVPCertificateId() {
@@ -72,15 +82,13 @@ public class FIPSAuditEventEmitterUtil {
 				return persistedId.trim();
 			}
 
-			String deploymentInstanceUUID = UUID.randomUUID(
-			).toString();
+			String generatedId = String.valueOf(UUID.randomUUID());
 
 			Files.createDirectories(path.getParent());
 
-			Files.write(
-				path, deploymentInstanceUUID.getBytes(StandardCharsets.UTF_8));
+			Files.write(path, generatedId.getBytes(StandardCharsets.UTF_8));
 
-			return deploymentInstanceUUID;
+			return generatedId;
 		}
 		catch (IOException ioException) {
 			throw new UncheckedIOException(
@@ -90,22 +98,31 @@ public class FIPSAuditEventEmitterUtil {
 	}
 
 	private static String _getProviderName() {
-		Provider[] providers = Security.getProviders();
+		Provider provider = _fetchProvider();
 
-		if (ArrayUtil.isEmpty(providers)) {
+		if (provider == null) {
 			return "";
 		}
 
-		Provider provider = providers[0];
-
 		return provider.getName();
+	}
+
+	private static String _getProviderVersion() {
+		Provider provider = _fetchProvider();
+
+		if (provider == null) {
+			return "";
+		}
+
+		return provider.getVersionStr();
 	}
 
 	private static final FIPSAuditEventEmitter _fipsAuditEventEmitter =
 		new FIPSAuditEventEmitter(
 			new FileSink(), FIPSAuditEventEmitterUtil::_getCMVPCertificateId,
 			FIPSAuditEventEmitterUtil::_getDeploymentInstanceId,
-			FIPSAuditEventEmitterUtil::_getProviderName);
+			FIPSAuditEventEmitterUtil::_getProviderName,
+			FIPSAuditEventEmitterUtil::_getProviderVersion);
 
 	private static class FileSink implements Appendable, Flushable {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditSeverity.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditSeverity.java
@@ -1,0 +1,28 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+/**
+ * Severity of a FIPS audit event: {@link #INFO} for a normal state transition
+ * and {@link #CRITICAL} for an Error State entry.
+ *
+ * @author Jorge García Jiménez
+ */
+public enum FIPSAuditSeverity {
+
+	CRITICAL("critical"), INFO("info");
+
+	public String getValue() {
+		return _value;
+	}
+
+	private FIPSAuditSeverity(String value) {
+		_value = value;
+	}
+
+	private final String _value;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditTimestamp.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditTimestamp.java
@@ -1,0 +1,77 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+import java.util.Date;
+
+/**
+ * Formats FIPS audit event timestamps in a single canonical representation: UTC,
+ * ISO 8601 extended form with millisecond precision and a literal <code>Z</code>
+ * suffix (for example <code>2026-05-06T14:19:23.471Z</code>), sourced from the
+ * host clock.
+ *
+ * <p>
+ * Every FIPS audit event across §5.2 to §5.5 shares this format so the audit
+ * trail keeps a stable time ordering across cluster nodes and downstream SIEM
+ * correlation. Sub millisecond precision is truncated rather than rounded, and
+ * the format is emitted in UTC regardless of the host default time zone.
+ * </p>
+ *
+ * <p>
+ * The timestamp carries millisecond precision only; it does not by itself
+ * guarantee a unique ordering for two events emitted within the same
+ * millisecond, so the §5.4 audit log integrity chain, not the timestamp, is the
+ * authority on order.
+ * </p>
+ *
+ * @author Jorge García Jiménez
+ */
+public class FIPSAuditTimestamp {
+
+	public static String format(Instant instant) {
+		return _dateTimeFormatter.format(instant.atZone(ZoneOffset.UTC));
+	}
+
+	public static String format(long epochMillis) {
+		return format(Instant.ofEpochMilli(epochMillis));
+	}
+
+	public static String normalize(Date date) {
+		return format(date.toInstant());
+	}
+
+	public static String normalize(String timestamp) {
+		try {
+			return format(Instant.parse(timestamp));
+		}
+		catch (DateTimeParseException dateTimeParseException1) {
+			try {
+				OffsetDateTime offsetDateTime = OffsetDateTime.parse(timestamp);
+
+				return format(offsetDateTime.toInstant());
+			}
+			catch (DateTimeParseException dateTimeParseException2) {
+				throw new IllegalArgumentException(
+					"Unable to normalize timestamp \"" + timestamp + "\"",
+					dateTimeParseException2);
+			}
+		}
+	}
+
+	public static String now() {
+		return format(Instant.now());
+	}
+
+	private static final DateTimeFormatter _dateTimeFormatter =
+		DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1076,6 +1076,12 @@ public interface PropsKeys {
 		FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS =
 			"field.enable.com.liferay.portal.kernel.model.Organization.status";
 
+	public static final String FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID =
+		"fips.audit.deployment.instance.id";
+
+	public static final String FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID =
+		"fips.audit.provider.cmvp.certificate.id";
+
 	public static final String FIPS_ENABLED = "fips.enabled";
 
 	public static final String FULL_PAGE_DISPLAYABLE = "full.page.displayable";

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -884,6 +884,12 @@ public class PropsValues {
 					PropsKeys.
 						FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS));
 
+	public static final String FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID =
+		PropsUtil.get(PropsKeys.FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID);
+
+	public static final String FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID =
+		PropsUtil.get(PropsKeys.FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID);
+
 	public static final boolean FIPS_ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.FIPS_ENABLED));
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterTest.java
@@ -79,10 +79,6 @@ public class FIPSAuditEventEmitterTest {
 			ndjson.matches(
 				"(?s).*\"timestamp\":\"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:" +
 					"\\d{2}\\.\\d{3}Z\".*"));
-
-		Assert.assertTrue(
-			ndjson,
-			ndjson.indexOf("provider-name") < ndjson.indexOf("from-state"));
 	}
 
 	@Test
@@ -137,40 +133,6 @@ public class FIPSAuditEventEmitterTest {
 	}
 
 	@Test
-	public void testEmitPreservesEnvelopeKeyOrder() {
-		RecordingAppendable recordingAppendable = new RecordingAppendable();
-
-		FIPSAuditEventEmitter fipsAuditEventEmitter = new FIPSAuditEventEmitter(
-			recordingAppendable, () -> "", () -> "", () -> "", () -> "");
-
-		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
-			"", FIPSAuditSeverity.CRITICAL);
-
-		fipsAuditEvent.put("from-state", "");
-		fipsAuditEvent.put("to-state", "");
-
-		fipsAuditEventEmitter.emit(fipsAuditEvent);
-
-		String ndjson = recordingAppendable.toString();
-
-		String[] keys = {
-			"event-schema-version", "timestamp", "severity", "event-type",
-			"deployment-instance-id", "provider-name", "provider-version",
-			"cmvp-certificate-id", "fields", "from-state", "to-state"
-		};
-
-		int previousIndex = -1;
-
-		for (String key : keys) {
-			int index = ndjson.indexOf("\"" + key);
-
-			Assert.assertTrue(key, index > previousIndex);
-
-			previousIndex = index;
-		}
-	}
-
-	@Test
 	public void testEmitRendersTypedFieldValues() {
 		RecordingAppendable recordingAppendable = new RecordingAppendable();
 
@@ -194,6 +156,41 @@ public class FIPSAuditEventEmitterTest {
 		Assert.assertTrue(
 			ndjson, ndjson.contains("\"duration-ms\":" + duration));
 		Assert.assertTrue(ndjson, ndjson.contains("\"passed\":true"));
+	}
+
+	@Test
+	public void testEmitSortsRecordKeys() {
+		RecordingAppendable recordingAppendable = new RecordingAppendable();
+
+		FIPSAuditEventEmitter fipsAuditEventEmitter = new FIPSAuditEventEmitter(
+			recordingAppendable, () -> "", () -> "", () -> "", () -> "");
+
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			"", FIPSAuditSeverity.CRITICAL);
+
+		fipsAuditEvent.put("from-state", "");
+		fipsAuditEvent.put("to-state", "");
+
+		fipsAuditEventEmitter.emit(fipsAuditEvent);
+
+		String ndjson = recordingAppendable.toString();
+
+		String[] keys = {
+			"cmvp-certificate-id", "deployment-instance-id",
+			"event-schema-version", "event-type", "fields", "from-state",
+			"to-state", "provider-name", "provider-version", "severity",
+			"timestamp"
+		};
+
+		int previousIndex = -1;
+
+		for (String key : keys) {
+			int index = ndjson.indexOf("\"" + key);
+
+			Assert.assertTrue(key, index > previousIndex);
+
+			previousIndex = index;
+		}
 	}
 
 	private static class RecordingAppendable implements Appendable, Flushable {

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterTest.java
@@ -1,0 +1,206 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+
+import java.io.Flushable;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSAuditEventEmitterTest {
+
+	@Test
+	public void testEmit() {
+		RecordingAppendable recordingAppendable = new RecordingAppendable();
+
+		String cmvpCertificateId = RandomTestUtil.randomString();
+		String deploymentInstanceId = RandomTestUtil.randomString();
+		String providerName = RandomTestUtil.randomString();
+
+		FIPSAuditEventEmitter fipsAuditEventEmitter = new FIPSAuditEventEmitter(
+			recordingAppendable, () -> cmvpCertificateId,
+			() -> deploymentInstanceId, () -> providerName);
+
+		String eventType = RandomTestUtil.randomString();
+
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			eventType, FIPSAuditSeverity.CRITICAL);
+
+		String fromState = RandomTestUtil.randomString();
+		String toState = RandomTestUtil.randomString();
+
+		fipsAuditEvent.put("from-state", fromState);
+		fipsAuditEvent.put("to-state", toState);
+
+		fipsAuditEventEmitter.emit(fipsAuditEvent);
+
+		String ndjson = recordingAppendable.toString();
+
+		Assert.assertTrue(ndjson, ndjson.endsWith("}\n"));
+		Assert.assertEquals(ndjson, 1, recordingAppendable.getFlushCount());
+
+		Assert.assertTrue(
+			ndjson, ndjson.contains("\"event-schema-version\":\"1.0\""));
+		Assert.assertTrue(ndjson, ndjson.contains("\"severity\":\"critical\""));
+		Assert.assertTrue(
+			ndjson, ndjson.contains("\"event-type\":\"" + eventType + "\""));
+		Assert.assertTrue(
+			ndjson,
+			ndjson.contains(
+				"\"deployment-instance-id\":\"" + deploymentInstanceId + "\""));
+		Assert.assertTrue(
+			ndjson,
+			ndjson.contains("\"provider-name\":\"" + providerName + "\""));
+		Assert.assertTrue(
+			ndjson,
+			ndjson.contains(
+				"\"cmvp-certificate-id\":\"" + cmvpCertificateId + "\""));
+		Assert.assertTrue(
+			ndjson, ndjson.contains("\"from-state\":\"" + fromState + "\""));
+		Assert.assertTrue(
+			ndjson, ndjson.contains("\"to-state\":\"" + toState + "\""));
+
+		Assert.assertTrue(
+			ndjson,
+			ndjson.matches(
+				"(?s).*\"timestamp\":\"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:" +
+					"\\d{2}\\.\\d{3}Z\".*"));
+
+		Assert.assertTrue(
+			ndjson,
+			ndjson.indexOf("provider-name") < ndjson.indexOf("from-state"));
+	}
+
+	@Test
+	public void testEmitEscapesFieldValues() {
+		RecordingAppendable recordingAppendable = new RecordingAppendable();
+
+		FIPSAuditEventEmitter fipsAuditEventEmitter = new FIPSAuditEventEmitter(
+			recordingAppendable, () -> "", () -> "", () -> "");
+
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			RandomTestUtil.randomString(), FIPSAuditSeverity.INFO);
+
+		fipsAuditEvent.put("reason", "a\\b\"c\nd\re\tfg");
+
+		fipsAuditEventEmitter.emit(fipsAuditEvent);
+
+		String ndjson = recordingAppendable.toString();
+
+		Assert.assertTrue(
+			ndjson, ndjson.contains("\"reason\":\"a\\\\b\\\"c\\nd\\re\\tfg\""));
+	}
+
+	@Test
+	public void testEmitPreservesEnvelopeKeyOrder() {
+		RecordingAppendable recordingAppendable = new RecordingAppendable();
+
+		FIPSAuditEventEmitter fipsAuditEventEmitter = new FIPSAuditEventEmitter(
+			recordingAppendable, () -> "", () -> "", () -> "");
+
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			"", FIPSAuditSeverity.CRITICAL);
+
+		fipsAuditEvent.put("from-state", "");
+		fipsAuditEvent.put("to-state", "");
+
+		fipsAuditEventEmitter.emit(fipsAuditEvent);
+
+		String ndjson = recordingAppendable.toString();
+
+		String[] keys = {
+			"event-schema-version", "timestamp", "severity", "event-type",
+			"deployment-instance-id", "provider-name", "cmvp-certificate-id",
+			"from-state", "to-state"
+		};
+
+		int previousIndex = -1;
+
+		for (String key : keys) {
+			int index = ndjson.indexOf("\"" + key);
+
+			Assert.assertTrue(key, index > previousIndex);
+
+			previousIndex = index;
+		}
+	}
+
+	@Test
+	public void testEmitRendersTypedFieldValues() {
+		RecordingAppendable recordingAppendable = new RecordingAppendable();
+
+		FIPSAuditEventEmitter fipsAuditEventEmitter = new FIPSAuditEventEmitter(
+			recordingAppendable, () -> "", () -> "", () -> "");
+
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			RandomTestUtil.randomString(), FIPSAuditSeverity.INFO);
+
+		int duration = RandomTestUtil.randomInt();
+
+		fipsAuditEvent.put("detail", null);
+		fipsAuditEvent.put("duration-ms", duration);
+		fipsAuditEvent.put("passed", true);
+
+		fipsAuditEventEmitter.emit(fipsAuditEvent);
+
+		String ndjson = recordingAppendable.toString();
+
+		Assert.assertTrue(ndjson, ndjson.contains("\"detail\":null"));
+		Assert.assertTrue(
+			ndjson, ndjson.contains("\"duration-ms\":" + duration));
+		Assert.assertTrue(ndjson, ndjson.contains("\"passed\":true"));
+	}
+
+	private static class RecordingAppendable implements Appendable, Flushable {
+
+		@Override
+		public Appendable append(char c) {
+			_stringBuilder.append(c);
+
+			return this;
+		}
+
+		@Override
+		public Appendable append(CharSequence charSequence) {
+			_stringBuilder.append(charSequence);
+
+			return this;
+		}
+
+		@Override
+		public Appendable append(
+			CharSequence charSequence, int start, int end) {
+
+			_stringBuilder.append(charSequence, start, end);
+
+			return this;
+		}
+
+		@Override
+		public void flush() {
+			_flushCount++;
+		}
+
+		public int getFlushCount() {
+			return _flushCount;
+		}
+
+		@Override
+		public String toString() {
+			return _stringBuilder.toString();
+		}
+
+		private int _flushCount;
+		private final StringBuilder _stringBuilder = new StringBuilder();
+
+	}
+
+}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterTest.java
@@ -24,10 +24,12 @@ public class FIPSAuditEventEmitterTest {
 		String cmvpCertificateId = RandomTestUtil.randomString();
 		String deploymentInstanceId = RandomTestUtil.randomString();
 		String providerName = RandomTestUtil.randomString();
+		String providerVersion = RandomTestUtil.randomString();
 
 		FIPSAuditEventEmitter fipsAuditEventEmitter = new FIPSAuditEventEmitter(
 			recordingAppendable, () -> cmvpCertificateId,
-			() -> deploymentInstanceId, () -> providerName);
+			() -> deploymentInstanceId, () -> providerName,
+			() -> providerVersion);
 
 		String eventType = RandomTestUtil.randomString();
 
@@ -62,6 +64,10 @@ public class FIPSAuditEventEmitterTest {
 		Assert.assertTrue(
 			ndjson,
 			ndjson.contains(
+				"\"provider-version\":\"" + providerVersion + "\""));
+		Assert.assertTrue(
+			ndjson,
+			ndjson.contains(
 				"\"cmvp-certificate-id\":\"" + cmvpCertificateId + "\""));
 		Assert.assertTrue(
 			ndjson, ndjson.contains("\"from-state\":\"" + fromState + "\""));
@@ -84,7 +90,7 @@ public class FIPSAuditEventEmitterTest {
 		RecordingAppendable recordingAppendable = new RecordingAppendable();
 
 		FIPSAuditEventEmitter fipsAuditEventEmitter = new FIPSAuditEventEmitter(
-			recordingAppendable, () -> "", () -> "", () -> "");
+			recordingAppendable, () -> "", () -> "", () -> "", () -> "");
 
 		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
 			RandomTestUtil.randomString(), FIPSAuditSeverity.INFO);
@@ -100,11 +106,42 @@ public class FIPSAuditEventEmitterTest {
 	}
 
 	@Test
+	public void testEmitNestsFields() {
+		RecordingAppendable recordingAppendable = new RecordingAppendable();
+
+		String providerName = RandomTestUtil.randomString();
+
+		FIPSAuditEventEmitter fipsAuditEventEmitter = new FIPSAuditEventEmitter(
+			recordingAppendable, () -> "", () -> "", () -> providerName,
+			() -> "");
+
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			RandomTestUtil.randomString(), FIPSAuditSeverity.INFO);
+
+		String spoofedProviderName = RandomTestUtil.randomString();
+
+		fipsAuditEvent.put("provider-name", spoofedProviderName);
+
+		fipsAuditEventEmitter.emit(fipsAuditEvent);
+
+		String ndjson = recordingAppendable.toString();
+
+		Assert.assertTrue(
+			ndjson,
+			ndjson.contains("\"provider-name\":\"" + providerName + "\""));
+		Assert.assertTrue(
+			ndjson,
+			ndjson.contains(
+				"\"fields\":{\"provider-name\":\"" + spoofedProviderName +
+					"\"}"));
+	}
+
+	@Test
 	public void testEmitPreservesEnvelopeKeyOrder() {
 		RecordingAppendable recordingAppendable = new RecordingAppendable();
 
 		FIPSAuditEventEmitter fipsAuditEventEmitter = new FIPSAuditEventEmitter(
-			recordingAppendable, () -> "", () -> "", () -> "");
+			recordingAppendable, () -> "", () -> "", () -> "", () -> "");
 
 		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
 			"", FIPSAuditSeverity.CRITICAL);
@@ -118,8 +155,8 @@ public class FIPSAuditEventEmitterTest {
 
 		String[] keys = {
 			"event-schema-version", "timestamp", "severity", "event-type",
-			"deployment-instance-id", "provider-name", "cmvp-certificate-id",
-			"from-state", "to-state"
+			"deployment-instance-id", "provider-name", "provider-version",
+			"cmvp-certificate-id", "fields", "from-state", "to-state"
 		};
 
 		int previousIndex = -1;
@@ -138,7 +175,7 @@ public class FIPSAuditEventEmitterTest {
 		RecordingAppendable recordingAppendable = new RecordingAppendable();
 
 		FIPSAuditEventEmitter fipsAuditEventEmitter = new FIPSAuditEventEmitter(
-			recordingAppendable, () -> "", () -> "", () -> "");
+			recordingAppendable, () -> "", () -> "", () -> "", () -> "");
 
 		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
 			RandomTestUtil.randomString(), FIPSAuditSeverity.INFO);

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterUtilTest.java
@@ -59,6 +59,7 @@ public class FIPSAuditEventEmitterUtilTest {
 			Assert.assertTrue(
 				ndjson, ndjson.contains("\"from-state\":\"Operational\""));
 			Assert.assertTrue(ndjson, ndjson.contains("\"provider-name\":"));
+			Assert.assertTrue(ndjson, ndjson.contains("\"provider-version\":"));
 		}
 		finally {
 			_delete(liferayHome);

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterUtilTest.java
@@ -1,0 +1,140 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSAuditEventEmitterUtilTest {
+
+	@Test
+	public void testEmit() throws Exception {
+		Path liferayHome = Files.createTempDirectory("fips-audit-test");
+
+		try (SafeCloseable safeCloseable1 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"LIFERAY_HOME", liferayHome.toString());
+			SafeCloseable safeCloseable2 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", "instance-1");
+			SafeCloseable safeCloseable3 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID", "4743")) {
+
+			FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+				RandomTestUtil.randomString(), FIPSAuditSeverity.CRITICAL);
+
+			fipsAuditEvent.put("from-state", "Operational");
+			fipsAuditEvent.put("to-state", RandomTestUtil.randomString());
+
+			FIPSAuditEventEmitterUtil.emit(fipsAuditEvent);
+
+			String ndjson = _read(
+				liferayHome.resolve("logs/fips-audit.ndjson"));
+
+			Assert.assertTrue(ndjson, ndjson.endsWith("}\n"));
+			Assert.assertTrue(
+				ndjson, ndjson.contains("\"cmvp-certificate-id\":\"4743\""));
+			Assert.assertTrue(
+				ndjson,
+				ndjson.contains("\"deployment-instance-id\":\"instance-1\""));
+			Assert.assertTrue(
+				ndjson, ndjson.contains("\"from-state\":\"Operational\""));
+			Assert.assertTrue(ndjson, ndjson.contains("\"provider-name\":"));
+		}
+		finally {
+			_delete(liferayHome);
+		}
+	}
+
+	@Test
+	public void testEmitDerivesStableDeploymentInstanceIdWhenUnset()
+		throws Exception {
+
+		Path liferayHome = Files.createTempDirectory("fips-audit-test");
+
+		try (SafeCloseable safeCloseable1 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"LIFERAY_HOME", liferayHome.toString());
+			SafeCloseable safeCloseable2 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", "");
+			SafeCloseable safeCloseable3 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID", "")) {
+
+			FIPSAuditEventEmitterUtil.emit(
+				new FIPSAuditEvent(
+					RandomTestUtil.randomString(), FIPSAuditSeverity.INFO));
+			FIPSAuditEventEmitterUtil.emit(
+				new FIPSAuditEvent(
+					RandomTestUtil.randomString(), FIPSAuditSeverity.INFO));
+
+			String[] lines = StringUtil.split(
+				_read(liferayHome.resolve("logs/fips-audit.ndjson")), '\n');
+
+			String deploymentInstanceId = _extractDeploymentInstanceId(
+				lines[0]);
+
+			Assert.assertTrue(
+				deploymentInstanceId, !deploymentInstanceId.isEmpty());
+			Assert.assertEquals(
+				deploymentInstanceId, _extractDeploymentInstanceId(lines[1]));
+
+			Assert.assertTrue(
+				Files.exists(
+					liferayHome.resolve(
+						"data/fips-audit-deployment-instance-id")));
+		}
+		finally {
+			_delete(liferayHome);
+		}
+	}
+
+	private void _delete(Path path) throws IOException {
+		File file = path.toFile();
+
+		File[] childFiles = file.listFiles();
+
+		if (childFiles != null) {
+			for (File childFile : childFiles) {
+				_delete(childFile.toPath());
+			}
+		}
+
+		Files.delete(path);
+	}
+
+	private String _extractDeploymentInstanceId(String ndjson) {
+		String prefix = "\"deployment-instance-id\":\"";
+
+		int start = ndjson.indexOf(prefix) + prefix.length();
+
+		int end = ndjson.indexOf("\"", start);
+
+		return ndjson.substring(start, end);
+	}
+
+	private String _read(Path path) throws IOException {
+		return new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+	}
+
+}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditTimestampTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditTimestampTest.java
@@ -1,0 +1,86 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+
+import java.time.Instant;
+
+import java.util.Date;
+import java.util.TimeZone;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSAuditTimestampTest {
+
+	@Test
+	public void testFormat() {
+		Assert.assertEquals(
+			_TIMESTAMP,
+			FIPSAuditTimestamp.format(Instant.ofEpochMilli(_EPOCH_MILLIS)));
+		Assert.assertEquals(
+			_TIMESTAMP, FIPSAuditTimestamp.format(_EPOCH_MILLIS));
+
+		Assert.assertEquals(
+			"2025-05-06T14:19:23.000Z",
+			FIPSAuditTimestamp.format(Instant.ofEpochSecond(_EPOCH_SECONDS)));
+		Assert.assertEquals(
+			"2025-05-06T14:19:23.123Z",
+			FIPSAuditTimestamp.format(
+				Instant.ofEpochSecond(_EPOCH_SECONDS, 123_999_999)));
+	}
+
+	@Test
+	public void testFormatIsUTCIndependentOfDefaultTimeZone() {
+		TimeZone timeZone = TimeZone.getDefault();
+
+		try {
+			TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+
+			Assert.assertEquals(
+				_TIMESTAMP,
+				FIPSAuditTimestamp.format(Instant.ofEpochMilli(_EPOCH_MILLIS)));
+		}
+		finally {
+			TimeZone.setDefault(timeZone);
+		}
+	}
+
+	@Test
+	public void testNormalize() {
+		Assert.assertEquals(
+			_TIMESTAMP, FIPSAuditTimestamp.normalize(new Date(_EPOCH_MILLIS)));
+		Assert.assertEquals(
+			_TIMESTAMP, FIPSAuditTimestamp.normalize(_TIMESTAMP));
+		Assert.assertEquals(
+			_TIMESTAMP,
+			FIPSAuditTimestamp.normalize("2025-05-06T16:19:23.471+02:00"));
+
+		Assert.assertThrows(
+			IllegalArgumentException.class,
+			() -> FIPSAuditTimestamp.normalize(RandomTestUtil.randomString()));
+	}
+
+	@Test
+	public void testNow() {
+		String now = FIPSAuditTimestamp.now();
+
+		Assert.assertTrue(
+			now,
+			now.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"));
+	}
+
+	private static final long _EPOCH_MILLIS = 1746541163471L;
+
+	private static final long _EPOCH_SECONDS = 1746541163L;
+
+	private static final String _TIMESTAMP = "2025-05-06T14:19:23.471Z";
+
+}


### PR DESCRIPTION
## What

Delivers the shared FIPS audit-event emitter — subtask A of the **LPD-93284** "FIPS State Transition Logging" story — together with the **LPD-93283** "Universal Timestamp Formatting" it depends on, combined into one master-based change so they land together.

**Timestamp — LPD-93283:**

- **`FIPSAuditTimestamp`** — the single canonical timestamp every FIPS audit event shares: UTC, ISO 8601 with millisecond precision and a literal `Z` (e.g. `2026-05-06T14:19:23.471Z`), sourced from the host clock, never caller-supplied.

**Emitter — LPD-93284:**

- **`FIPSAuditSeverity`** — `INFO` (normal state transition) / `CRITICAL` (Error State entry).
- **`FIPSAuditEvent`** — value object: event type, severity, and an insertion-ordered set of event-specific fields (fluent `put`).
- **`FIPSAuditEventEmitter`** — writes each event as one NDJSON line with its keys sorted: `cmvp-certificate-id`, `deployment-instance-id`, `event-schema-version`, `event-type`, `fields`, `provider-name`, `provider-version`, `severity`, `timestamp`. The event-specific fields are nested under the reserved `fields` object rather than merged into the envelope, so an event can never overwrite an envelope key and misattribute the record. Every line is flushed synchronously.
- **`FIPSAuditEventEmitterUtil`** — the process-wide static facade that writes to `${liferay.home}/logs/fips-audit.ndjson`, `fsync`ing on flush so a critical Error-State entry survives a crash, and sources the envelope from deployment configuration: CMVP certificate ID and deployment-instance ID from `fips.audit.*` properties, provider name and version from the validated JCE provider, with a stable per-install UUID fallback for the deployment-instance ID.

## Why boot-safe

FIPS finite-state-model transitions are emitted during boot, before the OSGi `AuditRouter` exists — so the emitter is framework-free (`Appendable` + `Supplier<String>` injection) and the facade uses only kernel `PropsValues` and `java.io`/`java.nio`. Every critical record is `fsync`ed before the process continues. The deployment-instance ID is per-node and stable across restarts, so a SIEM aggregating every cluster node can attribute each event to the node that emitted it.

## Tests

`FIPSAuditTimestampTest`, `FIPSAuditEventEmitterTest` (envelope + fields, nested `fields` object, JSON escaping, sorted record keys, typed number/boolean/null), and `FIPSAuditEventEmitterUtilTest` (file sink + property/UUID sourcing) — all green.

## Review feedback

@caio-farias's review is addressed in `33c4e1eb` and `79e7094d`:

- The envelope is authoritative — event fields moved under the reserved `fields` object, so a matching key is now impossible rather than merely unlikely. This resolves the open design question this description previously carried about the trailing `putAll`.
- `provider-version` joins `provider-name`, so a record ties back to the build that wrote it. The CMVP certificate ID alone does not, since one certificate can cover several versions (ISO/IEC 19790 AS02.10).
- The record keys are sorted.
- The chained `UUID.randomUUID().toString()` became `String.valueOf(UUID.randomUUID())`.
