### PR TITLE
LPD-98489 Reject plaintext credentials in portal-ext at FIPS activation

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeValidator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeValidator.java
@@ -10,21 +10,28 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.io.IOException;
+
 import java.lang.reflect.Method;
+
+import java.net.URL;
 
 import java.security.Provider;
 import java.security.Security;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -71,6 +78,30 @@ public class FIPSModeValidator {
 			throw new SecurityException(
 				"AES key must be 128, 192, or 256 bits");
 		}
+	}
+
+	private static List<String> _getPlaintextSecretProperties(
+		Properties properties) {
+
+		List<String> plaintextSecretProperties = new ArrayList<>();
+
+		for (String key : PropsValues.ADMIN_OBFUSCATED_PROPERTIES) {
+			String value = properties.getProperty(key);
+
+			if (Validator.isNull(value)) {
+				continue;
+			}
+
+			value = value.trim();
+
+			if (value.startsWith("${") && value.endsWith("}")) {
+				continue;
+			}
+
+			plaintextSecretProperties.add(key);
+		}
+
+		return plaintextSecretProperties;
 	}
 
 	private static void _validateFIPSProvider(Provider[] providers) {
@@ -215,6 +246,40 @@ public class FIPSModeValidator {
 		}
 	}
 
+	private static void _validatePlaintextSecrets() {
+		List<String> messages = new ArrayList<>();
+
+		for (String source : PropsUtil.getLoadedSources()) {
+			String fileName = source.substring(source.lastIndexOf('/') + 1);
+
+			if (fileName.equals("portal.properties")) {
+				continue;
+			}
+
+			Properties properties = null;
+
+			try {
+				properties = PropertiesUtil.load(new URL(source));
+			}
+			catch (IOException ioException) {
+				continue;
+			}
+
+			for (String key : _getPlaintextSecretProperties(properties)) {
+				messages.add(
+					StringBundler.concat(
+						"property \"", key, "\" in \"", fileName, "\""));
+			}
+		}
+
+		if (!messages.isEmpty()) {
+			throw new SecurityException(
+				StringBundler.concat(
+					"A plaintext value for ", StringUtil.merge(messages, ", "),
+					" is not allowed in FIPS mode"));
+		}
+	}
+
 	private static void _validateProperties() {
 		if (GetterUtil.getBoolean(PropsUtil.get(PropsKeys.AUTH_MAC_ALLOW))) {
 			validateAlgorithm(PropsUtil.get(PropsKeys.AUTH_MAC_ALGORITHM));
@@ -226,6 +291,7 @@ public class FIPSModeValidator {
 
 		_validatePasswordsEncryptionAlgorithm(
 			PropsUtil.get(PropsKeys.PASSWORDS_ENCRYPTION_ALGORITHM));
+		_validatePlaintextSecrets();
 	}
 
 	private static void _validateProviders(Provider[] providers) {

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSModeValidatorTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSModeValidatorTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.kernel.security.fips;
 
 import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -14,6 +15,7 @@ import java.security.Provider;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -23,6 +25,41 @@ import org.junit.function.ThrowingRunnable;
  * @author Caio Farias
  */
 public class FIPSModeValidatorTest {
+
+	@Test
+	public void testGetPlaintextSecretProperties() {
+		String obfuscatedKey1 = RandomTestUtil.randomString();
+		String obfuscatedKey2 = RandomTestUtil.randomString();
+		String obfuscatedKey3 = RandomTestUtil.randomString();
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"ADMIN_OBFUSCATED_PROPERTIES",
+					new String[] {
+						obfuscatedKey1, obfuscatedKey2, obfuscatedKey3
+					})) {
+
+			Properties properties = new Properties();
+
+			properties.setProperty(
+				obfuscatedKey1, RandomTestUtil.randomString());
+			properties.setProperty(
+				obfuscatedKey2, "${" + RandomTestUtil.randomString() + "}");
+			properties.setProperty(obfuscatedKey3, StringPool.BLANK);
+			properties.setProperty(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+			List<String> plaintextSecretProperties = ReflectionTestUtil.invoke(
+				FIPSModeValidator.class, "_getPlaintextSecretProperties",
+				new Class<?>[] {Properties.class}, properties);
+
+			Assert.assertEquals(
+				plaintextSecretProperties.toString(), 1,
+				plaintextSecretProperties.size());
+			Assert.assertTrue(
+				plaintextSecretProperties.contains(obfuscatedKey1));
+		}
+	}
 
 	@Test
 	public void testValidateAlgorithm() {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98489

Re-opens #3111 (closed) with @brianchandotcom's forward-review feedback (https://github.com/brianchandotcom/liferay-portal/pull/179150) applied: the unit test method is renamed `testFindPlaintextSecretProperties` → `testGetPlaintextSecretProperties` so its name matches the method it exercises, `_getPlaintextSecretProperties` (the `find` → `get` name was settled earlier in the #3111 review round with @rafaprax). Production code is unchanged from #3111 — the logic commit is the same object.

## What Is Being Fixed

Under FIPS 140-3 (LPD-93648 AC10), DXP must not run with a known secret stored as a plaintext literal in the portal property override files. Nothing stops an operator from placing, for example, a `jdbc.default.password` value directly in `portal-ext.properties`, so a plaintext secret can be present while FIPS mode is enabled. Unlike DB- and keystore-plane secrets, portal-ext properties have no KMS migration path (LPD-88882 excludes them), so the only correct behavior is to reject at activation.

## How It Is Being Fixed

`FIPSModeValidator.validate()` gains a boot step, `_validatePlaintextSecrets()`, that runs when FIPS mode is enabled, before the OSGi framework initializes. It reads the loaded property source files via `PropsUtil.getLoadedSources()`, skips the shipped base `portal.properties`, and parses each operator override file with `PropertiesUtil.load`. For each file, `_getPlaintextSecretProperties(Properties)` collects every key listed in `PropsValues.ADMIN_OBFUSCATED_PROPERTIES` whose value is a non-blank literal that is not a `${...}` reference. Any hit aborts boot with a `SecurityException` naming the offending property and file. Because the check inspects the file literal rather than the resolved value, a secret injected through an environment variable or a `-D` system property (the sanctioned Secret Zero remediation) leaves no file literal and therefore passes.

## PR Check

**pr-check: PASS** — the production code (logic commit) is the exact commit that passed the full pr-check suite in #3111 (tested on `696bb2fc`). This branch differs only by the test-method rename, which has no compile or build impact; Java Unit Tests re-verified locally (6/6 `FIPSModeValidatorTest`). Source Format also re-runs via the appsec `ci:test:sf` job.

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "5db204faa1d04d342ad8db494e135f851e2d8ae3"} -->
