### PR TITLE
LPD-98316 Record a rejected federation token in the FIPS audit trail

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/audit/FIPSFederationTokenAuditUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/audit/FIPSFederationTokenAuditUtil.java
@@ -9,6 +9,7 @@ import com.liferay.portal.kernel.security.fips.FIPSApplicationState;
 import com.liferay.portal.kernel.security.fips.FIPSApplicationStateMachineUtil;
 import com.liferay.portal.kernel.security.fips.FIPSAuditEvent;
 import com.liferay.portal.kernel.security.fips.FIPSAuditEventEmitterUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 
 import jakarta.servlet.http.HttpServletRequest;
 
@@ -23,6 +24,10 @@ public class FIPSFederationTokenAuditUtil {
 
 	public static void emitFederationTokenRejected(
 		String issuer, String offendingValue) {
+
+		if (!PropsValues.FIPS_ENABLED) {
+			return;
+		}
 
 		FIPSApplicationState fipsApplicationState =
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState();

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/audit/FIPSFederationTokenAuditUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/audit/FIPSFederationTokenAuditUtil.java
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.rest.internal.audit;
+
+import com.liferay.portal.kernel.security.fips.FIPSApplicationState;
+import com.liferay.portal.kernel.security.fips.FIPSApplicationStateMachineUtil;
+import com.liferay.portal.kernel.security.fips.FIPSAuditEvent;
+import com.liferay.portal.kernel.security.fips.FIPSAuditEventEmitterUtil;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.apache.cxf.jaxrs.utils.JAXRSUtils;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.transport.http.AbstractHTTPDestination;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSFederationTokenAuditUtil {
+
+	public static void emitFederationTokenRejected(
+		String issuer, String offendingValue) {
+
+		FIPSApplicationState fipsApplicationState =
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState();
+
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			"federation-token-rejected", FIPSAuditEvent.Severity.WARNING);
+
+		fipsAuditEvent.put("fips-state", fipsApplicationState.getValue());
+		fipsAuditEvent.put("offending-value", offendingValue);
+		fipsAuditEvent.put("receiving-endpoint", _fetchReceivingEndpoint());
+		fipsAuditEvent.put("token-issuer", issuer);
+		fipsAuditEvent.put("token-type", "JWT");
+
+		FIPSAuditEventEmitterUtil.emit(fipsAuditEvent);
+	}
+
+	private static String _fetchReceivingEndpoint() {
+		Message message = JAXRSUtils.getCurrentMessage();
+
+		if (message == null) {
+			return null;
+		}
+
+		HttpServletRequest httpServletRequest = (HttpServletRequest)message.get(
+			AbstractHTTPDestination.HTTP_REQUEST);
+
+		if (httpServletRequest == null) {
+			return null;
+		}
+
+		return httpServletRequest.getRequestURI();
+	}
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/authentication/handler/LiferayJWTBearerAuthenticationHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/authentication/handler/LiferayJWTBearerAuthenticationHandler.java
@@ -5,6 +5,7 @@
 
 package com.liferay.oauth2.provider.rest.internal.endpoint.access.token.authentication.handler;
 
+import com.liferay.oauth2.provider.rest.internal.audit.FIPSFederationTokenAuditUtil;
 import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
 import com.liferay.oauth2.provider.util.OAuth2JWKValidatorUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -117,8 +118,19 @@ public class LiferayJWTBearerAuthenticationHandler
 		String tokenEndpointAuthMethod = client.getTokenEndpointAuthMethod();
 
 		try {
-			OAuth2JWKValidatorUtil.validateJWSAlgorithm(
-				(String)jwtToken.getJwsHeader(JoseConstants.HEADER_ALGORITHM));
+			String algorithm = (String)jwtToken.getJwsHeader(
+				JoseConstants.HEADER_ALGORITHM);
+
+			try {
+				OAuth2JWKValidatorUtil.validateJWSAlgorithm(algorithm);
+			}
+			catch (SecurityException securityException) {
+				FIPSFederationTokenAuditUtil.emitFederationTokenRejected(
+					(String)jwtToken.getClaim(JwtConstants.CLAIM_ISSUER),
+					algorithm);
+
+				throw securityException;
+			}
 
 			if (tokenEndpointAuthMethod.equals("client_secret_jwt")) {
 				String clientSecret = client.getClientSecret();

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayJWTBearerGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayJWTBearerGrantHandler.java
@@ -6,6 +6,7 @@
 package com.liferay.oauth2.provider.rest.internal.endpoint.access.token.grant.handler;
 
 import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
+import com.liferay.oauth2.provider.rest.internal.audit.FIPSFederationTokenAuditUtil;
 import com.liferay.oauth2.provider.rest.internal.configuration.OAuth2InAssertionConfiguration;
 import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
 import com.liferay.oauth2.provider.rest.internal.endpoint.liferay.LiferayOAuthDataProvider;
@@ -255,8 +256,19 @@ public class LiferayJWTBearerGrantHandler extends BaseAccessTokenGrantHandler {
 
 				JwsHeaders jwsHeaders = jwtToken.getJwsHeaders();
 
-				OAuth2JWKValidatorUtil.validateJWSAlgorithm(
-					jwsHeaders.getAlgorithm());
+				try {
+					OAuth2JWKValidatorUtil.validateJWSAlgorithm(
+						jwsHeaders.getAlgorithm());
+				}
+				catch (SecurityException securityException) {
+					JwtClaims rejectedJwtClaims = jwtToken.getClaims();
+
+					FIPSFederationTokenAuditUtil.emitFederationTokenRejected(
+						rejectedJwtClaims.getIssuer(),
+						jwsHeaders.getAlgorithm());
+
+					throw securityException;
+				}
 
 				JwtClaims jwtClaims = jwtToken.getClaims();
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/FIPSFederationTokenAuditTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/FIPSFederationTokenAuditTest.java
@@ -1,0 +1,112 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.token.endpoint.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.internal.test.PasswordAuthorizationGrant;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+
+import jakarta.ws.rs.core.Response;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.BundleActivator;
+
+/**
+ * @author Jorge García Jiménez
+ */
+@RunWith(Arquillian.class)
+public class FIPSFederationTokenAuditTest extends BaseTokenEndpointTestCase {
+
+	@Test
+	public void testRejectedClientAssertionIsAudited() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable("FIPS_ENABLED", true);
+			LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_LOGGER_NAME, LoggerTestUtil.WARN)) {
+
+			Response response = _getTokenResponse();
+
+			Assert.assertEquals(401, response.getStatus());
+
+			List<String> messages = _getAuditRecordMessages(logCapture);
+
+			Assert.assertEquals(messages.toString(), 1, messages.size());
+
+			String message = messages.get(0);
+
+			_assertField("fips-state=", message);
+			_assertField("offending-value=HS256", message);
+			_assertField("receiving-endpoint=/o/oauth2/token", message);
+			_assertField("token-issuer=" + TEST_CLIENT_ID_2, message);
+			_assertField("token-type=JWT", message);
+		}
+	}
+
+	@Test
+	public void testRejectedClientAssertionIsNotAuditedOutsideFIPSMode()
+		throws Exception {
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_LOGGER_NAME, LoggerTestUtil.WARN)) {
+
+			Response response = _getTokenResponse();
+
+			Assert.assertEquals(200, response.getStatus());
+
+			List<String> messages = _getAuditRecordMessages(logCapture);
+
+			Assert.assertTrue(messages.toString(), messages.isEmpty());
+		}
+	}
+
+	@Override
+	protected BundleActivator getBundleActivator() {
+		return new TestPreparatorBundleActivator() {
+		};
+	}
+
+	private void _assertField(String field, String message) {
+		Assert.assertTrue(message, message.contains(field));
+	}
+
+	private List<String> _getAuditRecordMessages(LogCapture logCapture) {
+		List<String> messages = new ArrayList<>();
+
+		for (String message : logCapture.getMessages()) {
+			if (message.contains("event-type=federation-token-rejected")) {
+				messages.add(message);
+			}
+		}
+
+		return messages;
+	}
+
+	private Response _getTokenResponse() throws Exception {
+		User user = UserTestUtil.getAdminUser(TestPropsValues.getCompanyId());
+
+		return getTokenResponse(
+			new PasswordAuthorizationGrant(
+				user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD),
+			clientAuthentications.get(TEST_CLIENT_ID_2));
+	}
+
+	private static final String _LOGGER_NAME =
+		"com.liferay.portal.kernel.security.fips.FIPSAuditEventEmitterUtil";
+
+}

