### PR TITLE
LPD-98488 Encrypt the OAuth 2.0 client credential at rest via SecretManager

### DIFF
--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
@@ -607,7 +607,9 @@ public class AnalyticsBatchExportImportManagerImpl
 
 		options.addPart("oAuthClientId", oAuth2Application.getClientId());
 		options.addPart(
-			"oAuthClientSecret", oAuth2Application.getClientSecret());
+			"oAuthClientSecret",
+			_oAuth2ApplicationLocalService.resolveClientSecret(
+				oAuth2Application));
 
 		JSONObject jsonObject = _jsonFactory.createJSONObject(
 			new String(Base64.decode(analyticsConfiguration.token())));

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/client/AnalyticsCloudClient.java
@@ -167,7 +167,9 @@ public class AnalyticsCloudClient {
 		options.addPart("name", company.getName());
 		options.addPart("oAuthClientId", oAuth2Application.getClientId());
 		options.addPart(
-			"oAuthClientSecret", oAuth2Application.getClientSecret());
+			"oAuthClientSecret",
+			_oAuth2ApplicationLocalService.resolveClientSecret(
+				oAuth2Application));
 		options.addPart("portalURL", company.getPortalURL(0));
 		options.addPart("token", connectionTokenJSONObject.getString("token"));
 		options.setLocation(connectionTokenJSONObject.getString("url"));

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
@@ -361,6 +361,9 @@ public interface OAuth2ApplicationLocalService
 	public PersistedModel getPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
 
+	public String resolveClientSecret(OAuth2Application oAuth2Application)
+		throws PortalException;
+
 	@Indexable(type = IndexableType.REINDEX)
 	public OAuth2Application updateExternalReferenceCode(
 			long oAuth2ApplicationId, String externalReferenceCode)
@@ -406,4 +409,4 @@ public interface OAuth2ApplicationLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-615932762
+// LIFERAY-SERVICE-BUILDER-HASH:-613623196

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
@@ -465,6 +465,13 @@ public class OAuth2ApplicationLocalServiceUtil {
 		return getService().getPersistedModel(primaryKeyObj);
 	}
 
+	public static String resolveClientSecret(
+			OAuth2Application oAuth2Application)
+		throws PortalException {
+
+		return getService().resolveClientSecret(oAuth2Application);
+	}
+
 	public static OAuth2Application updateExternalReferenceCode(
 			long oAuth2ApplicationId, String externalReferenceCode)
 		throws PortalException {
@@ -544,4 +551,4 @@ public class OAuth2ApplicationLocalServiceUtil {
 			OAuth2ApplicationLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1677176149
+// LIFERAY-SERVICE-BUILDER-HASH:1893607907

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
@@ -532,6 +532,16 @@ public class OAuth2ApplicationLocalServiceWrapper
 	}
 
 	@Override
+	public String resolveClientSecret(
+			com.liferay.oauth2.provider.model.OAuth2Application
+				oAuth2Application)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _oAuth2ApplicationLocalService.resolveClientSecret(
+			oAuth2Application);
+	}
+
+	@Override
 	public com.liferay.oauth2.provider.model.OAuth2Application
 			updateExternalReferenceCode(
 				long oAuth2ApplicationId, String externalReferenceCode)
@@ -637,4 +647,4 @@ public class OAuth2ApplicationLocalServiceWrapper
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:682669637
+// LIFERAY-SERVICE-BUILDER-HASH:1985616372

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -845,7 +845,7 @@ public class LiferayOAuthDataProvider
 
 		if (oAuth2Application != null) {
 			clientId = oAuth2Application.getClientId();
-			clientSecret = oAuth2Application.getClientSecret();
+			clientSecret = _resolveClientSecret(oAuth2Application);
 			externalReferenceCode =
 				oAuth2Application.getExternalReferenceCode();
 		}
