### PR TITLE
LPD-93649 Add a source check for unguarded TLS verification bypasses

### DIFF
--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaTLSVerificationCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/JavaTLSVerificationCheck.java
@@ -1,0 +1,137 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.check;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.tools.ToolsUtil;
+import com.liferay.source.formatter.parser.JavaClass;
+import com.liferay.source.formatter.parser.JavaTerm;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * @author Caio Farias
+ */
+public class JavaTLSVerificationCheck extends BaseJavaTermCheck {
+
+	@Override
+	public boolean isLiferaySourceCheck() {
+		return true;
+	}
+
+	@Override
+	protected String doProcess(
+		String fileName, String absolutePath, JavaTerm javaTerm,
+		String fileContent) {
+
+		String content = javaTerm.getContent();
+
+		if (absolutePath.contains("/test/") ||
+			absolutePath.contains("/testIntegration/") ||
+			absolutePath.contains("/third-party/") || _hasGuard(fileContent)) {
+
+			return content;
+		}
+
+		if (javaTerm.isJavaConstructor() && _isTrustManager(javaTerm)) {
+			addMessage(
+				fileName,
+				StringBundler.concat(
+					"Call \"", _GUARD_PREFIX,
+					"*\" in the same file as a trust manager, see LPD-93649"),
+				javaTerm.getLineNumber());
+		}
+
+		for (String bypassString : _bypassStrings) {
+			int x = -1;
+
+			while (true) {
+				x = content.indexOf(bypassString, x + 1);
+
+				if (x == -1) {
+					break;
+				}
+
+				if (ToolsUtil.isInsideQuotes(content, x)) {
+					continue;
+				}
+
+				_addMessage(fileName, bypassString, javaTerm, x);
+			}
+		}
+
+		return content;
+	}
+
+	@Override
+	protected String[] getCheckableJavaTermNames() {
+		return new String[] {JAVA_CONSTRUCTOR, JAVA_METHOD};
+	}
+
+	private void _addMessage(
+		String fileName, String bypassString, JavaTerm javaTerm, int pos) {
+
+		addMessage(
+			fileName,
+			StringBundler.concat(
+				"Call \"", _GUARD_PREFIX, "*\" in the same file as \"",
+				bypassString, "\", see LPD-93649"),
+			javaTerm.getLineNumber(pos));
+	}
+
+	private boolean _hasGuard(String fileContent) {
+		int x = -1;
+
+		while (true) {
+			x = fileContent.indexOf(_GUARD_PREFIX, x + 1);
+
+			if (x == -1) {
+				return false;
+			}
+
+			if (!ToolsUtil.isInsideQuotes(fileContent, x)) {
+				return true;
+			}
+		}
+	}
+
+	private boolean _isTrustManager(JavaTerm javaTerm) {
+		JavaClass javaClass = javaTerm.getParentJavaClass();
+
+		if (javaClass == null) {
+			return false;
+		}
+
+		for (String extendedClassName : javaClass.getExtendedClassNames()) {
+			if (_trustManagerClassNames.contains(extendedClassName)) {
+				return true;
+			}
+		}
+
+		for (String implementedClassName :
+				javaClass.getImplementedClassNames()) {
+
+			if (_trustManagerClassNames.contains(implementedClassName)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private static final String _GUARD_PREFIX =
+		"FIPSModeValidator.validateServer";
+
+	private static final List<String> _bypassStrings = Arrays.asList(
+		"ALLOW_ALL_HOSTNAME_VERIFIER", "AllowAllHostnameVerifier",
+		"NoopHostnameVerifier", "TrustAllStrategy", "TrustSelfSignedStrategy",
+		"new HostnameVerifier(", "new X509ExtendedTrustManager(",
+		"new X509TrustManager(");
+	private static final List<String> _trustManagerClassNames = Arrays.asList(
+		"X509ExtendedTrustManager", "X509TrustManager");
+
+}

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.md
@@ -331,6 +331,7 @@ JavaStylingCheck | [Styling](styling_checks.md#styling-checks) | .java | Applies
 [JavaSwitchCheck](check/java_switch_check.md#javaswitchcheck) | [Styling](styling_checks.md#styling-checks) | .java | Checks that `if/else` statement is used instead of `switch` statement. |
 JavaSystemEventAnnotationCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Finds missing method `setDeletionSystemEventStagedModelTypes` in class with annotation @SystemEvent. |
 JavaSystemExceptionCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Finds unnecessary SystemExceptions. |
+JavaTLSVerificationCheck | [Security](security_checks.md#security-checks) | .java | Checks that outbound TLS verification bypasses are guarded by `FIPSModeValidator`, see LPD-93649. |
 JavaTaglibMethodCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Checks that a `*Tag` class has a `set*` and `get*` or `is*` method for each attribute. |
 JavaTermDividersCheck | [Styling](styling_checks.md#styling-checks) | .java | Finds missing or unnecessary empty lines between javaterms. |
 JavaTermOrderCheck | [Styling](styling_checks.md#styling-checks) | .java | Checks the order of javaterms. |

--- a/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.md
@@ -179,6 +179,7 @@ JavaStylingCheck | [Styling](styling_checks.md#styling-checks) | Applies rules t
 [JavaSwitchCheck](check/java_switch_check.md#javaswitchcheck) | [Styling](styling_checks.md#styling-checks) | Checks that `if/else` statement is used instead of `switch` statement. |
 JavaSystemEventAnnotationCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Finds missing method `setDeletionSystemEventStagedModelTypes` in class with annotation @SystemEvent. |
 JavaSystemExceptionCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Finds unnecessary SystemExceptions. |
+JavaTLSVerificationCheck | [Security](security_checks.md#security-checks) | Checks that outbound TLS verification bypasses are guarded by `FIPSModeValidator`, see LPD-93649. |
 JavaTaglibMethodCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Checks that a `*Tag` class has a `set*` and `get*` or `is*` method for each attribute. |
 JavaTermDividersCheck | [Styling](styling_checks.md#styling-checks) | Finds missing or unnecessary empty lines between javaterms. |
 JavaTermOrderCheck | [Styling](styling_checks.md#styling-checks) | Checks the order of javaterms. |

--- a/modules/util/source-formatter/src/main/resources/documentation/security_checks.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/security_checks.md
@@ -4,4 +4,5 @@ Check | File Extensions | Description
 ----- | --------------- | -----------
 JSPXSSVulnerabilitiesCheck | .jsp, .jspf, .jspx, .tag, .tpl, or .vm | Finds xss vulnerabilities. |
 JavaDeserializationSecurityCheck | .java | Finds Java serialization vulnerabilities. |
+JavaTLSVerificationCheck | .java | Checks that outbound TLS verification bypasses are guarded by `FIPSModeValidator`, see LPD-93649. |
 JavaXMLSecurityCheck | .java | Finds possible XXE or Quadratic Blowup security vulnerabilities. |

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -718,6 +718,10 @@
 			<category name="Styling" />
 			<description name="Applies rules to enforce consistency in code style." />
 		</check>
+		<check name="JavaTLSVerificationCheck">
+			<category name="Security" />
+			<description name="Checks that outbound TLS verification bypasses are guarded by `FIPSModeValidator`, see LPD-93649." />
+		</check>
 		<check name="JavaUpgradeModelPermissionsCheck">
 			<category name="Upgrade" />
 			<description name="Replace setGroupPermissions and setGuestPermissions by new implementation." />

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
@@ -1053,6 +1053,31 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testTLSVerification() throws Exception {
+		test(
+			SourceProcessorTestParameters.create(
+				"TLSVerification1.testjava"
+			).addExpectedMessage(
+				"Call \"FIPSModeValidator.validateServer*\" in the same file " +
+					"as \"new HostnameVerifier(\", see LPD-93649",
+				25
+			).addExpectedMessage(
+				"Call \"FIPSModeValidator.validateServer*\" in the same file " +
+					"as \"NoopHostnameVerifier\", see LPD-93649",
+				36
+			).addExpectedMessage(
+				"Call \"FIPSModeValidator.validateServer*\" in the same file " +
+					"as \"TrustSelfSignedStrategy\", see LPD-93649",
+				49
+			));
+		test("TLSVerification2.testjava");
+		test(
+			"TLSVerification3.testjava",
+			"Call \"FIPSModeValidator.validateServer*\" in the same file as " +
+				"a trust manager, see LPD-93649");
+	}
+
+	@Test
 	public void testToJSONStringMethodCalls() throws Exception {
 		test(
 			SourceProcessorTestParameters.create(

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/TLSVerification1.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/TLSVerification1.testjava
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import java.security.KeyStore;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSession;
+
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.ssl.SSLContextBuilder;
+
+/**
+ * @author Caio Farias
+ */
+public class TLSVerification1 {
+
+	public void anonymousHostnameVerifier(HttpClientBuilder httpClientBuilder) {
+		httpClientBuilder.setSSLHostnameVerifier(
+			new HostnameVerifier() {
+
+				@Override
+				public boolean verify(String hostName, SSLSession sslSession) {
+					return true;
+				}
+
+			});
+	}
+
+	public void noopHostnameVerifier(HttpClientBuilder httpClientBuilder) {
+		httpClientBuilder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+	}
+
+	public void pinnedTrustAnchor(
+			SSLContextBuilder sslContextBuilder, KeyStore keyStore)
+		throws Exception {
+
+		sslContextBuilder.loadTrustMaterial(keyStore, null);
+	}
+
+	public void selfSignedTrustStrategy(SSLContextBuilder sslContextBuilder)
+		throws Exception {
+
+		sslContextBuilder.loadTrustMaterial(new TrustSelfSignedStrategy());
+	}
+
+	public void strictHostnameVerifier(
+		HttpClientBuilder httpClientBuilder,
+		HostnameVerifier hostnameVerifier) {
+
+		httpClientBuilder.setSSLHostnameVerifier(hostnameVerifier);
+	}
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/TLSVerification2.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/TLSVerification2.testjava
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import com.liferay.portal.kernel.security.fips.FIPSModeValidator;
+
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+/**
+ * @author Caio Farias
+ */
+public class TLSVerification2 {
+
+	public void guarded(HttpClientBuilder httpClientBuilder) {
+		FIPSModeValidator.validateServerHostnameVerification(
+			_VERIFY_SERVER_HOSTNAME);
+
+		httpClientBuilder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+	}
+
+	private static final boolean _VERIFY_SERVER_HOSTNAME = true;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/TLSVerification3.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/TLSVerification3.testjava
@@ -1,0 +1,38 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * @author Caio Farias
+ */
+public class TLSVerification3 implements X509TrustManager {
+
+	public TLSVerification3(boolean verifyServerCertificate) {
+		_verifyServerCertificate = verifyServerCertificate;
+	}
+
+	@Override
+	public void checkClientTrusted(
+		X509Certificate[] x509Certificates, String authType) {
+	}
+
+	@Override
+	public void checkServerTrusted(
+		X509Certificate[] x509Certificates, String authType) {
+	}
+
+	@Override
+	public X509Certificate[] getAcceptedIssuers() {
+		return null;
+	}
+
+	private final boolean _verifyServerCertificate;
+
+}

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/TLSVerification2.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/expected/TLSVerification2.testjava
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import com.liferay.portal.kernel.security.fips.FIPSModeValidator;
+
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+/**
+ * @author Caio Farias
+ */
+public class TLSVerification2 {
+
+	public void guarded(HttpClientBuilder httpClientBuilder) {
+		FIPSModeValidator.validateServerHostnameVerification(
+			_VERIFY_SERVER_HOSTNAME);
+
+		httpClientBuilder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+	}
+
+	private static final boolean _VERIFY_SERVER_HOSTNAME = true;
+
+}

--- a/source-formatter-suppressions.xml
+++ b/source-formatter-suppressions.xml
@@ -110,6 +110,8 @@
 		<suppress checks="JavaStaticMethodCheck" files="portal-impl/src/com/liferay/portal/struts/FindStrutsAction\.java" />
 		<suppress checks="JavaTaglibMethodCheck" files="util-taglib/src/com/liferay/taglib/ui/IconTag\.java" />
 		<suppress checks="JavaTaglibMethodCheck" files="util-taglib/src/com/liferay/taglib/ui/SearchFormTag\.java" />
+
+		<suppress checks="JavaTLSVerificationCheck" files="portal-kernel/src/com/liferay/portal/kernel/service/http/TunnelUtil\.java" />
 		<suppress checks="JavaUnsafeCastingCheck" files="portal-impl/src/com/liferay/portal/util/PortalImpl\.java" />
 		<suppress checks="JavaUpgradeClassCheck" files="portal-impl/src/com/liferay/portal/upgrade/data/cleanup/CounterDataCleanupPreupgradeProcess\.java" />
 		<suppress checks="JavaUpgradeClassCheck" files="portal-impl/src/com/liferay/portal/upgrade/data/cleanup/DatabaseTableAndColumnCaseDataCleanupPreupgradeProcess\.java" />


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93649

## Why

AC3 requires that no trust-all trust manager and no allow-all hostname verifier exist in DXP code. Remediating today's sites does not stop tomorrow's from reintroducing one, so the invariant needs a build-time gate rather than a convention a reviewer has to notice. Technical task: LPD-101282.

## Key changes

- Match the bypass by type name rather than by setter — a setter's trust semantics live in an argument SourceFormatter cannot resolve
- Exempt any file calling `FIPSModeValidator.validateServer*` — the file is the largest scope a text-based check can decide reliably
- Detect a trust manager through the parser's `implements`/`extends` lists, not a string match
- Suppress `TunnelUtil`, whose bypass is guarded at startup from a different file
- Depends on #3207, which adds `FIPSModeValidator.validateServer*` — merge this after it