--- a/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditLogTest.java
+++ b/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditLogTest.java
@@ -130,6 +130,29 @@ public class FIPSAuditLogTest {
 	}
 
 	@Test
+	public void testAuditLogRecordsCarryTheFederationTokenRejectedFields()
+		throws Exception {
+
+		for (JSONObject jsonObject : _getRecordJSONObjects()) {
+			String eventType = jsonObject.getString("event-type");
+
+			if (!eventType.equals("federation-token-rejected")) {
+				continue;
+			}
+
+			JSONObject fieldsJSONObject = jsonObject.getJSONObject("fields");
+
+			for (String fieldKey : _FEDERATION_TOKEN_REJECTED_FIELD_KEYS) {
+				Assert.assertTrue(
+					StringBundler.concat(
+						"Unable to find \"", fieldKey,
+						"\" in the FIPS audit record ", jsonObject),
+					fieldsJSONObject.has(fieldKey));
+			}
+		}
+	}
+
+	@Test
 	public void testAuditLogRecordsTheBootStateTransitions() throws Exception {
 		List<String> transitions = new ArrayList<>();
 
@@ -178,6 +201,11 @@ public class FIPSAuditLogTest {
 		"cmvp-certificate-id", "deployment-instance-id", "event-schema-version",
 		"event-sequence", "event-type", "fields", "provider-name",
 		"provider-version", "severity", "timestamp"
+	};
+
+	private static final String[] _FEDERATION_TOKEN_REJECTED_FIELD_KEYS = {
+		"fips-state", "offending-value", "receiving-endpoint", "token-issuer",
+		"token-type"
 	};
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
@@ -52,7 +52,7 @@ public class FIPSAuditEvent {
 
 	public enum Severity {
 
-		CRITICAL("critical"), INFO("info");
+		CRITICAL("critical"), INFO("info"), WARNING("warning");
 
 		public String getValue() {
 			return _value;

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterUtil.java
@@ -63,6 +63,10 @@ import org.apache.logging.log4j.message.ObjectMessage;
 public class FIPSAuditEventEmitterUtil {
 
 	public static void emit(FIPSAuditEvent fipsAuditEvent) {
+		if (!PropsValues.FIPS_ENABLED) {
+			return;
+		}
+
 		FIPSAuditEvent.Severity severity = fipsAuditEvent.getSeverity();
 
 		_write(

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterUtil.java
@@ -187,6 +187,10 @@ public class FIPSAuditEventEmitterUtil {
 			return Level.ERROR;
 		}
 
+		if (severity == FIPSAuditEvent.Severity.WARNING) {
+			return Level.WARN;
+		}
+
 		return Level.INFO;
 	}
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -10,6 +10,7 @@ import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.ServerDetector;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -54,19 +55,31 @@ public class FIPSApplicationStateMachineUtilTest {
 		).thenReturn(
 			_logger
 		);
+
+		_serverDetectorMockedStatic = Mockito.mockStatic(
+			ServerDetector.class, Mockito.CALLS_REAL_METHODS);
+
+		_serverDetectorMockedStatic.when(
+			ServerDetector::getServerId
+		).thenReturn(
+			null
+		);
 	}
 
 	@AfterClass
 	public static void tearDownClass() {
 		_logManagerMockedStatic.close();
+		_serverDetectorMockedStatic.close();
 	}
 
 	@Before
 	public void setUp() {
 		Mockito.reset(_logger);
 
-		_safeCloseable = PropsValuesTestUtil.swapWithSafeCloseable(
+		_safeCloseable1 = PropsValuesTestUtil.swapWithSafeCloseable(
 			"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", RandomTestUtil.randomString());
+		_safeCloseable2 = PropsValuesTestUtil.swapWithSafeCloseable(
+			"FIPS_ENABLED", true);
 
 		Mockito.doAnswer(
 			invocation -> {
@@ -87,7 +100,8 @@ public class FIPSApplicationStateMachineUtilTest {
 
 	@After
 	public void tearDown() {
-		_safeCloseable.close();
+		_safeCloseable1.close();
+		_safeCloseable2.close();
 	}
 
 	@Test
@@ -569,8 +583,10 @@ public class FIPSApplicationStateMachineUtilTest {
 	private static Logger _logger;
 
 	private static MockedStatic<LogManager> _logManagerMockedStatic;
+	private static MockedStatic<ServerDetector> _serverDetectorMockedStatic;
 
 	private final List<Map<String, Object>> _records = new ArrayList<>();
-	private SafeCloseable _safeCloseable;
+	private SafeCloseable _safeCloseable1;
+	private SafeCloseable _safeCloseable2;
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterUtilTest.java
@@ -299,6 +299,8 @@ public class FIPSAuditEventEmitterUtilTest {
 			Level.ERROR, FIPSAuditEvent.Severity.CRITICAL);
 		_testEmitLogsRecordAtTheSeverityLevel(
 			Level.INFO, FIPSAuditEvent.Severity.INFO);
+		_testEmitLogsRecordAtTheSeverityLevel(
+			Level.WARN, FIPSAuditEvent.Severity.WARNING);
 	}
 
 	@Test

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventEmitterUtilTest.java
@@ -79,26 +79,34 @@ public class FIPSAuditEventEmitterUtilTest {
 		).thenReturn(
 			_logger
 		);
+
+		_serverDetectorMockedStatic = Mockito.mockStatic(
+			ServerDetector.class, Mockito.CALLS_REAL_METHODS);
 	}
 
 	@AfterClass
 	public static void tearDownClass() {
 		_logManagerMockedStatic.close();
+		_serverDetectorMockedStatic.close();
 	}
 
 	@Before
 	public void setUp() {
 		Mockito.reset(_logger);
 
-		_safeCloseable = PropsValuesTestUtil.swapWithSafeCloseable(
+		_safeCloseable1 = PropsValuesTestUtil.swapWithSafeCloseable(
 			"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", RandomTestUtil.randomString());
+		_safeCloseable2 = PropsValuesTestUtil.swapWithSafeCloseable(
+			"FIPS_ENABLED", true);
 
 		_mockLogManager(null);
+		_mockServerId(null);
 	}
 
 	@After
 	public void tearDown() {
-		_safeCloseable.close();
+		_safeCloseable1.close();
+		_safeCloseable2.close();
 	}
 
 	@Test
@@ -156,61 +164,49 @@ public class FIPSAuditEventEmitterUtilTest {
 
 	@Test
 	public void testEmitChecksTheAuditLogPermissionsAfterWritingTheRecord() {
-		try (SafeCloseable safeCloseable =
-				PropsValuesTestUtil.swapWithSafeCloseable("FIPS_ENABLED", true);
-			MockedStatic<ServerDetector> serverDetectorMockedStatic =
-				Mockito.mockStatic(
-					ServerDetector.class, Mockito.CALLS_REAL_METHODS)) {
+		_mockServerId("tomcat");
 
-			serverDetectorMockedStatic.when(
-				ServerDetector::getServerId
-			).thenReturn(
-				"tomcat"
-			);
+		Mockito.when(
+			_logger.isEnabled(Level.INFO)
+		).thenReturn(
+			true
+		);
 
-			Mockito.when(
-				_logger.isEnabled(Level.INFO)
-			).thenReturn(
-				true
-			);
+		RollingFileAppender rollingFileAppender = _mockRollingFileAppender(
+			"/dev/null/missing.ndjson");
 
-			RollingFileAppender rollingFileAppender = _mockRollingFileAppender(
-				"/dev/null/missing.ndjson");
+		Mockito.doReturn(
+			Mockito.mock(FIPSAuditNDJSONLayout.class)
+		).when(
+			rollingFileAppender
+		).getLayout();
 
-			Mockito.doReturn(
-				Mockito.mock(FIPSAuditNDJSONLayout.class)
-			).when(
-				rollingFileAppender
-			).getLayout();
+		RollingFileManager rollingFileManager =
+			rollingFileAppender.getManager();
 
-			RollingFileManager rollingFileManager =
-				rollingFileAppender.getManager();
+		Mockito.when(
+			rollingFileManager.getFilePermissions()
+		).thenReturn(
+			null
+		);
 
-			Mockito.when(
-				rollingFileManager.getFilePermissions()
-			).thenReturn(
-				null
-			);
+		_mockLogManager(rollingFileAppender);
 
-			_mockLogManager(rollingFileAppender);
+		FIPSAuditEventEmitterUtil.emit(
+			new FIPSAuditEvent(
+				RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO));
 
-			FIPSAuditEventEmitterUtil.emit(
-				new FIPSAuditEvent(
-					RandomTestUtil.randomString(),
-					FIPSAuditEvent.Severity.INFO));
+		InOrder inOrder = Mockito.inOrder(_logger, rollingFileManager);
 
-			InOrder inOrder = Mockito.inOrder(_logger, rollingFileManager);
+		inOrder.verify(
+			_logger
+		).log(
+			Mockito.eq(Level.INFO), Mockito.any(Message.class)
+		);
 
-			inOrder.verify(
-				_logger
-			).log(
-				Mockito.eq(Level.INFO), Mockito.any(Message.class)
-			);
-
-			inOrder.verify(
-				rollingFileManager
-			).getFilePermissions();
-		}
+		inOrder.verify(
+			rollingFileManager
+		).getFilePermissions();
 	}
 
 	@Test
@@ -407,6 +403,21 @@ public class FIPSAuditEventEmitterUtilTest {
 	}
 
 	@Test
+	public void testEmitSkipsRecordWhenFIPSIsDisabled() {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_ENABLED", false)) {
+
+			FIPSAuditEventEmitterUtil.emit(
+				new FIPSAuditEvent(
+					RandomTestUtil.randomString(),
+					FIPSAuditEvent.Severity.INFO));
+
+			Mockito.verifyNoInteractions(_logger);
+		}
+	}
+
+	@Test
 	public void testEmitSyncsCriticalRecordOnly() {
 		_mockLogManager(_mockRollingFileAppender("/dev/null/missing.ndjson"));
 
@@ -559,6 +570,14 @@ public class FIPSAuditEventEmitterUtilTest {
 		return rollingFileAppender;
 	}
 
+	private void _mockServerId(String serverId) {
+		_serverDetectorMockedStatic.when(
+			ServerDetector::getServerId
+		).thenReturn(
+			serverId
+		);
+	}
+
 	private void _testEmitLogsRecordAtTheSeverityLevel(
 		Level level, FIPSAuditEvent.Severity severity) {
 
@@ -589,31 +608,22 @@ public class FIPSAuditEventEmitterUtilTest {
 	}
 
 	private void _testEmitThrows() {
-		try (SafeCloseable safeCloseable =
-				PropsValuesTestUtil.swapWithSafeCloseable("FIPS_ENABLED", true);
-			MockedStatic<ServerDetector> serverDetectorMockedStatic =
-				Mockito.mockStatic(
-					ServerDetector.class, Mockito.CALLS_REAL_METHODS)) {
+		_mockServerId("tomcat");
 
-			serverDetectorMockedStatic.when(
-				ServerDetector::getServerId
-			).thenReturn(
-				"tomcat"
-			);
-
-			Assert.assertThrows(
-				IllegalStateException.class,
-				() -> FIPSAuditEventEmitterUtil.emit(
-					new FIPSAuditEvent(
-						RandomTestUtil.randomString(),
-						FIPSAuditEvent.Severity.INFO)));
-		}
+		Assert.assertThrows(
+			IllegalStateException.class,
+			() -> FIPSAuditEventEmitterUtil.emit(
+				new FIPSAuditEvent(
+					RandomTestUtil.randomString(),
+					FIPSAuditEvent.Severity.INFO)));
 	}
 
 	private static Logger _logger;
 
 	private static MockedStatic<LogManager> _logManagerMockedStatic;
+	private static MockedStatic<ServerDetector> _serverDetectorMockedStatic;
 
-	private SafeCloseable _safeCloseable;
+	private SafeCloseable _safeCloseable1;
+	private SafeCloseable _safeCloseable2;
 
 }


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98316

**Stacked on #3200** (base `LPD-93284-fips-audit-ndjson`, not `master`). Reviewing this PR reviews only the four LPD-98316 commits; the emitter, the NDJSON layout, and the state machine they build on belong to #3200.

## What This Delivers

A rejected federation token now leaves a record in the FIPS audit trail. `OAuth2JWKValidatorUtil.validateJWSAlgorithm` already refused a nonapproved JWS algorithm in FIPS mode, but it refused silently: the token was rejected and nothing said so. `FIPSFederationTokenAuditUtil.emitFederationTokenRejected` records the refusal with five fields — `fips-state`, `offending-value`, `receiving-endpoint`, `token-issuer`, `token-type` — at the new `WARNING` severity, which maps to Log4j `WARN`.

Both places that validate an inbound assertion's algorithm feed it: `LiferayJWTBearerAuthenticationHandler` for `client_secret_jwt` and `private_key_jwt` client authentication, and `LiferayJWTBearerGrantHandler` for the `jwt-bearer` grant.

## The Trail Is FIPS Mode Only

Two guards, deliberately redundant:

- `FIPSAuditEventEmitterUtil.emit` returns early when FIPS mode is off, so no caller can put a record in the trail outside the approved mode. The trail describes a cryptographic module running in the approved mode; a record written while FIPS mode is off describes nothing and only pollutes the file.

- `FIPSFederationTokenAuditUtil.emitFederationTokenRejected` returns early too, matching the idiom of its sibling `OAuth2JWKValidatorUtil` and of `FIPSModeValidator`, both of which lead with the same check.

Nothing enforced this locally before. The event was unreachable outside FIPS mode only because the algorithm validation it hangs off already returns early there, so a second caller — the SAML sibling under LPD-93648, for instance — would have written a record.

The guard on `emit` means the FIPS unit tests now have to opt in to FIPS mode, so `FIPSAuditEventEmitterUtilTest` and `FIPSApplicationStateMachineUtilTest` swap `FIPS_ENABLED` on in `setUp`. That exposed a second thing: with FIPS mode on, `_validateDeliverable` no longer short-circuits, because `ServerDetector.getServerId()` is nonnull under the Ant JUnit runner. Both classes now mock it to null and re-stub it only in the tests that exercise the deliverability failures.

## Test Coverage

`FIPSFederationTokenAuditTest` drives the token endpoint against the `client_secret_jwt` fixture, whose assertion is signed with HS256:

- With FIPS mode swapped on, HS256 is refused: the request returns 401 and one record carrying all five fields reaches the trail.

- With FIPS mode off, HS256 is allowed: the request returns 200 and nothing reaches the trail.

The assertions filter the captured records by event type rather than asserting a record count. The emitter logs its own one-shot audit-log permissions warning through the same logger name, so a count assertion would depend on which test ran first in the JVM.

`FIPSAuditEventEmitterUtilTest` gains `testEmitSkipsRecordWhenFIPSIsDisabled`, which asserts the logger sees no interaction at all outside FIPS mode. `FIPSAuditLogTest` asserts the field set that a `federation-token-rejected` record carries on disk, in the same shape as the existing common-envelope check.

## PR Check

`pr-check` was run on the base branch rather than here. Its first precondition rebases onto `master`, which a stacked branch cannot satisfy without losing its base. The base run covers every portal-kernel and portal-impl file this PR touches.

**pr-check: PASS** — tested on `db9f0b1054de0` (base branch tip)

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |
| PQL Validation | PASS |

Run against this branch directly: the 38 FIPS unit tests in `portal-kernel` pass, and both `FIPSFederationTokenAuditTest` cases pass against a portal booted with the branch's kernel.