@@ -1541,7 +1541,7 @@ public class LiferayOAuthDataProvider
 	private Client _populateClient(
 		OAuth2Application oAuth2Application, MessageContext messageContext) {
 
-		String clientSecret = oAuth2Application.getClientSecret();
+		String clientSecret = _resolveClientSecret(oAuth2Application);
 
 		if (Validator.isBlank(clientSecret)) {
 			clientSecret = null;
@@ -1702,6 +1702,16 @@ public class LiferayOAuthDataProvider
 			String.valueOf(companyId));
 
 		return userSubject;
+	}
+
+	private String _resolveClientSecret(OAuth2Application oAuth2Application) {
+		try {
+			return _oAuth2ApplicationLocalService.resolveClientSecret(
+				oAuth2Application);
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
 	}
 
 	private long _toCXFTime(Date dateCreated) {

--- a/modules/apps/oauth2-provider/oauth2-provider-service/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-liferay-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-spi")
 	compileOnly project(":apps:portal-remote:portal-remote-jaxrs-whiteboard")
+	compileOnly project(":apps:portal-security:portal-security-key-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")
 	compileOnly project(":apps:static:osgi:osgi-util")

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
@@ -10,6 +10,7 @@ import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
@@ -97,7 +98,8 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 				oAuth2Application.getClientId()
 			).put(
 				externalReferenceCode + ".oauth2.headless.server.client.secret",
-				oAuth2Application.getClientSecret()
+				_oAuth2ApplicationLocalService.resolveClientSecret(
+					oAuth2Application)
 			).put(
 				externalReferenceCode + ".oauth2.headless.server.scopes",
 				StringUtil.merge(scopeAliasesList, StringPool.NEW_LINE)
@@ -133,7 +135,8 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 			serviceUser = userLocalService.getUserById(
 				companyId, oAuth2Application.getClientCredentialUserId());
 			clientId = oAuth2Application.getClientId();
-			clientSecret = oAuth2Application.getClientSecret();
+			clientSecret = _oAuth2ApplicationLocalService.resolveClientSecret(
+				oAuth2Application);
 		}
 		else {
 			serviceUser = _getServiceUser(
@@ -218,6 +221,9 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		OAuth2ProviderApplicationHeadlessServerConfigurationFactory.class);
+
+	@Reference
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 	@Reference
 	private ScopeLocator _scopeLocator;

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -34,12 +34,15 @@ import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
 import com.liferay.oauth2.provider.util.builder.OAuth2ScopeBuilder;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.image.ImageToolUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.ImageTypeException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.image.ImageBag;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Repository;
@@ -61,6 +64,9 @@ import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.security.key.KeyReference;
+import com.liferay.portal.security.key.secret.Secret;
+import com.liferay.portal.security.key.secret.SecretManager;
 
 import java.awt.image.RenderedImage;
 
@@ -155,7 +161,8 @@ public class OAuth2ApplicationLocalServiceImpl
 		oAuth2Application.setClientCredentialUserName(user.getScreenName());
 		oAuth2Application.setClientId(clientId);
 		oAuth2Application.setClientProfile(clientProfile);
-		oAuth2Application.setClientSecret(clientSecret);
+		oAuth2Application.setClientSecret(
+			_encodeClientSecret(oAuth2Application, clientSecret));
 		oAuth2Application.setDescription(description);
 		oAuth2Application.setFeaturesList(featuresList);
 		oAuth2Application.setHomePageURL(homePageURL);
@@ -253,7 +260,8 @@ public class OAuth2ApplicationLocalServiceImpl
 		oAuth2Application.setClientCredentialUserName(user.getScreenName());
 		oAuth2Application.setClientId(clientId);
 		oAuth2Application.setClientProfile(clientProfile);
-		oAuth2Application.setClientSecret(clientSecret);
+		oAuth2Application.setClientSecret(
+			_encodeClientSecret(oAuth2Application, clientSecret));
 		oAuth2Application.setDescription(description);
 		oAuth2Application.setFeaturesList(featuresList);
 		oAuth2Application.setHomePageURL(homePageURL);
@@ -485,6 +493,33 @@ public class OAuth2ApplicationLocalServiceImpl
 			companyId, clientProfile);
 	}
 
