### PR TITLE
LPD-98644 Fix unresponsive CAPTCHA refresh on JSF portlets

### DIFF
--- a/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
+++ b/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
@@ -9,7 +9,6 @@
 
 <%
 String captchaId = PortalUtil.generateRandomKey(request, "captchaId");
-String refreshCaptchaId = PortalUtil.generateRandomKey(request, "refreshCaptchaId");
 
 String errorMessage = (String)request.getAttribute("liferay-captcha:captcha:errorMessage");
 String url = (String)request.getAttribute("liferay-captcha:captcha:url");
@@ -30,13 +29,12 @@ String namespace = portletDisplay.getNamespace();
 	url = HttpComponentsUtil.addParameter(url, "t", String.valueOf(System.currentTimeMillis()));
 	%>
 
-	<div class="<%= cssClass %>">
-		<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="text-to-identify" />" class="captcha d-inline-block mb-2" id="<portlet:namespace /><%= captchaId %>" src="<%= HtmlUtil.escapeAttribute(url) %>" />
+	<div class="<%= cssClass %>" data-captcha-id="<%= HtmlUtil.escapeAttribute(captchaId) %>">
+		<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="text-to-identify" />" class="captcha d-inline-block mb-2" src="<%= HtmlUtil.escapeAttribute(url) %>" />
 
 		<liferay-ui:icon
 			cssClass="align-top d-inline-block refresh"
 			icon="reload"
-			id="<%= refreshCaptchaId %>"
 			label="<%= false %>"
 			localizeMessage="<%= true %>"
 			markupView="lexicon"
