### PR TITLE
[FIPS] LPD-98488 Encrypt the OAuth 2.0 client credential at rest via SecretManager

### DIFF
--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
@@ -607,7 +607,9 @@ public class AnalyticsBatchExportImportManagerImpl
 
 		options.addPart("oAuthClientId", oAuth2Application.getClientId());
 		options.addPart(
-			"oAuthClientSecret", oAuth2Application.getClientSecret());
+			"oAuthClientSecret",
+			_oAuth2ApplicationLocalService.resolveClientSecret(
+				oAuth2Application));
 
 		JSONObject jsonObject = _jsonFactory.createJSONObject(
 			new String(Base64.decode(analyticsConfiguration.token())));

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/client/AnalyticsCloudClient.java
@@ -167,7 +167,9 @@ public class AnalyticsCloudClient {
 		options.addPart("name", company.getName());
 		options.addPart("oAuthClientId", oAuth2Application.getClientId());
 		options.addPart(
-			"oAuthClientSecret", oAuth2Application.getClientSecret());
+			"oAuthClientSecret",
+			_oAuth2ApplicationLocalService.resolveClientSecret(
+				oAuth2Application));
 		options.addPart("portalURL", company.getPortalURL(0));
 		options.addPart("token", connectionTokenJSONObject.getString("token"));
 		options.setLocation(connectionTokenJSONObject.getString("url"));

--- a/modules/apps/oauth2-provider/oauth2-provider-api/bnd.bnd
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay OAuth2 Provider API
 Bundle-SymbolicName: com.liferay.oauth2.provider.api
