### PR TITLE
LPD-101741 Upgrade httpclient5 to 5.6.3 to fix CVE-2026-64607

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -267,7 +267,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.commerce.payment.method.authorize.net.jar!httpclient5.jar</file-name>
-				<version>5.4.4</version>
+				<version>5.6.3</version>
 				<project-name>Apache HttpClient</project-name>
 				<licenses>
 					<license>
@@ -3015,7 +3015,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.search.elasticsearch8.impl.jar!httpclient5.jar</file-name>
-				<version>5.4.4</version>
+				<version>5.6.3</version>
 				<project-name>Apache HttpClient</project-name>
 				<licenses>
 					<license>
@@ -3319,7 +3319,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.portal.security.antisamy.jar!httpclient5.jar</file-name>
-				<version>5.4.4</version>
+				<version>5.6.3</version>
 				<project-name>Apache HttpClient</project-name>
 				<licenses>
 					<license>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -177,7 +177,7 @@
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.commerce.payment.method.authorize.net.jar!httpclient5.jar</td><td nowrap="nowrap">5.4.4</td><td nowrap="nowrap">Apache HttpClient</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
+                    <td nowrap="nowrap">com.liferay.commerce.payment.method.authorize.net.jar!httpclient5.jar</td><td nowrap="nowrap">5.6.3</td><td nowrap="nowrap">Apache HttpClient</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
                         <br>
                     </td><td></td>
                 </tr>
@@ -1593,7 +1593,7 @@
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.portal.search.elasticsearch8.impl.jar!httpclient5.jar</td><td nowrap="nowrap">5.4.4</td><td nowrap="nowrap">Apache HttpClient</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
+                    <td nowrap="nowrap">com.liferay.portal.search.elasticsearch8.impl.jar!httpclient5.jar</td><td nowrap="nowrap">5.6.3</td><td nowrap="nowrap">Apache HttpClient</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
                         <br>
                     </td><td></td>
                 </tr>
@@ -1749,7 +1749,7 @@
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.portal.security.antisamy.jar!httpclient5.jar</td><td nowrap="nowrap">5.4.4</td><td nowrap="nowrap">Apache HttpClient</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
+                    <td nowrap="nowrap">com.liferay.portal.security.antisamy.jar!httpclient5.jar</td><td nowrap="nowrap">5.6.3</td><td nowrap="nowrap">Apache HttpClient</td><td nowrap><a href="https://www.apache.org/licenses/LICENSE-2.0.txt">Apache License, Version 2.0</a>
                         <br>
                     </td><td></td>
                 </tr>

--- a/modules/apps/commerce/commerce-payment-method-authorize-net/bnd.bnd
+++ b/modules/apps/commerce/commerce-payment-method-authorize-net/bnd.bnd
@@ -2,6 +2,12 @@ Bundle-Name: Liferay Commerce Payment Method Authorize Net
 Bundle-SymbolicName: com.liferay.commerce.payment.method.authorize.net
 Bundle-Version: 4.0.46
 Import-Package:\
+	!com.aayushatharva.brotli4j.*,\
+	\
+	!com.github.luben.zstd.*,\
+	\
+	!org.apache.commons.compress.*,\
+	\
 	!org.brotli.dec.*,\
 	\
 	!org.conscrypt.*,\

--- a/modules/apps/commerce/commerce-payment-method-authorize-net/build.gradle
+++ b/modules/apps/commerce/commerce-payment-method-authorize-net/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
 	compileInclude group: "net.authorize", name: "anet-java-sdk", version: "3.0.0"
-	compileInclude group: "org.apache.httpcomponents.client5", name: "httpclient5", version: "5.4.4"
+	compileInclude group: "org.apache.httpcomponents.client5", name: "httpclient5", version: "5.6.3"
 	compileInclude group: "org.apache.httpcomponents.core5", name: "httpcore5", version: "5.4.3"
 	compileInclude group: "org.apache.httpcomponents.core5", name: "httpcore5-h2", version: "5.4.3"
 	compileOnly group: "com.google.code.gson", name: "gson", version: "2.9.0"

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/bnd.bnd
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/bnd.bnd
@@ -5,6 +5,8 @@ Bundle-Version: 1.0.0
 Import-Package:\
 	!co.elastic.logging.*,\
 	\
+	!com.aayushatharva.brotli4j.*,\
+	\
 	!com.barchart.udt.*,\
 	\
 	!com.beust.jcommander.*,\
@@ -79,6 +81,7 @@ Import-Package:\
 	!org.apache.avalon.framework.*,\
 	!org.apache.bsf.*,\
 	!org.apache.commons.cli.*,\
