### PR TITLE
LPD-93649 Enforce outbound TLS verification and revocation in FIPS

### DIFF
--- a/modules/apps/archived/portal-search-solr8-impl/build.gradle
+++ b/modules/apps/archived/portal-search-solr8-impl/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	testImplementation project(":apps:portal-search:portal-search-test-util")
 	testImplementation project(":apps:static:portal-configuration:portal-configuration-persistence-api")
 	testImplementation project(":apps:static:portal-file-install:portal-file-install-api")
+	testImplementation project(":core:petra:petra-lang")
 }
 
 test {

--- a/modules/apps/archived/portal-search-solr8-impl/src/main/java/com/liferay/portal/search/solr8/internal/http/SSLSocketFactoryBuilderImpl.java
+++ b/modules/apps/archived/portal-search-solr8-impl/src/main/java/com/liferay/portal/search/solr8/internal/http/SSLSocketFactoryBuilderImpl.java
@@ -8,6 +8,7 @@ package com.liferay.portal.search.solr8.internal.http;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.fips.FIPSModeValidator;
 import com.liferay.portal.search.solr8.configuration.SolrSSLSocketFactoryConfiguration;
 
 import java.security.KeyStore;
@@ -40,6 +41,11 @@ public class SSLSocketFactoryBuilderImpl implements SSLSocketFactoryBuilder {
 
 	@Override
 	public SSLConnectionSocketFactory build() throws Exception {
+		FIPSModeValidator.validateServerCertificateVerification(
+			_verifyServerCertificate);
+		FIPSModeValidator.validateServerHostnameVerification(
+			_verifyServerHostname);
+
 		KeyStore keyStore = _keyStoreLoader.load(
 			_keyStoreType, _keyStorePath, _keyStorePassword);
 

--- a/modules/apps/archived/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/http/SSLSocketFactoryBuilderImplTest.java
+++ b/modules/apps/archived/portal-search-solr8-impl/src/test/java/com/liferay/portal/search/solr8/internal/http/SSLSocketFactoryBuilderImplTest.java
@@ -1,0 +1,82 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.search.solr8.internal.http;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Caio Farias
+ */
+public class SSLSocketFactoryBuilderImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testBuild() throws Exception {
+		SSLSocketFactoryBuilderImpl sslSocketFactoryBuilderImpl =
+			new SSLSocketFactoryBuilderImpl();
+
+		_assertVerificationRequired(
+			sslSocketFactoryBuilderImpl, "_verifyServerCertificate",
+			"Servers certificates must be verified in FIPS mode");
+
+		_assertVerificationRequired(
+			sslSocketFactoryBuilderImpl, "_verifyServerHostname",
+			"Servers hostname must be verified in FIPS mode");
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			Assert.assertThrows(
+				NullPointerException.class, sslSocketFactoryBuilderImpl::build);
+		}
+	}
+
+	private void _assertVerificationRequired(
+			SSLSocketFactoryBuilderImpl sslSocketFactoryBuilderImpl,
+			String fieldName, String expectedMessage)
+		throws Exception {
+
+		try (AutoCloseable autoCloseable =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					sslSocketFactoryBuilderImpl, fieldName, false)) {
+
+			try (SafeCloseable safeCloseable =
+					PropsValuesTestUtil.swapWithSafeCloseable(
+						"FIPS_ENABLED", false)) {
+
+				Assert.assertThrows(
+					NullPointerException.class,
+					sslSocketFactoryBuilderImpl::build);
+			}
+
+			try (SafeCloseable safeCloseable =
+					PropsValuesTestUtil.swapWithSafeCloseable(
+						"FIPS_ENABLED", true)) {
+
+				SecurityException securityException = Assert.assertThrows(
+					SecurityException.class,
+					sslSocketFactoryBuilderImpl::build);
+
+				Assert.assertEquals(
+					expectedMessage, securityException.getMessage());
+			}
+		}
+	}
+
+}

--- a/modules/apps/portal/portal-json-web-service-client/build.gradle
+++ b/modules/apps/portal/portal-json-web-service-client/build.gradle
@@ -15,4 +15,5 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly group: "org.slf4j", name: "slf4j-api", version: "1.7.26"
+	testImplementation project(":core:petra:petra-lang")
 }