@@ -60,9 +58,15 @@ String namespace = portletDisplay.getNamespace();
 
 	<aui:script>
 		function <%= captchaId %>attachEvent() {
-			var refreshCaptcha = document.getElementById(
-				'<portlet:namespace /><%= refreshCaptchaId %>'
+			var container = document.querySelector(
+				'[data-captcha-id="<%= HtmlUtil.escapeJS(captchaId) %>"]'
 			);
+
+			if (!container) {
+				return;
+			}
+
+			var refreshCaptcha = container.querySelector('.refresh');
 
 			if (refreshCaptcha && !refreshCaptcha.hasEventAttached) {
 				refreshCaptcha.hasEventAttached = true;
@@ -72,9 +76,7 @@ String namespace = portletDisplay.getNamespace();
 						'<%= HtmlUtil.escapeJS(url) %>'
 					);
 
-					var captcha = document.getElementById(
-						'<portlet:namespace /><%= captchaId %>'
-					);
+					var captcha = container.querySelector('.captcha');
 
 					if (captcha) {
 						captcha.setAttribute('src', url);

--- a/modules/test/playwright/tests/captcha-web/main/simplecaptcha.spec.ts
+++ b/modules/test/playwright/tests/captcha-web/main/simplecaptcha.spec.ts
@@ -37,65 +37,76 @@ const test = mergeTests(
 	pageManagementSiteTest
 );
 
-test('LPD-47067 check that two forms on same page with simplecaptcha could refresh both captchas', async ({
-	apiHelpers,
-	captchaConfigPage,
-	formBuilderPage,
-	formBuilderSidePanelPage,
-	formSettingsModalPage,
-	formWidgetPage,
-	page,
-	site,
-	widgetPagePage,
-}) => {
-	await captchaConfigPage.goTo();
+test(
+	'LPD-47067 check that two forms on same page with simplecaptcha could refresh both captchas',
+	{tag: ['@LPD-47067', '@LPD-98644']},
+	async ({
+		apiHelpers,
+		captchaConfigPage,
+		formBuilderPage,
+		formBuilderSidePanelPage,
+		formSettingsModalPage,
+		formWidgetPage,
+		page,
+		site,
+		widgetPagePage,
+	}) => {
+		await captchaConfigPage.goTo();
 
-	await captchaConfigPage.resetCaptchaConfiguration();
+		await captchaConfigPage.resetCaptchaConfiguration();
 
-	await formBuilderPage.goToNew(site.friendlyUrlPath);
+		await formBuilderPage.goToNew(site.friendlyUrlPath);
 
-	await expect(formBuilderPage.newFormHeading).toBeVisible();
+		await expect(formBuilderPage.newFormHeading).toBeVisible();
 
-	const formName = 'Form' + getRandomInt();
+		const formName = 'Form' + getRandomInt();
 
-	await formBuilderPage.fillFormTitle(formName);
+		await formBuilderPage.fillFormTitle(formName);
 
-	await formBuilderSidePanelPage.addFieldByDoubleClick('Text');
+		await formBuilderSidePanelPage.addFieldByDoubleClick('Text');
 
-	await formBuilderPage.formSettingsButton.click();
+		await formBuilderPage.formSettingsButton.click();
 
-	await formBuilderPage.requireCaptchaToggle.click();
+		await formBuilderPage.requireCaptchaToggle.click();
 
-	await formSettingsModalPage.clickDoneButton();
+		await formSettingsModalPage.clickDoneButton();
 
-	await formBuilderPage.publishButton.click();
+		await formBuilderPage.publishButton.click();
 
-	await expect(
-		page.getByText('Your request completed successfully')
-	).toBeVisible();
+		await expect(
+			page.getByText('Your request completed successfully')
+		).toBeVisible();
 
-	const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
-		groupId: site.id,
-		options: {
-			type: 'portlet',
-		},
-		title: getRandomString(),
-	});
+		const layout = await apiHelpers.jsonWebServicesLayout.addLayout({
+			groupId: site.id,
+			options: {
+				type: 'portlet',
+			},
+			title: getRandomString(),
+		});
 
-	await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyURL}`);
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyURL}`);
 
-	await addAndConfigureForms(formName, formWidgetPage, widgetPagePage);
+		await addAndConfigureForms(formName, formWidgetPage, widgetPagePage);
 
-	await refreshAndCheckCaptcha(2, page);
+		const container = page.locator('[data-captcha-id]').first();
 
-	await performLogout(page);
+		await expect(container).toHaveAttribute('data-captcha-id', /.+/);
 
-	await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyURL}`);
+		await expect(container.locator('.captcha')).toBeVisible();
+		await expect(container.locator('.refresh')).toBeVisible();
 
-	await refreshAndCheckCaptcha(2, page);
+		await refreshAndCheckCaptcha(2, page);
 
-	await apiHelpers.jsonWebServicesLayout.deleteLayout(layout.plid);
-});
+		await performLogout(page);
+
+		await page.goto(`/web${site.friendlyUrlPath}${layout.friendlyURL}`);
+
+		await refreshAndCheckCaptcha(2, page);
+
+		await apiHelpers.jsonWebServicesLayout.deleteLayout(layout.plid);
+	}
+);
 
 test('LPD-66742 Check if image refresh works when multiple elements have the modal-body class', async ({
 	apiHelpers,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98644

## What Is Being Fixed

LPD-66742 replaced the CAPTCHA refresh icon's static id ("refreshCaptcha") with a randomly generated one to support multiple CAPTCHAs per page. The external com.liferay.faces.portal library's <portal:captcha> JSF component renders through this same JSP, but injects the portlet namespace into the icon's id via a brittle literal string replace that assumes the id is exactly id="refreshCaptcha". Once the id became random, that replace became a silent no-op, leaving the icon's rendered id un-namespaced and its click handler's element lookup never matching, so refresh silently does nothing.

## How It Is Being Fixed

Scope the refresh-icon and captcha-image DOM lookups via a data-captcha-id attribute on their shared container plus CSS class selectors instead, removing the dependency on id/namespace matching entirely.

We also added a markup regression test in playwright simplecaptcha.spec.ts that directly asserts the presence of the data-captcha-id attribute on the container, as well as the .captcha and .refresh class-based elements inside it, verifying the contract without requiring complex JSF-specific sample modules.

## PR Check

**pr-check: PASS** — tested on 51b7b5ee23ced3c3bce33aef52a2c6a36db5b540

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| JSP Compile | PASS |

<!-- pr-check {"result": "success", "sha": "51b7b5ee23ced3c3bce33aef52a2c6a36db5b540"} -->