### PR TITLE
[FIPS] LPD-86301 Redirect back to the same LDAP server after a save error

### DIFF
--- a/modules/apps/portal-settings/portal-settings-authentication-ldap-web/src/main/java/com/liferay/portal/settings/authentication/ldap/web/internal/portlet/action/EditLDAPServerMVCActionCommand.java
+++ b/modules/apps/portal-settings/portal-settings-authentication-ldap-web/src/main/java/com/liferay/portal/settings/authentication/ldap/web/internal/portlet/action/EditLDAPServerMVCActionCommand.java
@@ -33,7 +33,6 @@ import com.liferay.portal.security.ldap.validator.LDAPFilterValidator;
 import jakarta.portlet.ActionRequest;
 import jakarta.portlet.ActionResponse;
 import jakarta.portlet.PortletRequest;
-import jakarta.portlet.PortletURL;
 
 import java.util.Dictionary;
 import java.util.List;
@@ -92,21 +91,20 @@ public class EditLDAPServerMVCActionCommand extends BaseMVCActionCommand {
 				SessionErrors.add(
 					actionRequest, throwable.getClass(), throwable);
 
-				PortletURL portletURL = PortletURLBuilder.create(
-					PortletURLFactoryUtil.create(
-						actionRequest,
-						ConfigurationAdminPortletKeys.INSTANCE_SETTINGS,
-						PortletRequest.RENDER_PHASE)
-				).setMVCRenderCommandName(
-					"/portal_settings_authentication_ldap/edit_ldap_server"
-				).buildPortletURL();
-
-				String redirect = ParamUtil.getString(
-					actionRequest, "redirect");
-
-				portletURL.setParameter("redirect", redirect);
-
-				actionResponse.sendRedirect(portletURL.toString());
+				actionResponse.sendRedirect(
+					PortletURLBuilder.create(
+						PortletURLFactoryUtil.create(
+							actionRequest, _portal.getPortletId(actionRequest),
+							PortletRequest.RENDER_PHASE)
+					).setMVCRenderCommandName(
+						"/portal_settings_authentication_ldap/edit_ldap_server"
+					).setRedirect(
+						ParamUtil.getString(actionRequest, "redirect")
+					).setParameter(
+						LDAPConstants.LDAP_SERVER_ID,
+						ParamUtil.getLong(
+							actionRequest, LDAPConstants.LDAP_SERVER_ID)
+					).buildString());
 
 				return;
 			}
@@ -249,5 +247,8 @@ public class EditLDAPServerMVCActionCommand extends BaseMVCActionCommand {
 	)
 	private ConfigurationProvider<LDAPServerConfiguration>
 		_ldapServerConfigurationProvider;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/test/playwright/pages/portal-security-ldap/LdapServerPage.ts