--- a/modules/apps/portal/portal-json-web-service-client/src/main/java/com/liferay/portal/json/web/service/client/BaseJSONWebServiceClientImpl.java
+++ b/modules/apps/portal/portal-json-web-service-client/src/main/java/com/liferay/portal/json/web/service/client/BaseJSONWebServiceClientImpl.java
@@ -16,6 +16,7 @@ import com.liferay.portal.json.web.service.client.internal.IdleConnectionMonitor
 import com.liferay.portal.json.web.service.client.internal.X509TrustManagerImpl;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.security.fips.FIPSModeValidator;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
@@ -922,6 +923,9 @@ public abstract class BaseJSONWebServiceClientImpl
 	}
 
 	protected SSLIOSessionStrategy getSSLIOSessionStrategy() {
+		FIPSModeValidator.validateServerCertificateVerification(
+			!_trustSelfSignedCertificates);
+
 		SSLContextBuilder sslContextBuilder = SSLContexts.custom();
 
 		SSLContext sslContext = null;

--- a/modules/apps/portal/portal-json-web-service-client/src/main/java/com/liferay/portal/json/web/service/client/internal/X509TrustManagerImpl.java
+++ b/modules/apps/portal/portal-json-web-service-client/src/main/java/com/liferay/portal/json/web/service/client/internal/X509TrustManagerImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.json.web.service.client.internal;
 
+import com.liferay.portal.kernel.security.fips.FIPSModeValidator;
 import com.liferay.portal.kernel.util.ArrayUtil;
 
 import java.security.KeyStore;
@@ -22,10 +23,15 @@ import javax.net.ssl.X509TrustManager;
 public class X509TrustManagerImpl implements X509TrustManager {
 
 	public X509TrustManagerImpl() {
+		boolean trustSelfSignedCertificates = true;
+
+		FIPSModeValidator.validateServerCertificateVerification(
+			!trustSelfSignedCertificates);
+
 		try {
 			_defaultX509TrustManager = _getX509TrustManager(null);
 			_extraX509TrustManager = null;
-			_trustSelfSignedCertificates = true;
+			_trustSelfSignedCertificates = trustSelfSignedCertificates;
 		}
 		catch (Exception exception) {
 			throw new RuntimeException(exception);
@@ -34,6 +40,9 @@ public class X509TrustManagerImpl implements X509TrustManager {
 
 	public X509TrustManagerImpl(
 		KeyStore keyStore, boolean trustSelfSignedCertificates) {
+
+		FIPSModeValidator.validateServerCertificateVerification(
+			!trustSelfSignedCertificates);
 
 		try {
 			_defaultX509TrustManager = _getX509TrustManager(null);

--- a/modules/apps/portal/portal-json-web-service-client/src/test/java/com/liferay/portal/json/web/service/client/BaseJSONWebServiceClientImplTest.java
+++ b/modules/apps/portal/portal-json-web-service-client/src/test/java/com/liferay/portal/json/web/service/client/BaseJSONWebServiceClientImplTest.java
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.json.web.service.client;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.json.web.service.client.internal.JSONWebServiceClientImpl;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Caio Farias
+ */
+public class BaseJSONWebServiceClientImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetSSLIOSessionStrategy() {
+		JSONWebServiceClientImpl jsonWebServiceClientImpl =
+			new JSONWebServiceClientImpl();
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", false)) {
+
+			jsonWebServiceClientImpl.getSSLIOSessionStrategy();
+		}
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			SecurityException securityException = Assert.assertThrows(
+				SecurityException.class,
+				jsonWebServiceClientImpl::getSSLIOSessionStrategy);
+
+			Assert.assertEquals(
+				"Servers certificates must be verified in FIPS mode",
+				securityException.getMessage());
+
+			jsonWebServiceClientImpl.setTrustSelfSignedCertificates(false);
+
+			jsonWebServiceClientImpl.getSSLIOSessionStrategy();
+		}
+	}
+
+}

--- a/modules/apps/portal/portal-json-web-service-client/src/test/java/com/liferay/portal/json/web/service/client/internal/X509TrustManagerImplTest.java
+++ b/modules/apps/portal/portal-json-web-service-client/src/test/java/com/liferay/portal/json/web/service/client/internal/X509TrustManagerImplTest.java
@@ -1,0 +1,52 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.json.web.service.client.internal;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Caio Farias
+ */
+public class X509TrustManagerImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testX509TrustManagerImpl() {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", false)) {
+
+			new X509TrustManagerImpl();
+		}
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			new X509TrustManagerImpl(null, false);
+
+			SecurityException securityException = Assert.assertThrows(
+				SecurityException.class,
+				() -> new X509TrustManagerImpl(null, true));
+
+			Assert.assertEquals(
+				"Servers certificates must be verified in FIPS mode",
+				securityException.getMessage());
+		}
+	}
+
+}

--- a/modules/apps/portal/portal-json-web-service-client/src/test/java/com/liferay/portal/json/web/service/client/internal/X509TrustManagerImplTest.java
+++ b/modules/apps/portal/portal-json-web-service-client/src/test/java/com/liferay/portal/json/web/service/client/internal/X509TrustManagerImplTest.java
@@ -31,6 +31,7 @@ public class X509TrustManagerImplTest {
 					"FIPS_ENABLED", false)) {
 
 			new X509TrustManagerImpl();
+			new X509TrustManagerImpl(null, true);
 		}
 
 		try (SafeCloseable safeCloseable =
@@ -40,6 +41,13 @@ public class X509TrustManagerImplTest {
 			new X509TrustManagerImpl(null, false);
 
 			SecurityException securityException = Assert.assertThrows(
+				SecurityException.class, () -> new X509TrustManagerImpl());
+
+			Assert.assertEquals(
+				"Servers certificates must be verified in FIPS mode",
+				securityException.getMessage());
+
+			securityException = Assert.assertThrows(
 				SecurityException.class,
 				() -> new X509TrustManagerImpl(null, true));
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeValidator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeValidator.java
@@ -86,6 +86,24 @@ public class FIPSModeValidator {
 		}
 	}
 
+	public static void validateServerCertificateVerification(
+		boolean verifyServerCertificate) {
+
+		if (PropsValues.FIPS_ENABLED && !verifyServerCertificate) {
+			throw new SecurityException(
+				"Servers certificates must be verified in FIPS mode");
+		}
+	}
+
+	public static void validateServerHostnameVerification(
+		boolean verifyServerHostname) {
+
+		if (PropsValues.FIPS_ENABLED && !verifyServerHostname) {
+			throw new SecurityException(
+				"Servers hostname must be verified in FIPS mode");
+		}
+	}
+
 	private static void _assertAllowedValue(
 		String name, String value, String[] requiredValues) {
 
@@ -264,6 +282,12 @@ public class FIPSModeValidator {
 		validateAlgorithm(
 			PropsUtil.get(PropsKeys.COMPANY_ENCRYPTION_ALGORITHM));
 		validateAlgorithm(PropsValues.TUNNELING_SERVLET_ENCRYPTION_ALGORITHM);
+
+		validateServerHostnameVerification(
+			GetterUtil.getBoolean(
+				PropsUtil.get(
+					"com.liferay.portal.kernel.service.http.TunnelUtil." +
+						"verify.ssl.hostname")));
 
 		_validatePasswordsEncryptionAlgorithm(
 			PropsUtil.get(PropsKeys.PASSWORDS_ENCRYPTION_ALGORITHM));

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeValidator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeValidator.java
@@ -5,7 +5,9 @@
 
 package com.liferay.portal.kernel.security.fips;
 
+import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.reflect.ReflectionUtil;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -26,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -40,7 +43,17 @@ public class FIPSModeValidator {
 		_validateFIPSProvider(providers);
 		_validateProviders(providers);
 
-		_validateProperties();
+		_validatePortalProperties();
+
+		_validateProperties(
+			_requiredSecurityProperties, Security::getProperty,
+			FIPSModeValidator::_assertAllRequiredValues);
+		_validateProperties(
+			_requiredSystemProperties, System::getProperty,
+			FIPSModeValidator::_assertAllRequiredValues);
+		_validateProperties(
+			_allowedSystemProperties, System::getProperty,
+			FIPSModeValidator::_assertAllowedValue);
 	}
 
 	public static void validateAlgorithm(String algorithm) {
@@ -70,6 +83,34 @@ public class FIPSModeValidator {
 		if ((keySize != 0) && !_allowedKeySizes.contains(keySize)) {
 			throw new SecurityException(
 				"AES key must be 128, 192, or 256 bits");
+		}
+	}
+
+	private static void _assertAllowedValue(
+		String name, String value, String[] requiredValues) {
+
+		for (String requiredValue : requiredValues) {
+			if (StringUtil.contains(value, requiredValue)) {
+				return;
+			}
+		}
+
+		throw new SecurityException(
+			StringBundler.concat(
+				"FIPS mode requires the property \"", name,
+				"\" to include one of ", Arrays.toString(requiredValues)));
+	}
+
+	private static void _assertAllRequiredValues(
+		String name, String value, String[] requiredValues) {
+
+		for (String requiredValue : requiredValues) {
+			if (!StringUtil.containsIgnoreCase(value, requiredValue)) {
+				throw new SecurityException(
+					StringBundler.concat(
+						"FIPS mode requires the property \"", name,
+						"\" to include \"", requiredValue, "\""));
+			}
 		}
 	}
 
@@ -215,7 +256,7 @@ public class FIPSModeValidator {
 		}
 	}
 
-	private static void _validateProperties() {
+	private static void _validatePortalProperties() {
 		if (GetterUtil.getBoolean(PropsUtil.get(PropsKeys.AUTH_MAC_ALLOW))) {
 			validateAlgorithm(PropsUtil.get(PropsKeys.AUTH_MAC_ALGORITHM));
 		}
@@ -226,6 +267,19 @@ public class FIPSModeValidator {
 
 		_validatePasswordsEncryptionAlgorithm(
 			PropsUtil.get(PropsKeys.PASSWORDS_ENCRYPTION_ALGORITHM));
+	}
+
+	private static void _validateProperties(
+		Map<String, String[]> properties, Function<String, String> function,
+		UnsafeTriConsumer<String, String, String[], SecurityException>
+			unsafeTriConsumer) {
+
+		for (Map.Entry<String, String[]> entry : properties.entrySet()) {
+			String value = StringUtil.removeChar(
+				function.apply(entry.getKey()), CharPool.SPACE);
+
+			unsafeTriConsumer.accept(entry.getKey(), value, entry.getValue());
+		}
 	}
 
 	private static void _validateProviders(Provider[] providers) {
@@ -270,7 +324,19 @@ public class FIPSModeValidator {
 			List.of(
 				"BCJSSE", "JdkLDAP", "JdkSASL", "SUN", "SunJCE", "SunJGSS",
 				"SunSASL", "XMLDSig"));
+	private static final Map<String, String[]> _allowedSystemProperties =
+		Map.of("jdk.tls.client.protocols", new String[] {"TLSv1.2", "TLSv1.3"});
 	private static final Pattern _pbkdf2Pattern = Pattern.compile(
 		"^[^/]*(?:/([0-9]+))?/([0-9]+)$");
+	private static final Map<String, String[]> _requiredSecurityProperties =
+		Map.of(
+			"jdk.tls.disabledAlgorithms",
+			new String[] {"SSLv3", "TLS_RSA_*", "TLSv1", "TLSv1.1"},
+			"ocsp.enable", new String[] {"true"},
+			"ssl.TrustManagerFactory.algorithm", new String[] {"PKIX"});
+	private static final Map<String, String[]> _requiredSystemProperties =
+		Map.of(
+			"com.sun.net.ssl.checkRevocation", new String[] {"true"},
+			"com.sun.security.enableCRLDP", new String[] {"true"});
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSModeValidatorTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSModeValidatorTest.java
@@ -5,15 +5,21 @@
 
 package com.liferay.portal.kernel.security.fips;
 
+import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
 
 import java.security.Provider;
+import java.security.Security;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -49,32 +55,6 @@ public class FIPSModeValidatorTest {
 					() -> FIPSModeValidator.validateAlgorithm(algorithm));
 			}
 		}
-	}
-
-	@Test
-	public void testValidateFIPSProvider() {
-		for (String name : List.of("AmazonCorrettoCryptoProvider", "BCFIPS")) {
-			_assertSecurityException(
-				"FIPS provider integrity failed:",
-				() -> ReflectionTestUtil.invoke(
-					FIPSModeValidator.class, "_validateFIPSProvider",
-					new Class<?>[] {Provider[].class},
-					(Object)new Provider[] {_createProvider(name)}));
-		}
-
-		_assertSecurityException(
-			"The first security provider must be an allowed FIPS provider",
-			() -> ReflectionTestUtil.invoke(
-				FIPSModeValidator.class, "_validateFIPSProvider",
-				new Class<?>[] {Provider[].class},
-				(Object)new Provider[] {
-					_createProvider(RandomTestUtil.randomString())
-				}));
-		_assertSecurityException(
-			"There are no security providers",
-			() -> ReflectionTestUtil.invoke(
-				FIPSModeValidator.class, "_validateFIPSProvider",
-				new Class<?>[] {Provider[].class}, (Object)new Provider[0]));
 	}
 
 	@Test
@@ -139,6 +119,151 @@ public class FIPSModeValidatorTest {
 	}
 
 	@Test
+	public void testValidatePortalProperties() {
+		try (SafeCloseable safeCloseable1 =
+				PropsValuesTestUtil.swapWithSafeCloseable("FIPS_ENABLED", true);
+			SafeCloseable safeCloseable2 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"TUNNELING_SERVLET_ENCRYPTION_ALGORITHM", "AES");
+			SafeCloseable safeCloseable3 = _swapPortalProperty(
+				PropsKeys.COMPANY_ENCRYPTION_ALGORITHM, "AES");
+			SafeCloseable safeCloseable4 = _swapPortalProperty(
+				PropsKeys.PASSWORDS_ENCRYPTION_ALGORITHM,
+				"PBKDF2WithHmacSHA256/256/1300000")) {
+
+			try (SafeCloseable safeCloseable5 = _swapPortalProperty(
+					_TUNNEL_VERIFY_SSL_HOSTNAME_KEY, "true")) {
+
+				_validatePortalProperties();
+			}
+
+			for (String value : new String[] {"", "false"}) {
+				try (SafeCloseable safeCloseable5 = _swapPortalProperty(
+						_TUNNEL_VERIFY_SSL_HOSTNAME_KEY, value)) {
+
+					_assertSecurityException(
+						"Servers hostname must be verified in FIPS mode",
+						this::_validatePortalProperties);
+				}
+			}
+		}
+	}
+
+	@Test
+	public void testValidateProperties() {
+		String name = RandomTestUtil.randomString();
+
+		for (String[] validProperty :
+				new String[][] {
+					{"PKIX", "PKIX"}, {"SSLv3, TLSv1", "TLSv1"},
+					{"TLSv1.2,TLSv1.3", "TLSv1.2"}, {"TRUE", "true"},
+					{"pkix", "PKIX"}, {"true", "true"}
+				}) {
+
+			_validateProperties(
+				Map.of(name, new String[] {validProperty[1]}),
+				curName -> validProperty[0], this::_assertAllRequiredValues);
+		}
+
+		for (String[] invalidProperty :
+				new String[][] {
+					{"SunPKIXFoo", "PKIX"}, {"TLSv1.1", "TLSv1"},
+					{"untrue", "true"}
+				}) {
+
+			_assertSecurityException(
+				_REQUIRED_PROPERTY_MESSAGE_PREFIX + name + "\"",
+				() -> _validateProperties(
+					Map.of(name, new String[] {invalidProperty[1]}),
+					curName -> invalidProperty[0],
+					this::_assertAllRequiredValues));
+		}
+
+		_assertSecurityException(
+			_REQUIRED_PROPERTY_MESSAGE_PREFIX + name + "\"",
+			() -> _validateProperties(
+				Map.of(name, new String[] {"true"}), curName -> null,
+				this::_assertAllRequiredValues));
+
+		try (SafeCloseable safeCloseable = _swapSystemProperty(name, "true")) {
+			_validateProperties(
+				Map.of(name, new String[] {"true"}), System::getProperty,
+				this::_assertAllRequiredValues);
+
+			_assertSecurityException(
+				_REQUIRED_PROPERTY_MESSAGE_PREFIX + name + "\"",
+				() -> _validateProperties(
+					Map.of(name, new String[] {"true"}), Security::getProperty,
+					this::_assertAllRequiredValues));
+		}
+
+		for (String value : List.of("TLSv1.2", "TLSv1.2,TLSv1.3", "TLSv1.3")) {
+			_validateProperties(
+				Map.of(name, new String[] {"TLSv1.2", "TLSv1.3"}),
+				curName -> value, this::_assertAllowedValue);
+		}
+
+		for (String value :
+				List.of("TLSv1", "TLSv1.1", "TLSv1.11", "tlsv1.2")) {
+
+			_assertSecurityException(
+				_REQUIRED_PROPERTY_MESSAGE_PREFIX + name + "\"",
+				() -> _validateProperties(
+					Map.of(name, new String[] {"TLSv1.2", "TLSv1.3"}),
+					curName -> value, this::_assertAllowedValue));
+		}
+
+		_assertSecurityException(
+			_REQUIRED_PROPERTY_MESSAGE_PREFIX + name + "\"",
+			() -> _validateProperties(
+				Map.of(name, new String[] {"TLSv1.2", "TLSv1.3"}),
+				curName -> null, this::_assertAllowedValue));
+
+		Map<String, String[]> requiredSecurityProperties =
+			ReflectionTestUtil.getFieldValue(
+				FIPSModeValidator.class, "_requiredSecurityProperties");
+
+		Assert.assertEquals(
+			requiredSecurityProperties.toString(), 3,
+			requiredSecurityProperties.size());
+		Assert.assertArrayEquals(
+			new String[] {"SSLv3", "TLS_RSA_*", "TLSv1", "TLSv1.1"},
+			requiredSecurityProperties.get("jdk.tls.disabledAlgorithms"));
+		Assert.assertArrayEquals(
+			new String[] {"true"},
+			requiredSecurityProperties.get("ocsp.enable"));
+		Assert.assertArrayEquals(
+			new String[] {"PKIX"},
+			requiredSecurityProperties.get(
+				"ssl.TrustManagerFactory.algorithm"));
+
+		Map<String, String[]> requiredSystemProperties =
+			ReflectionTestUtil.getFieldValue(
+				FIPSModeValidator.class, "_requiredSystemProperties");
+
+		Assert.assertEquals(
+			requiredSystemProperties.toString(), 2,
+			requiredSystemProperties.size());
+		Assert.assertArrayEquals(
+			new String[] {"true"},
+			requiredSystemProperties.get("com.sun.net.ssl.checkRevocation"));
+		Assert.assertArrayEquals(
+			new String[] {"true"},
+			requiredSystemProperties.get("com.sun.security.enableCRLDP"));
+
+		Map<String, String[]> requiredOneOfSystemProperties =
+			ReflectionTestUtil.getFieldValue(
+				FIPSModeValidator.class, "_allowedSystemProperties");
+
+		Assert.assertEquals(
+			requiredOneOfSystemProperties.toString(), 1,
+			requiredOneOfSystemProperties.size());
+		Assert.assertArrayEquals(
+			new String[] {"TLSv1.2", "TLSv1.3"},
+			requiredOneOfSystemProperties.get("jdk.tls.client.protocols"));
+	}
+
+	@Test
 	public void testValidateProviders() {
 		Map<String, List<String>> allowedProviderNames =
 			ReflectionTestUtil.getFieldValue(
@@ -155,6 +280,73 @@ public class FIPSModeValidatorTest {
 						_createProvider(RandomTestUtil.randomString())
 					}));
 		}
+	}
+
+	@Test
+	public void testValidateServerCertificateVerification() {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", false)) {
+
+			for (boolean verifyServerCertificate :
+					new boolean[] {false, true}) {
+
+				FIPSModeValidator.validateServerCertificateVerification(
+					verifyServerCertificate);
+			}
+		}
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			FIPSModeValidator.validateServerCertificateVerification(true);
+
+			_assertSecurityException(
+				"Servers certificates must be verified in FIPS mode",
+				() -> FIPSModeValidator.validateServerCertificateVerification(
+					false));
+		}
+	}
+
+	@Test
+	public void testValidateServerHostnameVerification() {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", false)) {
+
+			FIPSModeValidator.validateServerHostnameVerification(false);
+		}
+
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", true)) {
+
+			FIPSModeValidator.validateServerHostnameVerification(true);
+
+			_assertSecurityException(
+				"Servers hostname must be verified in FIPS mode",
+				() -> FIPSModeValidator.validateServerHostnameVerification(
+					false));
+		}
+	}
+
+	private void _assertAllowedValue(
+		String name, String value, String[] requiredValues) {
+
+		ReflectionTestUtil.invoke(
+			FIPSModeValidator.class, "_assertAllowedValue",
+			new Class<?>[] {String.class, String.class, String[].class}, name,
+			value, requiredValues);
+	}
+
+	private void _assertAllRequiredValues(
+		String name, String value, String[] requiredValues) {
+
+		ReflectionTestUtil.invoke(
+			FIPSModeValidator.class, "_assertAllRequiredValues",
+			new Class<?>[] {String.class, String.class, String[].class}, name,
+			value, requiredValues);
 	}
 
 	private void _assertSecurityException(
@@ -174,5 +366,51 @@ public class FIPSModeValidatorTest {
 			RandomTestUtil.randomString()) {
 		};
 	}