+	!org.apache.commons.compress.*,\
 	!org.apache.commons.csv.*,\
 	!org.apache.commons.lang.*,\
 	!org.apache.ivy.*,\

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/build.gradle
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 	compileInclude group: "io.opentelemetry", name: "opentelemetry-context", version: "1.57.0"
 	compileInclude group: "jakarta.json", name: "jakarta.json-api", version: "2.1.3"
 	compileInclude group: "jakarta.json.bind", name: "jakarta.json.bind-api", version: "2.0.0"
-	compileInclude group: "org.apache.httpcomponents.client5", name: "httpclient5", version: "5.4.4"
+	compileInclude group: "org.apache.httpcomponents.client5", name: "httpclient5", version: "5.6.3"
 	compileInclude group: "org.apache.httpcomponents.core5", name: "httpcore5", version: "5.4.3"
 	compileInclude group: "org.apache.httpcomponents.core5", name: "httpcore5-h2", version: "5.4.3"
 	compileInclude group: "org.apache.logging.log4j", name: "log4j-api", version: "2.20.0"

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/bnd.bnd
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/bnd.bnd
@@ -2,6 +2,10 @@ Bundle-Name: Liferay Portal Search OpenSearch 2 Implementation
 Bundle-SymbolicName: com.liferay.portal.search.opensearch2.impl
 Bundle-Version: 1.0.23
 Import-Package:\
+	!com.aayushatharva.brotli4j.*,\
+	\
+	!com.github.luben.zstd.*,\
+	\
 	!jakarta.enterprise.context.*,\
 	!jakarta.enterprise.inject.*,\
 	\
@@ -10,6 +14,7 @@ Import-Package:\
 	!javax.servlet.*,\
 	\
 	!org.apache.avalon.framework.*,\
+	!org.apache.commons.compress.*,\
 	!org.apache.log.*,\
 	\
 	!org.brotli.dec.*,\

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/build.gradle
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 	compileInclude group: "commons-lang", name: "commons-lang", version: "2.6"
 	compileInclude group: "jakarta.json", name: "jakarta.json-api", version: "2.1.3"
 	compileInclude group: "jakarta.json.bind", name: "jakarta.json.bind-api", version: "2.0.0"
-	compileInclude group: "org.apache.httpcomponents.client5", name: "httpclient5", version: "5.4.4"
+	compileInclude group: "org.apache.httpcomponents.client5", name: "httpclient5", version: "5.6.3"
 	compileInclude group: "org.apache.httpcomponents.core5", name: "httpcore5", version: "5.4.3"
 	compileInclude group: "org.apache.httpcomponents.core5", name: "httpcore5-h2", version: "5.4.3"
 	compileInclude group: "org.eclipse", name: "yasson", version: "2.0.4"

--- a/modules/apps/portal-security/portal-security-antisamy/bnd.bnd
+++ b/modules/apps/portal-security/portal-security-antisamy/bnd.bnd
@@ -2,7 +2,12 @@ Bundle-Name: Liferay Portal Security AntiSamy
 Bundle-SymbolicName: com.liferay.portal.security.antisamy
 Bundle-Version: 6.0.50
 Import-Package:\
+	!com.aayushatharva.brotli4j.*,\
+	\
+	!com.github.luben.zstd.*,\
+	\
 	!org.apache.avalon.framework.*,\
+	!org.apache.commons.compress.*,\
 	!org.apache.commons.logging.*,\
 	!org.apache.log.*,\
 	!org.apache.log4j.*,\

