### PR TITLE
LPD-101135 Keep Require Password Reset when the policy requires it

### DIFF
--- a/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/web/internal/portlet/action/test/UpdatePasswordMVCActionCommandTest.java
+++ b/modules/apps/users-admin/users-admin-test/src/testIntegration/java/com/liferay/users/admin/web/internal/portlet/action/test/UpdatePasswordMVCActionCommandTest.java
@@ -1,0 +1,219 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.users.admin.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutTypePortlet;
+import com.liferay.portal.kernel.model.PasswordPolicy;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.portlet.LiferayActionRequest;
+import com.liferay.portal.kernel.portlet.LiferayStateAwareResponse;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.PasswordPolicyLocalService;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.servlet.PortletServlet;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.Sync;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portlet.ActionRequestFactory;
+import com.liferay.portlet.passwordpoliciesadmin.util.test.PasswordPolicyTestUtil;
+import com.liferay.users.admin.constants.UsersAdminPortletKeys;
+
+import jakarta.portlet.ActionRequest;
+import jakarta.portlet.Event;
+import jakarta.portlet.Portlet;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Manuele Castro
+ */
+@RunWith(Arquillian.class)
+@Sync
+public class UpdatePasswordMVCActionCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Test
+	public void testProcessAction() throws Exception {
+		_testProcessAction(false, false, false);
+		_testProcessAction(true, false, true);
+		_testProcessAction(true, true, false);
+	}
+
+	private LiferayActionRequest _getLiferayActionRequest(
+			User selectedUser, User signedInUser)
+		throws Exception {
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.addParameter(
+			ActionRequest.ACTION_NAME, "/users_admin/update_password");
+		mockLiferayPortletActionRequest.addParameter(
+			"p_u_i_d", String.valueOf(selectedUser.getUserId()));
+
+		mockLiferayPortletActionRequest.setAttribute(
+			PortletServlet.PORTLET_SERVLET_REQUEST,
+			mockLiferayPortletActionRequest.getHttpServletRequest());
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.PORTLET_ID, UsersAdminPortletKeys.USERS_ADMIN);
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay(signedInUser));
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.USER_ID, signedInUser.getUserId());
+
+		LiferayActionRequest liferayActionRequest = ActionRequestFactory.create(
+			mockLiferayPortletActionRequest.getHttpServletRequest(),
+			_portletLocalService.getPortletById(
+				UsersAdminPortletKeys.USERS_ADMIN),
+			null, null, null, null, null, TestPropsValues.getPlid());
+
+		liferayActionRequest.setPortletRequestDispatcherRequest(
+			mockLiferayPortletActionRequest.getHttpServletRequest());
+
+		return liferayActionRequest;
+	}
+
+	private ThemeDisplay _getThemeDisplay(User user) throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+
+		Layout layout = _layoutLocalService.getLayout(
+			TestPropsValues.getPlid());
+
+		themeDisplay.setLayout(layout);
+		themeDisplay.setLayoutSet(layout.getLayoutSet());
+		themeDisplay.setLayoutTypePortlet(
+			(LayoutTypePortlet)layout.getLayoutType());
+
+		themeDisplay.setPermissionChecker(
+			PermissionThreadLocal.getPermissionChecker());
+		themeDisplay.setScopeGroupId(TestPropsValues.getGroupId());
+		themeDisplay.setSiteGroupId(TestPropsValues.getGroupId());
+		themeDisplay.setUser(user);
+
+		return themeDisplay;
+	}
+
+	private void _testProcessAction(
+			boolean changeRequired, boolean expectedPasswordReset,
+			boolean selectedUser)
+		throws Exception {
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setUserId(TestPropsValues.getUserId());
+
+		PasswordPolicy passwordPolicy =
+			PasswordPolicyTestUtil.addPasswordPolicy(serviceContext);
+
+		passwordPolicy.setChangeable(true);
+		passwordPolicy.setChangeRequired(changeRequired);
+
+		passwordPolicy = _passwordPolicyLocalService.updatePasswordPolicy(
+			passwordPolicy);
+
+		User user = UserTestUtil.addUser();
+
+		_userLocalService.addPasswordPolicyUsers(
+			passwordPolicy.getPasswordPolicyId(),
+			new long[] {user.getUserId()});
+
+		_userLocalService.updateLastLogin(
+			user.getUserId(), RandomTestUtil.randomString());
+
+		user = _userLocalService.updatePasswordReset(user.getUserId(), true);
+
+		Assert.assertTrue(user.isPasswordReset());
+
+		User signedInUser = TestPropsValues.getUser();
+
+		if (selectedUser) {
+			signedInUser = user;
+		}
+
+		_portlet.processAction(
+			_getLiferayActionRequest(user, signedInUser),
+			new UpdatePasswordMVCActionCommandTest.
+				CustomMockLiferayPortletActionResponse());
+
+		user = _userLocalService.getUser(user.getUserId());
+
+		Assert.assertEquals(expectedPasswordReset, user.isPasswordReset());
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private PasswordPolicyLocalService _passwordPolicyLocalService;
+
+	@Inject(
+		filter = "component.name=com.liferay.users.admin.web.internal.portlet.UsersAdminPortlet"
+	)
+	private Portlet _portlet;
+
+	@Inject
+	private PortletLocalService _portletLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
+
+	private class CustomMockLiferayPortletActionResponse
+		extends MockLiferayPortletActionResponse
+		implements LiferayStateAwareResponse {
+
+		@Override
+		public List<Event> getEvents() {
+			return Collections.emptyList();
+		}
+
+		@Override
+		public String getRedirectLocation() {
+			return StringPool.BLANK;
+		}
+
+		@Override
+		public boolean isCalledSetRenderParameter() {
+			return false;
+		}
+
+	}
+
+}

