### PR TITLE
LPD-93274 Add a FIPS application state machine

### DIFF
--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.lpkg.StaticLPKGResolver;
 import com.liferay.portal.kernel.module.framework.ThrowableCollector;
+import com.liferay.portal.kernel.security.fips.FIPSApplicationStateMachineUtil;
 import com.liferay.portal.kernel.security.fips.FIPSModeValidator;
 import com.liferay.portal.kernel.service.BaseLocalService;
 import com.liferay.portal.kernel.service.BaseService;
@@ -207,7 +208,8 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 	@Override
 	public void initFramework() throws Exception {
 		if (PropsValues.FIPS_ENABLED) {
-			FIPSModeValidator.validate();
+			FIPSApplicationStateMachineUtil.selfTest(
+				FIPSModeValidator::validate);
 		}
 
 		if (_log.isDebugEnabled()) {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationState.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationState.java
@@ -1,0 +1,15 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public enum FIPSApplicationState {
+
+	ERROR, INITIALIZING, OPERATIONAL, POWER_OFF, SELF_TEST
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
@@ -39,7 +39,8 @@ public class FIPSApplicationStateMachineUtil {
 		_fipsApplicationStateAtomicReference.updateAndGet(
 			currentFIPSApplicationState -> {
 				Set<FIPSApplicationState> nextFIPSApplicationStates =
-					_allowedTransitions.get(currentFIPSApplicationState);
+					_allowedTransitions.getOrDefault(
+						currentFIPSApplicationState, Set.of());
 
 				if (!nextFIPSApplicationStates.contains(fipsApplicationState)) {
 					throw new IllegalStateException(

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.petra.string.StringBundler;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSApplicationStateMachineUtil {
+
+	public static FIPSApplicationState getFIPSApplicationState() {
+		return _fipsApplicationState;
+	}
+
+	public static void selfTest(Runnable runnable) {
+		transition(FIPSApplicationState.SELF_TEST);
+
+		try {
+			runnable.run();
+		}
+		catch (Throwable throwable) {
+			transition(FIPSApplicationState.ERROR);
+
+			throw throwable;
+		}
+
+		transition(FIPSApplicationState.OPERATIONAL);
+	}
+
+	public static synchronized void transition(
+		FIPSApplicationState fipsApplicationState) {
+
+		Set<FIPSApplicationState> nextFIPSApplicationStates =
+			_allowedTransitions.get(_fipsApplicationState);
+
+		if (!nextFIPSApplicationStates.contains(fipsApplicationState)) {
+			throw new IllegalStateException(
+				StringBundler.concat(
+					"Unable to transition the FIPS application state from \"",
+					_fipsApplicationState, "\" to \"", fipsApplicationState,
+					"\""));
+		}
+
+		_fipsApplicationState = fipsApplicationState;
+	}
+
+	private static final Map<FIPSApplicationState, Set<FIPSApplicationState>>
+		_allowedTransitions = Map.of(
+			FIPSApplicationState.ERROR, Set.of(FIPSApplicationState.POWER_OFF),
+			FIPSApplicationState.INITIALIZING,
+			Set.of(
+				FIPSApplicationState.ERROR, FIPSApplicationState.POWER_OFF,
+				FIPSApplicationState.SELF_TEST),
+			FIPSApplicationState.OPERATIONAL,
+			Set.of(FIPSApplicationState.ERROR, FIPSApplicationState.POWER_OFF),
+			FIPSApplicationState.POWER_OFF, Set.of(),
+			FIPSApplicationState.SELF_TEST,
+			Set.of(
+				FIPSApplicationState.ERROR, FIPSApplicationState.OPERATIONAL,
+				FIPSApplicationState.POWER_OFF));
+	private static volatile FIPSApplicationState _fipsApplicationState =
+		FIPSApplicationState.INITIALIZING;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
@@ -9,6 +9,7 @@ import com.liferay.petra.string.StringBundler;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author Jorge García Jiménez
@@ -16,39 +17,40 @@ import java.util.Set;
 public class FIPSApplicationStateMachineUtil {
 
 	public static FIPSApplicationState getFIPSApplicationState() {
-		return _fipsApplicationState;
+		return _fipsApplicationStateAtomicReference.get();
 	}
 
 	public static void selfTest(Runnable runnable) {
-		transition(FIPSApplicationState.SELF_TEST);
+		_transition(FIPSApplicationState.SELF_TEST);
 
 		try {
 			runnable.run();
 		}
 		catch (Throwable throwable) {
-			transition(FIPSApplicationState.ERROR);
+			_transition(FIPSApplicationState.ERROR);
 
 			throw throwable;
 		}
 
-		transition(FIPSApplicationState.OPERATIONAL);
+		_transition(FIPSApplicationState.OPERATIONAL);
 	}
 
-	public static synchronized void transition(
-		FIPSApplicationState fipsApplicationState) {
+	private static void _transition(FIPSApplicationState fipsApplicationState) {
+		_fipsApplicationStateAtomicReference.updateAndGet(
+			currentFIPSApplicationState -> {
+				Set<FIPSApplicationState> nextFIPSApplicationStates =
+					_allowedTransitions.get(currentFIPSApplicationState);
 
-		Set<FIPSApplicationState> nextFIPSApplicationStates =
-			_allowedTransitions.get(_fipsApplicationState);
+				if (!nextFIPSApplicationStates.contains(fipsApplicationState)) {
+					throw new IllegalStateException(
+						StringBundler.concat(
+							"Unable to transition the FIPS application state ",
+							"from \"", currentFIPSApplicationState, "\" to \"",
+							fipsApplicationState, "\""));
+				}
 
-		if (!nextFIPSApplicationStates.contains(fipsApplicationState)) {
-			throw new IllegalStateException(
-				StringBundler.concat(
-					"Unable to transition the FIPS application state from \"",
-					_fipsApplicationState, "\" to \"", fipsApplicationState,
-					"\""));
-		}
-
-		_fipsApplicationState = fipsApplicationState;
+				return fipsApplicationState;
+			});
 	}
 
 	private static final Map<FIPSApplicationState, Set<FIPSApplicationState>>
@@ -65,7 +67,8 @@ public class FIPSApplicationStateMachineUtil {
 			Set.of(
 				FIPSApplicationState.ERROR, FIPSApplicationState.OPERATIONAL,
 				FIPSApplicationState.POWER_OFF));
-	private static volatile FIPSApplicationState _fipsApplicationState =
-		FIPSApplicationState.INITIALIZING;
+	private static final AtomicReference<FIPSApplicationState>
+		_fipsApplicationStateAtomicReference = new AtomicReference<>(
+			FIPSApplicationState.INITIALIZING);
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -39,88 +39,63 @@ public class FIPSApplicationStateMachineUtilTest {
 
 	@Test
 	public void testTransition() {
-		_assertTransition(
+		_testTransition(
 			FIPSApplicationState.ERROR, FIPSApplicationState.POWER_OFF);
-		_assertTransition(
+		_testTransition(
 			FIPSApplicationState.INITIALIZING, FIPSApplicationState.ERROR);
-		_assertTransition(
+		_testTransition(
 			FIPSApplicationState.INITIALIZING, FIPSApplicationState.POWER_OFF);
-		_assertTransition(
+		_testTransition(
 			FIPSApplicationState.INITIALIZING, FIPSApplicationState.SELF_TEST);
-		_assertTransition(
+		_testTransition(
 			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.ERROR);
-		_assertTransition(
+		_testTransition(
 			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.POWER_OFF);
-		_assertTransition(
+		_testTransition(
 			FIPSApplicationState.SELF_TEST, FIPSApplicationState.ERROR);
-		_assertTransition(
+		_testTransition(
 			FIPSApplicationState.SELF_TEST, FIPSApplicationState.OPERATIONAL);
-		_assertTransition(
+		_testTransition(
 			FIPSApplicationState.SELF_TEST, FIPSApplicationState.POWER_OFF);
 	}
 
 	@Test
 	public void testTransitionWithIllegalState() {
-		_assertIllegalTransition(
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.ERROR, FIPSApplicationState.ERROR);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.ERROR, FIPSApplicationState.INITIALIZING);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.ERROR, FIPSApplicationState.OPERATIONAL);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.ERROR, FIPSApplicationState.SELF_TEST);
+		_testTransitionWithIllegalState(
 			FIPSApplicationState.INITIALIZING,
 			FIPSApplicationState.INITIALIZING);
-		_assertIllegalTransition(
+		_testTransitionWithIllegalState(
 			FIPSApplicationState.INITIALIZING,
 			FIPSApplicationState.OPERATIONAL);
-		_assertIllegalTransition(
+		_testTransitionWithIllegalState(
 			FIPSApplicationState.OPERATIONAL,
 			FIPSApplicationState.INITIALIZING);
-		_assertIllegalTransition(
+		_testTransitionWithIllegalState(
 			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.OPERATIONAL);
-		_assertIllegalTransition(
+		_testTransitionWithIllegalState(
 			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.SELF_TEST);
-		_assertIllegalTransition(
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.POWER_OFF, FIPSApplicationState.ERROR);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.POWER_OFF, FIPSApplicationState.INITIALIZING);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.POWER_OFF, FIPSApplicationState.OPERATIONAL);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.POWER_OFF, FIPSApplicationState.POWER_OFF);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.POWER_OFF, FIPSApplicationState.SELF_TEST);
+		_testTransitionWithIllegalState(
 			FIPSApplicationState.SELF_TEST, FIPSApplicationState.INITIALIZING);
-		_assertIllegalTransition(
+		_testTransitionWithIllegalState(
 			FIPSApplicationState.SELF_TEST, FIPSApplicationState.SELF_TEST);
-	}
-
-	@Test
-	public void testTransitionWithTerminalState() {
-		for (FIPSApplicationState fipsApplicationState :
-				FIPSApplicationState.values()) {
-
-			if (fipsApplicationState != FIPSApplicationState.POWER_OFF) {
-				_assertIllegalTransition(
-					FIPSApplicationState.ERROR, fipsApplicationState);
-			}
-
-			_assertIllegalTransition(
-				FIPSApplicationState.POWER_OFF, fipsApplicationState);
-		}
-	}
-
-	private void _assertIllegalTransition(
-		FIPSApplicationState fromFIPSApplicationState,
-		FIPSApplicationState toFIPSApplicationState) {
-
-		_setFIPSApplicationState(fromFIPSApplicationState);
-
-		Assert.assertThrows(
-			IllegalStateException.class,
-			() -> _transition(toFIPSApplicationState));
-
-		Assert.assertEquals(
-			fromFIPSApplicationState,
-			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
-	}
-
-	private void _assertTransition(
-		FIPSApplicationState fromFIPSApplicationState,
-		FIPSApplicationState toFIPSApplicationState) {
-
-		_setFIPSApplicationState(fromFIPSApplicationState);
-
-		_transition(toFIPSApplicationState);
-
-		Assert.assertEquals(
-			toFIPSApplicationState,
-			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 	}
 
 	private void _setFIPSApplicationState(
@@ -147,6 +122,34 @@ public class FIPSApplicationStateMachineUtilTest {
 
 		Assert.assertEquals(
 			FIPSApplicationState.ERROR,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+	}
+
+	private void _testTransition(
+		FIPSApplicationState fromFIPSApplicationState,
+		FIPSApplicationState toFIPSApplicationState) {
+
+		_setFIPSApplicationState(fromFIPSApplicationState);
+
+		_transition(toFIPSApplicationState);
+
+		Assert.assertEquals(
+			toFIPSApplicationState,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+	}
+
+	private void _testTransitionWithIllegalState(
+		FIPSApplicationState fromFIPSApplicationState,
+		FIPSApplicationState toFIPSApplicationState) {
+
+		_setFIPSApplicationState(fromFIPSApplicationState);
+
+		Assert.assertThrows(
+			IllegalStateException.class,
+			() -> _transition(toFIPSApplicationState));
+
+		Assert.assertEquals(
+			fromFIPSApplicationState,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 	}
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -7,6 +7,8 @@ package com.liferay.portal.kernel.security.fips;
 
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -101,8 +103,7 @@ public class FIPSApplicationStateMachineUtilTest {
 
 		Assert.assertThrows(
 			IllegalStateException.class,
-			() -> FIPSApplicationStateMachineUtil.transition(
-				toFIPSApplicationState));
+			() -> _transition(toFIPSApplicationState));
 
 		Assert.assertEquals(
 			fromFIPSApplicationState,
@@ -115,7 +116,7 @@ public class FIPSApplicationStateMachineUtilTest {
 
 		_setFIPSApplicationState(fromFIPSApplicationState);
 
-		FIPSApplicationStateMachineUtil.transition(toFIPSApplicationState);
+		_transition(toFIPSApplicationState);
 
 		Assert.assertEquals(
 			toFIPSApplicationState,
@@ -125,9 +126,13 @@ public class FIPSApplicationStateMachineUtilTest {
 	private void _setFIPSApplicationState(
 		FIPSApplicationState fipsApplicationState) {
 
-		ReflectionTestUtil.setFieldValue(
-			FIPSApplicationStateMachineUtil.class, "_fipsApplicationState",
-			fipsApplicationState);
+		AtomicReference<FIPSApplicationState>
+			fipsApplicationStateAtomicReference =
+				ReflectionTestUtil.getFieldValue(
+					FIPSApplicationStateMachineUtil.class,
+					"_fipsApplicationStateAtomicReference");
+
+		fipsApplicationStateAtomicReference.set(fipsApplicationState);
 	}
 
 	private void _testSelfTest(RuntimeException runtimeException) {
@@ -143,6 +148,12 @@ public class FIPSApplicationStateMachineUtilTest {
 		Assert.assertEquals(
 			FIPSApplicationState.ERROR,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+	}
+
+	private void _transition(FIPSApplicationState fipsApplicationState) {
+		ReflectionTestUtil.invoke(
+			FIPSApplicationStateMachineUtil.class, "_transition",
+			new Class<?>[] {FIPSApplicationState.class}, fipsApplicationState);
 	}
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -1,0 +1,148 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSApplicationStateMachineUtilTest {
+
+	@Before
+	public void setUp() {
+		_setFIPSApplicationState(FIPSApplicationState.INITIALIZING);
+	}
+
+	@Test
+	public void testSelfTest() {
+		FIPSApplicationStateMachineUtil.selfTest(
+			() -> {
+			});
+
+		Assert.assertEquals(
+			FIPSApplicationState.OPERATIONAL,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		_testSelfTest(new RuntimeException());
+		_testSelfTest(new SecurityException());
+	}
+
+	@Test
+	public void testTransition() {
+		_assertTransition(
+			FIPSApplicationState.ERROR, FIPSApplicationState.POWER_OFF);
+		_assertTransition(
+			FIPSApplicationState.INITIALIZING, FIPSApplicationState.ERROR);
+		_assertTransition(
+			FIPSApplicationState.INITIALIZING, FIPSApplicationState.POWER_OFF);
+		_assertTransition(
+			FIPSApplicationState.INITIALIZING, FIPSApplicationState.SELF_TEST);
+		_assertTransition(
+			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.ERROR);
+		_assertTransition(
+			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.POWER_OFF);
+		_assertTransition(
+			FIPSApplicationState.SELF_TEST, FIPSApplicationState.ERROR);
+		_assertTransition(
+			FIPSApplicationState.SELF_TEST, FIPSApplicationState.OPERATIONAL);
+		_assertTransition(
+			FIPSApplicationState.SELF_TEST, FIPSApplicationState.POWER_OFF);
+	}
+
+	@Test
+	public void testTransitionWithIllegalState() {
+		_assertIllegalTransition(
+			FIPSApplicationState.INITIALIZING,
+			FIPSApplicationState.INITIALIZING);
+		_assertIllegalTransition(
+			FIPSApplicationState.INITIALIZING,
+			FIPSApplicationState.OPERATIONAL);
+		_assertIllegalTransition(
+			FIPSApplicationState.OPERATIONAL,
+			FIPSApplicationState.INITIALIZING);
+		_assertIllegalTransition(
+			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.OPERATIONAL);
+		_assertIllegalTransition(
+			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.SELF_TEST);
+		_assertIllegalTransition(
+			FIPSApplicationState.SELF_TEST, FIPSApplicationState.INITIALIZING);
+		_assertIllegalTransition(
+			FIPSApplicationState.SELF_TEST, FIPSApplicationState.SELF_TEST);
+	}
+
+	@Test
+	public void testTransitionWithTerminalState() {
+		for (FIPSApplicationState fipsApplicationState :
+				FIPSApplicationState.values()) {
+
+			if (fipsApplicationState != FIPSApplicationState.POWER_OFF) {
+				_assertIllegalTransition(
+					FIPSApplicationState.ERROR, fipsApplicationState);
+			}
+
+			_assertIllegalTransition(
+				FIPSApplicationState.POWER_OFF, fipsApplicationState);
+		}
+	}
+
+	private void _assertIllegalTransition(
+		FIPSApplicationState fromFIPSApplicationState,
+		FIPSApplicationState toFIPSApplicationState) {
+
+		_setFIPSApplicationState(fromFIPSApplicationState);
+
+		Assert.assertThrows(
+			IllegalStateException.class,
+			() -> FIPSApplicationStateMachineUtil.transition(
+				toFIPSApplicationState));
+
+		Assert.assertEquals(
+			fromFIPSApplicationState,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+	}
+
+	private void _assertTransition(
+		FIPSApplicationState fromFIPSApplicationState,
+		FIPSApplicationState toFIPSApplicationState) {
+
+		_setFIPSApplicationState(fromFIPSApplicationState);
+
+		FIPSApplicationStateMachineUtil.transition(toFIPSApplicationState);
+
+		Assert.assertEquals(
+			toFIPSApplicationState,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+	}
+
+	private void _setFIPSApplicationState(
+		FIPSApplicationState fipsApplicationState) {
+
+		ReflectionTestUtil.setFieldValue(
+			FIPSApplicationStateMachineUtil.class, "_fipsApplicationState",
+			fipsApplicationState);
+	}
+
+	private void _testSelfTest(RuntimeException runtimeException) {
+		_setFIPSApplicationState(FIPSApplicationState.INITIALIZING);
+
+		Assert.assertThrows(
+			runtimeException.getClass(),
+			() -> FIPSApplicationStateMachineUtil.selfTest(
+				() -> {
+					throw runtimeException;
+				}));
+
+		Assert.assertEquals(
+			FIPSApplicationState.ERROR,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93274

## What Is Being Fixed

Portal called `FIPSModeValidator.validate()` at boot and discarded the outcome. Nothing recorded whether the module was initializing, running its self test, operational, or in error, so no later code could ask what state FIPS was in, and a self test failure left no state behind to act on. ISO/IEC 19790 §7.11.4 [AS11.09] requires the module's operation to be specified as a finite state model, and §7.10 [AS10.07] requires it to enter an error state when a self test fails.

## How It Is Being Fixed

`FIPSApplicationState` declares the five states the module can occupy and `FIPSApplicationStateMachineUtil` owns the current one. The allowed edges live in a `Map`, and a move that is not in the table throws an `IllegalStateException` and leaves the state unchanged. `ERROR` exits only to `POWER_OFF` and `POWER_OFF` is terminal, so a module that fails its self test cannot be walked back into service without a restart.

`selfTest(Runnable)` is the only public mutator. It moves to `SELF_TEST`, runs the supplied check, and lands on `OPERATIONAL` or, on any `Throwable`, on `ERROR` before rethrowing. That makes the self test the unit of exclusion: only one thread can leave `INITIALIZING`, so the winner owns the whole sequence while a second caller is rejected by the table itself. State lives in an `AtomicReference` rather than behind `static synchronized`, because the self test reaches a `Class.forName` into the BC-FIPS provider's classloader during framework startup and a publicly reachable class monitor would let unrelated code stall every transition, including the one into `ERROR`.

`ModuleFrameworkImpl.initFramework()` drives it, passing `FIPSModeValidator::validate` as the self test when `PropsValues.FIPS_ENABLED` is set.

This supersedes #3149. Since that review the state machine collapsed into the util class, the lock became an `AtomicReference`, an unmapped state reports an illegal move instead of throwing `NullPointerException`, and the illegal transition tests merged into one method covering all 16 illegal edges.

## PR Check

**pr-check: PASS** — tested on `4c0a6685038e46117e90caee622eb46b624be245`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "4c0a6685038e46117e90caee622eb46b624be245"} -->
