### PR TITLE
LPD-98129 Fix groupId and timestamp in audit log serialization

### DIFF
--- a/portal-impl/test/unit/com/liferay/portal/kernel/audit/AuditMessageTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/audit/AuditMessageTest.java
@@ -1,0 +1,80 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.audit;
+
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.text.DateFormat;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class AuditMessageTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testToJSONObject() throws Exception {
+		long groupId = RandomTestUtil.randomLong();
+
+		Date timestamp = RandomTestUtil.nextDate();
+
+		AuditMessage auditMessage = new AuditMessage(
+			groupId, RandomTestUtil.randomLong(), RandomTestUtil.randomLong(),
+			RandomTestUtil.randomString(), timestamp,
+			JSONFactoryUtil.createJSONObject(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString());
+
+		JSONObject jsonObject = auditMessage.toJSONObject();
+
+		DateFormat dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyyMMddkkmmssSSS");
+
+		Assert.assertEquals(groupId, jsonObject.getLong("groupId"));
+		Assert.assertEquals(
+			dateFormat.format(timestamp), jsonObject.getString("timestamp"));
+
+		AuditMessage deserializedAuditMessage = new AuditMessage(
+			jsonObject.toString());
+
+		Assert.assertEquals(groupId, deserializedAuditMessage.getGroupId());
+		Assert.assertEquals(
+			dateFormat.format(timestamp),
+			dateFormat.format(deserializedAuditMessage.getTimestamp()));
+
+		auditMessage.setTimestamp(null);
+
+		long beforeTime = System.currentTimeMillis();
+
+		jsonObject = auditMessage.toJSONObject();
+
+		long afterTime = System.currentTimeMillis();
+
+		Date fallbackTimestamp = GetterUtil.getDate(
+			jsonObject.getString("timestamp"), dateFormat);
+
+		Assert.assertTrue(
+			(fallbackTimestamp.getTime() >= beforeTime) &&
+			(fallbackTimestamp.getTime() <= afterTime));
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessage.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessage.java
@@ -377,6 +377,8 @@ public class AuditMessage implements Serializable {
 		).put(
 			_EVENT_TYPE, _eventType
 		).put(
+			_GROUP_ID, _groupId
+		).put(
 			_MESSAGE, _message
 		).put(
 			_SERVER_NAME, _serverName
@@ -385,7 +387,9 @@ public class AuditMessage implements Serializable {
 		).put(
 			_SESSION_ID, _sessionID
 		).put(
-			_TIMESTAMP, _getDateFormat().format(new Date())
+			_TIMESTAMP,
+			_getDateFormat().format(
+				(_timestamp != null) ? _timestamp : new Date())
 		).put(
 			_USER_EMAIL_ADDRESS, _userEmailAddress
 		).put(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98129

## Why

AuditMessage.toJSONObject() is the single method that serializes an audited event into the JSON and CSV output consumed by the Logging audit processor, and it had two defects. It never wrote the groupId key even though the JSON round trip constructor already reads that key back, so groupId was missing from every JSON and CSV audit log entry and came back as 0 after a round trip. It also formatted a fresh new Date() instead of the message's own timestamp, so the logged time reflected when the log line was serialized rather than when the audited action actually happened. Both defects were isolated to this method; the database path (AuditEventLocalServiceImpl._toAuditEvent) reads the AuditMessage getters directly and was never affected.

## Key Changes

AuditMessage.toJSONObject() now writes the groupId key with the existing _GROUP_ID constant and formats the event's own _timestamp, falling back to the current time only when it is null, instead of always calling new Date(). AuditMessageTest exercises toJSONObject() directly, including a round trip that would regress without the fix, and CSVLogMessageFormatterTest exercises the same defect through the real CSVLogMessageFormatter, confirming a groupId column is included when configured and stays absent otherwise since CSVLogMessageFormatterConfiguration keeps it opt in. The router module's build.gradle gains test only dependencies needed to run that formatter outside of an OSGi container.

## PR Check

**pr-check: PASS** — tested on `45a422457a792ed82e1cc5ac4773c2fe9f63f725`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "45a422457a792ed82e1cc5ac4773c2fe9f63f725"} -->