+
+	private SafeCloseable _swapPortalProperty(String key, String value) {
+		String oldValue = GetterUtil.getString(PropsUtil.get(key));
+
+		PropsUtil.set(key, value);
+
+		return () -> PropsUtil.set(key, oldValue);
+	}
+
+	private SafeCloseable _swapSystemProperty(String name, String value) {
+		String oldValue = System.getProperty(name);
+
+		System.setProperty(name, value);
+
+		return () -> {
+			if (oldValue == null) {
+				System.clearProperty(name);
+			}
+			else {
+				System.setProperty(name, oldValue);
+			}
+		};
+	}
+
+	private void _validatePortalProperties() {
+		ReflectionTestUtil.invoke(
+			FIPSModeValidator.class, "_validatePortalProperties",
+			new Class<?>[0]);
+	}
+
+	private void _validateProperties(
+		Map<String, String[]> properties, Function<String, String> function,
+		UnsafeTriConsumer<String, String, String[], SecurityException>
+			unsafeTriConsumer) {
+
+		ReflectionTestUtil.invoke(
+			FIPSModeValidator.class, "_validateProperties",
+			new Class<?>[] {Map.class, Function.class, UnsafeTriConsumer.class},
+			properties, function, unsafeTriConsumer);
+	}
+
+	private static final String _REQUIRED_PROPERTY_MESSAGE_PREFIX =
+		"FIPS mode requires the property \"";
+
+	private static final String _TUNNEL_VERIFY_SSL_HOSTNAME_KEY =
+		"com.liferay.portal.kernel.service.http.TunnelUtil.verify.ssl.hostname";
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSModeValidatorTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSModeValidatorTest.java
@@ -58,6 +58,32 @@ public class FIPSModeValidatorTest {
 	}
 
 	@Test