--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdatePasswordMVCActionCommand.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/portlet/action/UpdatePasswordMVCActionCommand.java
@@ -79,7 +79,8 @@ public class UpdatePasswordMVCActionCommand extends BaseMVCActionCommand {
 			boolean ldapPasswordPolicyEnabled =
 				LDAPSettingsUtil.isPasswordPolicyEnabled(user.getCompanyId());
 
-			if ((user.getLastLoginDate() == null) &&
+			if (((user.getLastLoginDate() == null) ||
+				 (themeDisplay.getUserId() != user.getUserId())) &&
 				(((passwordPolicy == null) && !ldapPasswordPolicyEnabled) ||
 				 ((passwordPolicy != null) && passwordPolicy.isChangeable() &&
 				  passwordPolicy.isChangeRequired()))) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101135

## What Is Being Fixed

The "Require Password Reset" checkbox on a user's Password tab is rendered checked and disabled when the applicable password policy has Change Required enabled. Browsers exclude disabled controls from the submitted form data, so the `passwordReset` parameter never reaches the server. `UpdatePasswordMVCActionCommand` read it with `ParamUtil.getBoolean`, which falls back to `false`, and then called `UserLocalService.updatePasswordReset` with `false` — silently clearing the flag the form had just displayed as set.

The existing guard only compensated when the user had never logged in, so the defect was limited to users with a last login date. An administrator saving that user's Password tab would drop the policy-mandated reset requirement without any indication.

## How It Is Being Fixed

The server, not the form, now decides. The condition that already forced a reset for never-logged-in users is widened to also cover an administrator editing another user, which is exactly when the checkbox is rendered and disabled. A user updating their own password never sees the checkbox, so an absent parameter still means "unchecked" there and self-service reset continues to clear the flag as before.

The guard is keyed on the same `isChangeable() && isChangeRequired()` pairing used everywhere else in the portal — `UserLocalServiceImpl`, `SetupWizardUtil`, and the headless `_isPasswordResetRequired` — so a policy that forbids changing the password is not treated as requiring one. Because the condition only fires when the policy requires a change, it can never override an administrator deliberately unchecking an enabled checkbox.

`UpdatePasswordMVCActionCommandTest` covers three cases: an administrator editing another user keeps the flag set, a user updating their own password still clears it, and a policy without Change Required leaves a deliberate uncheck respected.

## PR Check

**pr-check: PASS** — tested on `e911ed6cf2c43a222c2c2492178e0c483a6e79fd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "e911ed6cf2c43a222c2c2492178e0c483a6e79fd"} -->