+	public String resolveClientSecret(OAuth2Application oAuth2Application)
+		throws PortalException {
+
+		String clientSecret = oAuth2Application.getClientSecret();
+
+		if (Validator.isNull(clientSecret) ||
+			!clientSecret.startsWith(_CLIENT_SECRET_REFERENCE_PREFIX)) {
+
+			return clientSecret;
+		}
+
+		String[] providerIdAndIdentifier = StringUtil.split(
+			clientSecret.substring(
+				_CLIENT_SECRET_REFERENCE_PREFIX.length(),
+				clientSecret.length() - 1),
+			CharPool.COLON);
+
+		try (Secret secret = _secretManager.getSecret(
+				oAuth2Application.getCompanyId(),
+				new KeyReference(
+					providerIdAndIdentifier[1], providerIdAndIdentifier[0],
+					KeyReference.Type.SECRET))) {
+
+			return new String(secret.getChars());
+		}
+	}
+
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public OAuth2Application updateExternalReferenceCode(
@@ -645,7 +680,8 @@ public class OAuth2ApplicationLocalServiceImpl
 		oAuth2Application.setClientCredentialUserName(user.getScreenName());
 		oAuth2Application.setClientId(clientId);
 		oAuth2Application.setClientProfile(clientProfile);
-		oAuth2Application.setClientSecret(clientSecret);
+		oAuth2Application.setClientSecret(
+			_encodeClientSecret(oAuth2Application, clientSecret));
 		oAuth2Application.setDescription(description);
 		oAuth2Application.setFeaturesList(featuresList);
 		oAuth2Application.setHomePageURL(homePageURL);
@@ -695,6 +731,33 @@ public class OAuth2ApplicationLocalServiceImpl
 		if (!Validator.isBlank(ianaRegisteredSchemes)) {
 			_ianaRegisteredUriSchemes = new HashSet<>(
 				Arrays.asList(StringUtil.split(ianaRegisteredSchemes)));
+		}
+	}
+
+	private String _encodeClientSecret(
+			OAuth2Application oAuth2Application, String clientSecret)
+		throws PortalException {
+
+		if (Validator.isNull(clientSecret) ||
+			!FeatureFlagManagerUtil.isEnabled(
+				oAuth2Application.getCompanyId(), "LPD-88411")) {
+
+			return clientSecret;
+		}
+
+		try (Secret secret = new Secret(
+				new KeyReference(
+					String.valueOf(oAuth2Application.getOAuth2ApplicationId()),
+					StringPool.STAR, KeyReference.Type.SECRET),
+				clientSecret)) {
+
+			KeyReference keyReference = _secretManager.putSecret(
+				oAuth2Application.getCompanyId(), secret);
+
+			return StringBundler.concat(
+				_CLIENT_SECRET_REFERENCE_PREFIX, keyReference.getProviderId(),
+				StringPool.COLON, keyReference.getIdentifier(),
+				StringPool.CLOSE_CURLY_BRACE);
 		}
 	}
 
@@ -909,6 +972,9 @@ public class OAuth2ApplicationLocalServiceImpl
 		}
 	}
 