+	public void testValidateFIPSProvider() {
+		for (String name : List.of("AmazonCorrettoCryptoProvider", "BCFIPS")) {
+			_assertSecurityException(
+				"FIPS provider integrity failed:",
+				() -> ReflectionTestUtil.invoke(
+					FIPSModeValidator.class, "_validateFIPSProvider",
+					new Class<?>[] {Provider[].class},
+					(Object)new Provider[] {_createProvider(name)}));
+		}
+
+		_assertSecurityException(
+			"The first security provider must be an allowed FIPS provider",
+			() -> ReflectionTestUtil.invoke(
+				FIPSModeValidator.class, "_validateFIPSProvider",
+				new Class<?>[] {Provider[].class},
+				(Object)new Provider[] {
+					_createProvider(RandomTestUtil.randomString())
+				}));
+		_assertSecurityException(
+			"There are no security providers",
+			() -> ReflectionTestUtil.invoke(
+				FIPSModeValidator.class, "_validateFIPSProvider",
+				new Class<?>[] {Provider[].class}, (Object)new Provider[0]));
+	}
+
+	@Test
 	public void testValidateKey() {
 		try (SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93649

## Why

DXP code could disable outbound TLS certificate and hostname verification while running in FIPS mode, and nothing verified that the JVM's revocation and protocol policy was actually in force.

## Key changes

- Guard the four first-party trust-all and allow-all-hostname sites — each guard sits outside the surrounding `try`, whose `catch (Exception)` would swallow the `SecurityException`.
- Guard both `X509TrustManagerImpl` constructors — the no-arg one built the object its sibling refuses.
- Validate seven security, system, and portal properties at startup, naming the offending property.
- Keep `jdk.tls.client.protocols` case-sensitive — BCJSSE silently discards a lowercase value, leaving no restriction in force.
- Validate the tunnel hostname property at startup rather than in `TunnelUtil` — `_VERIFY_SSL_HOSTNAME` is `static final`, so a per-call check can never see a different value.

AC3's Source Formatter guard is on `LPD-93649-source-formatter`, to be sent after this lands.