### PR TITLE
[FIPS] LPD-92156 Add the AWS key manager module utilities and FIPS validators

### DIFF
--- a/modules/apps/portal-security/portal-security-key-provider-aws/bnd.bnd
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/bnd.bnd
@@ -1,0 +1,8 @@
+Bundle-Name: Liferay Portal Security Key Provider AWS
+Bundle-SymbolicName: com.liferay.portal.security.key.provider.aws
+Bundle-Version: 1.0.0
+Import-Package:\
+	com.amazonaws.*;resolution:=optional,\
+	\
+	*
+Liferay-Releng-Module-Group-Title: Portal Security Key

--- a/modules/apps/portal-security/portal-security-key-provider-aws/build.gradle
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/build.gradle
@@ -1,0 +1,18 @@
+dependencies {
+	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "6.4.0"
+	compileOnly group: "com.amazonaws", name: "aws-java-sdk-core", version: "1.12.719"
+	compileOnly group: "com.amazonaws", name: "aws-java-sdk-kms", version: "1.12.719"
+	compileOnly group: "com.amazonaws", name: "aws-java-sdk-secretsmanager", version: "1.12.778"
+	compileOnly group: "com.amazonaws", name: "aws-java-sdk-sts", version: "1.12.778"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "org.osgi", name: "org.osgi.framework", version: "1.9.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly project(":apps:portal-security:portal-security-key-api")
+	compileOnly project(":apps:portal-security:portal-security-key-spi")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":core:petra:petra-string")
+	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.test", version: "default"
+	testImplementation group: "junit", name: "junit", version: "4.13.1"
+	testImplementation group: "org.mockito", name: "mockito-core", version: "4.4.0"
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/fips/AWSKMSFipsValidator.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/fips/AWSKMSFipsValidator.java
@@ -1,0 +1,56 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.fips;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.security.key.ServiceIndicator;
+import com.liferay.portal.security.key.crypto.exception.CryptoException;
+
+import java.util.Objects;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSKMSFipsValidator extends BaseAWSFipsValidator {
+
+	public AWSKMSFipsValidator(String cipherMode, boolean useFipsEndpoint) {
+		super(cipherMode, useFipsEndpoint);
+	}
+
+	public boolean isFipsApprovedKeyOrigin(String keyOrigin) {
+		if (Objects.equals(keyOrigin, "AWS_CLOUDHSM")) {
+			return true;
+		}
+
+		return isUseFipsEndpoint();
+	}
+
+	public ServiceIndicator toServiceIndicator(
+			String keyOrigin, String securityFunctionName)
+		throws CryptoException {
+
+		return toServiceIndicator(
+			isFipsApprovedKeyOrigin(keyOrigin), securityFunctionName);
+	}
+
+	public void validateKeyOrigin(String keyOrigin) throws CryptoException {
+		if (!isFipsEnforced()) {
+			return;
+		}
+
+		if (Validator.isNull(keyOrigin) ||
+			!isFipsApprovedKeyOrigin(keyOrigin)) {
+
+			throw new CryptoException(
+				StringBundler.concat(
+					"FIPS enforcement requires an HSM backed CMK (Origin ",
+					"AWS_CLOUDHSM) or a FIPS KMS endpoint but the key Origin ",
+					"is \"", keyOrigin, "\""));
+		}
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/fips/BaseAWSFipsValidator.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/fips/BaseAWSFipsValidator.java
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.fips;
+
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.security.key.ServiceIndicator;
+import com.liferay.portal.security.key.crypto.exception.CryptoException;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * @author Christopher Kian
+ */
+public abstract class BaseAWSFipsValidator {
+
+	public BaseAWSFipsValidator(String cipherMode, boolean useFipsEndpoint) {
+		_cipherMode = cipherMode;
+		_useFipsEndpoint = useFipsEndpoint;
+
+		_fipsEnforced =
+			useFipsEndpoint ||
+			GetterUtil.getBoolean(System.getenv(_FIPS_ENFORCED_ENV_NAME));
+	}
+
+	public boolean isFipsEnforced() {
+		return _fipsEnforced;
+	}
+
+	public boolean isUseFipsEndpoint() {
+		return _useFipsEndpoint;
+	}
+
+	public ServiceIndicator toServiceIndicator(
+			boolean fipsApproved, String securityFunctionName)
+		throws CryptoException {
+
+		if (_fipsEnforced && !fipsApproved) {
+			throw new CryptoException(
+				"Security function \"" + securityFunctionName +
+					"\" is not FIPS approved under strict mode");
+		}
+
+		return new ServiceIndicator(fipsApproved, securityFunctionName);
+	}
+
+	public void validateCipherMode() throws CryptoException {
+		if (_fipsEnforced && !_isAEADCipherMode(_cipherMode)) {
+			throw new CryptoException(
+				"FIPS enforcement requires an AEAD cipher mode but \"" +
+					_cipherMode + "\" is not AEAD");
+		}
+	}
+
+	private boolean _isAEADCipherMode(String cipherMode) {
+		if (Validator.isNull(cipherMode)) {
+			return false;
+		}
+
+		return _aeadCipherModes.contains(StringUtil.toUpperCase(cipherMode));
+	}
+
+	private static final String _FIPS_ENFORCED_ENV_NAME =
+		"LIFERAY_KEYMANAGER_FIPS_ENFORCED";
+
+	private static final Set<String> _aeadCipherModes = new HashSet<>(
+		Arrays.asList("AES_256_GCM", "AES_GCM", "SYMMETRIC_DEFAULT"));
+
+	private final String _cipherMode;
+	private final boolean _fipsEnforced;
+	private final boolean _useFipsEndpoint;
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSARNResolver.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSARNResolver.java
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.util;
+
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSARNResolver {
+
+	public static String resolve(
+		String accountId, String arnTemplate, long companyId, String identifier,
+		String region) {
+
+		if (Validator.isNull(arnTemplate) || (identifier == null) ||
+			identifier.startsWith("arn:") || identifier.startsWith("alias/")) {
+
+			return identifier;
+		}
+
+		if (accountId != null) {
+			arnTemplate = StringUtil.replace(
+				arnTemplate, "{accountId}", accountId);
+		}
+
+		arnTemplate = StringUtil.replace(
+			arnTemplate, "{companyId}", String.valueOf(companyId));
+		arnTemplate = StringUtil.replace(
+			arnTemplate, "{identifier}", identifier);
+
+		if (region != null) {
+			arnTemplate = StringUtil.replace(arnTemplate, "{region}", region);
+		}
+
+		return arnTemplate;
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSAccountUtil.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSAccountUtil.java
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.util;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest;
+import com.amazonaws.services.securitytoken.model.GetCallerIdentityResult;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSAccountUtil {
+
+	public static String getAccountId() {
+		AWSSecurityTokenService awsSecurityTokenService =
+			_getAWSSecurityTokenService();
+
+		try {
+			GetCallerIdentityResult getCallerIdentityResult =
+				awsSecurityTokenService.getCallerIdentity(
+					new GetCallerIdentityRequest());
+
+			return getCallerIdentityResult.getAccount();
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to infer AWS account ID via STS", exception);
+			}
+		}
+		finally {
+			awsSecurityTokenService.shutdown();
+		}
+
+		return null;
+	}
+
+	private static AWSSecurityTokenService _getAWSSecurityTokenService() {
+		AWSSecurityTokenServiceClientBuilder
+			awsSecurityTokenServiceClientBuilder =
+				AWSSecurityTokenServiceClientBuilder.standard(
+				).withCredentials(
+					DefaultAWSCredentialsProviderChain.getInstance()
+				);
+
+		return awsSecurityTokenServiceClientBuilder.build();
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(AWSAccountUtil.class);
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSByteBufferUtil.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSByteBufferUtil.java
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.util;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+import java.nio.ByteBuffer;
+
+import java.util.Arrays;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSByteBufferUtil {
+
+	public static byte[] getBytes(ByteBuffer byteBuffer) {
+		if (byteBuffer == null) {
+			return new byte[0];
+		}
+
+		byte[] bytes = new byte[byteBuffer.remaining()];
+
+		byteBuffer.get(bytes);
+
+		if (byteBuffer.hasArray() && !byteBuffer.isReadOnly()) {
+			int arrayOffset = byteBuffer.arrayOffset();
+
+			Arrays.fill(
+				byteBuffer.array(), arrayOffset,
+				arrayOffset + byteBuffer.limit(), (byte)0);
+		}
+		else if (_log.isWarnEnabled()) {
+			_log.warn(
+				"Unable to zero AWS response buffer (direct or read only); " +
+					"sensitive bytes remain until JVM reclaims them");
+		}
+
+		return bytes;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AWSByteBufferUtil.class);
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSClientManager.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSClientManager.java
@@ -1,0 +1,209 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.util;
+
+import com.amazonaws.AmazonWebServiceClient;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.client.builder.AwsClientBuilder;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSClientManager<T> {
+
+	public AWSClientManager(
+		ClientFactory<T> clientFactory, String fipsEndpointTemplate,
+		String region, boolean useFipsEndpoint) {
+
+		_clientFactory = clientFactory;
+		_fipsEndpointTemplate = fipsEndpointTemplate;
+		_region = region;
+		_useFipsEndpoint = useFipsEndpoint;
+
+		if (Validator.isNull(region)) {
+			_region = AWSRegionUtil.getRegion();
+		}
+
+		_awsCredentialsProvider =
+			DefaultAWSCredentialsProviderChain.getInstance();
+	}
+
+	public void close() {
+		_reentrantReadWriteLock.writeLock(
+		).lock();
+
+		try {
+			_closeClient();
+		}
+		finally {
+			_reentrantReadWriteLock.writeLock(
+			).unlock();
+		}
+	}
+
+	public <R> R execute(AWSOperation<T, R> awsOperation) throws Exception {
+		_reentrantReadWriteLock.readLock(
+		).lock();
+
+		try {
+			T client = _getClient();
+
+			try {
+				return awsOperation.apply(client);
+			}
+			catch (Exception exception) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("AWS client operation failed", exception);
+				}
+
+				throw exception;
+			}
+		}
+		finally {
+			_reentrantReadWriteLock.readLock(
+			).unlock();
+		}
+	}
+
+	public String getRegion() {
+		return _region;
+	}
+
+	public void updateConfiguration(String region, boolean useFipsEndpoint) {
+		if (Validator.isNull(region)) {
+			region = AWSRegionUtil.getRegion();
+		}
+
+		if (Validator.isNull(region)) {
+			throw new IllegalArgumentException(
+				"AWS region could not be resolved");
+		}
+
+		_reentrantReadWriteLock.writeLock(
+		).lock();
+
+		try {
+			if (!region.equals(_region) ||
+				(useFipsEndpoint != _useFipsEndpoint)) {
+
+				_region = region;
+				_useFipsEndpoint = useFipsEndpoint;
+
+				_closeClient();
+			}
+		}
+		finally {
+			_reentrantReadWriteLock.writeLock(
+			).unlock();
+		}
+	}
+
+	@FunctionalInterface
+	public interface AWSOperation<T, R> {
+
+		public R apply(T client) throws Exception;
+
+	}
+
+	@FunctionalInterface
+	public interface ClientFactory<T> {
+
+		public T build(
+				AWSCredentialsProvider awsCredentialsProvider,
+				AwsClientBuilder.EndpointConfiguration endpointConfiguration,
+				String region)
+			throws Exception;
+
+	}
+
+	private void _closeClient() {
+		if (_client == null) {
+			return;
+		}
+
+		try {
+			if (_client instanceof AmazonWebServiceClient) {
+				AmazonWebServiceClient amazonWebServiceClient =
+					(AmazonWebServiceClient)_client;
+
+				amazonWebServiceClient.shutdown();
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to cleanly shut down AWS client", exception);
+			}
+		}
+
+		_client = null;
+	}
+
+	private T _getClient() throws Exception {
+		T client = _client;
+
+		if (client != null) {
+			return client;
+		}
+
+		_reentrantReadWriteLock.readLock(
+		).unlock();
+
+		_reentrantReadWriteLock.writeLock(
+		).lock();
+
+		try {
+			if (_client == null) {
+				AwsClientBuilder.EndpointConfiguration endpointConfiguration =
+					null;
+
+				if (_useFipsEndpoint &&
+					Validator.isNotNull(_fipsEndpointTemplate) &&
+					Validator.isNotNull(_region)) {
+
+					String endpoint = StringUtil.replace(
+						_fipsEndpointTemplate, "{region}", _region);
+
+					endpointConfiguration =
+						new AwsClientBuilder.EndpointConfiguration(
+							endpoint, _region);
+				}
+
+				_client = _clientFactory.build(
+					_awsCredentialsProvider, endpointConfiguration, _region);
+			}
+
+			_reentrantReadWriteLock.readLock(
+			).lock();
+		}
+		finally {
+			_reentrantReadWriteLock.writeLock(
+			).unlock();
+		}
+
+		return _client;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AWSClientManager.class);
+
+	private final AWSCredentialsProvider _awsCredentialsProvider;
+	private volatile T _client;
+	private final ClientFactory<T> _clientFactory;
+	private final String _fipsEndpointTemplate;
+	private final ReentrantReadWriteLock _reentrantReadWriteLock =
+		new ReentrantReadWriteLock();
+	private volatile String _region;
+	private volatile boolean _useFipsEndpoint;
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSRegionUtil.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSRegionUtil.java
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.util;
+
+import com.amazonaws.regions.DefaultAwsRegionProviderChain;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSRegionUtil {
+
+	public static String getRegion() {
+		try {
+			DefaultAwsRegionProviderChain defaultAwsRegionProviderChain =
+				new DefaultAwsRegionProviderChain();
+
+			return defaultAwsRegionProviderChain.getRegion();
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to infer AWS region from environment", exception);
+			}
+		}
+
+		return null;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(AWSRegionUtil.class);
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/fips/AWSKMSFipsValidatorTest.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/fips/AWSKMSFipsValidatorTest.java
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.fips;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.security.key.ServiceIndicator;
+import com.liferay.portal.security.key.crypto.exception.CryptoException;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSKMSFipsValidatorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testAEADCipherModeAllowedUnderFips() throws Exception {
+		AWSKMSFipsValidator awsKMSFipsValidator = new AWSKMSFipsValidator(
+			"AES_256_GCM", true);
+
+		awsKMSFipsValidator.validateCipherMode();
+	}
+
+	@Test(expected = CryptoException.class)
+	public void testCBCCipherModeRejectedUnderFips() throws Exception {
+		AWSKMSFipsValidator awsKMSFipsValidator = new AWSKMSFipsValidator(
+			"AES_CBC", true);
+
+		awsKMSFipsValidator.validateCipherMode();
+	}
+
+	@Test
+	public void testCloudHSMOriginIsFipsApproved() {
+		AWSKMSFipsValidator awsKMSFipsValidator = new AWSKMSFipsValidator(
+			"AES_256_GCM", false);
+
+		Assert.assertTrue(
+			awsKMSFipsValidator.isFipsApprovedKeyOrigin("AWS_CLOUDHSM"));
+	}
+
+	@Test
+	public void testFipsEndpointMakesAnyOriginApproved() {
+		AWSKMSFipsValidator awsKMSFipsValidator = new AWSKMSFipsValidator(
+			"AES_256_GCM", true);
+
+		Assert.assertTrue(
+			awsKMSFipsValidator.isFipsApprovedKeyOrigin("AWS_KMS"));
+		Assert.assertTrue(awsKMSFipsValidator.isFipsEnforced());
+	}
+
+	@Test
+	public void testServiceIndicatorAllowsUnapprovedWhenNotEnforced()
+		throws Exception {
+
+		AWSKMSFipsValidator awsKMSFipsValidator = new AWSKMSFipsValidator(
+			"AES_256_GCM", false);
+
+		ServiceIndicator serviceIndicator =
+			awsKMSFipsValidator.toServiceIndicator(
+				false, RandomTestUtil.randomString());
+
+		Assert.assertFalse(serviceIndicator.isApproved());
+	}
+
+	@Test
+	public void testServiceIndicatorApproved() throws Exception {
+		AWSKMSFipsValidator awsKMSFipsValidator = new AWSKMSFipsValidator(
+			"AES_256_GCM", true);
+
+		ServiceIndicator serviceIndicator =
+			awsKMSFipsValidator.toServiceIndicator(true, "AWS.KMS.Encrypt");
+
+		Assert.assertEquals(
+			"AWS.KMS.Encrypt", serviceIndicator.getSecurityFunctionName());
+		Assert.assertTrue(serviceIndicator.isApproved());
+	}
+
+	@Test(expected = CryptoException.class)
+	public void testServiceIndicatorRejectsUnapprovedUnderFips()
+		throws Exception {
+
+		AWSKMSFipsValidator awsKMSFipsValidator = new AWSKMSFipsValidator(
+			"AES_256_GCM", true);
+
+		awsKMSFipsValidator.toServiceIndicator(
+			false, RandomTestUtil.randomString());
+	}
+
+	@Test
+	public void testSoftwareOriginNotFipsApprovedWithoutFipsEndpoint() {
+		AWSKMSFipsValidator awsKMSFipsValidator = new AWSKMSFipsValidator(
+			"AES_256_GCM", false);
+
+		Assert.assertFalse(
+			awsKMSFipsValidator.isFipsApprovedKeyOrigin("AWS_KMS"));
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSARNResolverTest.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSARNResolverTest.java
@@ -1,0 +1,107 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.util;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSARNResolverTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testResolveCompanyTemplate() {
+		long companyId = RandomTestUtil.randomLong();
+		String identifier = RandomTestUtil.randomString();
+		String prefix = RandomTestUtil.randomString() + StringPool.SLASH;
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				prefix, companyId, StringPool.SLASH, identifier),
+			AWSARNResolver.resolve(
+				RandomTestUtil.randomString(),
+				prefix + "{companyId}/{identifier}", companyId, identifier,
+				RandomTestUtil.randomString()));
+	}
+
+	@Test
+	public void testResolveNullTemplateFallsBackToIdentifier() {
+		String identifier = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			identifier,
+			AWSARNResolver.resolve(
+				RandomTestUtil.randomString(), null,
+				RandomTestUtil.randomLong(), identifier,
+				RandomTestUtil.randomString()));
+	}
+
+	@Test
+	public void testResolvePassesThroughAliasIdentifier() {
+		String identifier = "alias/" + RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			identifier,
+			AWSARNResolver.resolve(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomLong(), identifier,
+				RandomTestUtil.randomString()));
+	}
+
+	@Test
+	public void testResolvePassesThroughARNIdentifier() {
+		String identifier = "arn:" + RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			identifier,
+			AWSARNResolver.resolve(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomLong(), identifier,
+				RandomTestUtil.randomString()));
+	}
+
+	@Test
+	public void testResolveSystemTemplate() {
+		String accountId = RandomTestUtil.randomString();
+		String identifier = RandomTestUtil.randomString();
+		String prefix = RandomTestUtil.randomString() + StringPool.SLASH;
+		String region = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				prefix, region, StringPool.SLASH, accountId, StringPool.SLASH,
+				identifier),
+			AWSARNResolver.resolve(
+				accountId, prefix + "{region}/{accountId}/{identifier}",
+				RandomTestUtil.randomLong(), identifier, region));
+	}
+
+	@Test
+	public void testResolveTolerantOfMissingAccountId() {
+		String identifier = RandomTestUtil.randomString();
+		String prefix = RandomTestUtil.randomString() + StringPool.SLASH;
+
+		Assert.assertEquals(
+			prefix + identifier,
+			AWSARNResolver.resolve(
+				null, prefix + "{identifier}", RandomTestUtil.randomLong(),
+				identifier, RandomTestUtil.randomString()));
+	}
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-92156

Stacked PR **1 of 3** for the AWS Key Manager provider (LPD-92156), split for reviewability.

This layer adds the `portal-security-key-provider-aws` module scaffolding, the AWS SDK client / ARN / region / account utilities, and the AWS FIPS validators (`BaseAWSFipsValidator`, `AWSKMSFipsValidator`), with unit tests for the ARN resolver and FIPS validator.
---
### Stack (LPD-92156)
- 1/3 — #3185 — module utilities and FIPS validators
- 2/3 — #3186 — AWS KMS crypto providers
- 3/3 — #3183 — AWS Secrets Manager providers and aws profile