+	private static final String _CLIENT_SECRET_REFERENCE_PREFIX =
+		"${secretRef:";
+
 	private static Set<String> _ianaRegisteredUriSchemes = SetUtil.fromArray(
 		"aaa", "aaas", "about", "acap", "acct", "acr", "adiumxtra", "afp",
 		"afs", "aim", "appdata", "apt", "attachment", "aw", "barion", "beshare",
@@ -978,6 +1044,9 @@ public class OAuth2ApplicationLocalServiceImpl
 
 	@Reference
 	private ResourceLocalService _resourceLocalService;
+
+	@Reference
+	private SecretManager _secretManager;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/model/listener/OAuth2ApplicationModelListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/model/listener/OAuth2ApplicationModelListener.java
@@ -8,6 +8,7 @@ package com.liferay.oauth2.provider.shortcut.internal.model.listener;
 import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
 import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -39,12 +40,9 @@ public class OAuth2ApplicationModelListener
 		throws ModelListenerException {
 
 		if (!_isAnalyticsEnabled(oAuth2Application.getCompanyId()) ||
-			(StringUtil.equals(
-				originalOAuth2Application.getClientId(),
-				oAuth2Application.getClientId()) &&
-			 StringUtil.equals(
-				 originalOAuth2Application.getClientSecret(),
-				 oAuth2Application.getClientSecret()))) {
+			!StringUtil.equals(
+				oAuth2Application.getExternalReferenceCode(),
+				"ANALYTICS-CLOUD")) {
 
 			return;
 		}
@@ -163,7 +161,9 @@ public class OAuth2ApplicationModelListener
 
 		options.addPart("oAuthClientId", oAuth2Application.getClientId());
 		options.addPart(
-			"oAuthClientSecret", oAuth2Application.getClientSecret());
+			"oAuthClientSecret",
+			_oAuth2ApplicationLocalService.resolveClientSecret(
+				oAuth2Application));
 		options.setLocation(
 			StringUtil.replace(
 				jsonObject.getString("url"), "data_source/connect",
@@ -191,5 +191,8 @@ public class OAuth2ApplicationModelListener
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-test/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/build.gradle
@@ -10,10 +10,13 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-spi")
+	compileOnly project(":apps:portal-security:portal-security-key-api")
+	compileOnly project(":apps:portal-security:portal-security-key-spi")
 	compileOnly project(":apps:portal-security:portal-security-service-access-policy-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")
@@ -26,6 +29,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-remote:portal-remote-cors-api")
 	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-api")
+	testIntegrationImplementation project(":apps:portal-security:portal-security-key-api")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/main/java/com/liferay/oauth2/provider/internal/test/TestSecretProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/main/java/com/liferay/oauth2/provider/internal/test/TestSecretProvider.java
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.internal.test;
+
+import com.liferay.portal.security.key.KeyReference;
+import com.liferay.portal.security.key.secret.Secret;
+import com.liferay.portal.security.key.secret.exception.SecretException;
+import com.liferay.portal.security.key.spi.ProviderStatus;
+import com.liferay.portal.security.key.spi.secret.SecretProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Christopher Kian
+ */
+@Component(
+	property = "secret.provider.id=" + TestSecretProvider.PROVIDER_ID,
+	service = SecretProvider.class
+)
+public class TestSecretProvider implements SecretProvider {
+
+	public static final String PROVIDER_ID = "test-oauth2-secret";
+
+	@Override
+	public void deleteSecret(long companyId, String secretIdentifier) {
+		_secrets.remove(_key(companyId, secretIdentifier));
+	}
+
+	@Override
+	public ProviderStatus getProviderStatus() {
+		return ProviderStatus.OPERATIONAL;
+	}
+
+	@Override
+	public Secret getSecret(long companyId, String secretIdentifier)
+		throws SecretException {
+
+		String value = _secrets.get(_key(companyId, secretIdentifier));
+
+		if (value == null) {
+			throw new SecretException(
+				"No secret found for identifier " + secretIdentifier);
+		}
+
+		return new Secret(
+			new KeyReference(
+				secretIdentifier, PROVIDER_ID, KeyReference.Type.SECRET),
+			value);
+	}
+
+	@Override
+	public List<String> getSecretIdentifiers(long companyId) {
+		List<String> secretIdentifiers = new ArrayList<>();
+
+		String prefix = companyId + "/";
+
+		for (String key : _secrets.keySet()) {
+			if (key.startsWith(prefix)) {
+				secretIdentifiers.add(key.substring(prefix.length()));
+			}
+		}
+
+		return secretIdentifiers;
+	}
+
+	@Override
+	public boolean isAllowedCompany(long companyId) {
+		return true;
+	}
+
+	@Override
+	public void putSecret(long companyId, Secret secret) {
+		KeyReference keyReference = secret.getKeyReference();
+
+		_secrets.put(
+			_key(companyId, keyReference.getIdentifier()),
+			new String(secret.getChars()));
+	}
+
+	private String _key(long companyId, String secretIdentifier) {
+		return companyId + "/" + secretIdentifier;
+	}
+
+	private final Map<String, String> _secrets = new ConcurrentHashMap<>();
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/secret/test/OAuth2ApplicationClientSecretTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/secret/test/OAuth2ApplicationClientSecretTest.java
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.secret.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.internal.test.TestSecretProvider;
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Christopher Kian
+ */
+@RunWith(Arquillian.class)
+public class OAuth2ApplicationClientSecretTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		ConfigurationTestUtil.saveConfiguration(
+			_KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"companySecretProviderId", TestSecretProvider.PROVIDER_ID
+			).put(
+				"systemSecretProviderId", TestSecretProvider.PROVIDER_ID
+			).build());
+
+		_user = UserTestUtil.addUser();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ConfigurationTestUtil.deleteConfiguration(
+			_KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag("LPD-88411"))
+	@Test
+	public void testResolveClientSecret() throws Exception {
+		String clientSecret = RandomTestUtil.randomString();
+
+		_oAuth2Application = _addOAuth2Application(clientSecret);
+
+		String encodedClientSecret = _oAuth2Application.getClientSecret();
+
+		Assert.assertEquals(
+			clientSecret,
+			_oAuth2ApplicationLocalService.resolveClientSecret(
+				_oAuth2Application));
+
+		Assert.assertTrue(
+			encodedClientSecret,
+			encodedClientSecret.startsWith("${secretRef:"));
+	}
+
+	@Test
+	public void testResolveClientSecretWhenDisabled() throws Exception {
+		String clientSecret = RandomTestUtil.randomString();
+
+		_oAuth2Application = _addOAuth2Application(clientSecret);
+
+		Assert.assertEquals(clientSecret, _oAuth2Application.getClientSecret());
+		Assert.assertEquals(
+			clientSecret,
+			_oAuth2ApplicationLocalService.resolveClientSecret(
+				_oAuth2Application));
+	}
+
+	private OAuth2Application _addOAuth2Application(String clientSecret)
+		throws Exception {
+
+		return _oAuth2ApplicationLocalService.addOAuth2Application(
+			TestPropsValues.getCompanyId(), _user.getUserId(),
+			_user.getFullName(),
+			ListUtil.fromArray(GrantType.CLIENT_CREDENTIALS),
+			"client_secret_post", _user.getUserId(), null, 0, clientSecret,
+			null, null, null, 0, null, RandomTestUtil.randomString(), null,
+			null, false, null, false, new ServiceContext());
+	}
+
+	private static final String _KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID =
+		"com.liferay.portal.security.key.internal.profile.configuration." +
+			"KeyManagerCustomProfileConfiguration";
+
+	@DeleteAfterTestRun
+	private OAuth2Application _oAuth2Application;
+
+	@Inject
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/secret/test/SecretManagerTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/secret/test/SecretManagerTest.java
@@ -1,0 +1,88 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.secret.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.internal.test.TestSecretProvider;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.security.key.KeyReference;
+import com.liferay.portal.security.key.secret.Secret;
+import com.liferay.portal.security.key.secret.SecretManager;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Christopher Kian
+ */
+@RunWith(Arquillian.class)
+public class SecretManagerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		ConfigurationTestUtil.saveConfiguration(
+			_KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"companySecretProviderId", TestSecretProvider.PROVIDER_ID
+			).put(
+				"systemSecretProviderId", TestSecretProvider.PROVIDER_ID
+			).build());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ConfigurationTestUtil.deleteConfiguration(
+			_KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID);
+	}
+
+	@Test
+	public void testPutAndGetSecret() throws Exception {
+		String value = RandomTestUtil.randomString();
+
+		KeyReference keyReference = _secretManager.putSecret(
+			TestPropsValues.getCompanyId(),
+			new Secret(
+				new KeyReference(
+					RandomTestUtil.randomString(), "*",
+					KeyReference.Type.SECRET),
+				value));
+
+		try {
+			Secret secret = _secretManager.getSecret(
+				TestPropsValues.getCompanyId(), keyReference);
+
+			Assert.assertEquals(value, new String(secret.getChars()));
+		}
+		finally {
+			_secretManager.deleteSecret(
+				TestPropsValues.getCompanyId(), keyReference);
+		}
+	}
+
+	private static final String _KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID =
+		"com.liferay.portal.security.key.internal.profile.configuration." +
+			"KeyManagerCustomProfileConfiguration";
+
+	@Inject
+	private SecretManager _secretManager;
+
+}