--- a/modules/apps/portal-security/portal-security-antisamy/build.gradle
+++ b/modules/apps/portal-security/portal-security-antisamy/build.gradle
@@ -16,7 +16,7 @@ copyCSS {
 }
 
 dependencies {
-	compileInclude group: "org.apache.httpcomponents.client5", name: "httpclient5", version: "5.4.4"
+	compileInclude group: "org.apache.httpcomponents.client5", name: "httpclient5", version: "5.6.3"
 	compileInclude group: "org.apache.httpcomponents.core5", name: "httpcore5", version: "5.4.3"
 	compileInclude group: "org.apache.httpcomponents.core5", name: "httpcore5-h2", version: "5.4.3"
 	compileInclude group: "org.apache.xmlgraphics", name: "batik-constants", version: "1.16"

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -857,7 +857,7 @@
         org.apache.httpcomponents:httpcore:4.4.14,\
         org.apache.httpcomponents:httpcore-nio:4.4.14,\
         org.apache.httpcomponents:httpmime:4.5.13,\
-        org.apache.httpcomponents.client5:httpclient5:5.4.4,\
+        org.apache.httpcomponents.client5:httpclient5:5.6.3,\
         org.apache.httpcomponents.core5:httpcore5:5.4.3,\
         org.apache.httpcomponents.core5:httpcore5-h2:5.4.3,\
         org.apache.logging.log4j:log4j-api:2.20.0,\

--- a/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/build.gradle
+++ b/workspaces/liferay-osbfaro-workspace/modules/osb-faro-engine-client/build.gradle
@@ -6,7 +6,7 @@ dependencies {
 	compileInclude group: "io.micrometer", name: "micrometer-commons", version: "1.14.3"
 	compileInclude group: "io.micrometer", name: "micrometer-observation", version: "1.14.3"
 	compileInclude group: "joda-time", name: "joda-time", version: "2.12.1"
-	compileInclude group: "org.apache.httpcomponents.client5", name: "httpclient5", version: "5.4.4"
+	compileInclude group: "org.apache.httpcomponents.client5", name: "httpclient5", version: "5.6.3"
 	compileInclude group: "org.apache.httpcomponents.core5", name: "httpcore5", version: "5.3.2"
 	compileInclude group: "org.apache.httpcomponents.core5", name: "httpcore5-h2", version: "5.3.4"
 	compileInclude group: "org.joda", name: "joda-convert", version: "2.2.1"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101741

## What Is Being Fixed

`portal-security-antisamy` shipped `httpclient5` 5.4.4, which is affected by CVE-2026-64607 (GHSA-hjcp-jmpx-g3qm, 5.3 Medium). HttpClient based on the classic i/o model fails to return the connection to the connection manager when a response carries an invalid or unsupported `Content-Encoding` header, so the pool leaks connections until it is exhausted. Every release from 5.0-alpha1 through 5.6.2 is affected and the fix landed in 5.6.3.

The pinned version is shared configuration, so the same jar was embedded by `commerce-payment-method-authorize-net`, `portal-search-elasticsearch8-impl`, `portal-search-opensearch2-impl` and `osb-faro-engine-client`. In `portal-security-antisamy` itself the only classic i/o path is AntiSamy's `CssScanner`, which is gated behind the `embedStyleSheets` directive that Liferay sets to `false` in all four policies, so the honest reading is a vulnerable dependency present in the delivered artifact rather than a reachable path in the default configuration.

## How It Is Being Fixed

The version is raised to 5.6.3 in `enforceVersionArtifacts`, which is the single source of truth, and the same rewrite is applied to every `build.gradle` that consumes the pin. `httpcore5` needs no change: the parent POM of httpclient5 5.6.3 declares `httpcore.version` as 5.4.3, which is exactly what the repository already pins, so the pair ends up aligned. `modules/third-party/org-opensearch-java-client` is deliberately left at 5.1.4, since that is a vendored OpenSearch pair whose upgrade predates this ticket and would need functional search testing of its own.

The upgrade also required a change that a version bump alone does not suggest. 5.6.3 replaces the optional `org.brotli:dec` codec with `brotli4j` and adds `zstd-jni` and `commons-compress`. Gradle never resolves optional dependencies, so those packages are neither embedded nor exported by any bundle, yet bnd derives `Import-Package` from the bytecode of the embedded jars and emitted four mandatory imports that nothing in the runtime can satisfy. Liferay already suppresses exactly this class of reference by hand, which is why `!org.brotli.dec.*` and `!org.conscrypt.*` were sitting in these `bnd.bnd` files, so the new packages are negated the same way. Without it the four bundles stop resolving after the merge. `osb-faro-engine-client` needs no negation because its `bnd.bnd` already ends in `*;resolution:=optional`.

Binary compatibility was checked rather than assumed. Between 5.4.4 and 5.6.3 no public class is removed and only three public or protected members disappear, all of them constructors of internal `impl` classes that no consumer references — Liferay's own code, AntiSamy, the Elasticsearch client and the OpenSearch client all reach those types through builders. The two `httpcore5` packages that 5.6.3 uses for the first time are present in the 5.4.3 artifacts already pinned and travel inside the bundle, so they produce no import.

Finally, `ant build-lib-versions` regenerates the license manifest, which is the file audits and third-party scans read. Skipping it leaves `lib/versions.html` declaring the vulnerable version after the fix has merged.

## Why Are There No Tests?

The change is a third-party version pin with no product code change, so there is no new behavior to cover. Verification was done against the runtime instead: the four affected bundles were rebuilt and their generated `Import-Package` inspected to confirm no unsatisfiable import remains, the portal was started and `portal-security-antisamy`, `commerce-payment-method-authorize-net` and `portal-search-elasticsearch8-impl` all reported `Active` with no bundle left in the `Installed` state, and the existing `AntiSamySanitizerImplTest` integration test passed.

## PR Check

**pr-check: PASS** — tested on `b2f817f12bc6a73dbda2ab6dc92d8c6b6715f1f0`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Per-Module Compile | PASS |
| Baseline | PASS |
| Workspace Build | PASS |
| Structural Smoke | PASS |

<!-- pr-check {"result": "success", "sha": "b2f817f12bc6a73dbda2ab6dc92d8c6b6715f1f0"} -->