-Bundle-Version: 20.1.1
+Bundle-Version: 20.2.0
 Export-Package:\
 	com.liferay.oauth2.provider.configuration,\
 	com.liferay.oauth2.provider.constants,\

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationModel.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationModel.java
@@ -330,6 +330,21 @@ public interface OAuth2ApplicationModel
 	public void setClientSecret(String clientSecret);
 
 	/**
+	 * Returns the client secret key reference of this o auth2 application.
+	 *
+	 * @return the client secret key reference of this o auth2 application
+	 */
+	@AutoEscape
+	public String getClientSecretKeyReference();
+
+	/**
+	 * Sets the client secret key reference of this o auth2 application.
+	 *
+	 * @param clientSecretKeyReference the client secret key reference of this o auth2 application
+	 */
+	public void setClientSecretKeyReference(String clientSecretKeyReference);
+
+	/**
 	 * Returns the description of this o auth2 application.
 	 *
 	 * @return the description of this o auth2 application
@@ -498,4 +513,4 @@ public interface OAuth2ApplicationModel
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1896141665
+// LIFERAY-SERVICE-BUILDER-HASH:1598805331

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationTable.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationTable.java
@@ -73,6 +73,10 @@ public class OAuth2ApplicationTable extends BaseTable<OAuth2ApplicationTable> {
 	public final Column<OAuth2ApplicationTable, String> clientSecret =
 		createColumn(
 			"clientSecret", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<OAuth2ApplicationTable, String>
+		clientSecretKeyReference = createColumn(
+			"clientSecretKeyReference", String.class, Types.VARCHAR,
+			Column.FLAG_DEFAULT);
 	public final Column<OAuth2ApplicationTable, String> description =
 		createColumn(
 			"description", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
@@ -109,4 +113,4 @@ public class OAuth2ApplicationTable extends BaseTable<OAuth2ApplicationTable> {
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1631243351
+// LIFERAY-SERVICE-BUILDER-HASH:1723588236

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/model/OAuth2ApplicationWrapper.java
@@ -54,6 +54,8 @@ public class OAuth2ApplicationWrapper
 		attributes.put("clientId", getClientId());
 		attributes.put("clientProfile", getClientProfile());
 		attributes.put("clientSecret", getClientSecret());
+		attributes.put(
+			"clientSecretKeyReference", getClientSecretKeyReference());
 		attributes.put("description", getDescription());
 		attributes.put("features", getFeatures());
 		attributes.put("homePageURL", getHomePageURL());
@@ -169,6 +171,13 @@ public class OAuth2ApplicationWrapper
 
 		if (clientSecret != null) {
 			setClientSecret(clientSecret);
+		}
+
+		String clientSecretKeyReference = (String)attributes.get(
+			"clientSecretKeyReference");
+
+		if (clientSecretKeyReference != null) {
+			setClientSecretKeyReference(clientSecretKeyReference);
 		}
 
 		String description = (String)attributes.get("description");
@@ -323,6 +332,16 @@ public class OAuth2ApplicationWrapper
 	@Override
 	public String getClientSecret() {
 		return model.getClientSecret();
+	}
+
+	/**
+	 * Returns the client secret key reference of this o auth2 application.
+	 *
+	 * @return the client secret key reference of this o auth2 application
+	 */
+	@Override
+	public String getClientSecretKeyReference() {
+		return model.getClientSecretKeyReference();
 	}
 
 	/**
@@ -661,6 +680,16 @@ public class OAuth2ApplicationWrapper
 	}
 
 	/**
+	 * Sets the client secret key reference of this o auth2 application.
+	 *
+	 * @param clientSecretKeyReference the client secret key reference of this o auth2 application
+	 */
+	@Override
+	public void setClientSecretKeyReference(String clientSecretKeyReference) {
+		model.setClientSecretKeyReference(clientSecretKeyReference);
+	}
+
+	/**
 	 * Sets the company ID of this o auth2 application.
 	 *
 	 * @param companyId the company ID of this o auth2 application
@@ -901,4 +930,4 @@ public class OAuth2ApplicationWrapper
 	}
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-237298256
+// LIFERAY-SERVICE-BUILDER-HASH:-912346748

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
@@ -361,6 +361,9 @@ public interface OAuth2ApplicationLocalService
 	public PersistedModel getPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
 
+	public String resolveClientSecret(OAuth2Application oAuth2Application)
+		throws PortalException;
+
 	@Indexable(type = IndexableType.REINDEX)
 	public OAuth2Application updateExternalReferenceCode(
 			long oAuth2ApplicationId, String externalReferenceCode)
@@ -406,4 +409,4 @@ public interface OAuth2ApplicationLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-615932762
+// LIFERAY-SERVICE-BUILDER-HASH:-613623196

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
@@ -465,6 +465,13 @@ public class OAuth2ApplicationLocalServiceUtil {
 		return getService().getPersistedModel(primaryKeyObj);
 	}
 
+	public static String resolveClientSecret(
+			OAuth2Application oAuth2Application)
+		throws PortalException {
+
+		return getService().resolveClientSecret(oAuth2Application);
+	}
+
 	public static OAuth2Application updateExternalReferenceCode(
 			long oAuth2ApplicationId, String externalReferenceCode)
 		throws PortalException {
@@ -544,4 +551,4 @@ public class OAuth2ApplicationLocalServiceUtil {
 			OAuth2ApplicationLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1677176149
+// LIFERAY-SERVICE-BUILDER-HASH:1893607907

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
@@ -532,6 +532,16 @@ public class OAuth2ApplicationLocalServiceWrapper
 	}
 
 	@Override
+	public String resolveClientSecret(
+			com.liferay.oauth2.provider.model.OAuth2Application
+				oAuth2Application)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _oAuth2ApplicationLocalService.resolveClientSecret(
+			oAuth2Application);
+	}
+
+	@Override
 	public com.liferay.oauth2.provider.model.OAuth2Application
 			updateExternalReferenceCode(
 				long oAuth2ApplicationId, String externalReferenceCode)
@@ -637,4 +647,4 @@ public class OAuth2ApplicationLocalServiceWrapper
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:682669637
+// LIFERAY-SERVICE-BUILDER-HASH:1985616372

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/model/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/model/packageinfo
@@ -1,1 +1,1 @@
-version 4.3.0
+version 4.4.0

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -845,7 +845,7 @@ public class LiferayOAuthDataProvider
 
 		if (oAuth2Application != null) {
 			clientId = oAuth2Application.getClientId();
-			clientSecret = oAuth2Application.getClientSecret();
+			clientSecret = _resolveClientSecret(oAuth2Application);
 			externalReferenceCode =
 				oAuth2Application.getExternalReferenceCode();
 		}
@@ -1541,7 +1541,7 @@ public class LiferayOAuthDataProvider
 	private Client _populateClient(
 		OAuth2Application oAuth2Application, MessageContext messageContext) {
 
-		String clientSecret = oAuth2Application.getClientSecret();
+		String clientSecret = _resolveClientSecret(oAuth2Application);
 
 		if (Validator.isBlank(clientSecret)) {
 			clientSecret = null;
@@ -1702,6 +1702,16 @@ public class LiferayOAuthDataProvider
 			String.valueOf(companyId));
 
 		return userSubject;
+	}
+
+	private String _resolveClientSecret(OAuth2Application oAuth2Application) {
+		try {
+			return _oAuth2ApplicationLocalService.resolveClientSecret(
+				oAuth2Application);
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
 	}
 
 	private long _toCXFTime(Date dateCreated) {

--- a/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay OAuth2 Provider Service
 Bundle-SymbolicName: com.liferay.oauth2.provider.service
 Bundle-Version: 4.0.113
-Liferay-Require-SchemaVersion: 5.0.0
+Liferay-Require-SchemaVersion: 5.1.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/oauth2-provider/oauth2-provider-service/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-liferay-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-spi")
 	compileOnly project(":apps:portal-remote:portal-remote-jaxrs-whiteboard")
+	compileOnly project(":apps:portal-security:portal-security-key-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")
 	compileOnly project(":apps:static:osgi:osgi-util")

--- a/modules/apps/oauth2-provider/oauth2-provider-service/service.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/service.xml
@@ -27,6 +27,7 @@
 		<column name="clientId" type="String" />
 		<column name="clientProfile" type="int" />
 		<column name="clientSecret" type="String" />
+		<column name="clientSecretKeyReference" type="String" />
 		<column name="description" type="String" />
 		<column name="features" type="String" />
 		<column name="homePageURL" type="String" />

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
@@ -10,6 +10,7 @@ import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
@@ -97,7 +98,8 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 				oAuth2Application.getClientId()
 			).put(
 				externalReferenceCode + ".oauth2.headless.server.client.secret",
-				oAuth2Application.getClientSecret()
+				_oAuth2ApplicationLocalService.resolveClientSecret(
+					oAuth2Application)
 			).put(
 				externalReferenceCode + ".oauth2.headless.server.scopes",
 				StringUtil.merge(scopeAliasesList, StringPool.NEW_LINE)
@@ -133,7 +135,8 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 			serviceUser = userLocalService.getUserById(
 				companyId, oAuth2Application.getClientCredentialUserId());
 			clientId = oAuth2Application.getClientId();
-			clientSecret = oAuth2Application.getClientSecret();
+			clientSecret = _oAuth2ApplicationLocalService.resolveClientSecret(
+				oAuth2Application);
 		}
 		else {
 			serviceUser = _getServiceUser(
@@ -218,6 +221,9 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		OAuth2ProviderApplicationHeadlessServerConfigurationFactory.class);
+
+	@Reference
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 	@Reference
 	private ScopeLocator _scopeLocator;

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/upgrade/registry/OAuth2ServiceUpgradeStepRegistrator.java
@@ -154,6 +154,12 @@ public class OAuth2ServiceUpgradeStepRegistrator
 			"4.2.8", "5.0.0",
 			new com.liferay.oauth2.provider.internal.upgrade.v5_0_0.
 				OAuth2ApplicationIndexedColumnSizeUpgradeProcess());
+
+		registry.register(
+			"5.0.0", "5.1.0",
+			UpgradeProcessFactory.addColumns(
+				"OAuth2Application",
+				"clientSecretKeyReference VARCHAR(75) null"));
 	}
 
 	@Reference

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationCacheModel.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationCacheModel.java
@@ -55,7 +55,7 @@ public class OAuth2ApplicationCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(53);
+		StringBundler sb = new StringBundler(55);
 
 		sb.append("{uuid=");
 		sb.append(uuid);
@@ -89,6 +89,8 @@ public class OAuth2ApplicationCacheModel
 		sb.append(clientProfile);
 		sb.append(", clientSecret=");
 		sb.append(clientSecret);
+		sb.append(", clientSecretKeyReference=");
+		sb.append(clientSecretKeyReference);
 		sb.append(", description=");
 		sb.append(description);
 		sb.append(", features=");
@@ -203,6 +205,14 @@ public class OAuth2ApplicationCacheModel
 			oAuth2ApplicationImpl.setClientSecret(clientSecret);
 		}
 
+		if (clientSecretKeyReference == null) {
+			oAuth2ApplicationImpl.setClientSecretKeyReference("");
+		}
+		else {
+			oAuth2ApplicationImpl.setClientSecretKeyReference(
+				clientSecretKeyReference);
+		}
+
 		if (description == null) {
 			oAuth2ApplicationImpl.setDescription("");
 		}
@@ -286,6 +296,7 @@ public class OAuth2ApplicationCacheModel
 
 		clientProfile = objectInput.readInt();
 		clientSecret = objectInput.readUTF();
+		clientSecretKeyReference = objectInput.readUTF();
 		description = objectInput.readUTF();
 		features = objectInput.readUTF();
 		homePageURL = objectInput.readUTF();
@@ -374,6 +385,13 @@ public class OAuth2ApplicationCacheModel
 			objectOutput.writeUTF(clientSecret);
 		}
 
+		if (clientSecretKeyReference == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(clientSecretKeyReference);
+		}
+
 		if (description == null) {
 			objectOutput.writeUTF("");
 		}
@@ -446,6 +464,7 @@ public class OAuth2ApplicationCacheModel
 	public String clientId;
 	public int clientProfile;
 	public String clientSecret;
+	public String clientSecretKeyReference;
 	public String description;
 	public String features;
 	public String homePageURL;
@@ -458,4 +477,4 @@ public class OAuth2ApplicationCacheModel
 	public boolean trustedApplication;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1038855590
+// LIFERAY-SERVICE-BUILDER-HASH:-514669466

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationModelImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/model/impl/OAuth2ApplicationModelImpl.java
@@ -74,12 +74,13 @@ public class OAuth2ApplicationModelImpl
 		{"clientCredentialUserId", Types.BIGINT},
 		{"clientCredentialUserName", Types.VARCHAR},
 		{"clientId", Types.VARCHAR}, {"clientProfile", Types.INTEGER},
-		{"clientSecret", Types.VARCHAR}, {"description", Types.VARCHAR},
-		{"features", Types.VARCHAR}, {"homePageURL", Types.VARCHAR},
-		{"iconFileEntryId", Types.BIGINT}, {"jwks", Types.VARCHAR},
-		{"name", Types.VARCHAR}, {"privacyPolicyURL", Types.VARCHAR},
-		{"redirectURIs", Types.VARCHAR}, {"rememberDevice", Types.BOOLEAN},
-		{"trustedApplication", Types.BOOLEAN}
+		{"clientSecret", Types.VARCHAR},
+		{"clientSecretKeyReference", Types.VARCHAR},
+		{"description", Types.VARCHAR}, {"features", Types.VARCHAR},
+		{"homePageURL", Types.VARCHAR}, {"iconFileEntryId", Types.BIGINT},
+		{"jwks", Types.VARCHAR}, {"name", Types.VARCHAR},
+		{"privacyPolicyURL", Types.VARCHAR}, {"redirectURIs", Types.VARCHAR},
+		{"rememberDevice", Types.BOOLEAN}, {"trustedApplication", Types.BOOLEAN}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -102,6 +103,7 @@ public class OAuth2ApplicationModelImpl
 		TABLE_COLUMNS_MAP.put("clientId", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("clientProfile", Types.INTEGER);
 		TABLE_COLUMNS_MAP.put("clientSecret", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("clientSecretKeyReference", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("description", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("features", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("homePageURL", Types.VARCHAR);
@@ -115,7 +117,7 @@ public class OAuth2ApplicationModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table OAuth2Application (uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(500) null,oAuth2ApplicationId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,oA2AScopeAliasesId LONG,allowedGrantTypes VARCHAR(128) null,clientAuthenticationMethod VARCHAR(75) null,clientCredentialUserId LONG,clientCredentialUserName VARCHAR(75) null,clientId VARCHAR(75) null,clientProfile INTEGER,clientSecret VARCHAR(75) null,description STRING null,features STRING null,homePageURL STRING null,iconFileEntryId LONG,jwks VARCHAR(3999) null,name VARCHAR(255) null,privacyPolicyURL STRING null,redirectURIs STRING null,rememberDevice BOOLEAN,trustedApplication BOOLEAN)";
+		"create table OAuth2Application (uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(500) null,oAuth2ApplicationId LONG not null primary key,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,oA2AScopeAliasesId LONG,allowedGrantTypes VARCHAR(128) null,clientAuthenticationMethod VARCHAR(75) null,clientCredentialUserId LONG,clientCredentialUserName VARCHAR(75) null,clientId VARCHAR(75) null,clientProfile INTEGER,clientSecret VARCHAR(75) null,clientSecretKeyReference VARCHAR(75) null,description STRING null,features STRING null,homePageURL STRING null,iconFileEntryId LONG,jwks VARCHAR(3999) null,name VARCHAR(255) null,privacyPolicyURL STRING null,redirectURIs STRING null,rememberDevice BOOLEAN,trustedApplication BOOLEAN)";
 
 	public static final String TABLE_SQL_DROP = "drop table OAuth2Application";
 
@@ -323,6 +325,9 @@ public class OAuth2ApplicationModelImpl
 			attributeGetterFunctions.put(
 				"clientSecret", OAuth2Application::getClientSecret);
 			attributeGetterFunctions.put(
+				"clientSecretKeyReference",
+				OAuth2Application::getClientSecretKeyReference);
+			attributeGetterFunctions.put(
 				"description", OAuth2Application::getDescription);
 			attributeGetterFunctions.put(
 				"features", OAuth2Application::getFeatures);
@@ -422,6 +427,10 @@ public class OAuth2ApplicationModelImpl
 				"clientSecret",
 				(BiConsumer<OAuth2Application, String>)
 					OAuth2Application::setClientSecret);
+			attributeSetterBiConsumers.put(
+				"clientSecretKeyReference",
+				(BiConsumer<OAuth2Application, String>)
+					OAuth2Application::setClientSecretKeyReference);
 			attributeSetterBiConsumers.put(
 				"description",
 				(BiConsumer<OAuth2Application, String>)
@@ -841,6 +850,26 @@ public class OAuth2ApplicationModelImpl
 
 	@JSON
 	@Override
+	public String getClientSecretKeyReference() {
+		if (_clientSecretKeyReference == null) {
+			return "";
+		}
+		else {
+			return _clientSecretKeyReference;
+		}
+	}
+
+	@Override
+	public void setClientSecretKeyReference(String clientSecretKeyReference) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_clientSecretKeyReference = clientSecretKeyReference;
+	}
+
+	@JSON
+	@Override
 	public String getDescription() {
 		if (_description == null) {
 			return "";
@@ -1120,6 +1149,8 @@ public class OAuth2ApplicationModelImpl
 		oAuth2ApplicationImpl.setClientId(getClientId());
 		oAuth2ApplicationImpl.setClientProfile(getClientProfile());
 		oAuth2ApplicationImpl.setClientSecret(getClientSecret());
+		oAuth2ApplicationImpl.setClientSecretKeyReference(
+			getClientSecretKeyReference());
 		oAuth2ApplicationImpl.setDescription(getDescription());
 		oAuth2ApplicationImpl.setFeatures(getFeatures());
 		oAuth2ApplicationImpl.setHomePageURL(getHomePageURL());
@@ -1173,6 +1204,8 @@ public class OAuth2ApplicationModelImpl
 			this.<Integer>getColumnOriginalValue("clientProfile"));
 		oAuth2ApplicationImpl.setClientSecret(
 			this.<String>getColumnOriginalValue("clientSecret"));
+		oAuth2ApplicationImpl.setClientSecretKeyReference(
+			this.<String>getColumnOriginalValue("clientSecretKeyReference"));
 		oAuth2ApplicationImpl.setDescription(
 			this.<String>getColumnOriginalValue("description"));
 		oAuth2ApplicationImpl.setFeatures(
@@ -1381,6 +1414,18 @@ public class OAuth2ApplicationModelImpl
 			oAuth2ApplicationCacheModel.clientSecret = null;
 		}
 
+		oAuth2ApplicationCacheModel.clientSecretKeyReference =
+			getClientSecretKeyReference();
+
+		String clientSecretKeyReference =
+			oAuth2ApplicationCacheModel.clientSecretKeyReference;
+
+		if ((clientSecretKeyReference != null) &&
+			(clientSecretKeyReference.length() == 0)) {
+
+			oAuth2ApplicationCacheModel.clientSecretKeyReference = null;
+		}
+
 		oAuth2ApplicationCacheModel.description = getDescription();
 
 		String description = oAuth2ApplicationCacheModel.description;
@@ -1522,6 +1567,7 @@ public class OAuth2ApplicationModelImpl
 	private String _clientId;
 	private int _clientProfile;
 	private String _clientSecret;
+	private String _clientSecretKeyReference;
 	private String _description;
 	private String _features;
 	private String _homePageURL;
@@ -1584,6 +1630,8 @@ public class OAuth2ApplicationModelImpl
 		_columnOriginalValues.put("clientId", _clientId);
 		_columnOriginalValues.put("clientProfile", _clientProfile);
 		_columnOriginalValues.put("clientSecret", _clientSecret);
+		_columnOriginalValues.put(
+			"clientSecretKeyReference", _clientSecretKeyReference);
 		_columnOriginalValues.put("description", _description);
 		_columnOriginalValues.put("features", _features);
 		_columnOriginalValues.put("homePageURL", _homePageURL);
@@ -1651,25 +1699,27 @@ public class OAuth2ApplicationModelImpl
 
 		columnBitmasks.put("clientSecret", 32768L);
 
-		columnBitmasks.put("description", 65536L);
+		columnBitmasks.put("clientSecretKeyReference", 65536L);
 
-		columnBitmasks.put("features", 131072L);
+		columnBitmasks.put("description", 131072L);
 
-		columnBitmasks.put("homePageURL", 262144L);
+		columnBitmasks.put("features", 262144L);
 
-		columnBitmasks.put("iconFileEntryId", 524288L);
+		columnBitmasks.put("homePageURL", 524288L);
 
-		columnBitmasks.put("jwks", 1048576L);
+		columnBitmasks.put("iconFileEntryId", 1048576L);
 
-		columnBitmasks.put("name", 2097152L);
+		columnBitmasks.put("jwks", 2097152L);
 
-		columnBitmasks.put("privacyPolicyURL", 4194304L);
+		columnBitmasks.put("name", 4194304L);
 
-		columnBitmasks.put("redirectURIs", 8388608L);
+		columnBitmasks.put("privacyPolicyURL", 8388608L);
 
-		columnBitmasks.put("rememberDevice", 16777216L);
+		columnBitmasks.put("redirectURIs", 16777216L);
 
-		columnBitmasks.put("trustedApplication", 33554432L);
+		columnBitmasks.put("rememberDevice", 33554432L);
+
+		columnBitmasks.put("trustedApplication", 67108864L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}
@@ -1678,4 +1728,4 @@ public class OAuth2ApplicationModelImpl
 	private OAuth2Application _escapedModel;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-123573437
+// LIFERAY-SERVICE-BUILDER-HASH:176044529

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -34,12 +34,15 @@ import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
 import com.liferay.oauth2.provider.util.builder.OAuth2ScopeBuilder;
 import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
 import com.liferay.petra.io.unsync.UnsyncByteArrayOutputStream;
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.image.ImageToolUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.ImageTypeException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.image.ImageBag;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Repository;
@@ -61,6 +64,9 @@ import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.security.key.KeyReference;
+import com.liferay.portal.security.key.secret.Secret;
+import com.liferay.portal.security.key.secret.SecretManager;
 
 import java.awt.image.RenderedImage;
 
@@ -155,7 +161,6 @@ public class OAuth2ApplicationLocalServiceImpl
 		oAuth2Application.setClientCredentialUserName(user.getScreenName());
 		oAuth2Application.setClientId(clientId);
 		oAuth2Application.setClientProfile(clientProfile);
-		oAuth2Application.setClientSecret(clientSecret);
 		oAuth2Application.setDescription(description);
 		oAuth2Application.setFeaturesList(featuresList);
 		oAuth2Application.setHomePageURL(homePageURL);
@@ -183,6 +188,8 @@ public class OAuth2ApplicationLocalServiceImpl
 			oAuth2Application.getCompanyId(), 0, oAuth2Application.getUserId(),
 			OAuth2Application.class.getName(),
 			oAuth2Application.getOAuth2ApplicationId(), false, false, false);
+
+		_setClientSecret(oAuth2Application, clientSecret);
 
 		return oAuth2ApplicationPersistence.update(oAuth2Application);
 	}
@@ -253,7 +260,6 @@ public class OAuth2ApplicationLocalServiceImpl
 		oAuth2Application.setClientCredentialUserName(user.getScreenName());
 		oAuth2Application.setClientId(clientId);
 		oAuth2Application.setClientProfile(clientProfile);
-		oAuth2Application.setClientSecret(clientSecret);
 		oAuth2Application.setDescription(description);
 		oAuth2Application.setFeaturesList(featuresList);
 		oAuth2Application.setHomePageURL(homePageURL);
@@ -281,6 +287,8 @@ public class OAuth2ApplicationLocalServiceImpl
 			oAuth2Application.getCompanyId(), 0, oAuth2Application.getUserId(),
 			OAuth2Application.class.getName(),
 			oAuth2Application.getOAuth2ApplicationId(), false, false, false);
+
+		_setClientSecret(oAuth2Application, clientSecret);
 
 		return oAuth2ApplicationPersistence.update(oAuth2Application);
 	}
@@ -485,6 +493,32 @@ public class OAuth2ApplicationLocalServiceImpl
 			companyId, clientProfile);
 	}
 
+	public String resolveClientSecret(OAuth2Application oAuth2Application)
+		throws PortalException {
+
+		String clientSecretKeyReference =
+			oAuth2Application.getClientSecretKeyReference();
+
+		if (Validator.isNull(clientSecretKeyReference)) {
+			return oAuth2Application.getClientSecret();
+		}
+
+		String[] providerIdAndIdentifier = StringUtil.split(
+			clientSecretKeyReference.substring(
+				_CLIENT_SECRET_REFERENCE_PREFIX.length(),
+				clientSecretKeyReference.length() - 1),
+			CharPool.COLON);
+
+		try (Secret secret = _secretManager.getSecret(
+				oAuth2Application.getCompanyId(),
+				new KeyReference(
+					providerIdAndIdentifier[1], providerIdAndIdentifier[0],
+					KeyReference.Type.SECRET))) {
+
+			return new String(secret.getChars());
+		}
+	}
+
 	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public OAuth2Application updateExternalReferenceCode(
@@ -645,7 +679,6 @@ public class OAuth2ApplicationLocalServiceImpl
 		oAuth2Application.setClientCredentialUserName(user.getScreenName());
 		oAuth2Application.setClientId(clientId);
 		oAuth2Application.setClientProfile(clientProfile);
-		oAuth2Application.setClientSecret(clientSecret);
 		oAuth2Application.setDescription(description);
 		oAuth2Application.setFeaturesList(featuresList);
 		oAuth2Application.setHomePageURL(homePageURL);
@@ -656,6 +689,8 @@ public class OAuth2ApplicationLocalServiceImpl
 		oAuth2Application.setRedirectURIsList(redirectURIsList);
 		oAuth2Application.setRememberDevice(rememberDevice);
 		oAuth2Application.setTrustedApplication(trustedApplication);
+
+		_setClientSecret(oAuth2Application, clientSecret);
 
 		return oAuth2ApplicationPersistence.update(oAuth2Application);
 	}
@@ -731,6 +766,40 @@ public class OAuth2ApplicationLocalServiceImpl
 
 		return oAuth2ApplicationScopeAliases.
 			getOAuth2ApplicationScopeAliasesId();
+	}
+
+	private void _setClientSecret(
+			OAuth2Application oAuth2Application, String clientSecret)
+		throws PortalException {
+
+		if (Validator.isNull(clientSecret) ||
+			!FeatureFlagManagerUtil.isEnabled(
+				oAuth2Application.getCompanyId(), "LPD-88411")) {
+
+			oAuth2Application.setClientSecret(clientSecret);
+			oAuth2Application.setClientSecretKeyReference(null);
+
+			return;
+		}
+
+		oAuth2Application.setClientSecret(null);
+
+		try (Secret secret = new Secret(
+				new KeyReference(
+					String.valueOf(oAuth2Application.getOAuth2ApplicationId()),
+					StringPool.STAR, KeyReference.Type.SECRET),
+				clientSecret)) {
+
+			KeyReference keyReference = _secretManager.putSecret(
+				oAuth2Application.getCompanyId(), secret);
+
+			oAuth2Application.setClientSecretKeyReference(
+				StringBundler.concat(
+					_CLIENT_SECRET_REFERENCE_PREFIX,
+					keyReference.getProviderId(), StringPool.COLON,
+					keyReference.getIdentifier(),
+					StringPool.CLOSE_CURLY_BRACE));
+		}
 	}
 
 	private void _validate(
@@ -909,6 +978,9 @@ public class OAuth2ApplicationLocalServiceImpl
 		}
 	}
 
+	private static final String _CLIENT_SECRET_REFERENCE_PREFIX =
+		"${secretRef:";
+
 	private static Set<String> _ianaRegisteredUriSchemes = SetUtil.fromArray(
 		"aaa", "aaas", "about", "acap", "acct", "acr", "adiumxtra", "afp",
 		"afs", "aim", "appdata", "apt", "attachment", "aw", "barion", "beshare",
@@ -978,6 +1050,9 @@ public class OAuth2ApplicationLocalServiceImpl
 
 	@Reference
 	private ResourceLocalService _resourceLocalService;
+
+	@Reference
+	private SecretManager _secretManager;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/module-hbm.xml
@@ -25,6 +25,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="clientId" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="clientProfile" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="clientSecret" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="clientSecretKeyReference" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="description" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="features" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="homePageURL" type="com.liferay.portal.dao.orm.hibernate.StringType" />

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -22,6 +22,7 @@
 		<field name="clientId" type="String" />
 		<field name="clientProfile" type="int" />
 		<field name="clientSecret" type="String" />
+		<field name="clientSecretKeyReference" type="String" />
 		<field name="description" type="String">
 			<hint-collection name="TEXTAREA" />
 		</field>

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/META-INF/sql/tables.sql
@@ -22,6 +22,7 @@ create table OAuth2Application (
 	clientId VARCHAR(75) null,
 	clientProfile INTEGER,
 	clientSecret VARCHAR(75) null,
+	clientSecretKeyReference VARCHAR(75) null,
 	description STRING null,
 	features STRING null,
 	homePageURL STRING null,

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/service.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.oauth2.provider.service
-    build.number=4
-    build.date=1780331622524
+    build.number=5
+    build.date=1785780849061

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/model/listener/OAuth2ApplicationModelListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/model/listener/OAuth2ApplicationModelListener.java
@@ -8,6 +8,7 @@ package com.liferay.oauth2.provider.shortcut.internal.model.listener;
 import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
 import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -39,12 +40,9 @@ public class OAuth2ApplicationModelListener
 		throws ModelListenerException {
 
 		if (!_isAnalyticsEnabled(oAuth2Application.getCompanyId()) ||
-			(StringUtil.equals(
-				originalOAuth2Application.getClientId(),
-				oAuth2Application.getClientId()) &&
-			 StringUtil.equals(
-				 originalOAuth2Application.getClientSecret(),
-				 oAuth2Application.getClientSecret()))) {
+			!StringUtil.equals(
+				oAuth2Application.getExternalReferenceCode(),
+				"ANALYTICS-CLOUD")) {
 
 			return;
 		}
@@ -163,7 +161,9 @@ public class OAuth2ApplicationModelListener
 
 		options.addPart("oAuthClientId", oAuth2Application.getClientId());
 		options.addPart(
-			"oAuthClientSecret", oAuth2Application.getClientSecret());
+			"oAuthClientSecret",
+			_oAuth2ApplicationLocalService.resolveClientSecret(
+				oAuth2Application));
 		options.setLocation(
 			StringUtil.replace(
 				jsonObject.getString("url"), "data_source/connect",
@@ -191,5 +191,8 @@ public class OAuth2ApplicationModelListener
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-test/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/build.gradle
@@ -10,10 +10,13 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-spi")
+	compileOnly project(":apps:portal-security:portal-security-key-api")
+	compileOnly project(":apps:portal-security:portal-security-key-spi")
 	compileOnly project(":apps:portal-security:portal-security-service-access-policy-api")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-string")
@@ -26,6 +29,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-remote:portal-remote-cors-api")
 	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-api")
+	testIntegrationImplementation project(":apps:portal-security:portal-security-key-api")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/main/java/com/liferay/oauth2/provider/internal/test/TestSecretProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/main/java/com/liferay/oauth2/provider/internal/test/TestSecretProvider.java
@@ -1,0 +1,94 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.internal.test;
+
+import com.liferay.portal.security.key.KeyReference;
+import com.liferay.portal.security.key.secret.Secret;
+import com.liferay.portal.security.key.secret.exception.SecretException;
+import com.liferay.portal.security.key.spi.ProviderStatus;
+import com.liferay.portal.security.key.spi.secret.SecretProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Christopher Kian
+ */
+@Component(
+	property = "secret.provider.id=" + TestSecretProvider.PROVIDER_ID,
+	service = SecretProvider.class
+)
+public class TestSecretProvider implements SecretProvider {
+
+	public static final String PROVIDER_ID = "test-oauth2-secret";
+
+	@Override
+	public void deleteSecret(long companyId, String secretIdentifier) {
+		_secrets.remove(_key(companyId, secretIdentifier));
+	}
+
+	@Override
+	public ProviderStatus getProviderStatus() {
+		return ProviderStatus.OPERATIONAL;
+	}
+
+	@Override
+	public Secret getSecret(long companyId, String secretIdentifier)
+		throws SecretException {
+
+		String value = _secrets.get(_key(companyId, secretIdentifier));
+
+		if (value == null) {
+			throw new SecretException(
+				"No secret found for identifier " + secretIdentifier);
+		}
+
+		return new Secret(
+			new KeyReference(
+				secretIdentifier, PROVIDER_ID, KeyReference.Type.SECRET),
+			value);
+	}
+
+	@Override
+	public List<String> getSecretIdentifiers(long companyId) {
+		List<String> secretIdentifiers = new ArrayList<>();
+
+		String prefix = companyId + "/";
+
+		for (String key : _secrets.keySet()) {
+			if (key.startsWith(prefix)) {
+				secretIdentifiers.add(key.substring(prefix.length()));
+			}
+		}
+
+		return secretIdentifiers;
+	}
+
+	@Override
+	public boolean isAllowedCompany(long companyId) {
+		return true;
+	}
+
+	@Override
+	public void putSecret(long companyId, Secret secret) {
+		KeyReference keyReference = secret.getKeyReference();
+
+		_secrets.put(
+			_key(companyId, keyReference.getIdentifier()),
+			new String(secret.getChars()));
+	}
+
+	private String _key(long companyId, String secretIdentifier) {
+		return companyId + "/" + secretIdentifier;
+	}
+
+	private final Map<String, String> _secrets = new ConcurrentHashMap<>();
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/secret/test/OAuth2ApplicationClientSecretTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/secret/test/OAuth2ApplicationClientSecretTest.java
@@ -1,0 +1,126 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.secret.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.internal.test.TestSecretProvider;
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.test.rule.FeatureFlag;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Christopher Kian
+ */
+@RunWith(Arquillian.class)
+public class OAuth2ApplicationClientSecretTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		ConfigurationTestUtil.saveConfiguration(
+			_KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"companySecretProviderId", TestSecretProvider.PROVIDER_ID
+			).put(
+				"systemSecretProviderId", TestSecretProvider.PROVIDER_ID
+			).build());
+
+		_user = UserTestUtil.addUser();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ConfigurationTestUtil.deleteConfiguration(
+			_KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID);
+	}
+
+	@FeatureFlags(featureFlags = @FeatureFlag("LPD-88411"))
+	@Test
+	public void testResolveClientSecret() throws Exception {
+		String clientSecret = RandomTestUtil.randomString();
+
+		_oAuth2Application = _addOAuth2Application(clientSecret);
+
+		Assert.assertEquals(
+			clientSecret,
+			_oAuth2ApplicationLocalService.resolveClientSecret(
+				_oAuth2Application));
+		Assert.assertNull(_oAuth2Application.getClientSecret());
+
+		String clientSecretKeyReference =
+			_oAuth2Application.getClientSecretKeyReference();
+
+		Assert.assertTrue(
+			clientSecretKeyReference,
+			clientSecretKeyReference.startsWith("${secretRef:"));
+	}
+
+	@Test
+	public void testResolveClientSecretWhenDisabled() throws Exception {
+		String clientSecret = RandomTestUtil.randomString();
+
+		_oAuth2Application = _addOAuth2Application(clientSecret);
+
+		Assert.assertEquals(clientSecret, _oAuth2Application.getClientSecret());
+		Assert.assertEquals(
+			clientSecret,
+			_oAuth2ApplicationLocalService.resolveClientSecret(
+				_oAuth2Application));
+		Assert.assertNull(_oAuth2Application.getClientSecretKeyReference());
+	}
+
+	private OAuth2Application _addOAuth2Application(String clientSecret)
+		throws Exception {
+
+		return _oAuth2ApplicationLocalService.addOAuth2Application(
+			TestPropsValues.getCompanyId(), _user.getUserId(),
+			_user.getFullName(),
+			ListUtil.fromArray(GrantType.CLIENT_CREDENTIALS),
+			"client_secret_post", _user.getUserId(), null, 0, clientSecret,
+			null, null, null, 0, null, RandomTestUtil.randomString(), null,
+			null, false, null, false, new ServiceContext());
+	}
+
+	private static final String _KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID =
+		"com.liferay.portal.security.key.internal.profile.configuration." +
+			"KeyManagerCustomProfileConfiguration";
+
+	@DeleteAfterTestRun
+	private OAuth2Application _oAuth2Application;
+
+	@Inject
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/secret/test/SecretManagerTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/secret/test/SecretManagerTest.java
@@ -1,0 +1,88 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.secret.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.internal.test.TestSecretProvider;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.security.key.KeyReference;
+import com.liferay.portal.security.key.secret.Secret;
+import com.liferay.portal.security.key.secret.SecretManager;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Christopher Kian
+ */
+@RunWith(Arquillian.class)
+public class SecretManagerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		ConfigurationTestUtil.saveConfiguration(
+			_KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"companySecretProviderId", TestSecretProvider.PROVIDER_ID
+			).put(
+				"systemSecretProviderId", TestSecretProvider.PROVIDER_ID
+			).build());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ConfigurationTestUtil.deleteConfiguration(
+			_KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID);
+	}
+
+	@Test
+	public void testPutAndGetSecret() throws Exception {
+		String value = RandomTestUtil.randomString();
+
+		KeyReference keyReference = _secretManager.putSecret(
+			TestPropsValues.getCompanyId(),
+			new Secret(
+				new KeyReference(
+					RandomTestUtil.randomString(), "*",
+					KeyReference.Type.SECRET),
+				value));
+
+		try {
+			Secret secret = _secretManager.getSecret(
+				TestPropsValues.getCompanyId(), keyReference);
+
+			Assert.assertEquals(value, new String(secret.getChars()));
+		}
+		finally {
+			_secretManager.deleteSecret(
+				TestPropsValues.getCompanyId(), keyReference);
+		}
+	}
+
+	private static final String _KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID =
+		"com.liferay.portal.security.key.internal.profile.configuration." +
+			"KeyManagerCustomProfileConfiguration";
+
+	@Inject
+	private SecretManager _secretManager;
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/display/context/OAuth2AdminPortletDisplayContext.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/display/context/OAuth2AdminPortletDisplayContext.java
@@ -10,6 +10,7 @@ import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalServiceUtil;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationScopeAliasesLocalService;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationServiceUtil;
@@ -126,6 +127,13 @@ public class OAuth2AdminPortletDisplayContext
 	public String[] getOAuth2Features(PortletPreferences portletPreferences) {
 		return StringUtil.split(
 			portletPreferences.getValue("oAuth2Features", StringPool.BLANK));
+	}
+
+	public String getResolvedClientSecret(OAuth2Application oAuth2Application)
+		throws PortalException {
+
+		return OAuth2ApplicationLocalServiceUtil.resolveClientSecret(
+			oAuth2Application);
 	}
 
 	public ClientProfile[] getSortedClientProfiles() {

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
@@ -13,7 +13,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 OAuth2Application oAuth2Application = oAuth2AdminPortletDisplayContext.getOAuth2Application();
 
 String clientId = (oAuth2Application == null) ? "" : oAuth2Application.getClientId();
-String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getClientSecret();
+String clientSecret = (oAuth2Application == null) ? "" : oAuth2AdminPortletDisplayContext.getResolvedClientSecret(oAuth2Application);
 String externalReferenceCode = (oAuth2Application == null) ? "" : oAuth2Application.getExternalReferenceCode();
 %>
 

--- a/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/feature/flag/SEOStudioFeatureFlagListener.java
+++ b/modules/dxp/apps/seo-studio/seo-studio-web/src/main/java/com/liferay/seo/studio/web/internal/feature/flag/SEOStudioFeatureFlagListener.java
@@ -91,7 +91,9 @@ public class SEOStudioFeatureFlagListener implements FeatureFlagListener {
 			HashMapDictionaryBuilder.<String, Object>put(
 				"clientId", oAuth2Application.getClientId()
 			).put(
-				"clientSecret", oAuth2Application.getClientSecret()
+				"clientSecret",
+				_oAuth2ApplicationLocalService.resolveClientSecret(
+					oAuth2Application)
 			).put(
 				"serviceURL", company.getPortalURL(0)
 			).build());


### PR DESCRIPTION
Encrypts the OAuth 2.0 client credential at rest via SecretManager, gated behind the `LPD-88411` feature flag (off by default).

When enabled, the client secret is stored in the vault and the row keeps a `${secretRef:provider:identifier}` pointer in a dedicated `clientSecretKeyReference` column; `resolveClientSecret` dereferences it. When disabled, the plaintext stays in `clientSecret` as before.

Design decisions from the review on #3157:
- Dedicated column (not a tagged union in `clientSecret`) — resolution is a null check, and the admin form no longer round-trips the reference.
- The stored reference pins the resolved provider ID.
- An optional trailing `:version` slot is reserved for rotation.
- The `${secretRef:}` codec moves onto `KeyReference` in LPD-88830.

Supersedes #3157.

<!-- pr-check {"result":"success","sha":"d89f901d2bbe64c03b090b1ebefd1478a37ef861"} -->