### PR TITLE
LPD-101663 Fix Store Consent read-back throwing on every lookup

### DIFF
--- a/modules/apps/cookies/cookies-api/bnd.bnd
+++ b/modules/apps/cookies/cookies-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Cookies API
 Bundle-SymbolicName: com.liferay.cookies.api
-Bundle-Version: 9.1.3
+Bundle-Version: 9.2.0
 Export-Package:\
 	com.liferay.cookies.configuration,\
 	com.liferay.cookies.configuration.banner,\

--- a/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalService.java
+++ b/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalService.java
@@ -211,6 +211,10 @@ public interface CookiesConsentPreferenceLocalService
 		long cookiesConsentPreferenceId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public CookiesConsentPreference fetchCookiesConsentPreference(
+		long userId, String domain, String name);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();
 
 	/**
@@ -290,4 +294,4 @@ public interface CookiesConsentPreferenceLocalService
 		CookiesConsentPreference cookiesConsentPreference);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1885118937
+// LIFERAY-SERVICE-BUILDER-HASH:1819426011

--- a/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalServiceUtil.java
+++ b/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalServiceUtil.java
@@ -241,6 +241,12 @@ public class CookiesConsentPreferenceLocalServiceUtil {
 			cookiesConsentPreferenceId);
 	}
 
+	public static CookiesConsentPreference fetchCookiesConsentPreference(
+		long userId, String domain, String name) {
+
+		return getService().fetchCookiesConsentPreference(userId, domain, name);
+	}
+
 	public static com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 
@@ -353,4 +359,4 @@ public class CookiesConsentPreferenceLocalServiceUtil {
 			CookiesConsentPreferenceLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-1988590670
+// LIFERAY-SERVICE-BUILDER-HASH:-949977715

--- a/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalServiceWrapper.java
+++ b/modules/apps/cookies/cookies-api/src/main/java/com/liferay/cookies/service/CookiesConsentPreferenceLocalServiceWrapper.java
@@ -275,6 +275,14 @@ public class CookiesConsentPreferenceLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.cookies.model.CookiesConsentPreference
+		fetchCookiesConsentPreference(long userId, String domain, String name) {
+
+		return _cookiesConsentPreferenceLocalService.
+			fetchCookiesConsentPreference(userId, domain, name);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 
@@ -418,4 +426,4 @@ public class CookiesConsentPreferenceLocalServiceWrapper
 		_cookiesConsentPreferenceLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-2076735159
+// LIFERAY-SERVICE-BUILDER-HASH:-1983608772

--- a/modules/apps/cookies/cookies-api/src/main/resources/com/liferay/cookies/service/packageinfo
+++ b/modules/apps/cookies/cookies-api/src/main/resources/com/liferay/cookies/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
+++ b/modules/apps/cookies/cookies-rest-impl/src/main/java/com/liferay/cookies/rest/internal/resource/v1_0/CookiesConsentPreferenceResourceImpl.java
@@ -9,7 +9,6 @@ import com.liferay.cookies.rest.dto.v1_0.CookiesConsentPreference;
 import com.liferay.cookies.rest.internal.dto.v1_0.util.CookiesConsentPreferenceUtil;
 import com.liferay.cookies.rest.resource.v1_0.CookiesConsentPreferenceResource;
 import com.liferay.cookies.service.CookiesConsentPreferenceLocalService;
-import com.liferay.cookies.service.persistence.CookiesConsentPreferencePersistence;
 import com.liferay.portal.kernel.exception.PortalException;
 
 import java.net.URI;
@@ -49,8 +48,9 @@ public class CookiesConsentPreferenceResourceImpl
 
 		com.liferay.cookies.model.CookiesConsentPreference
 			serviceBuilderCookiesConsentPreference =
-				_cookiesConsentPreferencePersistence.fetchByU_D_N(
-					contextUser.getUserId(), _getDomain(), name);
+				_cookiesConsentPreferenceLocalService.
+					fetchCookiesConsentPreference(
+						contextUser.getUserId(), _getDomain(), name);
 
 		if (serviceBuilderCookiesConsentPreference == null) {
 			return null;
@@ -67,10 +67,11 @@ public class CookiesConsentPreferenceResourceImpl
 
 		com.liferay.cookies.model.CookiesConsentPreference
 			serviceBuilderCookiesConsentPreference =
-				_cookiesConsentPreferencePersistence.fetchByU_D_N(
-					contextUser.getUserId(),
-					cookiesConsentPreference.getDomain(),
-					cookiesConsentPreference.getName());
+				_cookiesConsentPreferenceLocalService.
+					fetchCookiesConsentPreference(
+						contextUser.getUserId(),
+						cookiesConsentPreference.getDomain(),
+						cookiesConsentPreference.getName());
 
 		if (serviceBuilderCookiesConsentPreference != null) {
 			serviceBuilderCookiesConsentPreference.setExpirationDate(
@@ -79,8 +80,9 @@ public class CookiesConsentPreferenceResourceImpl
 				cookiesConsentPreference.getValue());
 
 			serviceBuilderCookiesConsentPreference =
-				_cookiesConsentPreferencePersistence.update(
-					serviceBuilderCookiesConsentPreference);
+				_cookiesConsentPreferenceLocalService.
+					updateCookiesConsentPreference(
+						serviceBuilderCookiesConsentPreference);
 		}
 		else {
 			serviceBuilderCookiesConsentPreference =
@@ -115,9 +117,5 @@ public class CookiesConsentPreferenceResourceImpl
 	@Reference
 	private CookiesConsentPreferenceLocalService
 		_cookiesConsentPreferenceLocalService;
-
-	@Reference
-	private CookiesConsentPreferencePersistence
-		_cookiesConsentPreferencePersistence;
 
 }

--- a/modules/apps/cookies/cookies-service/src/main/java/com/liferay/cookies/service/impl/CookiesConsentPreferenceLocalServiceImpl.java
+++ b/modules/apps/cookies/cookies-service/src/main/java/com/liferay/cookies/service/impl/CookiesConsentPreferenceLocalServiceImpl.java
@@ -29,6 +29,7 @@ import org.osgi.service.component.annotations.Reference;
 public class CookiesConsentPreferenceLocalServiceImpl
 	extends CookiesConsentPreferenceLocalServiceBaseImpl {
 
+	@Override
 	public CookiesConsentPreference addCookiesConsentPreference(
 			long userId, String domain, Date expirationDate, String name,
 			String value)
@@ -53,6 +54,7 @@ public class CookiesConsentPreferenceLocalServiceImpl
 			cookiesConsentPreference);
 	}
 
+	@Override
 	public void deleteCookiesConsentPreference(
 			long userId, String domain, String name)
 		throws PortalException {
@@ -60,14 +62,25 @@ public class CookiesConsentPreferenceLocalServiceImpl
 		cookiesConsentPreferencePersistence.removeByU_D_N(userId, domain, name);
 	}
 
+	@Override
 	public void deleteCookiesConsentPreferences(long userId) {
 		cookiesConsentPreferencePersistence.removeByUserId(userId);
 	}
 
+	@Override
 	public void deleteCookiesConsentPreferences(long userId, String domain) {
 		cookiesConsentPreferencePersistence.removeByU_D(userId, domain);
 	}
 
+	@Override
+	public CookiesConsentPreference fetchCookiesConsentPreference(
+		long userId, String domain, String name) {
+
+		return cookiesConsentPreferencePersistence.fetchByU_D_N(
+			userId, domain, name);
+	}
+
+	@Override
 	public CookiesConsentPreference getCookiesConsentPreference(
 			long userId, String domain, String name)
 		throws PortalException {
@@ -76,12 +89,14 @@ public class CookiesConsentPreferenceLocalServiceImpl
 			userId, domain, name);
 	}
 
+	@Override
 	public List<CookiesConsentPreference> getCookiesConsentPreferences(
 		long userId, String domain) {
 
 		return cookiesConsentPreferencePersistence.findByU_D(userId, domain);
 	}
 
+	@Override
 	public CookiesConsentPreference updateCookiesConsentPreference(
 		CookiesConsentPreference cookiesConsentPreference) {
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101663

## What Is Being Fixed

The "Store Consent" toggle on Account Settings > Data and Privacy never reflects a previously stored consent preference. The REST endpoint backing it, `GET /o/cookies/v1.0/cookies-consent-preferences/by-name/{name}`, throws `IllegalStateException: No current transaction executor` on every single call, so the client always treats the lookup as "nothing stored" regardless of what is actually in the database. This is a regression from LPD-99062 (commit `9adcff3`): that commit repointed `CookiesConsentPreferenceResourceImpl.getCookiesConsentPreferenceByName` and `putCookiesConsentPreference`'s lookup/update straight to `CookiesConsentPreferencePersistence.fetchByU_D_N`, bypassing the transactional Local Service layer that normally establishes the current transaction executor before persistence code runs.

## How It Is Being Fixed

Add a nullable `fetchCookiesConsentPreference(userId, domain, name)` method to `CookiesConsentPreferenceLocalServiceImpl`, following the same sibling pattern every other caller fixed in the LPD-99062 commit sweep uses (`fetchDefaultPasswordPolicy`, `fetchListType`, `fetchImage`, etc.), so the lookup runs through the transactional AOP layer instead of touching persistence directly, and add the missing `@Override` annotation on every public method in that class (each one implements a matching method the generated `CookiesConsentPreferenceLocalService` interface declares). Repoint `CookiesConsentPreferenceResourceImpl`'s `getCookiesConsentPreferenceByName` and `putCookiesConsentPreference` to call it. Regenerate the service API via Service Builder, which bumps `com.liferay.cookies.api` from `9.1.3` to `9.2.0` (MINOR, new public API method). Verified live on a clean bundle: the endpoint returned `500` and the toggle stayed unchecked before the fix, and returned `200` with the toggle correctly checked after it.

## PR Check

**pr-check: PASS** — tested on `18324338a36d08f2f94aa2e30f7dca6c18a32f95`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "18324338a36d08f2f94aa2e30f7dca6c18a32f95"} -->
