### PR TITLE
LPD-99777 Allow requests while impersonating a user who never signed in

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/AuthVerifierPipeline.java
@@ -23,10 +23,12 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.security.auth.registry.AuthVerifierRegistry;
 import com.liferay.portal.spring.context.PortalContextLoaderListener;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -286,6 +288,56 @@ public class AuthVerifierPipeline {
 			_requestURI = requestURI;
 		}
 
+		private boolean _isImpersonated(
+			AccessControlContext accessControlContext, long userId) {
+
+			HttpServletRequest httpServletRequest =
+				accessControlContext.getRequest();
+
+			long doAsUserId = GetterUtil.getLong(
+				httpServletRequest.getAttribute(WebKeys.USER_ID));
+
+			if (doAsUserId != userId) {
+				return false;
+			}
+
+			HttpServletRequest originalHttpServletRequest =
+				PortalUtil.getOriginalServletRequest(httpServletRequest);
+
+			HttpSession httpSession = originalHttpServletRequest.getSession(
+				false);
+
+			if (httpSession == null) {
+				return false;
+			}
+
+			long realUserId = GetterUtil.getLong(
+				httpSession.getAttribute(WebKeys.USER_ID));
+
+			if ((realUserId <= 0) || (realUserId == userId)) {
+				return false;
+			}
+
+			return true;
+		}
+
+		private boolean _isUserAuthSuccessful(
+			AccessControlContext accessControlContext, User user) {
+
+			if (!user.isActive()) {
+				return false;
+			}
+
+			if (_isImpersonated(accessControlContext, user.getUserId()) ||
+				(user.isEmailAddressVerificationComplete() &&
+				 !user.isPasswordResetRequired())) {
+
+				return true;
+			}
+
+			return false;
+		}
+
 		private Map<String, Object> _mergeSettings(
 			Properties properties, Map<String, Object> settings) {
 
@@ -351,9 +403,7 @@ public class AuthVerifierPipeline {
 				authVerifierResult.getUserId());
 
 			if ((user != null) &&
-				(!user.isActive() ||
-				 !user.isEmailAddressVerificationComplete() ||
-				 user.isPasswordResetRequired())) {
+				!_isUserAuthSuccessful(accessControlContext, user)) {
 
 				long userId = authVerifierResult.getUserId();
 

--- a/portal-impl/test/unit/com/liferay/portal/security/auth/AuthVerifierPipelineTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/security/auth/AuthVerifierPipelineTest.java
@@ -8,17 +8,22 @@ package com.liferay.portal.security.auth;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserConstants;
 import com.liferay.portal.kernel.module.util.SystemBundleUtil;
 import com.liferay.portal.kernel.security.auth.AccessControlContext;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifier;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierConfiguration;
 import com.liferay.portal.kernel.security.auth.verifier.AuthVerifierResult;
+import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ProxyUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.impl.UserImpl;
 import com.liferay.portal.security.auth.registry.AuthVerifierRegistry;
@@ -26,6 +31,8 @@ import com.liferay.portal.test.rule.LiferayUnitTestRule;
 import com.liferay.portal.util.PortalImpl;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpSession;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -46,6 +53,7 @@ import org.osgi.framework.BundleContext;
 import org.osgi.framework.ServiceRegistration;
 
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.mock.web.MockServletContext;
 
 /**
@@ -63,6 +71,7 @@ public class AuthVerifierPipelineTest {
 		_setUpAuthVerifier();
 		_setUpAuthVerifierConfiguration();
 		_setUpAuthVerifierRegistry();
+		_setUpCompanyLocalServiceUtil();
 		_setUpPortalUtil();
 		_setUpUserLocalServiceUtil();
 	}
@@ -70,6 +79,7 @@ public class AuthVerifierPipelineTest {
 	@After
 	public void tearDown() {
 		_authVerifierRegistryMockedStatic.close();
+		_companyLocalServiceUtilMockedStatic.close();
 		_userLocalServiceUtilMockedStatic.close();
 	}
 
@@ -131,6 +141,44 @@ public class AuthVerifierPipelineTest {
 	}
 
 	@Test
+	public void testVerifyRequestWithInactiveUser() throws PortalException {
+		_user.setType(UserConstants.TYPE_REGULAR);
+		_user.setStatus(WorkflowConstants.STATUS_INACTIVE);
+
+		_assertAuthVerifierResultForUser(
+			AuthVerifierResult.State.UNSUCCESSFUL, true);
+		_assertAuthVerifierResultForUser(
+			AuthVerifierResult.State.UNSUCCESSFUL, false);
+	}
+
+	@Test
+	public void testVerifyRequestWithIncompleteSetupUser()
+		throws PortalException {
+
+		_user.setType(UserConstants.TYPE_REGULAR);
+
+		// Email address not verified
+
+		_user.setPasswordReset(false);
+		_user.setEmailAddressVerified(false);
+
+		_assertAuthVerifierResultForUser(
+			AuthVerifierResult.State.SUCCESS, true);
+		_assertAuthVerifierResultForUser(
+			AuthVerifierResult.State.UNSUCCESSFUL, false);
+
+		// Password reset required
+
+		_user.setPasswordReset(true);
+		_user.setEmailAddressVerified(true);
+
+		_assertAuthVerifierResultForUser(
+			AuthVerifierResult.State.SUCCESS, true);
+		_assertAuthVerifierResultForUser(
+			AuthVerifierResult.State.UNSUCCESSFUL, false);
+	}
+
+	@Test
 	public void testVerifyRequestWithNonmatchingRequestURI()
 		throws PortalException {
 
@@ -153,9 +201,40 @@ public class AuthVerifierPipelineTest {
 		throws PortalException {
 
 		AuthVerifierResult authVerifierResult = _verifyRequest(
-			contextPath, includeURLs, requestURI);
+			contextPath, false, includeURLs, requestURI);
 
 		Assert.assertSame(expectedState, authVerifierResult.getState());
+	}
+
+	private void _assertAuthVerifierResultForUser(
+			AuthVerifierResult.State expectedState, boolean impersonated)
+		throws PortalException {
+
+		AuthVerifierResult authVerifierResult = _verifyRequest(
+			"", impersonated, _BASE_URL + "/regular/*",
+			_BASE_URL + "/regular/Hello");
+
+		Assert.assertSame(expectedState, authVerifierResult.getState());
+	}
+
+	private HttpServletRequest _getWrappedHttpServletRequest(
+		HttpServletRequest httpServletRequest) {
+
+		return new HttpServletRequestWrapper(httpServletRequest) {
+
+			@Override
+			public HttpSession getSession() {
+				return _httpSession;
+			}
+
+			@Override
+			public HttpSession getSession(boolean create) {
+				return _httpSession;
+			}
+
+			private final MockHttpSession _httpSession = new MockHttpSession();
+
+		};
 	}
 
 	private void _setUpAuthVerifier() {
@@ -193,6 +272,22 @@ public class AuthVerifierPipelineTest {
 		);
 	}
 
+	private void _setUpCompanyLocalServiceUtil() throws Exception {
+		Company company = Mockito.mock(Company.class);
+
+		Mockito.when(
+			company.isStrangersVerify()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			CompanyLocalServiceUtil.getCompany(Mockito.anyLong())
+		).thenReturn(
+			company
+		);
+	}
+
 	private void _setUpPortalUtil() {
 		PortalUtil portalUtil = new PortalUtil();
 
@@ -210,25 +305,27 @@ public class AuthVerifierPipelineTest {
 	}
 
 	private void _setUpUserLocalServiceUtil() throws Exception {
-		User user = new UserImpl();
+		_user = new UserImpl();
 
-		user.setStatus(WorkflowConstants.STATUS_APPROVED);
+		_user.setUserId(_DO_AS_USER_ID);
+		_user.setStatus(WorkflowConstants.STATUS_APPROVED);
 
 		Mockito.when(
 			UserLocalServiceUtil.fetchUser(Mockito.anyLong())
 		).thenReturn(
-			user
+			_user
 		);
 
 		Mockito.when(
 			UserLocalServiceUtil.getGuestUserId(Mockito.anyLong())
 		).thenReturn(
-			user.getUserId()
+			_user.getUserId()
 		);
 	}
 
 	private AuthVerifierResult _verifyRequest(
-			String contextPath, String includeURLs, String requestURI)
+			String contextPath, boolean impersonated, String includeURLs,
+			String requestURI)
 		throws PortalException {
 
 		BundleContext bundleContext = SystemBundleUtil.getBundleContext();
@@ -258,7 +355,20 @@ public class AuthVerifierPipelineTest {
 
 			mockHttpServletRequest.setRequestURI(requestURI);
 
-			accessControlContext.setRequest(mockHttpServletRequest);
+			if (impersonated) {
+				mockHttpServletRequest.setAttribute(
+					WebKeys.USER_ID, _DO_AS_USER_ID);
+
+				HttpSession httpSession = mockHttpServletRequest.getSession();
+
+				httpSession.setAttribute(WebKeys.USER_ID, _REAL_USER_ID);
+
+				accessControlContext.setRequest(
+					_getWrappedHttpServletRequest(mockHttpServletRequest));
+			}
+			else {
+				accessControlContext.setRequest(mockHttpServletRequest);
+			}
 
 			return authVerifierPipeline.verifyRequest(accessControlContext);
 		}
@@ -269,11 +379,19 @@ public class AuthVerifierPipelineTest {
 
 	private static final String _BASE_URL = "/TestAuthVerifier";
 
+	private static final long _DO_AS_USER_ID = RandomTestUtil.randomLong();
+
+	private static final long _REAL_USER_ID = _DO_AS_USER_ID + 1;
+
 	private AuthVerifier _authVerifier;
 	private AuthVerifierConfiguration _authVerifierConfiguration;
 	private final MockedStatic<AuthVerifierRegistry>
 		_authVerifierRegistryMockedStatic = Mockito.mockStatic(
 			AuthVerifierRegistry.class);
+	private final MockedStatic<CompanyLocalServiceUtil>
+		_companyLocalServiceUtilMockedStatic = Mockito.mockStatic(
+			CompanyLocalServiceUtil.class);
+	private User _user;
 	private final MockedStatic<UserLocalServiceUtil>
 		_userLocalServiceUtilMockedStatic = Mockito.mockStatic(
 			UserLocalServiceUtil.class);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99777

## What Is Being Fixed

Impersonating a user who has never signed in made every headless call fail with a 403. LPS-187785 added a check to `AuthVerifierPipeline` that rejects users who have not verified their email address or who must reset their credentials before their first sign in, but that check does not distinguish an impersonated user from the one making the request. The UI has always skipped the first login flow for impersonated sessions, so an administrator impersonating a fresh user could browse pages while `/o/headless-admin-user/v1.0/my-user-account` and every other headless endpoint was rejected.

## How It Is Being Fixed

`AuthVerifierPipeline` now grants impersonated requests the same exemption `PortalRequestProcessor` already grants the UI, and only for a request that is genuinely impersonating: the verified user must match the request attribute that `PortalImpl.getDoAsUserId` sets, which happens only after the impersonation permission check or a valid impersonation ticket, and the real user behind the session must be a different one. The real user is read through `PortalUtil.getOriginalServletRequest`, because the session of the request handed to the auth verifiers is scoped to the servlet context by the OSGi HTTP whiteboard and does not expose the portal session attributes. An inactive user is still rejected, as is a user calling the API directly, so the control LPS-187785 introduced keeps applying to everyone who is not being impersonated.

The unit test covers both gates the exemption relaxes and wraps the request so that its session is scoped separately from the portal session, reproducing what the whiteboard does at runtime. Reverting either half of the change makes it fail.

## PR Check

**pr-check: PASS** — tested on `54de61830a92422f4f183fbbd4cf08863f0fca44`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "54de61830a92422f4f183fbbd4cf08863f0fca44"} -->

