### PR TITLE
LPD-98488 Encrypt the OAuth 2.0 client credential at rest via SecretManager

### DIFF
--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
@@ -608,7 +608,7 @@ public class AnalyticsBatchExportImportManagerImpl
 		options.addPart("oAuthClientId", oAuth2Application.getClientId());
 		options.addPart(
 			"oAuthClientSecret",
-			_oAuth2ApplicationLocalService.resolveClientSecret(
+			_oAuth2ApplicationLocalService.getPlaintextClientSecret(
 				oAuth2Application));
 
 		JSONObject jsonObject = _jsonFactory.createJSONObject(

--- a/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
+++ b/modules/apps/analytics/analytics-batch-export-import-impl/src/main/java/com/liferay/analytics/batch/exportimport/internal/manager/AnalyticsBatchExportImportManagerImpl.java
@@ -607,7 +607,9 @@ public class AnalyticsBatchExportImportManagerImpl
 
 		options.addPart("oAuthClientId", oAuth2Application.getClientId());
 		options.addPart(
-			"oAuthClientSecret", oAuth2Application.getClientSecret());
+			"oAuthClientSecret",
+			_oAuth2ApplicationLocalService.resolveClientSecret(
+				oAuth2Application));
 
 		JSONObject jsonObject = _jsonFactory.createJSONObject(
 			new String(Base64.decode(analyticsConfiguration.token())));

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/client/AnalyticsCloudClient.java
@@ -168,7 +168,7 @@ public class AnalyticsCloudClient {
 		options.addPart("oAuthClientId", oAuth2Application.getClientId());
 		options.addPart(
 			"oAuthClientSecret",
-			_oAuth2ApplicationLocalService.resolveClientSecret(
+			_oAuth2ApplicationLocalService.getPlaintextClientSecret(
 				oAuth2Application));
 		options.addPart("portalURL", company.getPortalURL(0));
 		options.addPart("token", connectionTokenJSONObject.getString("token"));

--- a/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/client/AnalyticsCloudClient.java
+++ b/modules/apps/analytics/analytics-settings-rest-impl/src/main/java/com/liferay/analytics/settings/rest/internal/client/AnalyticsCloudClient.java
@@ -167,7 +167,9 @@ public class AnalyticsCloudClient {
 		options.addPart("name", company.getName());
 		options.addPart("oAuthClientId", oAuth2Application.getClientId());
 		options.addPart(
-			"oAuthClientSecret", oAuth2Application.getClientSecret());
+			"oAuthClientSecret",
+			_oAuth2ApplicationLocalService.resolveClientSecret(
+				oAuth2Application));
 		options.addPart("portalURL", company.getPortalURL(0));
 		options.addPart("token", connectionTokenJSONObject.getString("token"));
 		options.setLocation(connectionTokenJSONObject.getString("url"));

--- a/modules/apps/oauth2-provider/oauth2-provider-api/bnd.bnd
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay OAuth2 Provider API
 Bundle-SymbolicName: com.liferay.oauth2.provider.api
-Bundle-Version: 20.1.1
+Bundle-Version: 20.2.0
 Export-Package:\
 	com.liferay.oauth2.provider.configuration,\
 	com.liferay.oauth2.provider.constants,\

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
@@ -361,6 +361,9 @@ public interface OAuth2ApplicationLocalService
 	public PersistedModel getPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
 
+	public String resolveClientSecret(OAuth2Application oAuth2Application)
+		throws PortalException;
+
 	@Indexable(type = IndexableType.REINDEX)
 	public OAuth2Application updateExternalReferenceCode(
 			long oAuth2ApplicationId, String externalReferenceCode)
@@ -406,4 +409,4 @@ public interface OAuth2ApplicationLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-615932762
+// LIFERAY-SERVICE-BUILDER-HASH:-613623196

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalService.java
@@ -361,7 +361,8 @@ public interface OAuth2ApplicationLocalService
 	public PersistedModel getPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
 
-	public String resolveClientSecret(OAuth2Application oAuth2Application)
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public String getPlaintextClientSecret(OAuth2Application oAuth2Application)
 		throws PortalException;
 
 	@Indexable(type = IndexableType.REINDEX)
@@ -409,4 +410,4 @@ public interface OAuth2ApplicationLocalService
 		throws PortalException;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-613623196
+// LIFERAY-SERVICE-BUILDER-HASH:-962047129

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
@@ -465,11 +465,11 @@ public class OAuth2ApplicationLocalServiceUtil {
 		return getService().getPersistedModel(primaryKeyObj);
 	}
 
-	public static String resolveClientSecret(
+	public static String getPlaintextClientSecret(
 			OAuth2Application oAuth2Application)
 		throws PortalException {
 
-		return getService().resolveClientSecret(oAuth2Application);
+		return getService().getPlaintextClientSecret(oAuth2Application);
 	}
 
 	public static OAuth2Application updateExternalReferenceCode(
@@ -551,4 +551,4 @@ public class OAuth2ApplicationLocalServiceUtil {
 			OAuth2ApplicationLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1893607907
+// LIFERAY-SERVICE-BUILDER-HASH:-2022099425

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceUtil.java
@@ -465,6 +465,13 @@ public class OAuth2ApplicationLocalServiceUtil {
 		return getService().getPersistedModel(primaryKeyObj);
 	}
 
+	public static String resolveClientSecret(
+			OAuth2Application oAuth2Application)
+		throws PortalException {
+
+		return getService().resolveClientSecret(oAuth2Application);
+	}
+
 	public static OAuth2Application updateExternalReferenceCode(
 			long oAuth2ApplicationId, String externalReferenceCode)
 		throws PortalException {
@@ -544,4 +551,4 @@ public class OAuth2ApplicationLocalServiceUtil {
 			OAuth2ApplicationLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1677176149
+// LIFERAY-SERVICE-BUILDER-HASH:1893607907

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
@@ -532,6 +532,16 @@ public class OAuth2ApplicationLocalServiceWrapper
 	}
 
 	@Override
+	public String resolveClientSecret(
+			com.liferay.oauth2.provider.model.OAuth2Application
+				oAuth2Application)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _oAuth2ApplicationLocalService.resolveClientSecret(
+			oAuth2Application);
+	}
+
+	@Override
 	public com.liferay.oauth2.provider.model.OAuth2Application
 			updateExternalReferenceCode(
 				long oAuth2ApplicationId, String externalReferenceCode)
@@ -637,4 +647,4 @@ public class OAuth2ApplicationLocalServiceWrapper
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:682669637
+// LIFERAY-SERVICE-BUILDER-HASH:1985616372

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/java/com/liferay/oauth2/provider/service/OAuth2ApplicationLocalServiceWrapper.java
@@ -532,12 +532,12 @@ public class OAuth2ApplicationLocalServiceWrapper
 	}
 
 	@Override
-	public String resolveClientSecret(
+	public String getPlaintextClientSecret(
 			com.liferay.oauth2.provider.model.OAuth2Application
 				oAuth2Application)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
-		return _oAuth2ApplicationLocalService.resolveClientSecret(
+		return _oAuth2ApplicationLocalService.getPlaintextClientSecret(
 			oAuth2Application);
 	}
 
@@ -647,4 +647,4 @@ public class OAuth2ApplicationLocalServiceWrapper
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1985616372
+// LIFERAY-SERVICE-BUILDER-HASH:1297684656

--- a/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
+++ b/modules/apps/oauth2-provider/oauth2-provider-api/src/main/resources/com/liferay/oauth2/provider/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -845,7 +845,7 @@ public class LiferayOAuthDataProvider
 
 		if (oAuth2Application != null) {
 			clientId = oAuth2Application.getClientId();
-			clientSecret = oAuth2Application.getClientSecret();
+			clientSecret = _resolveClientSecret(oAuth2Application);
 			externalReferenceCode =
 				oAuth2Application.getExternalReferenceCode();
 		}
@@ -1541,7 +1541,7 @@ public class LiferayOAuthDataProvider
 	private Client _populateClient(
 		OAuth2Application oAuth2Application, MessageContext messageContext) {
 
-		String clientSecret = oAuth2Application.getClientSecret();
+		String clientSecret = _resolveClientSecret(oAuth2Application);
 
 		if (Validator.isBlank(clientSecret)) {
 			clientSecret = null;
@@ -1702,6 +1702,16 @@ public class LiferayOAuthDataProvider
 			String.valueOf(companyId));
 
 		return userSubject;
+	}
+
+	private String _resolveClientSecret(OAuth2Application oAuth2Application) {
+		try {
+			return _oAuth2ApplicationLocalService.resolveClientSecret(
+				oAuth2Application);
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
 	}
 
 	private long _toCXFTime(Date dateCreated) {

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/liferay/LiferayOAuthDataProvider.java
@@ -1706,7 +1706,7 @@ public class LiferayOAuthDataProvider
 
 	private String _resolveClientSecret(OAuth2Application oAuth2Application) {
 		try {
-			return _oAuth2ApplicationLocalService.resolveClientSecret(
+			return _oAuth2ApplicationLocalService.getPlaintextClientSecret(
 				oAuth2Application);
 		}
 		catch (PortalException portalException) {

--- a/modules/apps/oauth2-provider/oauth2-provider-service/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-liferay-api")
 	compileOnly project(":apps:oauth2-provider:oauth2-provider-scope-spi")
 	compileOnly project(":apps:portal-remote:portal-remote-jaxrs-whiteboard")
+	compileOnly project(":apps:portal-security:portal-security-key-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")
 	compileOnly project(":apps:static:osgi:osgi-util")

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
@@ -10,6 +10,7 @@ import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.scope.liferay.ScopeLocator;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.util.OAuth2SecureRandomGenerator;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
@@ -97,7 +98,8 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 				oAuth2Application.getClientId()
 			).put(
 				externalReferenceCode + ".oauth2.headless.server.client.secret",
-				oAuth2Application.getClientSecret()
+				_oAuth2ApplicationLocalService.resolveClientSecret(
+					oAuth2Application)
 			).put(
 				externalReferenceCode + ".oauth2.headless.server.scopes",
 				StringUtil.merge(scopeAliasesList, StringPool.NEW_LINE)
@@ -133,7 +135,8 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 			serviceUser = userLocalService.getUserById(
 				companyId, oAuth2Application.getClientCredentialUserId());
 			clientId = oAuth2Application.getClientId();
-			clientSecret = oAuth2Application.getClientSecret();
+			clientSecret = _oAuth2ApplicationLocalService.resolveClientSecret(
+				oAuth2Application);
 		}
 		else {
 			serviceUser = _getServiceUser(
@@ -218,6 +221,9 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		OAuth2ProviderApplicationHeadlessServerConfigurationFactory.class);
+
+	@Reference
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 	@Reference
 	private ScopeLocator _scopeLocator;

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/internal/configuration/OAuth2ProviderApplicationHeadlessServerConfigurationFactory.java
@@ -98,7 +98,7 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 				oAuth2Application.getClientId()
 			).put(
 				externalReferenceCode + ".oauth2.headless.server.client.secret",
-				_oAuth2ApplicationLocalService.resolveClientSecret(
+				_oAuth2ApplicationLocalService.getPlaintextClientSecret(
 					oAuth2Application)
 			).put(
 				externalReferenceCode + ".oauth2.headless.server.scopes",
@@ -135,8 +135,9 @@ public class OAuth2ProviderApplicationHeadlessServerConfigurationFactory
 			serviceUser = userLocalService.getUserById(
 				companyId, oAuth2Application.getClientCredentialUserId());
 			clientId = oAuth2Application.getClientId();
-			clientSecret = _oAuth2ApplicationLocalService.resolveClientSecret(
-				oAuth2Application);
+			clientSecret =
+				_oAuth2ApplicationLocalService.getPlaintextClientSecret(
+					oAuth2Application);
 		}
 		else {
 			serviceUser = _getServiceUser(

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -54,13 +54,19 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.security.key.KeyReference;
+import com.liferay.portal.security.key.KeyReferenceUtil;
+import com.liferay.portal.security.key.secret.Secret;
+import com.liferay.portal.security.key.secret.SecretManager;
 
 import java.awt.image.RenderedImage;
 
@@ -155,7 +161,6 @@ public class OAuth2ApplicationLocalServiceImpl
 		oAuth2Application.setClientCredentialUserName(user.getScreenName());
 		oAuth2Application.setClientId(clientId);
 		oAuth2Application.setClientProfile(clientProfile);
-		oAuth2Application.setClientSecret(clientSecret);
 		oAuth2Application.setDescription(description);
 		oAuth2Application.setFeaturesList(featuresList);
 		oAuth2Application.setHomePageURL(homePageURL);
@@ -183,6 +188,8 @@ public class OAuth2ApplicationLocalServiceImpl
 			oAuth2Application.getCompanyId(), 0, oAuth2Application.getUserId(),
 			OAuth2Application.class.getName(),
 			oAuth2Application.getOAuth2ApplicationId(), false, false, false);
+
+		_setClientSecret(clientSecret, oAuth2Application);
 
 		return oAuth2ApplicationPersistence.update(oAuth2Application);
 	}
@@ -253,7 +260,6 @@ public class OAuth2ApplicationLocalServiceImpl
 		oAuth2Application.setClientCredentialUserName(user.getScreenName());
 		oAuth2Application.setClientId(clientId);
 		oAuth2Application.setClientProfile(clientProfile);
-		oAuth2Application.setClientSecret(clientSecret);
 		oAuth2Application.setDescription(description);
 		oAuth2Application.setFeaturesList(featuresList);
 		oAuth2Application.setHomePageURL(homePageURL);
@@ -281,6 +287,8 @@ public class OAuth2ApplicationLocalServiceImpl
 			oAuth2Application.getCompanyId(), 0, oAuth2Application.getUserId(),
 			OAuth2Application.class.getName(),
 			oAuth2Application.getOAuth2ApplicationId(), false, false, false);
+
+		_setClientSecret(clientSecret, oAuth2Application);
 
 		return oAuth2ApplicationPersistence.update(oAuth2Application);
 	}
@@ -418,6 +426,21 @@ public class OAuth2ApplicationLocalServiceImpl
 		_resourceLocalService.deleteResource(
 			oAuth2Application, ResourceConstants.SCOPE_INDIVIDUAL);
 
+		String clientSecret = oAuth2Application.getClientSecret();
+
+		if (KeyReferenceUtil.isKeyReference(clientSecret)) {
+			long companyId = oAuth2Application.getCompanyId();
+
+			TransactionCommitCallbackUtil.registerCallback(
+				() -> {
+					_secretManager.deleteSecret(
+						companyId,
+						KeyReferenceUtil.toKeyReference(clientSecret));
+
+					return null;
+				});
+		}
+
 		List<OAuth2Authorization> oAuth2Authorizations =
 			_oAuth2AuthorizationPersistence.findByOAuth2ApplicationId(
 				oAuth2Application.getOAuth2ApplicationId(), QueryUtil.ALL_POS,
@@ -483,6 +506,24 @@ public class OAuth2ApplicationLocalServiceImpl
 
 		return oAuth2ApplicationPersistence.findByC_CP(
 			companyId, clientProfile);
+	}
+
+	@Override
+	public String resolveClientSecret(OAuth2Application oAuth2Application)
+		throws PortalException {
+
+		String clientSecret = oAuth2Application.getClientSecret();
+
+		if (!KeyReferenceUtil.isKeyReference(clientSecret)) {
+			return clientSecret;
+		}
+
+		try (Secret secret = _secretManager.getSecret(
+				oAuth2Application.getCompanyId(),
+				KeyReferenceUtil.toKeyReference(clientSecret))) {
+
+			return new String(secret.getChars());
+		}
 	}
 
 	@Indexable(type = IndexableType.REINDEX)
@@ -645,7 +686,6 @@ public class OAuth2ApplicationLocalServiceImpl
 		oAuth2Application.setClientCredentialUserName(user.getScreenName());
 		oAuth2Application.setClientId(clientId);
 		oAuth2Application.setClientProfile(clientProfile);
-		oAuth2Application.setClientSecret(clientSecret);
 		oAuth2Application.setDescription(description);
 		oAuth2Application.setFeaturesList(featuresList);
 		oAuth2Application.setHomePageURL(homePageURL);
@@ -656,6 +696,8 @@ public class OAuth2ApplicationLocalServiceImpl
 		oAuth2Application.setRedirectURIsList(redirectURIsList);
 		oAuth2Application.setRememberDevice(rememberDevice);
 		oAuth2Application.setTrustedApplication(trustedApplication);
+
+		_setClientSecret(clientSecret, oAuth2Application);
 
 		return oAuth2ApplicationPersistence.update(oAuth2Application);
 	}
@@ -733,6 +775,34 @@ public class OAuth2ApplicationLocalServiceImpl
 			getOAuth2ApplicationScopeAliasesId();
 	}
 
+	private void _setClientSecret(
+		String clientSecret, OAuth2Application oAuth2Application) {
+
+		if (Validator.isNull(clientSecret) || !PropsValues.FIPS_ENABLED) {
+			oAuth2Application.setClientSecret(clientSecret);
+
+			return;
+		}
+
+		KeyReference keyReference = new KeyReference(
+			String.valueOf(oAuth2Application.getOAuth2ApplicationId()),
+			StringPool.STAR, KeyReference.Type.SECRET);
+
+		oAuth2Application.setClientSecret(
+			KeyReferenceUtil.toKeyReferenceString(keyReference));
+
+		long companyId = oAuth2Application.getCompanyId();
+
+		TransactionCommitCallbackUtil.registerCallback(
+			() -> {
+				try (Secret secret = new Secret(keyReference, clientSecret)) {
+					_secretManager.putSecret(companyId, secret);
+				}
+
+				return null;
+			});
+	}
+
 	private void _validate(
 			long companyId, List<GrantType> allowedGrantTypesList,
 			String clientAuthenticationMethod, String clientId,
@@ -753,6 +823,12 @@ public class OAuth2ApplicationLocalServiceImpl
 			String clientSecret, String homePageURL, String jwks, String name,
 			String privacyPolicyURL, List<String> redirectURIsList)
 		throws PortalException {
+
+		if (KeyReferenceUtil.isKeyReference(clientSecret)) {
+			throw new PortalException(
+				"Client secret cannot begin with a reserved key reference " +
+					"prefix");
+		}
 
 		if (clientAuthenticationMethod.equals(
 				OAuthConstants.TOKEN_ENDPOINT_AUTH_NONE)) {
@@ -978,6 +1054,9 @@ public class OAuth2ApplicationLocalServiceImpl
 
 	@Reference
 	private ResourceLocalService _resourceLocalService;
+
+	@Reference
+	private SecretManager _secretManager;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -509,7 +509,7 @@ public class OAuth2ApplicationLocalServiceImpl
 	}
 
 	@Override
-	public String resolveClientSecret(OAuth2Application oAuth2Application)
+	public String getPlaintextClientSecret(OAuth2Application oAuth2Application)
 		throws PortalException {
 
 		String clientSecret = oAuth2Application.getClientSecret();

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/service.properties
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/resources/service.properties
@@ -13,5 +13,5 @@
 ##
 
     build.namespace=com.liferay.oauth2.provider.service
-    build.number=4
-    build.date=1780331622524
+    build.number=5
+    build.date=1785956529900

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/model/listener/OAuth2ApplicationModelListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/model/listener/OAuth2ApplicationModelListener.java
@@ -8,6 +8,7 @@ package com.liferay.oauth2.provider.shortcut.internal.model.listener;
 import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
 import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -39,12 +40,9 @@ public class OAuth2ApplicationModelListener
 		throws ModelListenerException {
 
 		if (!_isAnalyticsEnabled(oAuth2Application.getCompanyId()) ||
-			(StringUtil.equals(
-				originalOAuth2Application.getClientId(),
-				oAuth2Application.getClientId()) &&
-			 StringUtil.equals(
-				 originalOAuth2Application.getClientSecret(),
-				 oAuth2Application.getClientSecret()))) {
+			!StringUtil.equals(
+				oAuth2Application.getExternalReferenceCode(),
+				"ANALYTICS-CLOUD")) {
 
 			return;
 		}
@@ -163,7 +161,9 @@ public class OAuth2ApplicationModelListener
 
 		options.addPart("oAuthClientId", oAuth2Application.getClientId());
 		options.addPart(
-			"oAuthClientSecret", oAuth2Application.getClientSecret());
+			"oAuthClientSecret",
+			_oAuth2ApplicationLocalService.resolveClientSecret(
+				oAuth2Application));
 		options.setLocation(
 			StringUtil.replace(
 				jsonObject.getString("url"), "data_source/connect",
@@ -191,5 +191,8 @@ public class OAuth2ApplicationModelListener
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 }

--- a/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/model/listener/OAuth2ApplicationModelListener.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-shortcut/src/main/java/com/liferay/oauth2/provider/shortcut/internal/model/listener/OAuth2ApplicationModelListener.java
@@ -162,7 +162,7 @@ public class OAuth2ApplicationModelListener
 		options.addPart("oAuthClientId", oAuth2Application.getClientId());
 		options.addPart(
 			"oAuthClientSecret",
-			_oAuth2ApplicationLocalService.resolveClientSecret(
+			_oAuth2ApplicationLocalService.getPlaintextClientSecret(
 				oAuth2Application));
 		options.setLocation(
 			StringUtil.replace(

--- a/modules/apps/oauth2-provider/oauth2-provider-test/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-remote:portal-remote-cors-api")
 	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-api")
+	testIntegrationImplementation project(":apps:portal-security:portal-security-key-api")
+	testIntegrationImplementation project(":apps:portal-security:portal-security-key-spi")
 	testIntegrationImplementation project(":apps:portal:portal-upgrade-test-util")
 	testIntegrationImplementation project(":apps:static:portal:portal-upgrade-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/service/test/OAuth2ApplicationLocalServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/service/test/OAuth2ApplicationLocalServiceTest.java
@@ -98,7 +98,7 @@ public class OAuth2ApplicationLocalServiceTest {
 
 			Assert.assertEquals(
 				clientSecret,
-				_oAuth2ApplicationLocalService.resolveClientSecret(
+				_oAuth2ApplicationLocalService.getPlaintextClientSecret(
 					_oAuth2Application));
 
 			String storedClientSecret = _oAuth2Application.getClientSecret();
@@ -118,7 +118,7 @@ public class OAuth2ApplicationLocalServiceTest {
 		Assert.assertEquals(clientSecret, _oAuth2Application.getClientSecret());
 		Assert.assertEquals(
 			clientSecret,
-			_oAuth2ApplicationLocalService.resolveClientSecret(
+			_oAuth2ApplicationLocalService.getPlaintextClientSecret(
 				_oAuth2Application));
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/service/test/OAuth2ApplicationLocalServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/service/test/OAuth2ApplicationLocalServiceTest.java
@@ -1,0 +1,223 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.security.key.KeyReference;
+import com.liferay.portal.security.key.KeyReferenceUtil;
+import com.liferay.portal.security.key.secret.Secret;
+import com.liferay.portal.security.key.secret.exception.SecretException;
+import com.liferay.portal.security.key.spi.ProviderStatus;
+import com.liferay.portal.security.key.spi.secret.SecretProvider;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Christopher Kian
+ */
+@RunWith(Arquillian.class)
+public class OAuth2ApplicationLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_serviceRegistration = _bundleContext.registerService(
+			SecretProvider.class, new TestSecretProvider(),
+			HashMapDictionaryBuilder.<String, Object>put(
+				"secret.provider.id", _PROVIDER_ID
+			).build());
+
+		ConfigurationTestUtil.saveConfiguration(
+			_KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"companySecretProviderId", _PROVIDER_ID
+			).put(
+				"systemSecretProviderId", _PROVIDER_ID
+			).build());
+
+		_user = UserTestUtil.addUser();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		ConfigurationTestUtil.deleteConfiguration(
+			_KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID);
+
+		_serviceRegistration.unregister();
+	}
+
+	@Test
+	public void testResolveClientSecret() throws Exception {
+		try (AutoCloseable autoCloseable =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					PropsValues.class, "FIPS_ENABLED", true)) {
+
+			String clientSecret = RandomTestUtil.randomString();
+
+			_oAuth2Application = _addOAuth2Application(clientSecret);
+
+			Assert.assertEquals(
+				clientSecret,
+				_oAuth2ApplicationLocalService.resolveClientSecret(
+					_oAuth2Application));
+
+			String storedClientSecret = _oAuth2Application.getClientSecret();
+
+			Assert.assertTrue(
+				storedClientSecret,
+				KeyReferenceUtil.isKeyReference(storedClientSecret));
+		}
+	}
+
+	@Test
+	public void testResolveClientSecretWhenDisabled() throws Exception {
+		String clientSecret = RandomTestUtil.randomString();
+
+		_oAuth2Application = _addOAuth2Application(clientSecret);
+
+		Assert.assertEquals(clientSecret, _oAuth2Application.getClientSecret());
+		Assert.assertEquals(
+			clientSecret,
+			_oAuth2ApplicationLocalService.resolveClientSecret(
+				_oAuth2Application));
+	}
+
+	private OAuth2Application _addOAuth2Application(String clientSecret)
+		throws Exception {
+
+		return _oAuth2ApplicationLocalService.addOAuth2Application(
+			TestPropsValues.getCompanyId(), _user.getUserId(),
+			_user.getFullName(),
+			ListUtil.fromArray(GrantType.CLIENT_CREDENTIALS),
+			"client_secret_post", _user.getUserId(), null, 0, clientSecret,
+			null, null, null, 0, null, RandomTestUtil.randomString(), null,
+			null, false, null, false, new ServiceContext());
+	}
+
+	private static final String _KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID =
+		"com.liferay.portal.security.key.internal.profile.configuration." +
+			"KeyManagerCustomProfileConfiguration";
+
+	private static final String _PROVIDER_ID = "test-oauth2-secret";
+
+	private static final BundleContext _bundleContext =
+		SystemBundleUtil.getBundleContext();
+
+	@DeleteAfterTestRun
+	private OAuth2Application _oAuth2Application;
+
+	@Inject
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
+
+	private ServiceRegistration<SecretProvider> _serviceRegistration;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+	private static class TestSecretProvider implements SecretProvider {
+
+		@Override
+		public void deleteSecret(long companyId, String secretIdentifier) {
+			_secrets.remove(_key(companyId, secretIdentifier));
+		}
+
+		@Override
+		public ProviderStatus getProviderStatus() {
+			return ProviderStatus.OPERATIONAL;
+		}
+
+		@Override
+		public Secret getSecret(long companyId, String secretIdentifier)
+			throws SecretException {
+
+			String value = _secrets.get(_key(companyId, secretIdentifier));
+
+			if (value == null) {
+				throw new SecretException(
+					"No secret found for identifier " + secretIdentifier);
+			}
+
+			return new Secret(
+				new KeyReference(
+					secretIdentifier, _PROVIDER_ID, KeyReference.Type.SECRET),
+				value);
+		}
+
+		@Override
+		public List<String> getSecretIdentifiers(long companyId) {
+			List<String> secretIdentifiers = new ArrayList<>();
+
+			String prefix = companyId + StringPool.SLASH;
+
+			for (String key : _secrets.keySet()) {
+				if (key.startsWith(prefix)) {
+					secretIdentifiers.add(key.substring(prefix.length()));
+				}
+			}
+
+			return secretIdentifiers;
+		}
+
+		@Override
+		public boolean isAllowedCompany(long companyId) {
+			return true;
+		}
+
+		@Override
+		public void putSecret(long companyId, Secret secret) {
+			KeyReference keyReference = secret.getKeyReference();
+
+			_secrets.put(
+				_key(companyId, keyReference.getIdentifier()),
+				new String(secret.getChars()));
+		}
+
+		private String _key(long companyId, String secretIdentifier) {
+			return companyId + StringPool.SLASH + secretIdentifier;
+		}
+
+		private final Map<String, String> _secrets = new ConcurrentHashMap<>();
+
+	}
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/display/context/OAuth2AdminPortletDisplayContext.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/display/context/OAuth2AdminPortletDisplayContext.java
@@ -60,7 +60,7 @@ public class OAuth2AdminPortletDisplayContext
 	public String getClientSecret(OAuth2Application oAuth2Application)
 		throws PortalException {
 
-		return OAuth2ApplicationLocalServiceUtil.resolveClientSecret(
+		return OAuth2ApplicationLocalServiceUtil.getPlaintextClientSecret(
 			oAuth2Application);
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/display/context/OAuth2AdminPortletDisplayContext.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/java/com/liferay/oauth2/provider/web/internal/display/context/OAuth2AdminPortletDisplayContext.java
@@ -10,6 +10,7 @@ import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
 import com.liferay.oauth2.provider.constants.ClientProfile;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalServiceUtil;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationScopeAliasesLocalService;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationService;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationServiceUtil;
@@ -54,6 +55,13 @@ public class OAuth2AdminPortletDisplayContext
 
 		_resourceBundle = ResourceBundleUtil.getBundle(
 			"content.Language", themeDisplay.getLocale(), getClass());
+	}
+
+	public String getClientSecret(OAuth2Application oAuth2Application)
+		throws PortalException {
+
+		return OAuth2ApplicationLocalServiceUtil.resolveClientSecret(
+			oAuth2Application);
 	}
 
 	public String getExtraPropertiesContent(

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
@@ -13,7 +13,7 @@ String redirect = ParamUtil.getString(request, "redirect");
 OAuth2Application oAuth2Application = oAuth2AdminPortletDisplayContext.getOAuth2Application();
 
 String clientId = (oAuth2Application == null) ? "" : oAuth2Application.getClientId();
-String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getClientSecret();
+String clientSecret = (oAuth2Application == null) ? "" : oAuth2AdminPortletDisplayContext.getClientSecret(oAuth2Application);
 String externalReferenceCode = (oAuth2Application == null) ? "" : oAuth2Application.getExternalReferenceCode();
 %>
 

--- a/modules/apps/portal-security/portal-security-key-api/bnd.bnd
+++ b/modules/apps/portal-security/portal-security-key-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Security Key API
 Bundle-SymbolicName: com.liferay.portal.security.key.api
-Bundle-Version: 1.1.1
+Bundle-Version: 1.2.0
 Export-Package:\
 	com.liferay.portal.security.key,\
 	com.liferay.portal.security.key.crypto,\

--- a/modules/apps/portal-security/portal-security-key-api/src/main/java/com/liferay/portal/security/key/KeyReferenceUtil.java
+++ b/modules/apps/portal-security/portal-security-key-api/src/main/java/com/liferay/portal/security/key/KeyReferenceUtil.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+
+/**
+ * @author Christopher Kian
+ */
+public class KeyReferenceUtil {
+
+	public static boolean isKeyReference(String value) {
+		if ((value != null) &&
+			(value.startsWith(_KEY_REFERENCE_PREFIX_CRYPTO) ||
+			 value.startsWith(_KEY_REFERENCE_PREFIX_SECRET))) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	public static KeyReference toKeyReference(String keyReferenceString) {
+		String prefix = _KEY_REFERENCE_PREFIX_SECRET;
+		KeyReference.Type type = KeyReference.Type.SECRET;
+
+		if (keyReferenceString.startsWith(_KEY_REFERENCE_PREFIX_CRYPTO)) {
+			prefix = _KEY_REFERENCE_PREFIX_CRYPTO;
+			type = KeyReference.Type.CRYPTO;
+		}
+
+		String[] parts = StringUtil.split(
+			keyReferenceString.substring(
+				prefix.length(), keyReferenceString.length() - 1),
+			CharPool.COLON);
+
+		return new KeyReference(parts[1], parts[0], type);
+	}
+
+	public static String toKeyReferenceString(KeyReference keyReference) {
+		String prefix = _KEY_REFERENCE_PREFIX_SECRET;
+
+		if (keyReference.getType() == KeyReference.Type.CRYPTO) {
+			prefix = _KEY_REFERENCE_PREFIX_CRYPTO;
+		}
+
+		return StringBundler.concat(
+			prefix, keyReference.getProviderId(), StringPool.COLON,
+			keyReference.getIdentifier(), StringPool.CLOSE_CURLY_BRACE);
+	}
+
+	private static final String _KEY_REFERENCE_PREFIX_CRYPTO = "${keyRef:";
+
+	private static final String _KEY_REFERENCE_PREFIX_SECRET = "${secretRef:";
+
+}

--- a/modules/apps/portal-security/portal-security-key-api/src/main/resources/com/liferay/portal/security/key/packageinfo
+++ b/modules/apps/portal-security/portal-security-key-api/src/main/resources/com/liferay/portal/security/key/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/portal-security/portal-security-key-api/src/test/java/com/liferay/portal/security/key/KeyReferenceUtilTest.java
+++ b/modules/apps/portal-security/portal-security-key-api/src/test/java/com/liferay/portal/security/key/KeyReferenceUtilTest.java
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Christopher Kian
+ */
+public class KeyReferenceUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testIsKeyReference() {
+		Assert.assertFalse(KeyReferenceUtil.isKeyReference(null));
+		Assert.assertFalse(
+			KeyReferenceUtil.isKeyReference(RandomTestUtil.randomString()));
+		Assert.assertTrue(
+			KeyReferenceUtil.isKeyReference("${keyRef:provider:identifier}"));
+		Assert.assertTrue(
+			KeyReferenceUtil.isKeyReference(
+				"${secretRef:provider:identifier}"));
+	}
+
+	@Test
+	public void testToKeyReference() {
+		_testToKeyReference("${keyRef:", KeyReference.Type.CRYPTO);
+		_testToKeyReference("${secretRef:", KeyReference.Type.SECRET);
+	}
+
+	private void _testToKeyReference(String prefix, KeyReference.Type type) {
+		KeyReference keyReference = new KeyReference(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(), type);
+
+		String keyReferenceString = KeyReferenceUtil.toKeyReferenceString(
+			keyReference);
+
+		Assert.assertEquals(
+			keyReference, KeyReferenceUtil.toKeyReference(keyReferenceString));
+		Assert.assertTrue(
+			keyReferenceString, keyReferenceString.startsWith(prefix));
+	}
+
+}


### PR DESCRIPTION
Encrypt the OAuth 2.0 client credential at rest via SecretManager when FIPS is enabled: the plaintext is stored as a `${secretRef:...}` reference in the existing `clientSecret` column and resolved through SecretManager on read, with the vault write deferred to an after-commit callback so a rollback leaves no orphan.

Adds `KeyReferenceUtil` to `portal-security-key-api` to serialize a `KeyReference` to and from its reference string (`secretRef`/`keyRef`), reusable by other secret-storing modules.

Supersedes #3202.

### Note on the final commit (accessor rename)

The last commit renames the service method `resolveClientSecret` → `getPlaintextClientSecret` per Brian's suggestion (get prefix over resolve), isolated so it can be dropped cleanly if undesired. Service Builder marks `get*` methods `@Transactional(readOnly = true)`, which is safe here — the method only reads (in-memory value + external vault), never writing to the portal DB.

The `Plaintext` qualifier keeps it distinct from the `OAuth2Application` model's `getClientSecret()`, which returns the raw stored value (possibly a `${secretRef:...}` token). That removes the earlier naming overlap: there is no longer a reference-returning and a plaintext-returning method sharing the name `getClientSecret`.