### PR TITLE
LPD-99555 Standardize the plaintext and ciphertext casing

### DIFF
--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryServiceTest.java
@@ -217,7 +217,7 @@ public class FragmentEntryServiceTest {
 	}
 
 	@Test
-	public void testAddFragmentEntryUsingPlainTextHTML() throws Exception {
+	public void testAddFragmentEntryUsingPlaintextHTML() throws Exception {
 		_fragmentEntryService.addFragmentEntry(
 			null, _group.getGroupId(),
 			_fragmentCollection.getFragmentCollectionId(),

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/transformer/test/JournalTransformerTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/transformer/test/JournalTransformerTest.java
@@ -189,7 +189,7 @@ public class JournalTransformerTest {
 		_testCreateTemplateNodeMultipleSelectTypeDDMFormFieldWithoutOptions();
 		_testCreateTemplateNodeSingleSelectTypeDDMFormFieldWithOptions();
 		_testCreateTemplateNodeTextDDMFormFieldWithHTML();
-		_testCreateTemplateNodeTextDDMFormFieldWithPlainText();
+		_testCreateTemplateNodeTextDDMFormFieldWithPlaintext();
 	}
 
 	@Test
@@ -1005,7 +1005,7 @@ public class JournalTransformerTest {
 			"<img src=\"x\" onerror=alert(document.cookie)>");
 	}
 
-	private void _testCreateTemplateNodeTextDDMFormFieldWithPlainText() {
+	private void _testCreateTemplateNodeTextDDMFormFieldWithPlaintext() {
 		_testCreateTemplateNodeTextDDMFormField(RandomTestUtil.randomString());
 	}
 

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/BCryptPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/BCryptPasswordEncryptor.java
@@ -30,7 +30,7 @@ public class BCryptPasswordEncryptor implements PasswordEncryptor {
 
 	@Override
 	public String encrypt(
-		String algorithm, String plainTextPassword, String encryptedPassword,
+		String algorithm, String plaintextPassword, String encryptedPassword,
 		boolean upgradeHashSecurity) {
 
 		String salt = null;
@@ -54,7 +54,7 @@ public class BCryptPasswordEncryptor implements PasswordEncryptor {
 			salt = encryptedPassword.substring(0, 29);
 		}
 
-		return BCrypt.hashpw(plainTextPassword, salt);
+		return BCrypt.hashpw(plaintextPassword, salt);
 	}
 
 	@Override

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/CryptPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/CryptPasswordEncryptor.java
@@ -32,7 +32,7 @@ public class CryptPasswordEncryptor implements PasswordEncryptor {
 
 	@Override
 	public String encrypt(
-			String algorithm, String plainTextPassword,
+			String algorithm, String plaintextPassword,
 			String encryptedPassword, boolean upgradeHashSecurity)
 		throws PwdEncryptorException {
 
@@ -44,7 +44,7 @@ public class CryptPasswordEncryptor implements PasswordEncryptor {
 
 		try {
 			return Crypt.crypt(
-				saltBytes, plainTextPassword.getBytes(DigesterUtil.ENCODING));
+				saltBytes, plaintextPassword.getBytes(DigesterUtil.ENCODING));
 		}
 		catch (UnsupportedEncodingException unsupportedEncodingException) {
 			throw new PwdEncryptorException.UnsupportedEncoding(

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/DefaultPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/DefaultPasswordEncryptor.java
@@ -27,7 +27,7 @@ public class DefaultPasswordEncryptor implements PasswordEncryptor {
 
 	@Override
 	public String encrypt(
-			String algorithm, String plainTextPassword,
+			String algorithm, String plaintextPassword,
 			String encryptedPassword, boolean upgradeHashSecurity)
 		throws PwdEncryptorException {
 
@@ -41,7 +41,7 @@ public class DefaultPasswordEncryptor implements PasswordEncryptor {
 				noSuchAlgorithmException);
 		}
 
-		return DigesterUtil.digest(algorithm, plainTextPassword);
+		return DigesterUtil.digest(algorithm, plaintextPassword);
 	}
 
 }

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/NullPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/NullPasswordEncryptor.java
@@ -21,10 +21,10 @@ public class NullPasswordEncryptor implements PasswordEncryptor {
 
 	@Override
 	public String encrypt(
-		String algorithm, String plainTextPassword, String encryptedPassword,
+		String algorithm, String plaintextPassword, String encryptedPassword,
 		boolean upgradeHashSecurity) {
 
-		return plainTextPassword;
+		return plaintextPassword;
 	}
 
 }

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/PBKDF2PasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/PBKDF2PasswordEncryptor.java
@@ -43,7 +43,7 @@ public class PBKDF2PasswordEncryptor implements PasswordEncryptor {
 
 	@Override
 	public String encrypt(
-			String algorithm, String plainTextPassword,
+			String algorithm, String plaintextPassword,
 			String encryptedPassword, boolean upgradeHashSecurity)
 		throws PwdEncryptorException {
 
@@ -61,7 +61,7 @@ public class PBKDF2PasswordEncryptor implements PasswordEncryptor {
 		byte[] secretKeyBytes = _generateDerivedKey(
 			pbkdf2EncryptionConfiguration.getKeySize(),
 			pbkdf2EncryptionConfiguration.getMacAlgorithm(),
-			plainTextPassword.getBytes(),
+			plaintextPassword.getBytes(),
 			pbkdf2EncryptionConfiguration.getRounds(), saltBytes);
 
 		ByteBuffer byteBuffer = ByteBuffer.allocate(

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/SSHAPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/SSHAPasswordEncryptor.java
@@ -34,7 +34,7 @@ public class SSHAPasswordEncryptor implements PasswordEncryptor {
 
 	@Override
 	public String encrypt(
-			String algorithm, String plainTextPassword,
+			String algorithm, String plaintextPassword,
 			String encryptedPassword, boolean upgradeHashSecurity)
 		throws PwdEncryptorException {
 
@@ -49,11 +49,11 @@ public class SSHAPasswordEncryptor implements PasswordEncryptor {
 				PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 :
 					DigesterUtil.SHA_1);
 
-			byte[] plainTextPasswordBytes = plainTextPassword.getBytes(
+			byte[] plaintextPasswordBytes = plaintextPassword.getBytes(
 				DigesterUtil.ENCODING);
 
 			byte[] messageDigestBytes = messageDigest.digest(
-				ArrayUtil.append(plainTextPasswordBytes, saltBytes));
+				ArrayUtil.append(plaintextPasswordBytes, saltBytes));
 
 			return Base64.encode(
 				ArrayUtil.append(messageDigestBytes, saltBytes));

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/test/java/com/liferay/portal/security/password/encryptor/internal/PasswordEncryptorUtilTest.java
@@ -388,11 +388,11 @@ public class PasswordEncryptorUtilTest {
 	}
 
 	private void _testEncryptFailure(
-		String algorithm, String plainTextPassword, String encryptedPassword) {
+		String algorithm, String plaintextPassword, String encryptedPassword) {
 
 		try {
 			PasswordEncryptorUtil.encrypt(
-				algorithm, plainTextPassword, encryptedPassword);
+				algorithm, plaintextPassword, encryptedPassword);
 
 			Assert.fail();
 		}
@@ -423,15 +423,15 @@ public class PasswordEncryptorUtilTest {
 
 		@Override
 		public String encrypt(
-			String algorithm, String plainTextPassword,
+			String algorithm, String plaintextPassword,
 			String encryptedPassword, boolean upgradeHashSecurity) {
 
 			if (encryptedPassword != null) {
-				return plainTextPassword +
+				return plaintextPassword +
 					encryptedPassword.substring(encryptedPassword.indexOf(':'));
 			}
 
-			return plainTextPassword + ':' +
+			return plaintextPassword + ':' +
 				algorithm.substring(algorithm.indexOf('/') + 1);
 		}
 

--- a/modules/apps/portal/portal-json-web-service-client/src/test/java/com/liferay/portal/json/web/service/client/server/simulator/BaseHttpHandlerImpl.java
+++ b/modules/apps/portal/portal-json-web-service-client/src/test/java/com/liferay/portal/json/web/service/client/server/simulator/BaseHttpHandlerImpl.java
@@ -144,7 +144,7 @@ public class BaseHttpHandlerImpl implements HttpHandler {
 		return sb.toString();
 	}
 
-	protected String getAsPlainText(List<NameValuePair> parameters) {
+	protected String getAsPlaintext(List<NameValuePair> parameters) {
 		StringBuffer sb = new StringBuffer();
 
 		for (NameValuePair nameValuePair : parameters) {
@@ -214,7 +214,7 @@ public class BaseHttpHandlerImpl implements HttpHandler {
 			return getAsJSON(parameters);
 		}
 
-		return getAsPlainText(parameters);
+		return getAsPlaintext(parameters);
 	}
 
 	protected boolean hasHeaderValue(

--- a/modules/apps/static/portal/portal-encryptor/src/main/java/com/liferay/portal/encryptor/EncryptorImpl.java
+++ b/modules/apps/static/portal/portal-encryptor/src/main/java/com/liferay/portal/encryptor/EncryptorImpl.java
@@ -105,16 +105,16 @@ public class EncryptorImpl implements Encryptor {
 	}
 
 	@Override
-	public String encrypt(Key key, String plainText) throws EncryptorException {
+	public String encrypt(Key key, String plaintext) throws EncryptorException {
 		if (key == null) {
 			if (_log.isWarnEnabled()) {
 				_log.warn("Skip encrypting based on a null key");
 			}
 
-			return plainText;
+			return plaintext;
 		}
 
-		byte[] encryptedBytes = encryptUnencoded(key, plainText);
+		byte[] encryptedBytes = encryptUnencoded(key, plaintext);
 
 		return Base64.encode(encryptedBytes);
 	}
@@ -158,11 +158,11 @@ public class EncryptorImpl implements Encryptor {
 	}
 
 	@Override
-	public byte[] encryptUnencoded(Key key, String plainText)
+	public byte[] encryptUnencoded(Key key, String plaintext)
 		throws EncryptorException {
 
 		try {
-			byte[] decryptedBytes = plainText.getBytes(ENCODING);
+			byte[] decryptedBytes = plaintext.getBytes(ENCODING);
 
 			return encryptUnencoded(key, decryptedBytes);
 		}

--- a/modules/apps/static/portal/portal-encryptor/src/test/java/com/liferay/portal/encryptor/EncryptorImplTest.java
+++ b/modules/apps/static/portal/portal-encryptor/src/test/java/com/liferay/portal/encryptor/EncryptorImplTest.java
@@ -36,14 +36,14 @@ public class EncryptorImplTest {
 
 		Key key = encryptor.generateKey();
 
-		String encryptedString = encryptor.encrypt(key, _PLAIN_TEXT);
+		String encryptedString = encryptor.encrypt(key, _PLAINTEXT);
 
 		try (SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(
 					"FIPS_ENABLED", true)) {
 
 			Assert.assertEquals(
-				_PLAIN_TEXT, encryptor.decrypt(key, encryptedString));
+				_PLAINTEXT, encryptor.decrypt(key, encryptedString));
 		}
 	}
 
@@ -57,26 +57,26 @@ public class EncryptorImplTest {
 
 			Key key = encryptor.generateKey();
 
-			String encryptedString1 = encryptor.encrypt(key, _PLAIN_TEXT);
-			String encryptedString2 = encryptor.encrypt(key, _PLAIN_TEXT);
+			String encryptedString1 = encryptor.encrypt(key, _PLAINTEXT);
+			String encryptedString2 = encryptor.encrypt(key, _PLAINTEXT);
 
 			Assert.assertNotEquals(encryptedString1, encryptedString2);
 
 			Assert.assertEquals(
-				_PLAIN_TEXT, encryptor.decrypt(key, encryptedString1));
+				_PLAINTEXT, encryptor.decrypt(key, encryptedString1));
 			Assert.assertEquals(
-				_PLAIN_TEXT, encryptor.decrypt(key, encryptedString2));
+				_PLAINTEXT, encryptor.decrypt(key, encryptedString2));
 
 			Assert.assertThrows(
 				SecurityException.class,
 				() -> encryptor.decryptUnencodedAsBytes(
 					new SecretKeySpec(new byte[8], "AES"),
-					_PLAIN_TEXT.getBytes()));
+					_PLAINTEXT.getBytes()));
 			Assert.assertThrows(
 				SecurityException.class,
 				() -> encryptor.encryptUnencoded(
 					new SecretKeySpec(new byte[8], "AES"),
-					_PLAIN_TEXT.getBytes()));
+					_PLAINTEXT.getBytes()));
 		}
 	}
 
@@ -86,16 +86,16 @@ public class EncryptorImplTest {
 
 		Key key = encryptor.generateKey();
 
-		String encryptedString = encryptor.encrypt(key, _PLAIN_TEXT);
+		String encryptedString = encryptor.encrypt(key, _PLAINTEXT);
 
 		String serializedKey = encryptor.serializeKey(key);
 
 		key = encryptor.deserializeKey(serializedKey);
 
 		Assert.assertEquals(
-			_PLAIN_TEXT, encryptor.decrypt(key, encryptedString));
+			_PLAINTEXT, encryptor.decrypt(key, encryptedString));
 	}
 
-	private static final String _PLAIN_TEXT = RandomTestUtil.randomString();
+	private static final String _PLAINTEXT = RandomTestUtil.randomString();
 
 }

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/snapshot/XLIFFTranslationSnapshotProvider.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/snapshot/XLIFFTranslationSnapshotProvider.java
@@ -465,14 +465,14 @@ public class XLIFFTranslationSnapshotProvider
 						"There is no translation target");
 				}
 
-				String targetPlainText = targetFragment.getPlainText();
+				String targetPlaintext = targetFragment.getPlainText();
 
 				unsafeConsumer.accept(
 					new InfoFieldValue<>(
 						_createInfoField(targetLocale, unit.getId()),
 						InfoLocalizedValue.builder(
 						).value(
-							targetLocale, targetPlainText
+							targetLocale, targetPlaintext
 						).value(
 							biConsumer -> {
 								if (includeSource) {

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/SecretsUtil.java
@@ -200,13 +200,13 @@ public abstract class SecretsUtil {
 		aesCipher.init(
 			Cipher.DECRYPT_MODE, secretKey, new GCMParameterSpec(128, iv));
 
-		byte[] plainText = aesCipher.doFinal(
+		byte[] plaintext = aesCipher.doFinal(
 			decoder.decode(envelopeJSONObject.getString("cipherText")));
 
-		return new String(plainText, StandardCharsets.UTF_8);
+		return new String(plaintext, StandardCharsets.UTF_8);
 	}
 
-	private static String _encrypt(String plainText, PublicKey publicKey)
+	private static String _encrypt(String plaintext, PublicKey publicKey)
 		throws GeneralSecurityException {
 
 		KeyGenerator keyGenerator = KeyGenerator.getInstance("AES");
@@ -226,8 +226,8 @@ public abstract class SecretsUtil {
 		aesCipher.init(
 			Cipher.ENCRYPT_MODE, secretKey, new GCMParameterSpec(128, iv));
 
-		byte[] cipherText = aesCipher.doFinal(
-			plainText.getBytes(StandardCharsets.UTF_8));
+		byte[] ciphertext = aesCipher.doFinal(
+			plaintext.getBytes(StandardCharsets.UTF_8));
 
 		Cipher rsaCipher = Cipher.getInstance(
 			"RSA/ECB/OAEPWithSHA-256AndMGF1Padding");
@@ -243,7 +243,7 @@ public abstract class SecretsUtil {
 		envelopeJSONObject.put(
 			"cipher", _CACHE_CIPHER
 		).put(
-			"cipherText", encoder.encodeToString(cipherText)
+			"cipherText", encoder.encodeToString(ciphertext)
 		).put(
 			"encryptedKey", encoder.encodeToString(encryptedKey)
 		).put(

--- a/portal-kernel/src/com/liferay/portal/kernel/encryptor/Encryptor.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/encryptor/Encryptor.java
@@ -22,12 +22,12 @@ public interface Encryptor {
 
 	public Key deserializeKey(String base64String);
 
-	public String encrypt(Key key, String plainText) throws EncryptorException;
+	public String encrypt(Key key, String plaintext) throws EncryptorException;
 
 	public byte[] encryptUnencoded(Key key, byte[] plainBytes)
 		throws EncryptorException;
 
-	public byte[] encryptUnencoded(Key key, String plainText)
+	public byte[] encryptUnencoded(Key key, String plaintext)
 		throws EncryptorException;
 
 	public Key generateKey() throws EncryptorException;

--- a/portal-kernel/src/com/liferay/portal/kernel/encryptor/EncryptorUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/encryptor/EncryptorUtil.java
@@ -36,12 +36,12 @@ public class EncryptorUtil {
 		return encryptor.deserializeKey(base64String);
 	}
 
-	public static String encrypt(Key key, String plainText)
+	public static String encrypt(Key key, String plaintext)
 		throws EncryptorException {
 
 		Encryptor encryptor = _encryptorSnapshot.get();
 
-		return encryptor.encrypt(key, plainText);
+		return encryptor.encrypt(key, plaintext);
 	}
 
 	public static byte[] encryptUnencoded(Key key, byte[] plainBytes)
@@ -52,12 +52,12 @@ public class EncryptorUtil {
 		return encryptor.encryptUnencoded(key, plainBytes);
 	}
 
-	public static byte[] encryptUnencoded(Key key, String plainText)
+	public static byte[] encryptUnencoded(Key key, String plaintext)
 		throws EncryptorException {
 
 		Encryptor encryptor = _encryptorSnapshot.get();
 
-		return encryptor.encryptUnencoded(key, plainText);
+		return encryptor.encryptUnencoded(key, plaintext);
 	}
 
 	public static Key generateKey() throws EncryptorException {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptor.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptor.java
@@ -39,15 +39,15 @@ public interface PasswordEncryptor {
 	public static final String TYPE_UFC_CRYPT = "UFC-CRYPT";
 
 	public default String encrypt(
-			String algorithm, String plainTextPassword,
+			String algorithm, String plaintextPassword,
 			String encryptedPassword)
 		throws PwdEncryptorException {
 
-		return encrypt(algorithm, plainTextPassword, encryptedPassword, false);
+		return encrypt(algorithm, plaintextPassword, encryptedPassword, false);
 	}
 
 	public String encrypt(
-			String algorithm, String plainTextPassword,
+			String algorithm, String plaintextPassword,
 			String encryptedPassword, boolean upgradeHashSecurity)
 		throws PwdEncryptorException;
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptorUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/pwd/PasswordEncryptorUtil.java
@@ -30,14 +30,14 @@ import com.liferay.portal.kernel.util.Validator;
  */
 public class PasswordEncryptorUtil {
 
-	public static String encrypt(String plainTextPassword)
+	public static String encrypt(String plaintextPassword)
 		throws PwdEncryptorException {
 
-		return encrypt(plainTextPassword, null);
+		return encrypt(plaintextPassword, null);
 	}
 
 	public static String encrypt(
-			String plainTextPassword, String encryptedPassword)
+			String plaintextPassword, String encryptedPassword)
 		throws PwdEncryptorException {
 
 		long startTime = 0;
@@ -48,7 +48,7 @@ public class PasswordEncryptorUtil {
 
 		try {
 			return encrypt(
-				_PASSWORDS_ENCRYPTION_ALGORITHM, plainTextPassword,
+				_PASSWORDS_ENCRYPTION_ALGORITHM, plaintextPassword,
 				encryptedPassword);
 		}
 		finally {
@@ -61,7 +61,7 @@ public class PasswordEncryptorUtil {
 	}
 
 	public static String encrypt(
-			String plainTextPassword, String encryptedPassword,
+			String plaintextPassword, String encryptedPassword,
 			boolean upgradeHashSecurity)
 		throws PwdEncryptorException {
 
@@ -70,15 +70,15 @@ public class PasswordEncryptorUtil {
 		}
 
 		return _encrypt(
-			null, plainTextPassword, encryptedPassword, upgradeHashSecurity);
+			null, plaintextPassword, encryptedPassword, upgradeHashSecurity);
 	}
 
 	public static String encrypt(
-			String algorithm, String plainTextPassword,
+			String algorithm, String plaintextPassword,
 			String encryptedPassword)
 		throws PwdEncryptorException {
 
-		return _encrypt(algorithm, plainTextPassword, encryptedPassword, false);
+		return _encrypt(algorithm, plaintextPassword, encryptedPassword, false);
 	}
 
 	public static String getEncryptedPasswordAlgorithmSettings(
@@ -100,11 +100,11 @@ public class PasswordEncryptorUtil {
 	}
 
 	private static String _encrypt(
-			String algorithm, String plainTextPassword,
+			String algorithm, String plaintextPassword,
 			String encryptedPassword, boolean upgradeHashSecurity)
 		throws PwdEncryptorException {
 
-		if (Validator.isNull(plainTextPassword)) {
+		if (Validator.isNull(plaintextPassword)) {
 			throw new PwdEncryptorException.PwdMustNotBeNull(
 				"Unable to _encrypt blank password");
 		}
@@ -148,7 +148,7 @@ public class PasswordEncryptorUtil {
 		PasswordEncryptor passwordEncryptor = _getPasswordEncryptor(algorithm);
 
 		String newEncryptedPassword = passwordEncryptor.encrypt(
-			algorithm, plainTextPassword, encryptedPassword, false);
+			algorithm, plaintextPassword, encryptedPassword, false);
 
 		if (!prependAlgorithm) {
 			if (_log.isDebugEnabled()) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99555

Standardizes the cryptographic terms "plaintext" and "ciphertext" on the single-word forms (per NIST/ISO convention), which our FIPS code already uses. Raised by @brianchandotcom while reviewing the FIPS plaintext-secret work on LPD-98489.

## What Changed

Renamed to the single-word form across our code (not third-party). 18 files, 67 insertions / 67 deletions — pure renames.

- **Cryptographic:** `Encryptor` / `EncryptorUtil` / `EncryptorImpl` (`plainText` param), `PasswordEncryptor` / `PasswordEncryptorUtil` + the six impls (`plainTextPassword`), `EncryptorImplTest` (`_PLAIN_TEXT`), `SecretsUtil` locals.
- **Internal non-crypto identifiers:** test/simulator method names in `fragment-test`, `journal-test`, `portal-json-web-service-client`; a local variable in `translation-service`.

## Deliberately Excluded

| Excluded | Reason |
| --- | --- |
| `USERS_REMINDER_QUERIES_DISPLAY_IN_PLAIN_TEXT` + JSPs | breaking public property / operator config; non-crypto |
| Google Cloud `"PLAIN_TEXT"` enum | external API contract |
| Okapi XLIFF `getPlainText()` | third-party library method |
| `SecretsUtil` `"cipherText"` JSON keys | serialization/wire format (identifiers renamed, keys kept) |
| Playwright DOM selector, OAuth 1.0 plaintext signature | external names |

## Note — `SecretsUtil` `"cipherText"` JSON key

The Java identifiers (the `plainText` / `cipherText` locals) are renamed to `plaintext` / `ciphertext`, but the JSON envelope keys are intentionally left unchanged. `_encrypt` writes that envelope to a persisted, shared cache (a file, `s3://…`, or a URL) and `_decrypt` reads it back — potentially from a cache written by a different `jenkins-results-parser` version — guarding on `has("cipherText")`. Renaming the key would make an existing cache silently fail to decrypt (`_decrypt` returns `null`, no error), so it stays. Renaming it safely would require a dual-read shim (accept both keys, write the new one) over a transition window — out of scope for a casing cleanup; can be a follow-up if wanted.

## Verification

Affected modules compile and unit tests pass (`EncryptorImplTest`, `PasswordEncryptorUtilTest`; `translation-service` + `portal-json-web-service-client` compile). Full Portal Build via pr-check to follow (portal-kernel touched).

