### PR TITLE
[FIPS] LPD-92680 Add the CryptoManager implementation

### DIFF
--- a/modules/apps/portal-security/portal-security-key-api/bnd.bnd
+++ b/modules/apps/portal-security/portal-security-key-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Security Key API
 Bundle-SymbolicName: com.liferay.portal.security.key.api
-Bundle-Version: 1.0.2
+Bundle-Version: 1.1.0
 Export-Package:\
 	com.liferay.portal.security.key,\
 	com.liferay.portal.security.key.crypto,\

--- a/modules/apps/portal-security/portal-security-key-api/src/main/java/com/liferay/portal/security/key/crypto/CryptoManager.java
+++ b/modules/apps/portal-security/portal-security-key-api/src/main/java/com/liferay/portal/security/key/crypto/CryptoManager.java
@@ -22,14 +22,14 @@ import org.osgi.annotation.versioning.ProviderType;
 public interface CryptoManager {
 
 	public CryptoServiceResult<byte[]> decrypt(
-			byte[] cipherText, long companyId, KeyReference keyReference)
+			byte[] ciphertext, long companyId, KeyReference keyReference)
 		throws CryptoException;
 
 	public void deleteKey(long companyId, KeyReference keyReference)
 		throws CryptoException;
 
 	public CryptoServiceResult<byte[]> encrypt(
-			long companyId, KeyReference keyReference, byte[] plainText)
+			long companyId, KeyReference keyReference, byte[] plaintext)
 		throws CryptoException;
 
 	public CryptoServiceResult<Key> exportKey(

--- a/modules/apps/portal-security/portal-security-key-api/src/main/resources/com/liferay/portal/security/key/packageinfo
+++ b/modules/apps/portal-security/portal-security-key-api/src/main/resources/com/liferay/portal/security/key/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/portal-security/portal-security-key-impl/src/main/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImpl.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/main/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImpl.java
@@ -8,6 +8,7 @@ package com.liferay.portal.security.key.internal.crypto;
 import com.liferay.osgi.service.tracker.collections.map.PropertyServiceReferenceMapper;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
@@ -29,7 +30,6 @@ import java.security.Key;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -301,23 +301,8 @@ public class CryptoManagerImpl implements CryptoManager {
 			CryptoProvider cryptoProvider = _getCryptoProvider(
 				companyId, cryptoProviderId);
 
-			List<String> keyIdentifiers = cryptoProvider.getKeyIdentifiers(
-				companyId);
-
-			if (keyIdentifiers == null) {
-				return Collections.emptyList();
-			}
-
-			List<KeyReference> keyReferences = new ArrayList<>();
-
-			for (String keyIdentifier : keyIdentifiers) {
-				keyReferences.add(
-					new KeyReference(
-						keyIdentifier, cryptoProviderId,
-						KeyReference.Type.CRYPTO));
-			}
-
-			return keyReferences;
+			return _toKeyReferences(
+				cryptoProviderId, cryptoProvider.getKeyIdentifiers(companyId));
 		}
 		catch (CryptoException cryptoException) {
 			if (_log.isWarnEnabled()) {
@@ -376,9 +361,7 @@ public class CryptoManagerImpl implements CryptoManager {
 			throw cryptoException;
 		}
 		finally {
-			if (keyBytes != null) {
-				Arrays.fill(keyBytes, (byte)0);
-			}
+			Arrays.fill(keyBytes, (byte)0);
 		}
 	}
 
@@ -402,7 +385,7 @@ public class CryptoManagerImpl implements CryptoManager {
 		}
 
 		if (wrappedKeyBytes == null) {
-			throw new IllegalArgumentException("Wrapped key bytes is null");
+			throw new IllegalArgumentException("Wrapped key bytes are null");
 		}
 
 		try {
@@ -618,10 +601,10 @@ public class CryptoManagerImpl implements CryptoManager {
 			return cryptoProviderId;
 		}
 
-		KeyManagerProfile activeProfile =
+		KeyManagerProfile activeKeyManagerProfile =
 			_keyManagerProfileRegistry.getActiveKeyManagerProfile();
 
-		if (activeProfile == null) {
+		if (activeKeyManagerProfile == null) {
 			throw new CryptoException(
 				StringBundler.concat(
 					"No active key manager profile found to resolve the ",
@@ -630,17 +613,21 @@ public class CryptoManagerImpl implements CryptoManager {
 
 		if (companyId == CompanyConstants.SYSTEM) {
 			if (providerRole == ProviderRole.DEK) {
-				cryptoProviderId = activeProfile.getSystemDEKProviderId();
+				cryptoProviderId =
+					activeKeyManagerProfile.getSystemDEKProviderId();
 			}
 			else {
-				cryptoProviderId = activeProfile.getSystemKEKProviderId();
+				cryptoProviderId =
+					activeKeyManagerProfile.getSystemKEKProviderId();
 			}
 		}
 		else if (providerRole == ProviderRole.DEK) {
-			cryptoProviderId = activeProfile.getCompanyDEKProviderId();
+			cryptoProviderId =
+				activeKeyManagerProfile.getCompanyDEKProviderId();
 		}
 		else {
-			cryptoProviderId = activeProfile.getCompanyKEKProviderId();
+			cryptoProviderId =
+				activeKeyManagerProfile.getCompanyKEKProviderId();
 		}
 
 		if (Validator.isNull(cryptoProviderId)) {
@@ -651,6 +638,15 @@ public class CryptoManagerImpl implements CryptoManager {
 		}
 
 		return cryptoProviderId;
+	}
+
+	private List<KeyReference> _toKeyReferences(
+		String cryptoProviderId, List<String> keyIdentifiers) {
+
+		return TransformUtil.transform(
+			keyIdentifiers,
+			keyIdentifier -> new KeyReference(
+				keyIdentifier, cryptoProviderId, KeyReference.Type.CRYPTO));
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/portal-security/portal-security-key-impl/src/main/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImpl.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/main/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImpl.java
@@ -67,7 +67,7 @@ public class CryptoManagerImpl implements CryptoManager {
 				cryptoProvider.decrypt(
 					ciphertext, companyId, keyReference.getIdentifier());
 
-			_auditServiceIndicator(
+			_logServiceIndicator(
 				companyId, "decrypt",
 				cryptoServiceResult.getServiceIndicator());
 
@@ -126,7 +126,7 @@ public class CryptoManagerImpl implements CryptoManager {
 				cryptoProvider.encrypt(
 					companyId, keyReference.getIdentifier(), plaintext);
 
-			_auditServiceIndicator(
+			_logServiceIndicator(
 				companyId, "encrypt",
 				cryptoServiceResult.getServiceIndicator());
 
@@ -158,7 +158,7 @@ public class CryptoManagerImpl implements CryptoManager {
 				cryptoProvider.exportKey(
 					companyId, keyReference.getIdentifier());
 
-			_auditServiceIndicator(
+			_logServiceIndicator(
 				companyId, "exportKey",
 				cryptoServiceResult.getServiceIndicator());
 
@@ -187,9 +187,10 @@ public class CryptoManagerImpl implements CryptoManager {
 		}
 
 		try {
-			return _generate(
+			return _generateKeyReference(
 				algorithm, companyId,
-				CryptoProvider::generateAsymmetricKeyIdentifier, keyReference);
+				CryptoProvider::generateAsymmetricKeyIdentifier, keyReference,
+				"generateAsymmetricKeyReference");
 		}
 		catch (CryptoException cryptoException) {
 			if (_log.isWarnEnabled()) {
@@ -216,9 +217,10 @@ public class CryptoManagerImpl implements CryptoManager {
 		}
 
 		try {
-			return _generate(
+			return _generateKeyReference(
 				algorithm, companyId,
-				CryptoProvider::generateSecretKeyIdentifier, keyReference);
+				CryptoProvider::generateSecretKeyIdentifier, keyReference,
+				"generateSecretKeyReference");
 		}
 		catch (CryptoException cryptoException) {
 			if (_log.isWarnEnabled()) {
@@ -343,7 +345,7 @@ public class CryptoManagerImpl implements CryptoManager {
 					algorithm, companyId, keyBytes,
 					keyReference.getIdentifier());
 
-			_auditServiceIndicator(
+			_logServiceIndicator(
 				companyId, "importSecretKey",
 				cryptoServiceResult.getServiceIndicator());
 
@@ -390,19 +392,7 @@ public class CryptoManagerImpl implements CryptoManager {
 
 		try {
 			String cryptoProviderId = _getCryptoProviderId(
-				companyId, keyReference.getProviderId(), ProviderRole.DEK);
-
-			String masterCryptoProviderId = _getCryptoProviderId(
-				companyId, masterKeyReference.getProviderId(),
-				ProviderRole.KEK);
-
-			if (!Objects.equals(cryptoProviderId, masterCryptoProviderId)) {
-				throw new CryptoException(
-					StringBundler.concat(
-						"Key provider ", cryptoProviderId,
-						" does not match master key provider ",
-						masterCryptoProviderId));
-			}
+				companyId, keyReference, masterKeyReference);
 
 			CryptoProvider cryptoProvider = _getCryptoProvider(
 				companyId, cryptoProviderId);
@@ -413,7 +403,7 @@ public class CryptoManagerImpl implements CryptoManager {
 					masterKeyReference.getIdentifier(), wrappedKeyAlgorithm,
 					wrappedKeyBytes, wrappedKeyCipherType);
 
-			_auditServiceIndicator(
+			_logServiceIndicator(
 				companyId, "unwrap", cryptoServiceResult.getServiceIndicator());
 
 			return new CryptoServiceResult<>(
@@ -446,30 +436,17 @@ public class CryptoManagerImpl implements CryptoManager {
 		}
 
 		try {
-			String cryptoProviderId = _getCryptoProviderId(
-				companyId, keyReference.getProviderId(), ProviderRole.DEK);
-
-			String masterCryptoProviderId = _getCryptoProviderId(
-				companyId, masterKeyReference.getProviderId(),
-				ProviderRole.KEK);
-
-			if (!Objects.equals(cryptoProviderId, masterCryptoProviderId)) {
-				throw new CryptoException(
-					StringBundler.concat(
-						"Key provider ", cryptoProviderId,
-						" does not match master key provider ",
-						masterCryptoProviderId));
-			}
-
 			CryptoProvider cryptoProvider = _getCryptoProvider(
-				companyId, cryptoProviderId);
+				companyId,
+				_getCryptoProviderId(
+					companyId, keyReference, masterKeyReference));
 
 			CryptoServiceResult<byte[]> cryptoServiceResult =
 				cryptoProvider.wrap(
 					companyId, keyReference.getIdentifier(),
 					masterKeyReference.getIdentifier());
 
-			_auditServiceIndicator(
+			_logServiceIndicator(
 				companyId, "wrap", cryptoServiceResult.getServiceIndicator());
 
 			return cryptoServiceResult;
@@ -499,35 +476,9 @@ public class CryptoManagerImpl implements CryptoManager {
 		}
 	}
 
-	private void _auditServiceIndicator(
-		long companyId, String operation, ServiceIndicator serviceIndicator) {
-
-		if (serviceIndicator == null) {
-			if (_log.isWarnEnabled()) {
-				_log.warn(
-					StringBundler.concat(
-						"Operation ", operation, " for company ID ", companyId,
-						" returned a null service indicator"));
-			}
-
-			return;
-		}
-
-		if (_log.isInfoEnabled()) {
-			_log.info(
-				StringBundler.concat(
-					"Operation ", operation, " for company ID ", companyId,
-					" used ",
-					serviceIndicator.isApproved() ? "an approved " :
-						"a nonapproved ",
-					"security function ",
-					serviceIndicator.getSecurityFunctionName()));
-		}
-	}
-
-	private CryptoServiceResult<KeyReference> _generate(
+	private CryptoServiceResult<KeyReference> _generateKeyReference(
 			String algorithm, long companyId, KeyGenerator keyGenerator,
-			KeyReference keyReference)
+			KeyReference keyReference, String operation)
 		throws CryptoException {
 
 		String cryptoProviderId = _getCryptoProviderId(
@@ -537,8 +488,8 @@ public class CryptoManagerImpl implements CryptoManager {
 			_getCryptoProvider(companyId, cryptoProviderId), algorithm,
 			companyId, keyReference.getIdentifier());
 
-		_auditServiceIndicator(
-			companyId, "generate", cryptoServiceResult.getServiceIndicator());
+		_logServiceIndicator(
+			companyId, operation, cryptoServiceResult.getServiceIndicator());
 
 		return new CryptoServiceResult<>(
 			cryptoServiceResult.getServiceIndicator(),
@@ -550,10 +501,6 @@ public class CryptoManagerImpl implements CryptoManager {
 	private CryptoProvider _getCryptoProvider(
 			long companyId, String cryptoProviderId)
 		throws CryptoException {
-
-		if (Validator.isNull(cryptoProviderId)) {
-			throw new CryptoException("Crypto provider ID is null");
-		}
 
 		List<CryptoProvider> cryptoProviders = _serviceTrackerMap.getService(
 			cryptoProviderId);
@@ -594,8 +541,34 @@ public class CryptoManagerImpl implements CryptoManager {
 	}
 
 	private String _getCryptoProviderId(
+			long companyId, KeyReference keyReference,
+			KeyReference masterKeyReference)
+		throws CryptoException {
+
+		String cryptoProviderId = _getCryptoProviderId(
+			companyId, keyReference.getProviderId(), ProviderRole.DEK);
+
+		String masterCryptoProviderId = _getCryptoProviderId(
+			companyId, masterKeyReference.getProviderId(), ProviderRole.KEK);
+
+		if (!Objects.equals(cryptoProviderId, masterCryptoProviderId)) {
+			throw new CryptoException(
+				StringBundler.concat(
+					"Key provider ", cryptoProviderId,
+					" does not match master key provider ",
+					masterCryptoProviderId));
+		}
+
+		return cryptoProviderId;
+	}
+
+	private String _getCryptoProviderId(
 			long companyId, String cryptoProviderId, ProviderRole providerRole)
 		throws CryptoException {
+
+		if (Validator.isNull(cryptoProviderId)) {
+			throw new IllegalArgumentException("Crypto provider ID is null");
+		}
 
 		if (!Objects.equals(cryptoProviderId, StringPool.STAR)) {
 			return cryptoProviderId;
@@ -633,11 +606,41 @@ public class CryptoManagerImpl implements CryptoManager {
 		if (Validator.isNull(cryptoProviderId)) {
 			throw new CryptoException(
 				StringBundler.concat(
-					"Active key manager profile resolved a null provider ID ",
-					"for role ", providerRole, " and company ID ", companyId));
+					"The active key manager profile does not configure a ",
+					"crypto provider ID for role ", providerRole,
+					" and company ID ", companyId));
 		}
 
 		return cryptoProviderId;
+	}
+
+	private void _logServiceIndicator(
+		long companyId, String operation, ServiceIndicator serviceIndicator) {
+
+		if (serviceIndicator == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Operation ", operation, " for company ID ", companyId,
+						" returned a null service indicator"));
+			}
+
+			return;
+		}
+
+		if (_log.isInfoEnabled()) {
+			String approval = "a nonapproved";
+
+			if (serviceIndicator.isApproved()) {
+				approval = "an approved";
+			}
+
+			_log.info(
+				StringBundler.concat(
+					"Operation ", operation, " for company ID ", companyId,
+					" used ", approval, " security function ",
+					serviceIndicator.getSecurityFunctionName()));
+		}
 	}
 
 	private List<KeyReference> _toKeyReferences(

--- a/modules/apps/portal-security/portal-security-key-impl/src/main/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImpl.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/main/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImpl.java
@@ -48,10 +48,10 @@ public class CryptoManagerImpl implements CryptoManager {
 
 	@Override
 	public CryptoServiceResult<byte[]> decrypt(
-			byte[] ciphertextBytes, long companyId, KeyReference keyReference)
+			byte[] cipherText, long companyId, KeyReference keyReference)
 		throws CryptoException {
 
-		if (ciphertextBytes == null) {
+		if (cipherText == null) {
 			throw new IllegalArgumentException("Ciphertext is null");
 		}
 
@@ -65,7 +65,7 @@ public class CryptoManagerImpl implements CryptoManager {
 
 			CryptoServiceResult<byte[]> cryptoServiceResult =
 				cryptoProvider.decrypt(
-					ciphertextBytes, companyId, keyReference.getIdentifier());
+					cipherText, companyId, keyReference.getIdentifier());
 
 			_auditServiceIndicator(
 				companyId, "decrypt",
@@ -107,14 +107,14 @@ public class CryptoManagerImpl implements CryptoManager {
 
 	@Override
 	public CryptoServiceResult<byte[]> encrypt(
-			long companyId, KeyReference keyReference, byte[] plaintextBytes)
+			long companyId, KeyReference keyReference, byte[] plainText)
 		throws CryptoException {
 
 		if (keyReference == null) {
 			throw new IllegalArgumentException("Key reference is null");
 		}
 
-		if (plaintextBytes == null) {
+		if (plainText == null) {
 			throw new IllegalArgumentException("Plaintext is null");
 		}
 
@@ -124,7 +124,7 @@ public class CryptoManagerImpl implements CryptoManager {
 
 			CryptoServiceResult<byte[]> cryptoServiceResult =
 				cryptoProvider.encrypt(
-					companyId, keyReference.getIdentifier(), plaintextBytes);
+					companyId, keyReference.getIdentifier(), plainText);
 
 			_auditServiceIndicator(
 				companyId, "encrypt",

--- a/modules/apps/portal-security/portal-security-key-impl/src/main/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImpl.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/main/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImpl.java
@@ -48,10 +48,10 @@ public class CryptoManagerImpl implements CryptoManager {
 
 	@Override
 	public CryptoServiceResult<byte[]> decrypt(
-			byte[] cipherText, long companyId, KeyReference keyReference)
+			byte[] ciphertext, long companyId, KeyReference keyReference)
 		throws CryptoException {
 
-		if (cipherText == null) {
+		if (ciphertext == null) {
 			throw new IllegalArgumentException("Ciphertext is null");
 		}
 
@@ -65,7 +65,7 @@ public class CryptoManagerImpl implements CryptoManager {
 
 			CryptoServiceResult<byte[]> cryptoServiceResult =
 				cryptoProvider.decrypt(
-					cipherText, companyId, keyReference.getIdentifier());
+					ciphertext, companyId, keyReference.getIdentifier());
 
 			_auditServiceIndicator(
 				companyId, "decrypt",
@@ -107,14 +107,14 @@ public class CryptoManagerImpl implements CryptoManager {
 
 	@Override
 	public CryptoServiceResult<byte[]> encrypt(
-			long companyId, KeyReference keyReference, byte[] plainText)
+			long companyId, KeyReference keyReference, byte[] plaintext)
 		throws CryptoException {
 
 		if (keyReference == null) {
 			throw new IllegalArgumentException("Key reference is null");
 		}
 
-		if (plainText == null) {
+		if (plaintext == null) {
 			throw new IllegalArgumentException("Plaintext is null");
 		}
 
@@ -124,7 +124,7 @@ public class CryptoManagerImpl implements CryptoManager {
 
 			CryptoServiceResult<byte[]> cryptoServiceResult =
 				cryptoProvider.encrypt(
-					companyId, keyReference.getIdentifier(), plainText);
+					companyId, keyReference.getIdentifier(), plaintext);
 
 			_auditServiceIndicator(
 				companyId, "encrypt",

--- a/modules/apps/portal-security/portal-security-key-impl/src/main/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImpl.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/main/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImpl.java
@@ -1,0 +1,680 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.internal.crypto;
+
+import com.liferay.osgi.service.tracker.collections.map.PropertyServiceReferenceMapper;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.security.key.KeyReference;
+import com.liferay.portal.security.key.ServiceIndicator;
+import com.liferay.portal.security.key.crypto.CryptoKey;
+import com.liferay.portal.security.key.crypto.CryptoManager;
+import com.liferay.portal.security.key.crypto.CryptoServiceResult;
+import com.liferay.portal.security.key.crypto.exception.CryptoException;
+import com.liferay.portal.security.key.spi.ProviderStatus;
+import com.liferay.portal.security.key.spi.crypto.CryptoProvider;
+import com.liferay.portal.security.key.spi.profile.KeyManagerProfile;
+import com.liferay.portal.security.key.spi.profile.KeyManagerProfileRegistry;
+
+import java.security.Key;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Tomas Polesovsky
+ * @author Christopher Kian
+ */
+@Component(service = CryptoManager.class)
+public class CryptoManagerImpl implements CryptoManager {
+
+	@Override
+	public CryptoServiceResult<byte[]> decrypt(
+			byte[] ciphertextBytes, long companyId, KeyReference keyReference)
+		throws CryptoException {
+
+		if (ciphertextBytes == null) {
+			throw new IllegalArgumentException("Ciphertext is null");
+		}
+
+		if (keyReference == null) {
+			throw new IllegalArgumentException("Key reference is null");
+		}
+
+		try {
+			CryptoProvider cryptoProvider = _getCryptoProvider(
+				companyId, keyReference.getProviderId(), ProviderRole.DEK);
+
+			CryptoServiceResult<byte[]> cryptoServiceResult =
+				cryptoProvider.decrypt(
+					ciphertextBytes, companyId, keyReference.getIdentifier());
+
+			_auditServiceIndicator(
+				companyId, "decrypt",
+				cryptoServiceResult.getServiceIndicator());
+
+			return cryptoServiceResult;
+		}
+		catch (CryptoException cryptoException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to decrypt ciphertext", cryptoException);
+			}
+
+			throw cryptoException;
+		}
+	}
+
+	@Override
+	public void deleteKey(long companyId, KeyReference keyReference)
+		throws CryptoException {
+
+		if (keyReference == null) {
+			throw new IllegalArgumentException("Key reference is null");
+		}
+
+		try {
+			CryptoProvider cryptoProvider = _getCryptoProvider(
+				companyId, keyReference.getProviderId(), ProviderRole.DEK);
+
+			cryptoProvider.deleteKey(companyId, keyReference.getIdentifier());
+		}
+		catch (CryptoException cryptoException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to delete key", cryptoException);
+			}
+
+			throw cryptoException;
+		}
+	}
+
+	@Override
+	public CryptoServiceResult<byte[]> encrypt(
+			long companyId, KeyReference keyReference, byte[] plaintextBytes)
+		throws CryptoException {
+
+		if (keyReference == null) {
+			throw new IllegalArgumentException("Key reference is null");
+		}
+
+		if (plaintextBytes == null) {
+			throw new IllegalArgumentException("Plaintext is null");
+		}
+
+		try {
+			CryptoProvider cryptoProvider = _getCryptoProvider(
+				companyId, keyReference.getProviderId(), ProviderRole.DEK);
+
+			CryptoServiceResult<byte[]> cryptoServiceResult =
+				cryptoProvider.encrypt(
+					companyId, keyReference.getIdentifier(), plaintextBytes);
+
+			_auditServiceIndicator(
+				companyId, "encrypt",
+				cryptoServiceResult.getServiceIndicator());
+
+			return cryptoServiceResult;
+		}
+		catch (CryptoException cryptoException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to encrypt plaintext", cryptoException);
+			}
+
+			throw cryptoException;
+		}
+	}
+
+	@Override
+	public CryptoServiceResult<Key> exportKey(
+			long companyId, KeyReference keyReference)
+		throws CryptoException {
+
+		if (keyReference == null) {
+			throw new IllegalArgumentException("Key reference is null");
+		}
+
+		try {
+			CryptoProvider cryptoProvider = _getCryptoProvider(
+				companyId, keyReference.getProviderId(), ProviderRole.DEK);
+
+			CryptoServiceResult<Key> cryptoServiceResult =
+				cryptoProvider.exportKey(
+					companyId, keyReference.getIdentifier());
+
+			_auditServiceIndicator(
+				companyId, "exportKey",
+				cryptoServiceResult.getServiceIndicator());
+
+			return cryptoServiceResult;
+		}
+		catch (CryptoException cryptoException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to export key", cryptoException);
+			}
+
+			throw cryptoException;
+		}
+	}
+
+	@Override
+	public CryptoServiceResult<KeyReference> generateAsymmetricKeyReference(
+			String algorithm, long companyId, KeyReference keyReference)
+		throws CryptoException {
+
+		if (Validator.isNull(algorithm)) {
+			throw new IllegalArgumentException("Algorithm is null");
+		}
+
+		if (keyReference == null) {
+			throw new IllegalArgumentException("Key reference is null");
+		}
+
+		try {
+			return _generate(
+				algorithm, companyId,
+				CryptoProvider::generateAsymmetricKeyIdentifier, keyReference);
+		}
+		catch (CryptoException cryptoException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to generate asymmetric key reference",
+					cryptoException);
+			}
+
+			throw cryptoException;
+		}
+	}
+
+	@Override
+	public CryptoServiceResult<KeyReference> generateSecretKeyReference(
+			String algorithm, long companyId, KeyReference keyReference)
+		throws CryptoException {
+
+		if (Validator.isNull(algorithm)) {
+			throw new IllegalArgumentException("Algorithm is null");
+		}
+
+		if (keyReference == null) {
+			throw new IllegalArgumentException("Key reference is null");
+		}
+
+		try {
+			return _generate(
+				algorithm, companyId,
+				CryptoProvider::generateSecretKeyIdentifier, keyReference);
+		}
+		catch (CryptoException cryptoException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to generate secret key reference", cryptoException);
+			}
+
+			throw cryptoException;
+		}
+	}
+
+	@Override
+	public CryptoKey getCryptoKey(long companyId, KeyReference keyReference)
+		throws CryptoException {
+
+		if (keyReference == null) {
+			throw new IllegalArgumentException("Key reference is null");
+		}
+
+		try {
+			CryptoProvider cryptoProvider = _getCryptoProvider(
+				companyId, keyReference.getProviderId(), ProviderRole.DEK);
+
+			return cryptoProvider.getCryptoKey(
+				companyId, keyReference.getIdentifier());
+		}
+		catch (CryptoException cryptoException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to get crypto key", cryptoException);
+			}
+
+			throw cryptoException;
+		}
+	}
+
+	@Override
+	public List<String> getCryptoProviderIds(long companyId) {
+		List<String> cryptoProviderIds = new ArrayList<>();
+
+		ServiceTrackerMap<String, List<CryptoProvider>> serviceTrackerMap =
+			_serviceTrackerMap;
+
+		if (serviceTrackerMap == null) {
+			return cryptoProviderIds;
+		}
+
+		for (String cryptoProviderId : serviceTrackerMap.keySet()) {
+			List<CryptoProvider> cryptoProviders = serviceTrackerMap.getService(
+				cryptoProviderId);
+
+			if (cryptoProviders == null) {
+				continue;
+			}
+
+			for (CryptoProvider cryptoProvider : cryptoProviders) {
+				if (cryptoProvider.isAllowedCompany(companyId)) {
+					cryptoProviderIds.add(cryptoProviderId);
+
+					break;
+				}
+			}
+		}
+
+		return cryptoProviderIds;
+	}
+
+	@Override
+	public List<KeyReference> getKeyReferences(
+			long companyId, String cryptoProviderId)
+		throws CryptoException {
+
+		if (Validator.isNull(cryptoProviderId)) {
+			throw new IllegalArgumentException("Crypto provider ID is null");
+		}
+
+		try {
+			cryptoProviderId = _getCryptoProviderId(
+				companyId, cryptoProviderId, ProviderRole.DEK);
+
+			CryptoProvider cryptoProvider = _getCryptoProvider(
+				companyId, cryptoProviderId);
+
+			List<String> keyIdentifiers = cryptoProvider.getKeyIdentifiers(
+				companyId);
+
+			if (keyIdentifiers == null) {
+				return Collections.emptyList();
+			}
+
+			List<KeyReference> keyReferences = new ArrayList<>();
+
+			for (String keyIdentifier : keyIdentifiers) {
+				keyReferences.add(
+					new KeyReference(
+						keyIdentifier, cryptoProviderId,
+						KeyReference.Type.CRYPTO));
+			}
+
+			return keyReferences;
+		}
+		catch (CryptoException cryptoException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to get key identifiers", cryptoException);
+			}
+
+			throw cryptoException;
+		}
+	}
+
+	@Override
+	public CryptoServiceResult<KeyReference> importSecretKey(
+			String algorithm, long companyId, byte[] keyBytes,
+			KeyReference keyReference)
+		throws CryptoException {
+
+		if (Validator.isNull(algorithm)) {
+			throw new IllegalArgumentException("Algorithm is null");
+		}
+
+		if (keyBytes == null) {
+			throw new IllegalArgumentException("Key bytes are null");
+		}
+
+		if (keyReference == null) {
+			throw new IllegalArgumentException("Key reference is null");
+		}
+
+		try {
+			String cryptoProviderId = _getCryptoProviderId(
+				companyId, keyReference.getProviderId(), ProviderRole.DEK);
+
+			CryptoProvider cryptoProvider = _getCryptoProvider(
+				companyId, cryptoProviderId);
+
+			CryptoServiceResult<String> cryptoServiceResult =
+				cryptoProvider.importSecretKey(
+					algorithm, companyId, keyBytes,
+					keyReference.getIdentifier());
+
+			_auditServiceIndicator(
+				companyId, "importSecretKey",
+				cryptoServiceResult.getServiceIndicator());
+
+			return new CryptoServiceResult<>(
+				cryptoServiceResult.getServiceIndicator(),
+				new KeyReference(
+					cryptoServiceResult.getValue(), cryptoProviderId,
+					KeyReference.Type.CRYPTO));
+		}
+		catch (CryptoException cryptoException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to import secret key", cryptoException);
+			}
+
+			throw cryptoException;
+		}
+		finally {
+			if (keyBytes != null) {
+				Arrays.fill(keyBytes, (byte)0);
+			}
+		}
+	}
+
+	@Override
+	public CryptoServiceResult<KeyReference> unwrap(
+			long companyId, KeyReference keyReference,
+			KeyReference masterKeyReference, String wrappedKeyAlgorithm,
+			byte[] wrappedKeyBytes, int wrappedKeyCipherType)
+		throws CryptoException {
+
+		if (keyReference == null) {
+			throw new IllegalArgumentException("Key reference is null");
+		}
+
+		if (masterKeyReference == null) {
+			throw new IllegalArgumentException("Master key reference is null");
+		}
+
+		if (Validator.isNull(wrappedKeyAlgorithm)) {
+			throw new IllegalArgumentException("Wrapped key algorithm is null");
+		}
+
+		if (wrappedKeyBytes == null) {
+			throw new IllegalArgumentException("Wrapped key bytes is null");
+		}
+
+		try {
+			String cryptoProviderId = _getCryptoProviderId(
+				companyId, keyReference.getProviderId(), ProviderRole.DEK);
+
+			String masterCryptoProviderId = _getCryptoProviderId(
+				companyId, masterKeyReference.getProviderId(),
+				ProviderRole.KEK);
+
+			if (!Objects.equals(cryptoProviderId, masterCryptoProviderId)) {
+				throw new CryptoException(
+					StringBundler.concat(
+						"Key provider ", cryptoProviderId,
+						" does not match master key provider ",
+						masterCryptoProviderId));
+			}
+
+			CryptoProvider cryptoProvider = _getCryptoProvider(
+				companyId, cryptoProviderId);
+
+			CryptoServiceResult<String> cryptoServiceResult =
+				cryptoProvider.unwrap(
+					companyId, keyReference.getIdentifier(),
+					masterKeyReference.getIdentifier(), wrappedKeyAlgorithm,
+					wrappedKeyBytes, wrappedKeyCipherType);
+
+			_auditServiceIndicator(
+				companyId, "unwrap", cryptoServiceResult.getServiceIndicator());
+
+			return new CryptoServiceResult<>(
+				cryptoServiceResult.getServiceIndicator(),
+				new KeyReference(
+					cryptoServiceResult.getValue(), cryptoProviderId,
+					KeyReference.Type.CRYPTO));
+		}
+		catch (CryptoException cryptoException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to unwrap key", cryptoException);
+			}
+
+			throw cryptoException;
+		}
+	}
+
+	@Override
+	public CryptoServiceResult<byte[]> wrap(
+			long companyId, KeyReference keyReference,
+			KeyReference masterKeyReference)
+		throws CryptoException {
+
+		if (keyReference == null) {
+			throw new IllegalArgumentException("Key reference is null");
+		}
+
+		if (masterKeyReference == null) {
+			throw new IllegalArgumentException("Master key reference is null");
+		}
+
+		try {
+			String cryptoProviderId = _getCryptoProviderId(
+				companyId, keyReference.getProviderId(), ProviderRole.DEK);
+
+			String masterCryptoProviderId = _getCryptoProviderId(
+				companyId, masterKeyReference.getProviderId(),
+				ProviderRole.KEK);
+
+			if (!Objects.equals(cryptoProviderId, masterCryptoProviderId)) {
+				throw new CryptoException(
+					StringBundler.concat(
+						"Key provider ", cryptoProviderId,
+						" does not match master key provider ",
+						masterCryptoProviderId));
+			}
+
+			CryptoProvider cryptoProvider = _getCryptoProvider(
+				companyId, cryptoProviderId);
+
+			CryptoServiceResult<byte[]> cryptoServiceResult =
+				cryptoProvider.wrap(
+					companyId, keyReference.getIdentifier(),
+					masterKeyReference.getIdentifier());
+
+			_auditServiceIndicator(
+				companyId, "wrap", cryptoServiceResult.getServiceIndicator());
+
+			return cryptoServiceResult;
+		}
+		catch (CryptoException cryptoException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to wrap key", cryptoException);
+			}
+
+			throw cryptoException;
+		}
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_serviceTrackerMap = ServiceTrackerMapFactory.openMultiValueMap(
+			bundleContext, CryptoProvider.class, "(crypto.provider.id=*)",
+			new PropertyServiceReferenceMapper<>("crypto.provider.id"));
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		if (_serviceTrackerMap != null) {
+			_serviceTrackerMap.close();
+
+			_serviceTrackerMap = null;
+		}
+	}
+
+	private void _auditServiceIndicator(
+		long companyId, String operation, ServiceIndicator serviceIndicator) {
+
+		if (serviceIndicator == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"Operation ", operation, " for company ID ", companyId,
+						" returned a null service indicator"));
+			}
+
+			return;
+		}
+
+		if (_log.isInfoEnabled()) {
+			_log.info(
+				StringBundler.concat(
+					"Operation ", operation, " for company ID ", companyId,
+					" used ",
+					serviceIndicator.isApproved() ? "an approved " :
+						"a nonapproved ",
+					"security function ",
+					serviceIndicator.getSecurityFunctionName()));
+		}
+	}
+
+	private CryptoServiceResult<KeyReference> _generate(
+			String algorithm, long companyId, KeyGenerator keyGenerator,
+			KeyReference keyReference)
+		throws CryptoException {
+
+		String cryptoProviderId = _getCryptoProviderId(
+			companyId, keyReference.getProviderId(), ProviderRole.DEK);
+
+		CryptoServiceResult<String> cryptoServiceResult = keyGenerator.generate(
+			_getCryptoProvider(companyId, cryptoProviderId), algorithm,
+			companyId, keyReference.getIdentifier());
+
+		_auditServiceIndicator(
+			companyId, "generate", cryptoServiceResult.getServiceIndicator());
+
+		return new CryptoServiceResult<>(
+			cryptoServiceResult.getServiceIndicator(),
+			new KeyReference(
+				cryptoServiceResult.getValue(), cryptoProviderId,
+				KeyReference.Type.CRYPTO));
+	}
+
+	private CryptoProvider _getCryptoProvider(
+			long companyId, String cryptoProviderId)
+		throws CryptoException {
+
+		if (Validator.isNull(cryptoProviderId)) {
+			throw new CryptoException("Crypto provider ID is null");
+		}
+
+		List<CryptoProvider> cryptoProviders = _serviceTrackerMap.getService(
+			cryptoProviderId);
+
+		if (cryptoProviders != null) {
+			for (CryptoProvider cryptoProvider : cryptoProviders) {
+				if (!cryptoProvider.isAllowedCompany(companyId)) {
+					continue;
+				}
+
+				if (cryptoProvider.getProviderStatus() ==
+						ProviderStatus.ERROR) {
+
+					throw new CryptoException(
+						StringBundler.concat(
+							"Crypto provider ", cryptoProviderId,
+							" is in an error state for company ID ",
+							companyId));
+				}
+
+				return cryptoProvider;
+			}
+		}
+
+		throw new CryptoException(
+			StringBundler.concat(
+				"No crypto provider found for ID ", cryptoProviderId,
+				" and company ID ", companyId));
+	}
+
+	private CryptoProvider _getCryptoProvider(
+			long companyId, String cryptoProviderId, ProviderRole providerRole)
+		throws CryptoException {
+
+		return _getCryptoProvider(
+			companyId,
+			_getCryptoProviderId(companyId, cryptoProviderId, providerRole));
+	}
+
+	private String _getCryptoProviderId(
+			long companyId, String cryptoProviderId, ProviderRole providerRole)
+		throws CryptoException {
+
+		if (!Objects.equals(cryptoProviderId, StringPool.STAR)) {
+			return cryptoProviderId;
+		}
+
+		KeyManagerProfile activeProfile =
+			_keyManagerProfileRegistry.getActiveKeyManagerProfile();
+
+		if (activeProfile == null) {
+			throw new CryptoException(
+				StringBundler.concat(
+					"No active key manager profile found to resolve the ",
+					"provider wildcard for company ID ", companyId));
+		}
+
+		if (companyId == CompanyConstants.SYSTEM) {
+			if (providerRole == ProviderRole.DEK) {
+				cryptoProviderId = activeProfile.getSystemDEKProviderId();
+			}
+			else {
+				cryptoProviderId = activeProfile.getSystemKEKProviderId();
+			}
+		}
+		else if (providerRole == ProviderRole.DEK) {
+			cryptoProviderId = activeProfile.getCompanyDEKProviderId();
+		}
+		else {
+			cryptoProviderId = activeProfile.getCompanyKEKProviderId();
+		}
+
+		if (Validator.isNull(cryptoProviderId)) {
+			throw new CryptoException(
+				StringBundler.concat(
+					"Active key manager profile resolved a null provider ID ",
+					"for role ", providerRole, " and company ID ", companyId));
+		}
+
+		return cryptoProviderId;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		CryptoManagerImpl.class);
+
+	@Reference
+	private KeyManagerProfileRegistry _keyManagerProfileRegistry;
+
+	private ServiceTrackerMap<String, List<CryptoProvider>> _serviceTrackerMap;
+
+	@FunctionalInterface
+	private interface KeyGenerator {
+
+		public CryptoServiceResult<String> generate(
+				CryptoProvider cryptoProvider, String algorithm, long companyId,
+				String keyIdentifier)
+			throws CryptoException;
+
+	}
+
+	private enum ProviderRole {
+
+		DEK, KEK
+
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImplTest.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImplTest.java
@@ -58,14 +58,14 @@ public class CryptoManagerImplTest {
 
 	@Test
 	public void testDecrypt() throws Exception {
-		byte[] plainText = RandomTestUtil.randomBytes();
+		byte[] plaintext = RandomTestUtil.randomBytes();
 
 		Mockito.when(
 			_cryptoProvider.decrypt(
 				Mockito.any(byte[].class), Mockito.anyLong(),
 				Mockito.anyString())
 		).thenReturn(
-			_cryptoServiceResult(plainText)
+			_cryptoServiceResult(plaintext)
 		);
 
 		Mockito.when(
@@ -87,7 +87,7 @@ public class CryptoManagerImplTest {
 				RandomTestUtil.randomBytes(), RandomTestUtil.randomLong(),
 				_keyReference(cryptoProviderId));
 
-		Assert.assertArrayEquals(plainText, cryptoServiceResult.getValue());
+		Assert.assertArrayEquals(plaintext, cryptoServiceResult.getValue());
 	}
 
 	@Test

--- a/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImplTest.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImplTest.java
@@ -1,0 +1,595 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.internal.crypto;
+
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.CompanyConstants;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.security.key.KeyReference;
+import com.liferay.portal.security.key.ServiceIndicator;
+import com.liferay.portal.security.key.crypto.CryptoServiceResult;
+import com.liferay.portal.security.key.crypto.exception.CryptoException;
+import com.liferay.portal.security.key.spi.ProviderStatus;
+import com.liferay.portal.security.key.spi.crypto.CryptoProvider;
+import com.liferay.portal.security.key.spi.profile.KeyManagerProfile;
+import com.liferay.portal.security.key.spi.profile.KeyManagerProfileRegistry;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.security.Key;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+
+/**
+ * @author Christopher Kian
+ */
+public class CryptoManagerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		MockitoAnnotations.openMocks(this);
+
+		ReflectionTestUtil.setFieldValue(
+			_cryptoManagerImpl, "_keyManagerProfileRegistry",
+			_keyManagerProfileRegistry);
+		ReflectionTestUtil.setFieldValue(
+			_cryptoManagerImpl, "_serviceTrackerMap", _serviceTrackerMap);
+	}
+
+	@Test
+	public void testDecrypt() throws Exception {
+		byte[] plaintextBytes = RandomTestUtil.randomBytes();
+
+		Mockito.when(
+			_cryptoProvider.decrypt(
+				Mockito.any(byte[].class), Mockito.anyLong(),
+				Mockito.anyString())
+		).thenReturn(
+			_cryptoServiceResult(plaintextBytes)
+		);
+
+		Mockito.when(
+			_cryptoProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		String cryptoProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_serviceTrackerMap.getService(cryptoProviderId)
+		).thenReturn(
+			Collections.singletonList(_cryptoProvider)
+		);
+
+		CryptoServiceResult<byte[]> cryptoServiceResult =
+			_cryptoManagerImpl.decrypt(
+				RandomTestUtil.randomBytes(), RandomTestUtil.randomLong(),
+				_keyReference(cryptoProviderId));
+
+		Assert.assertArrayEquals(
+			plaintextBytes, cryptoServiceResult.getValue());
+	}
+
+	@Test
+	public void testDeleteKey() throws Exception {
+		Mockito.when(
+			_cryptoProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		String cryptoProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_serviceTrackerMap.getService(cryptoProviderId)
+		).thenReturn(
+			Collections.singletonList(_cryptoProvider)
+		);
+
+		long companyId = RandomTestUtil.randomLong();
+		String identifier = RandomTestUtil.randomString();
+
+		_cryptoManagerImpl.deleteKey(
+			companyId, _keyReference(cryptoProviderId, identifier));
+
+		Mockito.verify(
+			_cryptoProvider
+		).deleteKey(
+			companyId, identifier
+		);
+	}
+
+	@Test
+	public void testEncryptResolvesProviderWildcard() throws Exception {
+		_testEncryptResolvesProviderWildcard(CompanyConstants.SYSTEM);
+		_testEncryptResolvesProviderWildcard(RandomTestUtil.randomLong());
+	}
+
+	@Test
+	public void testEncryptThrows() {
+		Mockito.when(
+			_keyManagerProfileRegistry.getActiveKeyManagerProfile()
+		).thenReturn(
+			null
+		);
+
+		Assert.assertThrows(
+			CryptoException.class,
+			() -> _cryptoManagerImpl.encrypt(
+				RandomTestUtil.randomLong(), _keyReference(StringPool.STAR),
+				RandomTestUtil.randomBytes()));
+
+		String cryptoProviderId = RandomTestUtil.randomString();
+
+		Assert.assertThrows(
+			CryptoException.class,
+			() -> _cryptoManagerImpl.encrypt(
+				RandomTestUtil.randomLong(), _keyReference(cryptoProviderId),
+				RandomTestUtil.randomBytes()));
+
+		Mockito.when(
+			_cryptoProvider.getProviderStatus()
+		).thenReturn(
+			ProviderStatus.ERROR
+		);
+
+		Mockito.when(
+			_cryptoProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			_serviceTrackerMap.getService(cryptoProviderId)
+		).thenReturn(
+			Collections.singletonList(_cryptoProvider)
+		);
+
+		Assert.assertThrows(
+			CryptoException.class,
+			() -> _cryptoManagerImpl.encrypt(
+				RandomTestUtil.randomLong(), _keyReference(cryptoProviderId),
+				RandomTestUtil.randomBytes()));
+	}
+
+	@Test
+	public void testExportKey() throws Exception {
+		Key key = Mockito.mock(Key.class);
+
+		Mockito.when(
+			_cryptoProvider.exportKey(Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			_cryptoServiceResult(key)
+		);
+
+		Mockito.when(
+			_cryptoProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		String cryptoProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_serviceTrackerMap.getService(cryptoProviderId)
+		).thenReturn(
+			Collections.singletonList(_cryptoProvider)
+		);
+
+		CryptoServiceResult<Key> cryptoServiceResult =
+			_cryptoManagerImpl.exportKey(
+				RandomTestUtil.randomLong(), _keyReference(cryptoProviderId));
+
+		Assert.assertSame(key, cryptoServiceResult.getValue());
+	}
+
+	@Test
+	public void testGenerateAsymmetricKeyReference() throws Exception {
+		String identifier = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_cryptoProvider.generateAsymmetricKeyIdentifier(
+				Mockito.anyString(), Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			_cryptoServiceResult(identifier)
+		);
+
+		Mockito.when(
+			_cryptoProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		String cryptoProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_serviceTrackerMap.getService(cryptoProviderId)
+		).thenReturn(
+			Collections.singletonList(_cryptoProvider)
+		);
+
+		CryptoServiceResult<KeyReference> cryptoServiceResult =
+			_cryptoManagerImpl.generateAsymmetricKeyReference(
+				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+				_keyReference(cryptoProviderId));
+
+		KeyReference keyReference = cryptoServiceResult.getValue();
+
+		Assert.assertEquals(cryptoProviderId, keyReference.getProviderId());
+		Assert.assertEquals(identifier, keyReference.getIdentifier());
+	}
+
+	@Test
+	public void testGenerateSecretKeyReference() throws Exception {
+		String identifier = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_cryptoProvider.generateSecretKeyIdentifier(
+				Mockito.anyString(), Mockito.anyLong(), Mockito.anyString())
+		).thenReturn(
+			_cryptoServiceResult(identifier)
+		);
+
+		Mockito.when(
+			_cryptoProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		String cryptoProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_serviceTrackerMap.getService(cryptoProviderId)
+		).thenReturn(
+			Collections.singletonList(_cryptoProvider)
+		);
+
+		CryptoServiceResult<KeyReference> cryptoServiceResult =
+			_cryptoManagerImpl.generateSecretKeyReference(
+				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+				_keyReference(cryptoProviderId));
+
+		KeyReference keyReference = cryptoServiceResult.getValue();
+
+		Assert.assertEquals(cryptoProviderId, keyReference.getProviderId());
+		Assert.assertEquals(identifier, keyReference.getIdentifier());
+	}
+
+	@Test
+	public void testGetCryptoProviderIds() {
+		Mockito.when(
+			_cryptoProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		String cryptoProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_serviceTrackerMap.getService(cryptoProviderId)
+		).thenReturn(
+			Collections.singletonList(_cryptoProvider)
+		);
+
+		Mockito.when(
+			_serviceTrackerMap.keySet()
+		).thenReturn(
+			Collections.singleton(cryptoProviderId)
+		);
+
+		Assert.assertEquals(
+			Collections.singletonList(cryptoProviderId),
+			_cryptoManagerImpl.getCryptoProviderIds(
+				RandomTestUtil.randomLong()));
+	}
+
+	@Test
+	public void testGetKeyReferences() throws Exception {
+		String identifier = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_cryptoProvider.getKeyIdentifiers(Mockito.anyLong())
+		).thenReturn(
+			Collections.singletonList(identifier)
+		);
+
+		Mockito.when(
+			_cryptoProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		String cryptoProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_serviceTrackerMap.getService(cryptoProviderId)
+		).thenReturn(
+			Collections.singletonList(_cryptoProvider)
+		);
+
+		List<KeyReference> keyReferences = _cryptoManagerImpl.getKeyReferences(
+			RandomTestUtil.randomLong(), cryptoProviderId);
+
+		Assert.assertEquals(keyReferences.toString(), 1, keyReferences.size());
+
+		KeyReference keyReference = keyReferences.get(0);
+
+		Assert.assertEquals(cryptoProviderId, keyReference.getProviderId());
+		Assert.assertEquals(identifier, keyReference.getIdentifier());
+	}
+
+	@Test
+	public void testImportSecretKey() throws Exception {
+		String identifier = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_cryptoProvider.importSecretKey(
+				Mockito.anyString(), Mockito.anyLong(),
+				Mockito.any(byte[].class), Mockito.anyString())
+		).thenReturn(
+			_cryptoServiceResult(identifier)
+		);
+
+		Mockito.when(
+			_cryptoProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		String cryptoProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_serviceTrackerMap.getService(cryptoProviderId)
+		).thenReturn(
+			Collections.singletonList(_cryptoProvider)
+		);
+
+		CryptoServiceResult<KeyReference> cryptoServiceResult =
+			_cryptoManagerImpl.importSecretKey(
+				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+				RandomTestUtil.randomBytes(), _keyReference(cryptoProviderId));
+
+		KeyReference keyReference = cryptoServiceResult.getValue();
+
+		Assert.assertEquals(cryptoProviderId, keyReference.getProviderId());
+		Assert.assertEquals(identifier, keyReference.getIdentifier());
+	}
+
+	@Test
+	public void testImportSecretKeyZerosKeyBytesEvenOnFailure()
+		throws Exception {
+
+		Mockito.when(
+			_cryptoProvider.importSecretKey(
+				Mockito.anyString(), Mockito.anyLong(),
+				Mockito.any(byte[].class), Mockito.anyString())
+		).thenThrow(
+			new CryptoException()
+		);
+
+		Mockito.when(
+			_cryptoProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		String cryptoProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_serviceTrackerMap.getService(cryptoProviderId)
+		).thenReturn(
+			Collections.singletonList(_cryptoProvider)
+		);
+
+		byte[] keyBytes = RandomTestUtil.randomBytes();
+
+		Assert.assertThrows(
+			CryptoException.class,
+			() -> _cryptoManagerImpl.importSecretKey(
+				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
+				keyBytes, _keyReference(cryptoProviderId)));
+
+		for (byte b : keyBytes) {
+			Assert.assertEquals(0, b);
+		}
+	}
+
+	@Test
+	public void testUnwrap() throws Exception {
+		Mockito.when(
+			_cryptoProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		String unwrappedIdentifier = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_cryptoProvider.unwrap(
+				Mockito.anyLong(), Mockito.anyString(), Mockito.anyString(),
+				Mockito.anyString(), Mockito.any(byte[].class),
+				Mockito.anyInt())
+		).thenReturn(
+			_cryptoServiceResult(unwrappedIdentifier)
+		);
+
+		String cryptoProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_serviceTrackerMap.getService(cryptoProviderId)
+		).thenReturn(
+			Collections.singletonList(_cryptoProvider)
+		);
+
+		CryptoServiceResult<KeyReference> cryptoServiceResult =
+			_cryptoManagerImpl.unwrap(
+				RandomTestUtil.randomLong(), _keyReference(cryptoProviderId),
+				_keyReference(cryptoProviderId), RandomTestUtil.randomString(),
+				RandomTestUtil.randomBytes(), RandomTestUtil.randomInt());
+
+		KeyReference keyReference = cryptoServiceResult.getValue();
+
+		Assert.assertEquals(cryptoProviderId, keyReference.getProviderId());
+		Assert.assertEquals(unwrappedIdentifier, keyReference.getIdentifier());
+	}
+
+	@Test
+	public void testWrap() throws Exception {
+		Mockito.when(
+			_cryptoProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		byte[] wrappedKeyBytes = RandomTestUtil.randomBytes();
+
+		Mockito.when(
+			_cryptoProvider.wrap(
+				Mockito.anyLong(), Mockito.anyString(), Mockito.anyString())
+		).thenReturn(
+			_cryptoServiceResult(wrappedKeyBytes)
+		);
+
+		String cryptoProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_serviceTrackerMap.getService(cryptoProviderId)
+		).thenReturn(
+			Collections.singletonList(_cryptoProvider)
+		);
+
+		CryptoServiceResult<byte[]> cryptoServiceResult =
+			_cryptoManagerImpl.wrap(
+				RandomTestUtil.randomLong(), _keyReference(cryptoProviderId),
+				_keyReference(cryptoProviderId));
+
+		Assert.assertSame(wrappedKeyBytes, cryptoServiceResult.getValue());
+	}
+
+	@Test
+	public void testWrapThrowsWhenProvidersDiffer() {
+		Assert.assertThrows(
+			CryptoException.class,
+			() -> _cryptoManagerImpl.wrap(
+				RandomTestUtil.randomLong(),
+				_keyReference(RandomTestUtil.randomString()),
+				_keyReference(RandomTestUtil.randomString())));
+	}
+
+	private <T> CryptoServiceResult<T> _cryptoServiceResult(T value) {
+		return new CryptoServiceResult<>(
+			new ServiceIndicator(true, RandomTestUtil.randomString()), value);
+	}
+
+	private KeyReference _keyReference(String cryptoProviderId) {
+		return _keyReference(cryptoProviderId, RandomTestUtil.randomString());
+	}
+
+	private KeyReference _keyReference(
+		String cryptoProviderId, String identifier) {
+
+		return new KeyReference(
+			identifier, cryptoProviderId, KeyReference.Type.CRYPTO);
+	}
+
+	private void _testEncryptResolvesProviderWildcard(long companyId)
+		throws Exception {
+
+		String identifier = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_cryptoProvider.encrypt(
+				Mockito.eq(companyId), Mockito.eq(identifier),
+				Mockito.any(byte[].class))
+		).thenReturn(
+			_cryptoServiceResult(new byte[0])
+		);
+
+		Mockito.when(
+			_cryptoProvider.isAllowedCompany(companyId)
+		).thenReturn(
+			true
+		);
+
+		String cryptoProviderId = RandomTestUtil.randomString();
+
+		if (companyId == CompanyConstants.SYSTEM) {
+			Mockito.when(
+				_keyManagerProfile.getSystemDEKProviderId()
+			).thenReturn(
+				cryptoProviderId
+			);
+		}
+		else {
+			Mockito.when(
+				_keyManagerProfile.getCompanyDEKProviderId()
+			).thenReturn(
+				cryptoProviderId
+			);
+		}
+
+		Mockito.when(
+			_keyManagerProfileRegistry.getActiveKeyManagerProfile()
+		).thenReturn(
+			_keyManagerProfile
+		);
+
+		Mockito.when(
+			_serviceTrackerMap.getService(cryptoProviderId)
+		).thenReturn(
+			Collections.singletonList(_cryptoProvider)
+		);
+
+		_cryptoManagerImpl.encrypt(
+			companyId, _keyReference(StringPool.STAR, identifier),
+			RandomTestUtil.randomBytes());
+
+		if (companyId == CompanyConstants.SYSTEM) {
+			Mockito.verify(
+				_keyManagerProfile, Mockito.atLeastOnce()
+			).getSystemDEKProviderId();
+		}
+		else {
+			Mockito.verify(
+				_keyManagerProfile, Mockito.atLeastOnce()
+			).getCompanyDEKProviderId();
+		}
+	}
+
+	private final CryptoManagerImpl _cryptoManagerImpl =
+		new CryptoManagerImpl();
+
+	@Mock
+	private CryptoProvider _cryptoProvider;
+
+	@Mock
+	private KeyManagerProfile _keyManagerProfile;
+
+	@Mock
+	private KeyManagerProfileRegistry _keyManagerProfileRegistry;
+
+	@Mock
+	private ServiceTrackerMap<String, List<CryptoProvider>> _serviceTrackerMap;
+
+}

--- a/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImplTest.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImplTest.java
@@ -65,7 +65,7 @@ public class CryptoManagerImplTest {
 				Mockito.any(byte[].class), Mockito.anyLong(),
 				Mockito.anyString())
 		).thenReturn(
-			_cryptoServiceResult(plaintext)
+			_getCryptoServiceResult(plaintext)
 		);
 
 		Mockito.when(
@@ -85,7 +85,7 @@ public class CryptoManagerImplTest {
 		CryptoServiceResult<byte[]> cryptoServiceResult =
 			_cryptoManagerImpl.decrypt(
 				RandomTestUtil.randomBytes(), RandomTestUtil.randomLong(),
-				_keyReference(cryptoProviderId));
+				_getKeyReference(cryptoProviderId));
 
 		Assert.assertArrayEquals(plaintext, cryptoServiceResult.getValue());
 	}
@@ -107,15 +107,15 @@ public class CryptoManagerImplTest {
 		);
 
 		long companyId = RandomTestUtil.randomLong();
-		String identifier = RandomTestUtil.randomString();
+		String keyIdentifier = RandomTestUtil.randomString();
 
 		_cryptoManagerImpl.deleteKey(
-			companyId, _keyReference(cryptoProviderId, identifier));
+			companyId, _getKeyReference(cryptoProviderId, keyIdentifier));
 
 		Mockito.verify(
 			_cryptoProvider
 		).deleteKey(
-			companyId, identifier
+			companyId, keyIdentifier
 		);
 	}
 
@@ -136,7 +136,7 @@ public class CryptoManagerImplTest {
 		Assert.assertThrows(
 			CryptoException.class,
 			() -> _cryptoManagerImpl.encrypt(
-				RandomTestUtil.randomLong(), _keyReference(StringPool.STAR),
+				RandomTestUtil.randomLong(), _getKeyReference(StringPool.STAR),
 				RandomTestUtil.randomBytes()));
 
 		String cryptoProviderId = RandomTestUtil.randomString();
@@ -144,7 +144,7 @@ public class CryptoManagerImplTest {
 		Assert.assertThrows(
 			CryptoException.class,
 			() -> _cryptoManagerImpl.encrypt(
-				RandomTestUtil.randomLong(), _keyReference(cryptoProviderId),
+				RandomTestUtil.randomLong(), _getKeyReference(cryptoProviderId),
 				RandomTestUtil.randomBytes()));
 
 		Mockito.when(
@@ -168,7 +168,7 @@ public class CryptoManagerImplTest {
 		Assert.assertThrows(
 			CryptoException.class,
 			() -> _cryptoManagerImpl.encrypt(
-				RandomTestUtil.randomLong(), _keyReference(cryptoProviderId),
+				RandomTestUtil.randomLong(), _getKeyReference(cryptoProviderId),
 				RandomTestUtil.randomBytes()));
 	}
 
@@ -179,7 +179,7 @@ public class CryptoManagerImplTest {
 		Mockito.when(
 			_cryptoProvider.exportKey(Mockito.anyLong(), Mockito.anyString())
 		).thenReturn(
-			_cryptoServiceResult(key)
+			_getCryptoServiceResult(key)
 		);
 
 		Mockito.when(
@@ -198,20 +198,21 @@ public class CryptoManagerImplTest {
 
 		CryptoServiceResult<Key> cryptoServiceResult =
 			_cryptoManagerImpl.exportKey(
-				RandomTestUtil.randomLong(), _keyReference(cryptoProviderId));
+				RandomTestUtil.randomLong(),
+				_getKeyReference(cryptoProviderId));
 
 		Assert.assertSame(key, cryptoServiceResult.getValue());
 	}
 
 	@Test
 	public void testGenerateAsymmetricKeyReference() throws Exception {
-		String identifier = RandomTestUtil.randomString();
+		String keyIdentifier = RandomTestUtil.randomString();
 
 		Mockito.when(
 			_cryptoProvider.generateAsymmetricKeyIdentifier(
 				Mockito.anyString(), Mockito.anyLong(), Mockito.anyString())
 		).thenReturn(
-			_cryptoServiceResult(identifier)
+			_getCryptoServiceResult(keyIdentifier)
 		);
 
 		Mockito.when(
@@ -231,23 +232,23 @@ public class CryptoManagerImplTest {
 		CryptoServiceResult<KeyReference> cryptoServiceResult =
 			_cryptoManagerImpl.generateAsymmetricKeyReference(
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
-				_keyReference(cryptoProviderId));
+				_getKeyReference(cryptoProviderId));
 
 		KeyReference keyReference = cryptoServiceResult.getValue();
 
 		Assert.assertEquals(cryptoProviderId, keyReference.getProviderId());
-		Assert.assertEquals(identifier, keyReference.getIdentifier());
+		Assert.assertEquals(keyIdentifier, keyReference.getIdentifier());
 	}
 
 	@Test
 	public void testGenerateSecretKeyReference() throws Exception {
-		String identifier = RandomTestUtil.randomString();
+		String keyIdentifier = RandomTestUtil.randomString();
 
 		Mockito.when(
 			_cryptoProvider.generateSecretKeyIdentifier(
 				Mockito.anyString(), Mockito.anyLong(), Mockito.anyString())
 		).thenReturn(
-			_cryptoServiceResult(identifier)
+			_getCryptoServiceResult(keyIdentifier)
 		);
 
 		Mockito.when(
@@ -267,12 +268,12 @@ public class CryptoManagerImplTest {
 		CryptoServiceResult<KeyReference> cryptoServiceResult =
 			_cryptoManagerImpl.generateSecretKeyReference(
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
-				_keyReference(cryptoProviderId));
+				_getKeyReference(cryptoProviderId));
 
 		KeyReference keyReference = cryptoServiceResult.getValue();
 
 		Assert.assertEquals(cryptoProviderId, keyReference.getProviderId());
-		Assert.assertEquals(identifier, keyReference.getIdentifier());
+		Assert.assertEquals(keyIdentifier, keyReference.getIdentifier());
 	}
 
 	@Test
@@ -305,12 +306,12 @@ public class CryptoManagerImplTest {
 
 	@Test
 	public void testGetKeyReferences() throws Exception {
-		String identifier = RandomTestUtil.randomString();
+		String keyIdentifier = RandomTestUtil.randomString();
 
 		Mockito.when(
 			_cryptoProvider.getKeyIdentifiers(Mockito.anyLong())
 		).thenReturn(
-			Collections.singletonList(identifier)
+			Collections.singletonList(keyIdentifier)
 		);
 
 		Mockito.when(
@@ -335,19 +336,19 @@ public class CryptoManagerImplTest {
 		KeyReference keyReference = keyReferences.get(0);
 
 		Assert.assertEquals(cryptoProviderId, keyReference.getProviderId());
-		Assert.assertEquals(identifier, keyReference.getIdentifier());
+		Assert.assertEquals(keyIdentifier, keyReference.getIdentifier());
 	}
 
 	@Test
 	public void testImportSecretKey() throws Exception {
-		String identifier = RandomTestUtil.randomString();
+		String keyIdentifier = RandomTestUtil.randomString();
 
 		Mockito.when(
 			_cryptoProvider.importSecretKey(
 				Mockito.anyString(), Mockito.anyLong(),
 				Mockito.any(byte[].class), Mockito.anyString())
 		).thenReturn(
-			_cryptoServiceResult(identifier)
+			_getCryptoServiceResult(keyIdentifier)
 		);
 
 		Mockito.when(
@@ -367,12 +368,13 @@ public class CryptoManagerImplTest {
 		CryptoServiceResult<KeyReference> cryptoServiceResult =
 			_cryptoManagerImpl.importSecretKey(
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
-				RandomTestUtil.randomBytes(), _keyReference(cryptoProviderId));
+				RandomTestUtil.randomBytes(),
+				_getKeyReference(cryptoProviderId));
 
 		KeyReference keyReference = cryptoServiceResult.getValue();
 
 		Assert.assertEquals(cryptoProviderId, keyReference.getProviderId());
-		Assert.assertEquals(identifier, keyReference.getIdentifier());
+		Assert.assertEquals(keyIdentifier, keyReference.getIdentifier());
 	}
 
 	@Test
@@ -407,7 +409,7 @@ public class CryptoManagerImplTest {
 			CryptoException.class,
 			() -> _cryptoManagerImpl.importSecretKey(
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
-				keyBytes, _keyReference(cryptoProviderId)));
+				keyBytes, _getKeyReference(cryptoProviderId)));
 
 		for (byte b : keyBytes) {
 			Assert.assertEquals(0, b);
@@ -422,7 +424,7 @@ public class CryptoManagerImplTest {
 			true
 		);
 
-		String unwrappedIdentifier = RandomTestUtil.randomString();
+		String unwrappedKeyIdentifier = RandomTestUtil.randomString();
 
 		Mockito.when(
 			_cryptoProvider.unwrap(
@@ -430,7 +432,7 @@ public class CryptoManagerImplTest {
 				Mockito.anyString(), Mockito.any(byte[].class),
 				Mockito.anyInt())
 		).thenReturn(
-			_cryptoServiceResult(unwrappedIdentifier)
+			_getCryptoServiceResult(unwrappedKeyIdentifier)
 		);
 
 		String cryptoProviderId = RandomTestUtil.randomString();
@@ -443,14 +445,16 @@ public class CryptoManagerImplTest {
 
 		CryptoServiceResult<KeyReference> cryptoServiceResult =
 			_cryptoManagerImpl.unwrap(
-				RandomTestUtil.randomLong(), _keyReference(cryptoProviderId),
-				_keyReference(cryptoProviderId), RandomTestUtil.randomString(),
-				RandomTestUtil.randomBytes(), RandomTestUtil.randomInt());
+				RandomTestUtil.randomLong(), _getKeyReference(cryptoProviderId),
+				_getKeyReference(cryptoProviderId),
+				RandomTestUtil.randomString(), RandomTestUtil.randomBytes(),
+				RandomTestUtil.randomInt());
 
 		KeyReference keyReference = cryptoServiceResult.getValue();
 
 		Assert.assertEquals(cryptoProviderId, keyReference.getProviderId());
-		Assert.assertEquals(unwrappedIdentifier, keyReference.getIdentifier());
+		Assert.assertEquals(
+			unwrappedKeyIdentifier, keyReference.getIdentifier());
 	}
 
 	@Test
@@ -467,7 +471,7 @@ public class CryptoManagerImplTest {
 			_cryptoProvider.wrap(
 				Mockito.anyLong(), Mockito.anyString(), Mockito.anyString())
 		).thenReturn(
-			_cryptoServiceResult(wrappedKeyBytes)
+			_getCryptoServiceResult(wrappedKeyBytes)
 		);
 
 		String cryptoProviderId = RandomTestUtil.randomString();
@@ -480,8 +484,8 @@ public class CryptoManagerImplTest {
 
 		CryptoServiceResult<byte[]> cryptoServiceResult =
 			_cryptoManagerImpl.wrap(
-				RandomTestUtil.randomLong(), _keyReference(cryptoProviderId),
-				_keyReference(cryptoProviderId));
+				RandomTestUtil.randomLong(), _getKeyReference(cryptoProviderId),
+				_getKeyReference(cryptoProviderId));
 
 		Assert.assertSame(wrappedKeyBytes, cryptoServiceResult.getValue());
 	}
@@ -492,37 +496,38 @@ public class CryptoManagerImplTest {
 			CryptoException.class,
 			() -> _cryptoManagerImpl.wrap(
 				RandomTestUtil.randomLong(),
-				_keyReference(RandomTestUtil.randomString()),
-				_keyReference(RandomTestUtil.randomString())));
+				_getKeyReference(RandomTestUtil.randomString()),
+				_getKeyReference(RandomTestUtil.randomString())));
 	}
 
-	private <T> CryptoServiceResult<T> _cryptoServiceResult(T value) {
+	private <T> CryptoServiceResult<T> _getCryptoServiceResult(T value) {
 		return new CryptoServiceResult<>(
 			new ServiceIndicator(true, RandomTestUtil.randomString()), value);
 	}
 
-	private KeyReference _keyReference(String cryptoProviderId) {
-		return _keyReference(cryptoProviderId, RandomTestUtil.randomString());
+	private KeyReference _getKeyReference(String cryptoProviderId) {
+		return _getKeyReference(
+			cryptoProviderId, RandomTestUtil.randomString());
 	}
 
-	private KeyReference _keyReference(
-		String cryptoProviderId, String identifier) {
+	private KeyReference _getKeyReference(
+		String cryptoProviderId, String keyIdentifier) {
 
 		return new KeyReference(
-			identifier, cryptoProviderId, KeyReference.Type.CRYPTO);
+			keyIdentifier, cryptoProviderId, KeyReference.Type.CRYPTO);
 	}
 
 	private void _testEncryptResolvesProviderWildcard(long companyId)
 		throws Exception {
 
-		String identifier = RandomTestUtil.randomString();
+		String keyIdentifier = RandomTestUtil.randomString();
 
 		Mockito.when(
 			_cryptoProvider.encrypt(
-				Mockito.eq(companyId), Mockito.eq(identifier),
+				Mockito.eq(companyId), Mockito.eq(keyIdentifier),
 				Mockito.any(byte[].class))
 		).thenReturn(
-			_cryptoServiceResult(new byte[0])
+			_getCryptoServiceResult(new byte[0])
 		);
 
 		Mockito.when(
@@ -561,7 +566,7 @@ public class CryptoManagerImplTest {
 		);
 
 		_cryptoManagerImpl.encrypt(
-			companyId, _keyReference(StringPool.STAR, identifier),
+			companyId, _getKeyReference(StringPool.STAR, keyIdentifier),
 			RandomTestUtil.randomBytes());
 
 		if (companyId == CompanyConstants.SYSTEM) {

--- a/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImplTest.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImplTest.java
@@ -120,6 +120,40 @@ public class CryptoManagerImplTest {
 	}
 
 	@Test
+	public void testEncrypt() throws Exception {
+		byte[] ciphertext = RandomTestUtil.randomBytes();
+
+		Mockito.when(
+			_cryptoProvider.encrypt(
+				Mockito.anyLong(), Mockito.anyString(),
+				Mockito.any(byte[].class))
+		).thenReturn(
+			_getCryptoServiceResult(ciphertext)
+		);
+
+		Mockito.when(
+			_cryptoProvider.isAllowedCompany(Mockito.anyLong())
+		).thenReturn(
+			true
+		);
+
+		String cryptoProviderId = RandomTestUtil.randomString();
+
+		Mockito.when(
+			_serviceTrackerMap.getService(cryptoProviderId)
+		).thenReturn(
+			Collections.singletonList(_cryptoProvider)
+		);
+
+		CryptoServiceResult<byte[]> cryptoServiceResult =
+			_cryptoManagerImpl.encrypt(
+				RandomTestUtil.randomLong(), _getKeyReference(cryptoProviderId),
+				RandomTestUtil.randomBytes());
+
+		Assert.assertArrayEquals(ciphertext, cryptoServiceResult.getValue());
+	}
+
+	@Test
 	public void testEncryptResolvesProviderWildcard() throws Exception {
 		_testEncryptResolvesProviderWildcard(CompanyConstants.SYSTEM);
 		_testEncryptResolvesProviderWildcard(RandomTestUtil.randomLong());
@@ -278,8 +312,10 @@ public class CryptoManagerImplTest {
 
 	@Test
 	public void testGetCryptoProviderIds() {
+		long companyId = RandomTestUtil.randomLong();
+
 		Mockito.when(
-			_cryptoProvider.isAllowedCompany(Mockito.anyLong())
+			_cryptoProvider.isAllowedCompany(companyId)
 		).thenReturn(
 			true
 		);
@@ -300,8 +336,17 @@ public class CryptoManagerImplTest {
 
 		Assert.assertEquals(
 			Collections.singletonList(cryptoProviderId),
-			_cryptoManagerImpl.getCryptoProviderIds(
-				RandomTestUtil.randomLong()));
+			_cryptoManagerImpl.getCryptoProviderIds(companyId));
+
+		Mockito.when(
+			_cryptoProvider.isAllowedCompany(companyId)
+		).thenReturn(
+			false
+		);
+
+		Assert.assertEquals(
+			Collections.emptyList(),
+			_cryptoManagerImpl.getCryptoProviderIds(companyId));
 	}
 
 	@Test
@@ -335,6 +380,7 @@ public class CryptoManagerImplTest {
 
 		KeyReference keyReference = keyReferences.get(0);
 
+		Assert.assertEquals(KeyReference.Type.CRYPTO, keyReference.getType());
 		Assert.assertEquals(cryptoProviderId, keyReference.getProviderId());
 		Assert.assertEquals(keyIdentifier, keyReference.getIdentifier());
 	}
@@ -365,16 +411,19 @@ public class CryptoManagerImplTest {
 			Collections.singletonList(_cryptoProvider)
 		);
 
+		byte[] keyBytes = RandomTestUtil.randomBytes();
+
 		CryptoServiceResult<KeyReference> cryptoServiceResult =
 			_cryptoManagerImpl.importSecretKey(
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
-				RandomTestUtil.randomBytes(),
-				_getKeyReference(cryptoProviderId));
+				keyBytes, _getKeyReference(cryptoProviderId));
 
 		KeyReference keyReference = cryptoServiceResult.getValue();
 
 		Assert.assertEquals(cryptoProviderId, keyReference.getProviderId());
 		Assert.assertEquals(keyIdentifier, keyReference.getIdentifier());
+
+		Assert.assertArrayEquals(new byte[keyBytes.length], keyBytes);
 	}
 
 	@Test
@@ -411,13 +460,20 @@ public class CryptoManagerImplTest {
 				RandomTestUtil.randomString(), RandomTestUtil.randomLong(),
 				keyBytes, _getKeyReference(cryptoProviderId)));
 
-		for (byte b : keyBytes) {
-			Assert.assertEquals(0, b);
-		}
+		Assert.assertArrayEquals(new byte[keyBytes.length], keyBytes);
 	}
 
 	@Test
 	public void testUnwrap() throws Exception {
+		Assert.assertThrows(
+			CryptoException.class,
+			() -> _cryptoManagerImpl.unwrap(
+				RandomTestUtil.randomLong(),
+				_getKeyReference(RandomTestUtil.randomString()),
+				_getKeyReference(RandomTestUtil.randomString()),
+				RandomTestUtil.randomString(), RandomTestUtil.randomBytes(),
+				RandomTestUtil.randomInt()));
+
 		Mockito.when(
 			_cryptoProvider.isAllowedCompany(Mockito.anyLong())
 		).thenReturn(
@@ -459,6 +515,13 @@ public class CryptoManagerImplTest {
 
 	@Test
 	public void testWrap() throws Exception {
+		Assert.assertThrows(
+			CryptoException.class,
+			() -> _cryptoManagerImpl.wrap(
+				RandomTestUtil.randomLong(),
+				_getKeyReference(RandomTestUtil.randomString()),
+				_getKeyReference(RandomTestUtil.randomString())));
+
 		Mockito.when(
 			_cryptoProvider.isAllowedCompany(Mockito.anyLong())
 		).thenReturn(
@@ -490,16 +553,6 @@ public class CryptoManagerImplTest {
 		Assert.assertSame(wrappedKeyBytes, cryptoServiceResult.getValue());
 	}
 
-	@Test
-	public void testWrapThrowsWhenProvidersDiffer() {
-		Assert.assertThrows(
-			CryptoException.class,
-			() -> _cryptoManagerImpl.wrap(
-				RandomTestUtil.randomLong(),
-				_getKeyReference(RandomTestUtil.randomString()),
-				_getKeyReference(RandomTestUtil.randomString())));
-	}
-
 	private <T> CryptoServiceResult<T> _getCryptoServiceResult(T value) {
 		return new CryptoServiceResult<>(
 			new ServiceIndicator(true, RandomTestUtil.randomString()), value);
@@ -527,7 +580,7 @@ public class CryptoManagerImplTest {
 				Mockito.eq(companyId), Mockito.eq(keyIdentifier),
 				Mockito.any(byte[].class))
 		).thenReturn(
-			_getCryptoServiceResult(new byte[0])
+			_getCryptoServiceResult(RandomTestUtil.randomBytes())
 		);
 
 		Mockito.when(
@@ -571,12 +624,12 @@ public class CryptoManagerImplTest {
 
 		if (companyId == CompanyConstants.SYSTEM) {
 			Mockito.verify(
-				_keyManagerProfile, Mockito.atLeastOnce()
+				_keyManagerProfile
 			).getSystemDEKProviderId();
 		}
 		else {
 			Mockito.verify(
-				_keyManagerProfile, Mockito.atLeastOnce()
+				_keyManagerProfile
 			).getCompanyDEKProviderId();
 		}
 	}

--- a/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImplTest.java
+++ b/modules/apps/portal-security/portal-security-key-impl/src/test/java/com/liferay/portal/security/key/internal/crypto/CryptoManagerImplTest.java
@@ -58,14 +58,14 @@ public class CryptoManagerImplTest {
 
 	@Test
 	public void testDecrypt() throws Exception {
-		byte[] plaintextBytes = RandomTestUtil.randomBytes();
+		byte[] plainText = RandomTestUtil.randomBytes();
 
 		Mockito.when(
 			_cryptoProvider.decrypt(
 				Mockito.any(byte[].class), Mockito.anyLong(),
 				Mockito.anyString())
 		).thenReturn(
-			_cryptoServiceResult(plaintextBytes)
+			_cryptoServiceResult(plainText)
 		);
 
 		Mockito.when(
@@ -87,8 +87,7 @@ public class CryptoManagerImplTest {
 				RandomTestUtil.randomBytes(), RandomTestUtil.randomLong(),
 				_keyReference(cryptoProviderId));
 
-		Assert.assertArrayEquals(
-			plaintextBytes, cryptoServiceResult.getValue());
+		Assert.assertArrayEquals(plainText, cryptoServiceResult.getValue());
 	}
 
 	@Test

--- a/modules/apps/portal-security/portal-security-key-spi/src/main/java/com/liferay/portal/security/key/spi/crypto/CryptoProvider.java
+++ b/modules/apps/portal-security/portal-security-key-spi/src/main/java/com/liferay/portal/security/key/spi/crypto/CryptoProvider.java
@@ -21,14 +21,14 @@ import java.util.List;
 public interface CryptoProvider {
 
 	public CryptoServiceResult<byte[]> decrypt(
-			byte[] cipherText, long companyId, String keyIdentifier)
+			byte[] ciphertext, long companyId, String keyIdentifier)
 		throws CryptoException;
 
 	public void deleteKey(long companyId, String keyIdentifier)
 		throws CryptoException;
 
 	public CryptoServiceResult<byte[]> encrypt(
-			long companyId, String keyIdentifier, byte[] plainText)
+			long companyId, String keyIdentifier, byte[] plaintext)
 		throws CryptoException;
 
 	public CryptoServiceResult<Key> exportKey(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92680

Recreates liferay-appsec/liferay-portal#3166 (closed) — see it for the full description.

Addresses @brianchandotcom's review on the forward brianchandotcom/liferay-portal#179265: the value-returning test factories now carry the `_get` prefix (`_getCryptoServiceResult`, `_getKeyReference`), and the `identifier` parameter and its locals are renamed `keyIdentifier` to match the `CryptoProvider` SPI.

## PR Check

**pr-check: PASS** — tested on `a55fa528082ad0446354f99dd5fd4e4cab2ad0a4`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "a55fa528082ad0446354f99dd5fd4e4cab2ad0a4"} -->
