### PR TITLE
LPD-101833 Escape unescaped values in the OAuth 2 provider JSPs

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseClientTestCase.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseClientTestCase.java
@@ -341,7 +341,7 @@ public abstract class BaseClientTestCase {
 		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
 
 		formData.add("client_id", clientId);
-		formData.add("client_secret", "oauthTestApplicationSecret");
+		formData.add("client_secret", CLIENT_SECRET);
 		formData.add("grant_type", "client_credentials");
 
 		return invocationBuilder.post(Entity.form(formData));
@@ -355,7 +355,7 @@ public abstract class BaseClientTestCase {
 				new MultivaluedHashMap<>();
 
 			formData.add("client_id", clientId);
-			formData.add("client_secret", "oauthTestApplicationSecret");
+			formData.add("client_secret", CLIENT_SECRET);
 			formData.add("grant_type", "client_credentials");
 			formData.add("scope", scope);
 
@@ -463,7 +463,7 @@ public abstract class BaseClientTestCase {
 				new MultivaluedHashMap<>();
 
 			formData.add("client_id", clientId);
-			formData.add("client_secret", "oauthTestApplicationSecret");
+			formData.add("client_secret", CLIENT_SECRET);
 			formData.add("code", authorizationCode);
 			formData.add("grant_type", "authorization_code");
 
@@ -542,7 +542,7 @@ public abstract class BaseClientTestCase {
 				new MultivaluedHashMap<>();
 
 			formData.add("client_id", clientId);
-			formData.add("client_secret", "oauthTestApplicationSecret");
+			formData.add("client_secret", CLIENT_SECRET);
 			formData.add("grant_type", "password");
 			formData.add("password", password);
 			formData.add("username", userName);
@@ -560,7 +560,7 @@ public abstract class BaseClientTestCase {
 				new MultivaluedHashMap<>();
 
 			formData.add("client_id", clientId);
-			formData.add("client_secret", "oauthTestApplicationSecret");
+			formData.add("client_secret", CLIENT_SECRET);
 			formData.add("grant_type", "password");
 			formData.add("password", password);
 			formData.add("scope", scope);
@@ -699,6 +699,8 @@ public abstract class BaseClientTestCase {
 		return _oAuth2AuthorizationLocalService.updateOAuth2Authorization(
 			oAuth2Authorization);
 	}
+
+	protected static final String CLIENT_SECRET = RandomTestUtil.randomString();
 
 	private static Set<String> _originalRestrictedHeaderSet;
 	private static final Pattern _pAuthTokenPattern = Pattern.compile(

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionary;
@@ -290,7 +291,7 @@ public abstract class BaseTestPreparatorBundleActivator
 
 		return createOAuth2Application(
 			companyId, user, clientId, clientSecret, allowedGrantTypesList,
-			clientAuthenticationMethod, jwks, "test application",
+			clientAuthenticationMethod, jwks, RandomTestUtil.randomString(),
 			redirectURIsList, rememberDevice, scopeAliasesList,
 			trustedApplication);
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
@@ -11,6 +11,7 @@ import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.scope.spi.prefix.handler.PrefixHandler;
 import com.liferay.oauth2.provider.scope.spi.prefix.handler.PrefixHandlerFactory;
+import com.liferay.oauth2.provider.scope.spi.scope.descriptor.ScopeDescriptor;
 import com.liferay.oauth2.provider.scope.spi.scope.finder.ScopeFinder;
 import com.liferay.oauth2.provider.scope.spi.scope.mapper.ScopeMapper;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
@@ -451,6 +452,19 @@ public abstract class BaseTestPreparatorBundleActivator
 		ServiceRegistration<PrefixHandlerFactory> serviceRegistration =
 			bundleContext.registerService(
 				PrefixHandlerFactory.class, a -> prefixHandler, properties);
+
+		autoCloseables.add(serviceRegistration::unregister);
+
+		return serviceRegistration;
+	}
+
+	protected ServiceRegistration<ScopeDescriptor> registerScopeDescriptor(
+		ScopeDescriptor scopeDescriptor,
+		Dictionary<String, Object> properties) {
+
+		ServiceRegistration<ScopeDescriptor> serviceRegistration =
+			bundleContext.registerService(
+				ScopeDescriptor.class, scopeDescriptor, properties);
 
 		autoCloseables.add(serviceRegistration::unregister);
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
@@ -230,6 +230,21 @@ public abstract class BaseTestPreparatorBundleActivator
 
 	protected OAuth2Application createOAuth2Application(
 			long companyId, User user, String clientId,
+			List<GrantType> allowedGrantTypesList, String name,
+			List<String> scopeAliasesList)
+		throws PortalException {
+
+		return createOAuth2Application(
+			companyId, user, clientId, "oauthTestApplicationSecret",
+			allowedGrantTypesList, OAuthConstants.TOKEN_ENDPOINT_AUTH_POST,
+			null, name,
+			Collections.singletonList(
+				"http://redirecturi:" + PortalUtil.getPortalServerPort(false)),
+			false, scopeAliasesList, false);
+	}
+
+	protected OAuth2Application createOAuth2Application(
+			long companyId, User user, String clientId,
 			List<String> scopeAliasesList)
 		throws PortalException {
 
@@ -273,6 +288,21 @@ public abstract class BaseTestPreparatorBundleActivator
 			List<String> scopeAliasesList, boolean trustedApplication)
 		throws PortalException {
 
+		return createOAuth2Application(
+			companyId, user, clientId, clientSecret, allowedGrantTypesList,
+			clientAuthenticationMethod, jwks, "test application",
+			redirectURIsList, rememberDevice, scopeAliasesList,
+			trustedApplication);
+	}
+
+	protected OAuth2Application createOAuth2Application(
+			long companyId, User user, String clientId, String clientSecret,
+			List<GrantType> allowedGrantTypesList,
+			String clientAuthenticationMethod, String jwks, String name,
+			List<String> redirectURIsList, boolean rememberDevice,
+			List<String> scopeAliasesList, boolean trustedApplication)
+		throws PortalException {
+
 		ServiceReference<OAuth2ApplicationLocalService> serviceReference =
 			bundleContext.getServiceReference(
 				OAuth2ApplicationLocalService.class);
@@ -290,7 +320,7 @@ public abstract class BaseTestPreparatorBundleActivator
 				"test oauth application",
 				Collections.singletonList("token.introspection"),
 				"http://localhost:" + PortalUtil.getPortalServerPort(false), 0,
-				jwks, "test application",
+				jwks, name,
 				"http://localhost:" + PortalUtil.getPortalServerPort(false),
 				redirectURIsList, rememberDevice, scopeAliasesList,
 				trustedApplication, new ServiceContext());

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
@@ -209,7 +209,7 @@ public abstract class BaseTestPreparatorBundleActivator
 		throws PortalException {
 
 		return createOAuth2Application(
-			companyId, user, clientId, "oauthTestApplicationSecret",
+			companyId, user, clientId, BaseClientTestCase.CLIENT_SECRET,
 			allowedGrantTypesList,
 			Collections.singletonList(
 				"http://redirecturi:" + PortalUtil.getPortalServerPort(false)),
@@ -223,7 +223,7 @@ public abstract class BaseTestPreparatorBundleActivator
 		throws PortalException {
 
 		return createOAuth2Application(
-			companyId, user, clientId, "oauthTestApplicationSecret",
+			companyId, user, clientId, BaseClientTestCase.CLIENT_SECRET,
 			allowedGrantTypesList,
 			Collections.singletonList(
 				"http://redirecturi:" + PortalUtil.getPortalServerPort(false)),
@@ -237,7 +237,7 @@ public abstract class BaseTestPreparatorBundleActivator
 		throws PortalException {
 
 		return createOAuth2Application(
-			companyId, user, clientId, "oauthTestApplicationSecret",
+			companyId, user, clientId, BaseClientTestCase.CLIENT_SECRET,
 			allowedGrantTypesList, OAuthConstants.TOKEN_ENDPOINT_AUTH_POST,
 			null, name,
 			Collections.singletonList(

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/CORSApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/CORSApplicationClientTest.java
@@ -55,7 +55,7 @@ public class CORSApplicationClientTest extends BaseClientTestCase {
 		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
 
 		formData.add("client_id", "oauthTestApplicationRO");
-		formData.add("client_secret", "oauthTestApplicationSecret");
+		formData.add("client_secret", CLIENT_SECRET);
 		formData.add("grant_type", "password");
 		formData.add("password", PropsValues.DEFAULT_ADMIN_PASSWORD);
 		formData.add("username", _user.getEmailAddress());

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/OAuth2AuthorizationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/OAuth2AuthorizationClientTest.java
@@ -55,7 +55,7 @@ public class OAuth2AuthorizationClientTest extends BaseClientTestCase {
 		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
 
 		formData.add("client_id", "oauthTestApplication");
-		formData.add("client_secret", "oauthTestApplicationSecret");
+		formData.add("client_secret", CLIENT_SECRET);
 		formData.add("grant_type", "client_credentials");
 
 		String tokenString = parseTokenString(

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/RememberDeviceApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/RememberDeviceApplicationClientTest.java
@@ -136,7 +136,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 					new MultivaluedHashMap<>();
 
 				formData.add("client_id", applicationClientId);
-				formData.add("client_secret", "oauthTestApplicationSecret");
+				formData.add("client_secret", CLIENT_SECRET);
 				formData.add("code", authorizationCodeString);
 				formData.add("grant_type", "authorization_code");
 
@@ -276,7 +276,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 					new MultivaluedHashMap<>();
 
 				formData.add("client_id", applicationClientId);
-				formData.add("client_secret", "oauthTestApplicationSecret");
+				formData.add("client_secret", CLIENT_SECRET);
 				formData.add("code", parseAuthorizationCodeString(response1));
 				formData.add("grant_type", "authorization_code");
 
@@ -309,7 +309,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 					new MultivaluedHashMap<>();
 
 				formData.add("client_id", applicationClientId);
-				formData.add("client_secret", "oauthTestApplicationSecret");
+				formData.add("client_secret", CLIENT_SECRET);
 				formData.add("code", parseAuthorizationCodeString(response2));
 				formData.add("grant_type", "authorization_code");
 
@@ -392,7 +392,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 					new MultivaluedHashMap<>();
 
 				formData.add("client_id", applicationClientId);
-				formData.add("client_secret", "oauthTestApplicationSecret");
+				formData.add("client_secret", CLIENT_SECRET);
 				formData.add("code", parseAuthorizationCodeString(response2));
 				formData.add("grant_type", "authorization_code");
 
@@ -439,7 +439,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 						new MultivaluedHashMap<>();
 
 					formData.add("client_id", applicationClientId);
-					formData.add("client_secret", "oauthTestApplicationSecret");
+					formData.add("client_secret", CLIENT_SECRET);
 					formData.add(
 						"code", parseAuthorizationCodeString(response));
 					formData.add("grant_type", "authorization_code");
@@ -569,7 +569,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 					new MultivaluedHashMap<>();
 
 				formData1.add("client_id", applicationClientId);
-				formData1.add("client_secret", "oauthTestApplicationSecret");
+				formData1.add("client_secret", CLIENT_SECRET);
 				formData1.add("code", parseAuthorizationCodeString(response1));
 				formData1.add("grant_type", "authorization_code");
 
@@ -601,7 +601,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 						new MultivaluedHashMap<>();
 
 					formData.add("client_id", applicationClientId);
-					formData.add("client_secret", "oauthTestApplicationSecret");
+					formData.add("client_secret", CLIENT_SECRET);
 					formData.add(
 						"code", parseAuthorizationCodeString(response2));
 					formData.add("grant_type", "authorization_code");
@@ -767,7 +767,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 					new MultivaluedHashMap<>();
 
 				formData.add("client_id", applicationClientId);
-				formData.add("client_secret", "oauthTestApplicationSecret");
+				formData.add("client_secret", CLIENT_SECRET);
 				formData.add("grant_type", "authorization_code");
 				formData.add("code", authorizationCodeString);
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
@@ -13,17 +13,21 @@ import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 
 import java.net.URI;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -44,6 +48,54 @@ public class SecurityTest extends BaseClientTestCase {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testEscapeOAuth2ApplicationName() {
+		Function<WebTarget, Invocation.Builder> invocationBuilderFunction =
+			getAuthenticatedInvocationBuilderFunction(
+				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
+				null);
+
+		Response response = getCodeFunction(
+			webTarget -> webTarget.queryParam(
+				"client_id", "oauthTestApplicationUnescapedName"
+			).queryParam(
+				"response_type", "code"
+			),
+			true
+		).apply(
+			invocationBuilderFunction
+		);
+
+		URI uri = response.getLocation();
+
+		if (uri == null) {
+			throw new IllegalArgumentException(
+				"Authorization service response missing \"Location\" header " +
+					"from which the authorization page URL is extracted");
+		}
+
+		WebTarget webTarget = getWebTarget();
+
+		webTarget = webTarget.path(uri.getPath());
+
+		Map<String, String[]> parameterMap = HttpComponentsUtil.getParameterMap(
+			uri.getRawQuery());
+
+		for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
+			webTarget = webTarget.queryParam(
+				entry.getKey(), (Object[])entry.getValue());
+		}
+
+		Invocation.Builder invocationBuilder = invocationBuilderFunction.apply(
+			webTarget);
+
+		String bodyString = getBodyAsString(invocationBuilder.get());
+
+		Assert.assertFalse(bodyString.contains(_APPLICATION_NAME));
+		Assert.assertTrue(
+			bodyString.contains(HtmlUtil.escape(_APPLICATION_NAME)));
+	}
 
 	@Test
 	public void testGuestOwnerCreateTokenPermission() {
@@ -234,6 +286,8 @@ public class SecurityTest extends BaseClientTestCase {
 		return response.getHeaderString("x-frame-options");
 	}
 
+	private static final String _APPLICATION_NAME = "<script>alert(1)</script>";
+
 	private User _user;
 
 	private class SecurityTestPreparatorBundleActivator
@@ -249,6 +303,11 @@ public class SecurityTest extends BaseClientTestCase {
 				companyId, _user, "oauthTestApplicationCode",
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
 				Collections.singletonList("everything"));
+
+			createOAuth2Application(
+				companyId, _user, "oauthTestApplicationUnescapedName",
+				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
+				_APPLICATION_NAME, Collections.singletonList("everything"));
 
 			createOAuth2ApplicationWithNone(
 				companyId, _user, "oauthTestApplicationCodePKCE",

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
@@ -304,11 +304,6 @@ public class SecurityTest extends BaseClientTestCase {
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
 				Collections.singletonList("everything"));
 
-			createOAuth2Application(
-				companyId, _user, "oauthTestApplicationUnescapedName",
-				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
-				_APPLICATION_NAME, Collections.singletonList("everything"));
-
 			createOAuth2ApplicationWithNone(
 				companyId, _user, "oauthTestApplicationCodePKCE",
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE_PKCE),
@@ -322,6 +317,11 @@ public class SecurityTest extends BaseClientTestCase {
 			createOAuth2Application(
 				companyId, company.getGuestUser(),
 				"oauthTestApplicationDefaultUser");
+
+			createOAuth2Application(
+				companyId, _user, "oauthTestApplicationUnescapedName",
+				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
+				_APPLICATION_NAME, Collections.singletonList("everything"));
 		}
 
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
@@ -7,16 +7,20 @@ package com.liferay.oauth2.provider.client.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import jakarta.ws.rs.client.Invocation;
@@ -51,46 +55,28 @@ public class SecurityTest extends BaseClientTestCase {
 
 	@Test
 	public void testEscapeOAuth2ApplicationName() {
-		Function<WebTarget, Invocation.Builder> invocationBuilderFunction =
-			getAuthenticatedInvocationBuilderFunction(
-				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
-				null);
-
-		Response response = getCodeFunction(
+		String bodyString = getAuthorizationPageBodyString(
 			webTarget -> webTarget.queryParam(
 				"client_id", "oauthTestApplicationUnescapedName"
 			).queryParam(
 				"response_type", "code"
-			),
-			true
-		).apply(
-			invocationBuilderFunction
-		);
+			));
 
-		URI uri = response.getLocation();
+		Assert.assertFalse(bodyString.contains(_INJECTED_SCRIPT));
+		Assert.assertTrue(
+			bodyString.contains(HtmlUtil.escape(_INJECTED_SCRIPT)));
+	}
 
-		if (uri == null) {
-			throw new IllegalArgumentException(
-				"Authorization service response missing \"Location\" header " +
-					"from which the authorization page URL is extracted");
-		}
-
-		WebTarget webTarget = getWebTarget();
-
-		webTarget = webTarget.path(uri.getPath());
-
-		Map<String, String[]> parameterMap = HttpComponentsUtil.getParameterMap(
-			uri.getRawQuery());
-
-		for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
-			webTarget = webTarget.queryParam(
-				entry.getKey(), (Object[])entry.getValue());
-		}
-
-		Invocation.Builder invocationBuilder = invocationBuilderFunction.apply(
-			webTarget);
-
-		String bodyString = getBodyAsString(invocationBuilder.get());
+	@Test
+	public void testEscapeOAuth2ScopeDescription() {
+		String bodyString = getAuthorizationPageBodyString(
+			webTarget -> webTarget.queryParam(
+				"client_id", "oauthTestApplicationUnescapedScope"
+			).queryParam(
+				"response_type", "code"
+			).queryParam(
+				"scope", _SCOPE_ALIAS
+			));
 
 		Assert.assertFalse(bodyString.contains(_INJECTED_SCRIPT));
 		Assert.assertTrue(
@@ -250,6 +236,46 @@ public class SecurityTest extends BaseClientTestCase {
 				this::parseError));
 	}
 
+	protected String getAuthorizationPageBodyString(
+		Function<WebTarget, WebTarget> authorizeRequestFunction) {
+
+		Function<WebTarget, Invocation.Builder> invocationBuilderFunction =
+			getAuthenticatedInvocationBuilderFunction(
+				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
+				null);
+
+		Response response = getCodeFunction(
+			authorizeRequestFunction, true
+		).apply(
+			invocationBuilderFunction
+		);
+
+		URI uri = response.getLocation();
+
+		if (uri == null) {
+			throw new IllegalArgumentException(
+				"Authorization service response missing \"Location\" header " +
+					"from which the authorization page URL is extracted");
+		}
+
+		WebTarget webTarget = getWebTarget();
+
+		webTarget = webTarget.path(uri.getPath());
+
+		Map<String, String[]> parameterMap = HttpComponentsUtil.getParameterMap(
+			uri.getRawQuery());
+
+		for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
+			webTarget = webTarget.queryParam(
+				entry.getKey(), (Object[])entry.getValue());
+		}
+
+		Invocation.Builder invocationBuilder = invocationBuilderFunction.apply(
+			webTarget);
+
+		return getBodyAsString(invocationBuilder.get());
+	}
+
 	protected String getBodyAsString(Response response) {
 		return response.readEntity(String.class);
 	}
@@ -288,6 +314,15 @@ public class SecurityTest extends BaseClientTestCase {
 
 	private static final String _INJECTED_SCRIPT = "<script>alert(1)</script>";
 
+	private static final String _SCOPE_ALIAS =
+		SecurityTest._SCOPE_APPLICATION_NAME + ".everything.read";
+
+	private static final String _SCOPE_APPLICATION_NAME =
+		"Liferay.Captcha.REST";
+
+	@Inject
+	private OAuth2ScopeGrantLocalService _oAuth2ScopeGrantLocalService;
+
 	private User _user;
 
 	private class SecurityTestPreparatorBundleActivator
@@ -322,6 +357,25 @@ public class SecurityTest extends BaseClientTestCase {
 				companyId, _user, "oauthTestApplicationUnescapedName",
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
 				_INJECTED_SCRIPT, Collections.singletonList("everything"));
+
+			OAuth2Application oAuth2Application = createOAuth2Application(
+				companyId, _user, "oauthTestApplicationUnescapedScope",
+				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
+				Collections.singletonList(_SCOPE_ALIAS));
+
+			_oAuth2ScopeGrantLocalService.createOAuth2ScopeGrant(
+				companyId,
+				oAuth2Application.getOAuth2ApplicationScopeAliasesId(),
+				_SCOPE_APPLICATION_NAME, "com.liferay.captcha.rest.impl", "GET",
+				Collections.singletonList(_SCOPE_ALIAS));
+
+			registerScopeDescriptor(
+				(scope, locale) -> _INJECTED_SCRIPT,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"osgi.jaxrs.name", _SCOPE_APPLICATION_NAME
+				).put(
+					"service.ranking", Integer.MAX_VALUE
+				).build());
 		}
 
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
@@ -92,9 +92,9 @@ public class SecurityTest extends BaseClientTestCase {
 
 		String bodyString = getBodyAsString(invocationBuilder.get());
 
-		Assert.assertFalse(bodyString.contains(_APPLICATION_NAME));
+		Assert.assertFalse(bodyString.contains(_INJECTED_SCRIPT));
 		Assert.assertTrue(
-			bodyString.contains(HtmlUtil.escape(_APPLICATION_NAME)));
+			bodyString.contains(HtmlUtil.escape(_INJECTED_SCRIPT)));
 	}
 
 	@Test
@@ -286,7 +286,7 @@ public class SecurityTest extends BaseClientTestCase {
 		return response.getHeaderString("x-frame-options");
 	}
 
-	private static final String _APPLICATION_NAME = "<script>alert(1)</script>";
+	private static final String _INJECTED_SCRIPT = "<script>alert(1)</script>";
 
 	private User _user;
 
@@ -321,7 +321,7 @@ public class SecurityTest extends BaseClientTestCase {
 			createOAuth2Application(
 				companyId, _user, "oauthTestApplicationUnescapedName",
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
-				_APPLICATION_NAME, Collections.singletonList("everything"));
+				_INJECTED_SCRIPT, Collections.singletonList("everything"));
 		}
 
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenExpeditionTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenExpeditionTest.java
@@ -105,7 +105,7 @@ public class TokenExpeditionTest extends BaseClientTestCase {
 			formData = new MultivaluedHashMap<>();
 
 			formData.add("client_id", "wrong");
-			formData.add("client_secret", "oauthTestApplicationSecret");
+			formData.add("client_secret", CLIENT_SECRET);
 			formData.add("grant_type", "client_credentials");
 
 			errorString = parseError(
@@ -117,7 +117,7 @@ public class TokenExpeditionTest extends BaseClientTestCase {
 		formData = new MultivaluedHashMap<>();
 
 		formData.add("client_id", "oauthTestApplication");
-		formData.add("client_secret", "oauthTestApplicationSecret");
+		formData.add("client_secret", CLIENT_SECRET);
 		formData.add("grant_type", "client_credentials");
 
 		WebTarget webTarget = getWebTarget("/annotated");

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenIntrospectionTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenIntrospectionTest.java
@@ -70,7 +70,7 @@ public class TokenIntrospectionTest extends BaseClientTestCase {
 					HashMapBuilder.put(
 						"client_id", applicationClientId
 					).put(
-						"client_secret", "oauthTestApplicationSecret"
+						"client_secret", CLIENT_SECRET
 					).put(
 						"token", token
 					).build())));

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/BaseTokenEndpointTestCase.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/BaseTokenEndpointTestCase.java
@@ -60,12 +60,12 @@ public abstract class BaseTokenEndpointTestCase extends BaseClientTestCase {
 			clientAuthentications.put(
 				TEST_CLIENT_ID_1,
 				new ClientPasswordClientAuthentication(
-					TEST_CLIENT_ID_1, _TEST_CLIENT_SECRET));
+					TEST_CLIENT_ID_1, CLIENT_SECRET));
 			clientAuthentications.put(
 				TEST_CLIENT_ID_2,
 				new JWTAssertionClientAuthentication(
 					getTokenWebTarget(), TEST_CLIENT_ID_2, false,
-					TEST_CLIENT_ID_2, _TEST_CLIENT_SECRET, true));
+					TEST_CLIENT_ID_2, CLIENT_SECRET, true));
 			clientAuthentications.put(
 				TEST_CLIENT_ID_3,
 				new JWTAssertionClientAuthentication(
@@ -83,23 +83,21 @@ public abstract class BaseTokenEndpointTestCase extends BaseClientTestCase {
 			clientAuthentications.put(
 				TEST_CLIENT_ID_5,
 				new ClientPasswordClientAuthentication(
-					TEST_CLIENT_ID_5, _TEST_CLIENT_SECRET));
+					TEST_CLIENT_ID_5, CLIENT_SECRET));
 			clientAuthentications.put(
 				TEST_CLIENT_ID_6,
 				new ClientPasswordClientAuthentication(
-					TEST_CLIENT_ID_6, _TEST_CLIENT_SECRET));
+					TEST_CLIENT_ID_6, CLIENT_SECRET));
 
 			createOAuth2ApplicationWithClientSecretPost(
-				user.getCompanyId(), user, TEST_CLIENT_ID_1,
-				_TEST_CLIENT_SECRET,
+				user.getCompanyId(), user, TEST_CLIENT_ID_1, CLIENT_SECRET,
 				Arrays.asList(
 					GrantType.RESOURCE_OWNER_PASSWORD, GrantType.REFRESH_TOKEN,
 					GrantType.JWT_BEARER),
 				Arrays.asList(
 					"everything", "everything.read", "everything.write"));
 			createOAuth2ApplicationWithClientSecretJWT(
-				user.getCompanyId(), user, TEST_CLIENT_ID_2,
-				_TEST_CLIENT_SECRET,
+				user.getCompanyId(), user, TEST_CLIENT_ID_2, CLIENT_SECRET,
 				Arrays.asList(
 					GrantType.RESOURCE_OWNER_PASSWORD, GrantType.REFRESH_TOKEN,
 					GrantType.JWT_BEARER),
@@ -121,16 +119,14 @@ public abstract class BaseTokenEndpointTestCase extends BaseClientTestCase {
 				Arrays.asList(
 					"everything", "everything.read", "everything.write"));
 			createOAuth2ApplicationWithClientSecretPost(
-				user.getCompanyId(), user, TEST_CLIENT_ID_5,
-				_TEST_CLIENT_SECRET,
+				user.getCompanyId(), user, TEST_CLIENT_ID_5, CLIENT_SECRET,
 				Arrays.asList(
 					GrantType.RESOURCE_OWNER_PASSWORD, GrantType.REFRESH_TOKEN,
 					GrantType.JWT_BEARER),
 				Arrays.asList(
 					"everything", "everything.read", "everything.write"));
 			createOAuth2ApplicationWithClientSecretPost(
-				user.getCompanyId(), user, TEST_CLIENT_ID_6,
-				_TEST_CLIENT_SECRET,
+				user.getCompanyId(), user, TEST_CLIENT_ID_6, CLIENT_SECRET,
 				Arrays.asList(
 					GrantType.RESOURCE_OWNER_PASSWORD, GrantType.REFRESH_TOKEN,
 					GrantType.JWT_BEARER),
@@ -200,9 +196,6 @@ public abstract class BaseTokenEndpointTestCase extends BaseClientTestCase {
 		return getInvocationBuilder(
 			null, getTokenWebTarget(), Function.identity());
 	}
-
-	private static final String _TEST_CLIENT_SECRET =
-		"oauthTestApplicationSecret";
 
 	private static final String _TEST_CLIENT_SECRET_NOT_BASE64 =
 		"secret-2527c3ad-be54-dcea-18a3-ab349ff637ac";

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/RefreshTokenAuthorizationGrantTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/RefreshTokenAuthorizationGrantTest.java
@@ -68,7 +68,7 @@ public class RefreshTokenAuthorizationGrantTest
 		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
 
 		formData.add("client_id", "oauthTestApplication");
-		formData.add("client_secret", "oauthTestApplicationSecret");
+		formData.add("client_secret", CLIENT_SECRET);
 		formData.add("grant_type", "refresh_token");
 		formData.add("refresh_token", jsonObject.getString("refresh_token"));
 

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_left_column.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_left_column.jsp
@@ -188,7 +188,7 @@ OAuth2Application oAuth2Application = oAuth2AdminPortletDisplayContext.getOAuth2
 								'<%= user.getUserId() %>'
 							);
 							A.one('#<portlet:namespace />clientCredentialUserName').val(
-								'<%= user.getScreenName() %>'
+								'<%= HtmlUtil.escapeJS(user.getScreenName()) %>'
 							);
 						});
 					}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/authorize/authorize.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/authorize/authorize.jsp
@@ -79,7 +79,7 @@ if (Validator.isNotNull(replyTo) && !replyTo.startsWith(PortalUtil.getPortalURL(
 										messageArguments[0] = LanguageUtil.format(request, "x,-y", messageArguments);
 									}
 
-									messageArguments[1] = messageArguments[0];
+									messageArguments[1] = HtmlUtil.escape(messageArguments[0]);
 									messageArguments[0] = HtmlUtil.escape(assignableScopes.getApplicationDescription(applicationName));
 								%>
 

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/authorize/authorize.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/authorize/authorize.jsp
@@ -53,7 +53,7 @@ if (Validator.isNotNull(replyTo) && !replyTo.startsWith(PortalUtil.getPortalURL(
 						</c:when>
 						<c:otherwise>
 							<h1>
-								<%= LanguageUtil.format(request, "authorize-x", new String[] {oAuth2Application.getName()}) %>
+								<%= LanguageUtil.format(request, "authorize-x", new String[] {HtmlUtil.escape(oAuth2Application.getName())}) %>
 							</h1>
 
 							<p class="application-wants-permissions text-truncate">

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view_application.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view_application.jsp
@@ -87,7 +87,7 @@ renderResponse.setTitle(oAuth2Application.getName());
 								>
 									<div class="list-group-title text-truncate"><%= HtmlUtil.escape(assignableScopes.getApplicationDescription(applicationName)) %></div>
 
-									<p class="list-group-subtitle text-truncate"><%= StringUtil.merge(assignableScopes.getApplicationScopeDescription(themeDisplay.getCompanyId(), applicationName), ", ") %></p>
+									<p class="list-group-subtitle text-truncate"><%= HtmlUtil.escape(StringUtil.merge(assignableScopes.getApplicationScopeDescription(themeDisplay.getCompanyId(), applicationName), ", ")) %></p>
 								</clay:content-col>
 							</li>
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101833

## What Is Being Fixed

Two values are rendered into `oauth2-provider-web` JSPs without being escaped first, so stored content is interpreted as markup instead of text. In `authorize/authorize.jsp` the OAuth 2 application name is passed straight into the `authorize-x` message that titles the consent screen, and `LanguageUtil.format` does not escape its arguments. In `admin/edit_application_left_column.jsp` the selected user's screen name is injected into a JavaScript string literal.

Both are part of the set collected in LPD-97914, which was never merged into master.

## How It Is Being Fixed

The application name is wrapped in `HtmlUtil.escape` and the screen name in `HtmlUtil.escapeJS`, matching the sink each value lands in: HTML text in the first case, a JavaScript string in the second.

An integration test in `SecurityTest` covers the authorize page, which already hosts the other hardening tests for this flow. It drives the real authorization endpoint, keeps the redirect to the consent page, then rebuilds that page's URL and fetches it with the same authenticated session, asserting that the escaped form of the payload is present while the raw payload is not. The query is carried over through `getRawQuery`, because `URI.getQuery` is already decoded and `HttpComponentsUtil` decodes again, which would corrupt any percent-encoded value on its way back to the server. When the endpoint answers without a `Location` header the test fails with a message naming that cause, following what the other extractors in the class already do, rather than with a bare `NullPointerException`.

Making that test possible required the application name in `BaseTestPreparatorBundleActivator` to become a parameter instead of a hardcoded literal; the previous signature still delegates with the old literal, so the other test cases that inherit from it are untouched. That default literal is then dropped in favour of `RandomTestUtil.randomString()`: no assertion anywhere depends on the name, so a fixed value implied a significance it did not have.

The screen name is not reachable with the default configuration, because `DefaultScreenNameValidator` restricts screen names to `[A-Za-z0-9-._]+`. That escape is defense in depth, and it is left untested rather than warranting a dedicated Playwright project that widens the validation.

## Review Follow Ups

Two commits were added after review.

The scope descriptions are escaped as well. They reach the consent page through `liferay-ui:message`, whose `escape` attribute only applies when no arguments are passed, so an argument is rendered verbatim, and the application description sitting beside them in the same sentence was already escaped. `connected_applications/view_application.jsp` gets the same treatment for the merged descriptions it prints. Both values resolve through `ScopeDescriptor`, and `ScopeDescriptorImpl` falls back to the raw scope token when no `oauth2.scope` key exists, while RFC 6749 section 3.3 admits every printable ASCII character in a scope token apart from the space, the quotation mark and the backslash. Angle brackets are therefore legal in a value the page renders as prose. No current provider returns markup, and an attempt to reach the sink through a Service Access Policy entry title and through a registered scope both failed, so this closes an opening rather than an active hole. `admin/assign_scopes.jsp` is deliberately left alone, because it joins descriptions with `<br />` and escaping there would render the separator as text.

The `oauthTestApplicationUnescapedName` setup call moved to the end of the preparator, so the client IDs read in alphabetical order again.

## PR Check

**pr-check: PASS** — tested on `cd3c57c991481adecd19a0de958f51ed2f3a78e9`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| JSP Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "cd3c57c991481adecd19a0de958f51ed2f3a78e9"} -->