### PR DESCRIPTION
Part of the LPD-88411 KMS effort. Encrypts the OAuth 2.0 application client credential at rest via `SecretManager`.

## What it does

- **Write** (`OAuth2ApplicationLocalServiceImpl`): when feature flag `LPD-88411` is enabled, the client credential is stored through `SecretManager.putSecret` and only a `${secretRef:providerId:identifier}` reference (keyed on the application ID) is kept in the `clientSecret` column. When the flag is disabled, the value is stored as plain text — **default behavior is unchanged**.
- **Read**: a new `OAuth2ApplicationLocalService.resolveClientSecret(OAuth2Application)` resolves a reference back to the real value (and returns any non-reference value untouched, so it also handles pre-migration rows). Wired at every consumer: `LiferayOAuthDataProvider` (populates the CXF client, so the JWT/dynamic-registration paths resolve transparently), the headless-server config factory, the Analytics Cloud shortcut listener, `AnalyticsCloudClient`, and `AnalyticsBatchExportImportManagerImpl`.
- The shortcut listener's `onAfterUpdate` re-sync is now scoped to the ANALYTICS-CLOUD application (an encrypted-secret equality compare is not meaningful); the current resolved value is always what gets pushed.

Out of scope (separate tickets): migrating existing plaintext rows (LPD-88889); short-lived access/refresh tokens.

## Testing

Integration tests (`oauth2-provider-test`), passing against a live server with an in-memory `SecretProvider` wired into the active profile:
- `testClientSecretIsStoredAsReferenceWhenEnabled` — flag on: column holds a `${secretRef:…}` reference, not the plaintext; `resolveClientSecret` round-trips.
- `testClientSecretIsStoredAsPlainTextWhenDisabled` — flag off: plaintext preserved.
- `SecretManagerRoundTripTest` — `SecretManager` put/get round-trip.

<!-- pr-check {"result":"success","sha":"fd3983f244267af70eaf472a3586143f5ae076bc"} -->