+++ b/modules/test/playwright/pages/portal-security-ldap/LdapServerPage.ts
@@ -22,6 +22,7 @@ export class LdapServerPage {
 	readonly description: Locator;
 	readonly emailAddress: Locator;
 	readonly firstName: Locator;
+	readonly form: Locator;
 	readonly fullName: Locator;
 	readonly group: Locator;
 	readonly groupDefaultObjectClasses: Locator;
@@ -33,6 +34,7 @@ export class LdapServerPage {
 	readonly jobTitle: Locator;
 	readonly lastName: Locator;
 	readonly ldapConfigurationPage: LdapConfigurationPage;
+	readonly ldapServerIdInput: Locator;
 	readonly middleName: Locator;
 	readonly page: Page;
 	readonly password: Locator;
@@ -66,6 +68,7 @@ export class LdapServerPage {
 		this.description = page.getByLabel('Description');
 		this.emailAddress = page.getByLabel('Email Address');
 		this.firstName = page.getByLabel('First Name', {exact: true});
+		this.form = page.locator('form[name$="_fm"]');
 		this.fullName = page.getByLabel('Full Name');
 		this.group = page.getByLabel('Group', {exact: true});
 		this.groupDefaultObjectClasses = page.getByLabel(
@@ -85,6 +88,7 @@ export class LdapServerPage {
 		this.jobTitle = page.getByLabel('Job Title');
 		this.lastName = page.getByLabel('Last Name', {exact: true});
 		this.ldapConfigurationPage = new LdapConfigurationPage(page);
+		this.ldapServerIdInput = page.locator('input[name$="_ldapServerId"]');
 		this.middleName = page.getByLabel('Middle Name');
 		this.page = page;
 		this.password = page.getByLabel('Password');

--- a/modules/test/playwright/tests/portal-security-ldap/main/fips.spec.ts
+++ b/modules/test/playwright/tests/portal-security-ldap/main/fips.spec.ts
@@ -7,9 +7,9 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {ldapConfigurationPagesTest} from '../../../fixtures/ldapConfigurationPagesTest';
 import {loginTest} from '../../../fixtures/loginTest';
+import {LdapServerPage} from '../../../pages/portal-security-ldap/LdapServerPage';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
-import {waitForAlert} from '../../../utils/waitForAlert';
 
 export const test = mergeTests(loginTest(), ldapConfigurationPagesTest);
 
@@ -29,6 +29,16 @@ const PRESETS = [
 	['Novell eDirectory', 'ldaps://localhost:636'],
 	['OpenLDAP', 'ldaps://localhost:636'],
 ] as const;
+
+const expectSchemeErrorOnLdapServerForm = async (
+	ldapServerPage: LdapServerPage,
+	baseProviderURL: string
+) =>
+	expect(
+		ldapServerPage.form.getByText(
+			`The base provider URL "${baseProviderURL}" must use the "ldaps://" scheme in FIPS mode.`
+		)
+	).toBeVisible();
 
 test(
 	'New LDAP server form defaults the base provider URL to the ldaps:// scheme',
@@ -74,30 +84,58 @@ test(
 );
 
 test(
-	'Saving an LDAP server with an insecure ldap:// base provider URL shows the FIPS validation error',
+	'Saving an LDAP server with an insecure ldap:// base provider URL shows the FIPS validation error on the form',
 	{tag: '@LPD-86301'},
 	async ({ldapConfigurationPage, ldapServerPage}) => {
 		const baseProviderURL = `ldap://${getRandomString()}`;
+		const serverName = `fips-${getRandomString()}`;
 
-		await test.step('Open the Add LDAP Server form', async () => {
+		await test.step('Open the Add LDAP Server form and fill an insecure ldap:// URL', async () => {
 			await ldapConfigurationPage.addLdapServer();
-		});
 
-		await test.step('Fill the form with an insecure ldap:// URL', async () => {
 			await ldapServerPage.serverName.waitFor();
 
-			await ldapServerPage.serverName.fill(`fips-${getRandomString()}`);
+			await ldapServerPage.serverName.fill(serverName);
 			await ldapServerPage.baseProviderUrl.fill(baseProviderURL);
 		});
 
-		await test.step('Submit the form and assert the FIPS validation error names the URL and the required scheme', async () => {
-			await clickAndExpectToBeVisible({
-				target: ldapServerPage.page.getByText(
-					`The base provider URL "${baseProviderURL}" must use the "ldaps://" scheme in FIPS mode.`
-				),
-				trigger: ldapServerPage.saveButton,
+		await test.step('Assert the Add LDAP Server form redisplays carrying the error', async () => {
+			await ldapServerPage.saveButton.click();
+
+			await expectSchemeErrorOnLdapServerForm(
+				ldapServerPage,
+				baseProviderURL
+			);
+
+			await expect(ldapServerPage.ldapServerIdInput).toHaveValue('0');
+		});
+
+		await test.step('Save the server with a compliant URL', async () => {
+			await ldapServerPage.addLdapServer({
+				baseProviderUrl: 'ldaps://localhost:636',
+				serverName,
 			});
 		});
+
+		await test.step('Reopen it and enter an insecure ldap:// URL', async () => {
+			await ldapServerPage.viewLdapServer(serverName);
+
+			await ldapServerPage.baseProviderUrl.fill(baseProviderURL);
+		});
+
+		await test.step('Assert the Edit LDAP Server form redisplays carrying the error', async () => {
+			await ldapServerPage.saveButton.click();
+
+			await expectSchemeErrorOnLdapServerForm(
+				ldapServerPage,
+				baseProviderURL
+			);
+
+			await expect(ldapServerPage.ldapServerIdInput).not.toHaveValue('0');
+			await expect(ldapServerPage.serverName).toHaveValue(serverName);
+		});
+
+		await ldapServerPage.deleteLdapServer(serverName);
 	}
 );
 
@@ -138,24 +176,15 @@ test(
 test(
 	'The LDAP test pages refuse an insecure ldap:// base provider URL',
 	{tag: '@LPD-86301'},
-	async ({ldapConfigurationPage, ldapServerPage}) => {
+	async ({ldapServerPage}) => {
 		const baseProviderURL = `ldap://${getRandomString()}:389`;
 		const serverName = `fips-${getRandomString()}`;
 
 		await test.step('Add an LDAP server with a compliant URL', async () => {
-			await ldapConfigurationPage.addLdapServer();
-
-			await ldapServerPage.serverName.waitFor();
-
-			await ldapServerPage.serverName.fill(serverName);
-			await ldapServerPage.baseProviderUrl.fill('ldaps://localhost:636');
-
-			await ldapServerPage.saveButton.click();
-
-			await waitForAlert(
-				ldapServerPage.page,
-				'Success:Your request completed successfully.'
-			);
+			await ldapServerPage.addLdapServer({
+				baseProviderUrl: 'ldaps://localhost:636',
+				serverName,
+			});
 		});
 
 		await test.step('Reopen it and enter an insecure URL', async () => {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-86301

## Why

A rejected LDAP server save dropped the user into a blank Add form in the Instance Settings portlet, losing the server being edited. The redirect carried no `ldapServerId` and hardcoded `ConfigurationAdminPortletKeys.INSTANCE_SETTINGS`, although this action command is registered for System Settings too.

## Key changes

- Target the current portlet instead of a hardcoded one — the command serves both settings portlets.
- Carry `ldapServerId` on the redirect — without it the edit form reopens as Add.
- Scope the Playwright error assertion to the form — page-wide `getByText` passed regardless of where the text sat.
- Assert the hidden `ldapServerId` input — the observable proof the edit context survived.