### PR TITLE
LPD-100321 Widen SamlSpMessage.samlIdpResponseKey to VARCHAR(256)

### DIFF
--- a/modules/dxp/apps/saml/saml-persistence-service/bnd.bnd
+++ b/modules/dxp/apps/saml/saml-persistence-service/bnd.bnd
@@ -28,6 +28,6 @@ Import-Package:\
 	\
 	*
 Liferay-Releng-Module-Group-Title: SAML
-Liferay-Require-SchemaVersion: 3.2.0
+Liferay-Require-SchemaVersion: 3.2.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/registry/SamlServiceUpgradeStepRegistrator.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/internal/upgrade/registry/SamlServiceUpgradeStepRegistrator.java
@@ -155,6 +155,11 @@ public class SamlServiceUpgradeStepRegistrator
 				"SamlSpAuthRequest", "samlRelayState VARCHAR(2048) null"));
 
 		registry.register("3.1.0", "3.2.0", SamlIbSloMessageTable.create());
+
+		registry.register(
+			"3.2.0", "3.2.1",
+			UpgradeProcessFactory.alterColumnType(
+				"SamlSpMessage", "samlIdpResponseKey", "VARCHAR(256) null"));
 	}
 
 	@Reference

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/model/impl/SamlSpMessageModelImpl.java
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/java/com/liferay/saml/persistence/model/impl/SamlSpMessageModelImpl.java
@@ -75,7 +75,7 @@ public class SamlSpMessageModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table SamlSpMessage (samlSpMessageId LONG not null primary key,companyId LONG,createDate DATE null,samlIdpEntityId VARCHAR(1024) null,expirationDate DATE null,samlIdpResponseKey VARCHAR(75) null)";
+		"create table SamlSpMessage (samlSpMessageId LONG not null primary key,companyId LONG,createDate DATE null,samlIdpEntityId VARCHAR(1024) null,expirationDate DATE null,samlIdpResponseKey VARCHAR(256) null)";
 
 	public static final String TABLE_SQL_DROP = "drop table SamlSpMessage";
 
@@ -741,4 +741,4 @@ public class SamlSpMessageModelImpl
 	private SamlSpMessage _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-402995272
+// LIFERAY-SERVICE-BUILDER-HASH:-1228998859

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -147,7 +147,9 @@
 			<hint-collection name="ENTITY-ID" />
 		</field>
 		<field name="expirationDate" type="Date" />
-		<field name="samlIdpResponseKey" type="String" />
+		<field name="samlIdpResponseKey" type="String">
+			<hint name="max-length">256</hint>
+		</field>
 	</model>
 	<model name="com.liferay.saml.persistence.model.SamlSpSession">
 		<field name="samlSpSessionId" type="long" />

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/indexes.sql
@@ -18,7 +18,7 @@ create index IX_10D77E09 on SamlSpAuthRequest (samlIdpEntityId[$COLUMN_LENGTH:10
 create index IX_61204DD on SamlSpIdpConnection (companyId, samlIdpEntityId[$COLUMN_LENGTH:1024$]);
 
 create index IX_31762094 on SamlSpMessage (expirationDate);
-create index IX_5615F9DD on SamlSpMessage (samlIdpEntityId[$COLUMN_LENGTH:1024$], samlIdpResponseKey[$COLUMN_LENGTH:75$]);
+create index IX_5615F9DD on SamlSpMessage (samlIdpEntityId[$COLUMN_LENGTH:1024$], samlIdpResponseKey[$COLUMN_LENGTH:256$]);
 
 create index IX_C052F506 on SamlSpSession (companyId, sessionIndex[$COLUMN_LENGTH:200$]);
 create index IX_85F532ED on SamlSpSession (jSessionId[$COLUMN_LENGTH:200$]);

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/META-INF/sql/tables.sql
@@ -104,7 +104,7 @@ create table SamlSpMessage (
 	createDate DATE null,
 	samlIdpEntityId VARCHAR(1024) null,
 	expirationDate DATE null,
-	samlIdpResponseKey VARCHAR(75) null
+	samlIdpResponseKey VARCHAR(256) null
 );
 
 create table SamlSpSession (

--- a/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/service.properties
+++ b/modules/dxp/apps/saml/saml-persistence-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.saml.persistence.service
-    build.number=10
-    build.date=1758741168319
+    build.number=11
+    build.date=1785518198937

--- a/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/test/SamlSpMessageLocalServiceTest.java
+++ b/modules/dxp/apps/saml/saml-persistence-test/src/testIntegration/java/com/liferay/saml/persistence/service/test/SamlSpMessageLocalServiceTest.java
@@ -1,0 +1,61 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.saml.persistence.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.saml.persistence.model.SamlSpMessage;
+import com.liferay.saml.persistence.service.SamlSpMessageLocalService;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Regisson Aguiar
+ */
+@RunWith(Arquillian.class)
+public class SamlSpMessageLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testAddSamlSpMessage() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		String samlIdpResponseKey = StringUtil.randomString(256);
+
+		SamlSpMessage samlSpMessage =
+			_samlSpMessageLocalService.addSamlSpMessage(
+				StringUtil.randomString(),
+				new Date(System.currentTimeMillis() + Time.HOUR),
+				samlIdpResponseKey, serviceContext);
+
+		Assert.assertEquals(
+			samlIdpResponseKey, samlSpMessage.getSamlIdpResponseKey());
+	}
+
+	@Inject
+	private SamlSpMessageLocalService _samlSpMessageLocalService;
+
+}


### PR DESCRIPTION
see: https://liferay.atlassian.net/browse/LPD-100321

## Why

A customer's SAML IdP produces Assertion IDs longer than 75 characters. `SamlSpMessage.samlIdpResponseKey`, used for SAML replay protection tracking, stored that value as `VARCHAR(75)`, so those inserts failed. The SAML 2.0 specification does not cap the Assertion ID length, so 75 was an arbitrary internal limit rather than a real constraint.

## Key Changes

- Widens `SamlSpMessage.samlIdpResponseKey` to `VARCHAR(256)` through a new upgrade step (schema version `3.2.0` to `3.2.1`), mirroring the fix applied to `OAuthClientASLocalMetadata.issuer` in **LPD-89144** for the same class of problem.
- Regenerates the Service Builder output (`SamlSpMessageModelImpl`, `tables.sql`, `indexes.sql`, `service.properties`) to match the widened column.
- Adds an integration test that persists a 256 character `samlIdpResponseKey` and asserts it round trips without truncation.
