### PR TITLE
LPD-99556 Fall back to the primary email when serializing SCIM users

### DIFF
--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/util/ScimUtil.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/util/ScimUtil.java
@@ -292,12 +292,23 @@ public class ScimUtil {
 		scimUser.setBirthday(portalUser.getBirthday());
 		scimUser.setCompanyId(portalUser.getCompanyId());
 		scimUser.setCreateDate(_truncateDate(portalUser.getCreateDate()));
-		scimUser.setEmailAddresses(
-			_getEmailAddresses(
-				EmailAddressLocalServiceUtil.getEmailAddresses(
-					portalUser.getCompanyId(), Contact.class.getName(),
-					portalUser.getContactId()),
-				EmailAddress::getAddress, EmailAddress::isPrimary));
+
+		List<EmailAddress> emailAddresses =
+			EmailAddressLocalServiceUtil.getEmailAddresses(
+				portalUser.getCompanyId(), Contact.class.getName(),
+				portalUser.getContactId());
+
+		if (ListUtil.isEmpty(emailAddresses)) {
+			scimUser.setEmailAddresses(
+				new String[] {portalUser.getEmailAddress()});
+		}
+		else {
+			scimUser.setEmailAddresses(
+				_getEmailAddresses(
+					emailAddresses, EmailAddress::getAddress,
+					EmailAddress::isPrimary));
+		}
+
 		scimUser.setExternalReferenceCode(
 			portalUser.getExternalReferenceCode());
 		scimUser.setFirstName(portalUser.getFirstName());

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/UserResourceTest.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/UserResourceTest.java
@@ -19,9 +19,11 @@ import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.EmailAddressLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.TestInfo;
@@ -168,6 +170,19 @@ public class UserResourceTest extends BaseUserResourceTestCase {
 
 		assertHttpResponseStatusCode(200, httpResponse);
 		assertValid(User.toDTO(httpResponse.getContent()));
+
+		com.liferay.portal.kernel.model.User portalUser =
+			_userLocalService.getUser(GetterUtil.getLong(user.getId()));
+
+		_emailAddressLocalService.deleteEmailAddresses(
+			portalUser.getCompanyId(), Contact.class.getName(),
+			portalUser.getContactId());
+
+		user = _getUser(user.getId());
+
+		MultiValuedAttribute[] emails = user.getEmails();
+
+		Assert.assertEquals(portalUser.getEmailAddress(), emails[0].getValue());
 
 		_userLocalService.updateStatus(
 			GetterUtil.getLong(user.getId()), WorkflowConstants.STATUS_INACTIVE,
@@ -706,6 +721,9 @@ public class UserResourceTest extends BaseUserResourceTestCase {
 
 	@Inject
 	private ClassNameLocalService _classNameLocalService;
+
+	@Inject
+	private EmailAddressLocalService _emailAddressLocalService;
 
 	@Inject
 	private ExpandoColumnLocalService _expandoColumnLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99556

## What Is Being Fixed

Every SCIM API call returned HTTP 500 for any user without a secondary email
address. `ScimUtil.toScimUser` sourced a user's emails solely from the
secondary contact-email table (`EmailAddressLocalServiceUtil.getEmailAddresses`),
never from the user's primary email. When that table has no rows for a user, the
serialized email array is empty, and `toUser` then dereferences
`getEmailAddresses()[0]` with no bounds check, throwing an
`ArrayIndexOutOfBoundsException`. With no `ExceptionMapper` in the module, the
unchecked exception surfaced as a bare 500, and because the list transform stops
at the first failure, a single affected user broke the entire Users endpoint.

## How It Is Being Fixed

`toScimUser` now falls back to the user's primary email
(`portalUser.getEmailAddress()`) when the secondary-email list is empty, so a
standard portal user always serializes with a non-empty email array. When
secondary addresses do exist, the previous behavior is preserved.

The regression is covered by folding a new verification into the existing
`testGetV2UserById` integration test: it deletes the user's secondary
`EmailAddress` rows to reproduce the customer's data shape, re-fetches the SCIM
user, and asserts the returned email equals the primary email.

## PR Check

**pr-check: PASS** — tested on `64b408224cbd3c70d0bd6eb1637475470cb17f16`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "64b408224cbd3c70d0bd6eb1637475470cb17f16"} -->
