### PR TITLE
LPD-101000 Regenerate the library manifest for httpcore5 5.4.3

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -278,7 +278,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.commerce.payment.method.authorize.net.jar!httpcore5-h2.jar</file-name>
-				<version>5.3.4</version>
+				<version>5.4.3</version>
 				<project-name>Apache HttpComponents Core HTTP/2</project-name>
 				<licenses>
 					<license>
@@ -289,7 +289,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.commerce.payment.method.authorize.net.jar!httpcore5.jar</file-name>
-				<version>5.3.2</version>
+				<version>5.4.3</version>
 				<project-name>Apache HttpComponents Core HTTP/1.1</project-name>
 				<licenses>
 					<license>
@@ -3026,7 +3026,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.search.elasticsearch8.impl.jar!httpcore5-h2.jar</file-name>
-				<version>5.3.4</version>
+				<version>5.4.3</version>
 				<project-name>Apache HttpComponents Core HTTP/2</project-name>
 				<licenses>
 					<license>
@@ -3037,7 +3037,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.search.elasticsearch8.impl.jar!httpcore5.jar</file-name>
-				<version>5.3.2</version>
+				<version>5.4.3</version>
 				<project-name>Apache HttpComponents Core HTTP/1.1</project-name>
 				<licenses>
 					<license>
@@ -3330,7 +3330,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.security.antisamy.jar!httpcore5-h2.jar</file-name>
-				<version>5.3.4</version>
+				<version>5.4.3</version>
 				<project-name>Apache HttpComponents Core HTTP/2</project-name>
 				<licenses>
 					<license>
@@ -3341,7 +3341,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.security.antisamy.jar!httpcore5.jar</file-name>
-				<version>5.3.2</version>
+				<version>5.4.3</version>
 				<project-name>Apache HttpComponents Core HTTP/1.1</project-name>
 				<licenses>
 					<license>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -183,13 +183,13 @@
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.commerce.payment.method.authorize.net.jar!httpcore5-h2.jar</td><td nowrap="nowrap">5.3.4</td><td nowrap="nowrap">Apache HttpComponents Core HTTP/2</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
+                    <td nowrap="nowrap">com.liferay.commerce.payment.method.authorize.net.jar!httpcore5-h2.jar</td><td nowrap="nowrap">5.4.3</td><td nowrap="nowrap">Apache HttpComponents Core HTTP/2</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
                         <br>
                     </td><td></td>
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.commerce.payment.method.authorize.net.jar!httpcore5.jar</td><td nowrap="nowrap">5.3.2</td><td nowrap="nowrap">Apache HttpComponents Core HTTP/1.1</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
+                    <td nowrap="nowrap">com.liferay.commerce.payment.method.authorize.net.jar!httpcore5.jar</td><td nowrap="nowrap">5.4.3</td><td nowrap="nowrap">Apache HttpComponents Core HTTP/1.1</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
                         <br>
                     </td><td></td>
                 </tr>
@@ -1599,13 +1599,13 @@
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.portal.search.elasticsearch8.impl.jar!httpcore5-h2.jar</td><td nowrap="nowrap">5.3.4</td><td nowrap="nowrap">Apache HttpComponents Core HTTP/2</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
+                    <td nowrap="nowrap">com.liferay.portal.search.elasticsearch8.impl.jar!httpcore5-h2.jar</td><td nowrap="nowrap">5.4.3</td><td nowrap="nowrap">Apache HttpComponents Core HTTP/2</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
                         <br>
                     </td><td></td>
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.portal.search.elasticsearch8.impl.jar!httpcore5.jar</td><td nowrap="nowrap">5.3.2</td><td nowrap="nowrap">Apache HttpComponents Core HTTP/1.1</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
+                    <td nowrap="nowrap">com.liferay.portal.search.elasticsearch8.impl.jar!httpcore5.jar</td><td nowrap="nowrap">5.4.3</td><td nowrap="nowrap">Apache HttpComponents Core HTTP/1.1</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
                         <br>
                     </td><td></td>
                 </tr>
@@ -1755,13 +1755,13 @@
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.portal.security.antisamy.jar!httpcore5-h2.jar</td><td nowrap="nowrap">5.3.4</td><td nowrap="nowrap">Apache HttpComponents Core HTTP/2</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
+                    <td nowrap="nowrap">com.liferay.portal.security.antisamy.jar!httpcore5-h2.jar</td><td nowrap="nowrap">5.4.3</td><td nowrap="nowrap">Apache HttpComponents Core HTTP/2</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
                         <br>
                     </td><td></td>
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.portal.security.antisamy.jar!httpcore5.jar</td><td nowrap="nowrap">5.3.2</td><td nowrap="nowrap">Apache HttpComponents Core HTTP/1.1</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
+                    <td nowrap="nowrap">com.liferay.portal.security.antisamy.jar!httpcore5.jar</td><td nowrap="nowrap">5.4.3</td><td nowrap="nowrap">Apache HttpComponents Core HTTP/1.1</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
                         <br>
                     </td><td></td>
                 </tr>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101000

## What Is Being Fixed

`portal-security-antisamy` ships Apache HttpComponents Core as nested jars, and both were vulnerable: CVE-2026-54399 (uncontrolled resource consumption in the HTTP/1.1 message parser, httpcore5) and CVE-2026-54428 (unbounded allocation in the HTTP/2 HPACK decoder, httpcore5-h2), each CVSS 7.5 and fixed in 5.4.3.

The version bump itself already landed in master under LPD-100998, through https://github.com/brianchandotcom/liferay-portal/pull/179929. That PR raised the shared `enforceVersionArtifacts` pin in `source-formatter.properties` and, through its `Run formatSource` commit, updated all four consuming modules including `portal-security-antisamy`. Because the pin is a single shared line, one team's bump necessarily rewrites every module that matches it, which is why that PR also resolved the code change for LPD-100994 and LPD-101000.

What it did not include was the regeneration of the license manifest, so `lib/versions.html` and `lib/versions-complete.xml` still reported httpcore5 5.3.2 and httpcore5-h2 5.3.4.

That matters because the manifest is what license audits and third-party vulnerability scans read. Left stale, the CVEs resurface in the next report even though the shipped jars are already fixed.

## How It Is Being Fixed

This runs `ant build-lib-versions` and commits the regenerated manifest, completing the third step of the pattern established by LPD-83650 (upgrade the pin, run formatSource, regenerate the manifest).

The diff is limited to the six httpcore5 entries across the three modules that bundle the library — authorize-net, elasticsearch8 and antisamy — moving each from 5.3.2 / 5.3.4 to 5.4.3. Every changed `<version>` element was verified to sit under its matching httpcore5 `<file-name>`, so the regeneration picked up no unrelated drift.

Note that `osb-faro-engine-client` is deliberately untouched. It sits under `workspaces/`, which the manifest does not cover, and it is tracked separately under LPD-101001.

## Why Are There No Tests?

The change contains no code — only the regenerated `lib/versions.html` and `lib/versions-complete.xml`. The manifest's consistency is already covered by `LibraryReferenceTest`, which runs as part of the Structural Smoke validation below.

## PR Check

**pr-check: PASS** — tested on `3e9ac427c027d48266d7a7c2c85d11ae8a365f83`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "3e9ac427c027d48266d7a7c2c85d11ae8a365f83"} -->
