### PR TITLE
LPD-102477 Guard SCIM address fields when provisioning users

### DIFF
--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.model.Address;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Contact;
 import com.liferay.portal.kernel.model.Country;
+import com.liferay.portal.kernel.model.ListType;
 import com.liferay.portal.kernel.model.Region;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.UserGroupTable;
@@ -588,6 +589,18 @@ public class UserManagerImpl implements UserManager {
 			portalUser.getContactId());
 
 		for (ScimAddress scimAddress : scimUser.getAddresses()) {
+			String streetAddress = scimAddress.getStreetAddress();
+
+			if (Validator.isNull(streetAddress)) {
+				streetAddress = scimAddress.getFormatted();
+			}
+
+			if (Validator.isNull(streetAddress) ||
+				Validator.isNull(scimAddress.getLocality())) {
+
+				continue;
+			}
+
 			Address address = _addressLocalService.createAddress(
 				_counterLocalService.increment());
 
@@ -596,36 +609,45 @@ public class UserManagerImpl implements UserManager {
 			address.setClassName(Contact.class.getName());
 			address.setClassPK(portalUser.getContactId());
 
-			Country country = _countryLocalService.getCountryByA2(
+			Country country = _countryLocalService.fetchCountryByA2(
 				portalUser.getCompanyId(), scimAddress.getCountry());
 
-			address.setCountryId(country.getCountryId());
+			if (country != null) {
+				address.setCountryId(country.getCountryId());
 
-			if (Validator.isNull(scimAddress.getType())) {
-				scimAddress.setType("other");
-			}
+				for (Region region :
+						_regionLocalService.getRegions(
+							country.getCountryId(), true)) {
 
-			address.setListTypeId(
-				_listTypeLocalService.getListTypeId(
-					portalUser.getCompanyId(), scimAddress.getType(),
-					Contact.class.getName() + ".address"));
+					if (Objects.equals(
+							region.getName(), scimAddress.getRegion())) {
 
-			for (Region region :
-					_regionLocalService.getRegions(
-						country.getCountryId(), true)) {
+						address.setRegionId(region.getRegionId());
 
-				if (Objects.equals(region.getName(), scimAddress.getRegion())) {
-					address.setRegionId(region.getRegionId());
-
-					break;
+						break;
+					}
 				}
 			}
 
+			ListType listType = _listTypeLocalService.fetchListType(
+				portalUser.getCompanyId(), scimAddress.getType(),
+				Contact.class.getName() + ".address");
+
+			if (listType == null) {
+				listType = _listTypeLocalService.fetchListType(
+					portalUser.getCompanyId(), "other",
+					Contact.class.getName() + ".address");
+
+				if (listType == null) {
+					continue;
+				}
+			}
+
+			address.setListTypeId(listType.getListTypeId());
 			address.setCity(scimAddress.getLocality());
 			address.setPrimary(scimAddress.isPrimary());
 
-			String[] streetAddressParts = StringUtil.split(
-				scimAddress.getStreetAddress(), "\n");
+			String[] streetAddressParts = StringUtil.split(streetAddress, "\n");
 
 			address.setStreet1(streetAddressParts[0]);
 

--- a/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
+++ b/modules/dxp/apps/scim/scim-rest-impl/src/main/java/com/liferay/scim/rest/internal/manager/UserManagerImpl.java
@@ -589,15 +589,17 @@ public class UserManagerImpl implements UserManager {
 			portalUser.getContactId());
 
 		for (ScimAddress scimAddress : scimUser.getAddresses()) {
+			if (Validator.isNull(scimAddress.getLocality())) {
+				continue;
+			}
+
 			String streetAddress = scimAddress.getStreetAddress();
 
 			if (Validator.isNull(streetAddress)) {
 				streetAddress = scimAddress.getFormatted();
 			}
 
-			if (Validator.isNull(streetAddress) ||
-				Validator.isNull(scimAddress.getLocality())) {
-
+			if (Validator.isNull(streetAddress)) {
 				continue;
 			}
 

--- a/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/UserResourceTest.java
+++ b/modules/dxp/apps/scim/scim-rest-test/src/testIntegration/java/com/liferay/scim/rest/resource/v1_0/test/UserResourceTest.java
@@ -20,10 +20,13 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Contact;
+import com.liferay.portal.kernel.model.ListType;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.service.AddressLocalService;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.EmailAddressLocalService;
+import com.liferay.portal.kernel.service.ListTypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.TestInfo;
@@ -41,6 +44,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.scim.rest.client.dto.v1_0.Address;
 import com.liferay.scim.rest.client.dto.v1_0.MultiValuedAttribute;
 import com.liferay.scim.rest.client.dto.v1_0.Name;
 import com.liferay.scim.rest.client.dto.v1_0.Operation;
@@ -51,9 +55,11 @@ import com.liferay.scim.rest.client.http.HttpInvoker;
 import com.liferay.scim.rest.resource.v1_0.test.util.ScimTestUtil;
 import com.liferay.scim.rest.util.ScimClientUtil;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.List;
 
 import org.apache.commons.lang.time.DateUtils;
 
@@ -401,6 +407,34 @@ public class UserResourceTest extends BaseUserResourceTestCase {
 
 		User postUser4 = randomUser();
 
+		String expectedFormattedAddress = RandomTestUtil.randomString();
+		String expectedStreetAddress = RandomTestUtil.randomString();
+
+		postUser4.setAddresses(
+			new Address[] {
+				new Address() {
+					{
+						country = RandomTestUtil.randomString();
+						locality = RandomTestUtil.randomString();
+						primary = true;
+						streetAddress = expectedStreetAddress;
+						type = RandomTestUtil.randomString();
+					}
+				},
+				new Address() {
+					{
+						formatted = expectedFormattedAddress;
+						locality = RandomTestUtil.randomString();
+					}
+				},
+				new Address() {
+					{
+						country = RandomTestUtil.randomString();
+						type = RandomTestUtil.randomString();
+					}
+				}
+			});
+
 		postUser4.setActive((Boolean)null);
 
 		assertHttpResponseStatusCode(
@@ -411,6 +445,30 @@ public class UserResourceTest extends BaseUserResourceTestCase {
 				postUser4.getExternalId(), TestPropsValues.getCompanyId());
 
 		Assert.assertTrue(portalUser4.isActive());
+
+		List<com.liferay.portal.kernel.model.Address> addresses =
+			_addressLocalService.getAddresses(
+				portalUser4.getCompanyId(), Contact.class.getName(),
+				portalUser4.getContactId());
+
+		Assert.assertEquals(addresses.toString(), 2, addresses.size());
+
+		ListType listType = _listTypeLocalService.fetchListType(
+			portalUser4.getCompanyId(), "other",
+			Contact.class.getName() + ".address");
+
+		List<String> streets = new ArrayList<>();
+
+		for (com.liferay.portal.kernel.model.Address address : addresses) {
+			Assert.assertEquals(0, address.getCountryId());
+			Assert.assertEquals(
+				listType.getListTypeId(), address.getListTypeId());
+
+			streets.add(address.getStreet1());
+		}
+
+		Assert.assertTrue(streets.contains(expectedFormattedAddress));
+		Assert.assertTrue(streets.contains(expectedStreetAddress));
 
 		assertHttpResponseStatusCode(
 			204,
@@ -720,6 +778,9 @@ public class UserResourceTest extends BaseUserResourceTestCase {
 		RandomTestUtil.randomString());
 
 	@Inject
+	private AddressLocalService _addressLocalService;
+
+	@Inject
 	private ClassNameLocalService _classNameLocalService;
 
 	@Inject
@@ -736,6 +797,9 @@ public class UserResourceTest extends BaseUserResourceTestCase {
 
 	@Inject
 	private JSONFactory _jsonFactory;
+
+	@Inject
+	private ListTypeLocalService _listTypeLocalService;
 
 	private String _pid;
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102477

## What Is Being Fixed

Provisioning a SCIM user returned a bare HTTP 500 when an address had an unresolvable country, a type that did not match a configured list type, or no street address. The country and type lookups threw NoSuchCountryException and NoSuchListTypeException on an unknown value, and the street was split and indexed without a bounds check, throwing ArrayIndexOutOfBoundsException when it was blank. Azure AD's default SCIM connector sends addresses in exactly this shape, so a whole user failed to provision with no SCIM error body.

## How It Is Being Fixed

The address loop in UserManagerImpl now recovers each field where possible and skips the address otherwise. It uses the non-throwing fetchCountryByA2 and fetchListType lookups instead of the throwing variants: the street falls back to the formatted address when streetAddress is missing, the type falls back to the "other" list type when it does not map, and the country is left unset when its code does not resolve. An address that still lacks a street or city, or whose list type cannot be resolved even to "other", is skipped entirely, because the SCIM update path revalidates a user's addresses and the portal rejects an incomplete one, which would otherwise fail the next time the user is synced. A test provisions a user with the sparse addresses Azure AD sends and asserts the recoverable addresses persist with the country left unset and the type defaulted to "other", while the empty one is skipped.

## PR Check

**pr-check: SKIPPED** — Deferred to post-review per developer request; the SCIM integration suite (scim-rest-test) was run green locally instead.

<!-- pr-check {"reason": "Deferred to post-review per developer request; the SCIM integration suite (scim-rest-test) was run green locally instead.", "result": "skipped", "sha": "e3fdf4955705fa43217c53a9db98cac0acd5097e"} -->
