### PR TITLE
[FIPS] LPD-102580 Clear the secret buffers DXP owns

### DIFF
--- a/modules/apps/commerce/commerce-payment-method-authorize-net/src/main/java/com/liferay/commerce/payment/method/authorize/net/internal/servlet/CompletePaymentAuthorizeNetServlet.java
+++ b/modules/apps/commerce/commerce-payment-method-authorize-net/src/main/java/com/liferay/commerce/payment/method/authorize/net/internal/servlet/CompletePaymentAuthorizeNetServlet.java
@@ -43,6 +43,7 @@ import java.nio.charset.StandardCharsets;
 
 import java.security.MessageDigest;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 import javax.crypto.Mac;
@@ -252,12 +253,17 @@ public class CompletePaymentAuthorizeNetServlet extends HttpServlet {
 
 		Mac mac = Mac.getInstance("HmacSHA512");
 
-		mac.init(
-			new SecretKeySpec(
-				signatureKey.getBytes(StandardCharsets.UTF_8),
-				mac.getAlgorithm()));
+		byte[] signatureKeyBytes = signatureKey.getBytes(
+			StandardCharsets.UTF_8);
 
-		return StringUtil.bytesToHexString(mac.doFinal(bytes));
+		try {
+			mac.init(new SecretKeySpec(signatureKeyBytes, mac.getAlgorithm()));
+
+			return StringUtil.bytesToHexString(mac.doFinal(bytes));
+		}
+		finally {
+			Arrays.fill(signatureKeyBytes, (byte)0);
+		}
 	}
 
 	private boolean _isValidSignature(

--- a/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/connection/RestClientTransportFactory.java
+++ b/modules/apps/portal-search-elasticsearch8/portal-search-elasticsearch8-impl/src/main/java/com/liferay/portal/search/elasticsearch8/internal/connection/RestClientTransportFactory.java
@@ -23,6 +23,7 @@ import java.nio.file.Paths;
 
 import java.security.KeyStore;
 
+import java.util.Arrays;
 import java.util.concurrent.Future;
 
 import javax.net.ssl.SSLContext;
@@ -211,6 +212,8 @@ public class RestClientTransportFactory {
 	}
 
 	private SSLContext _createSSLContext() {
+		char[] truststorePasswordChars = _truststorePassword.toCharArray();
+
 		try {
 			Path path = Paths.get(_truststorePath);
 
@@ -218,18 +221,21 @@ public class RestClientTransportFactory {
 
 			KeyStore keyStore = KeyStore.getInstance(_truststoreType);
 
-			keyStore.load(inputStream, _truststorePassword.toCharArray());
+			keyStore.load(inputStream, truststorePasswordChars);
 
 			SSLContextBuilder sslContextBuilder = SSLContexts.custom();
 
 			sslContextBuilder.loadKeyMaterial(
-				keyStore, _truststorePassword.toCharArray());
+				keyStore, truststorePasswordChars);
 			sslContextBuilder.loadTrustMaterial(keyStore, null);
 
 			return sslContextBuilder.build();
 		}
 		catch (Exception exception) {
 			throw new RuntimeException(exception);
+		}
+		finally {
+			Arrays.fill(truststorePasswordChars, '\0');
 		}
 	}
 

--- a/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/connection/OpenSearchConnection.java
+++ b/modules/apps/portal-search-opensearch2/portal-search-opensearch2-impl/src/main/java/com/liferay/portal/search/opensearch2/internal/connection/OpenSearchConnection.java
@@ -18,6 +18,7 @@ import java.nio.file.Paths;
 
 import java.security.KeyStore;
 
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
@@ -272,6 +273,8 @@ public class OpenSearchConnection {
 	}
 
 	private SSLContext _createSSLContext() {
+		char[] truststorePasswordChars = _truststorePassword.toCharArray();
+
 		try {
 			Path path = Paths.get(_truststorePath);
 
@@ -279,18 +282,21 @@ public class OpenSearchConnection {
 
 			KeyStore keyStore = KeyStore.getInstance(_truststoreType);
 
-			keyStore.load(inputStream, _truststorePassword.toCharArray());
+			keyStore.load(inputStream, truststorePasswordChars);
 
 			SSLContextBuilder sslContextBuilder = SSLContexts.custom();
 
 			sslContextBuilder.loadKeyMaterial(
-				keyStore, _truststorePassword.toCharArray());
+				keyStore, truststorePasswordChars);
 			sslContextBuilder.loadTrustMaterial(keyStore, null);
 
 			return sslContextBuilder.build();
 		}
 		catch (Exception exception) {
 			throw new RuntimeException(exception);
+		}
+		finally {
+			Arrays.fill(truststorePasswordChars, '\0');
 		}
 	}
 

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/CryptPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/CryptPasswordEncryptor.java
@@ -14,6 +14,7 @@ import com.liferay.portal.kernel.util.Validator;
 
 import java.io.UnsupportedEncodingException;
 
+import java.util.Arrays;
 import java.util.Random;
 
 import org.osgi.service.component.annotations.Component;
@@ -42,14 +43,23 @@ public class CryptPasswordEncryptor implements PasswordEncryptor {
 
 		byte[] saltBytes = getSalt(encryptedPassword);
 
+		byte[] plaintextPasswordBytes = null;
+
 		try {
-			return Crypt.crypt(
-				saltBytes, plaintextPassword.getBytes(DigesterUtil.ENCODING));
+			plaintextPasswordBytes = plaintextPassword.getBytes(
+				DigesterUtil.ENCODING);
+
+			return Crypt.crypt(saltBytes, plaintextPasswordBytes);
 		}
 		catch (UnsupportedEncodingException unsupportedEncodingException) {
 			throw new PwdEncryptorException.UnsupportedEncoding(
 				unsupportedEncodingException.getMessage(),
 				unsupportedEncodingException);
+		}
+		finally {
+			if (plaintextPasswordBytes != null) {
+				Arrays.fill(plaintextPasswordBytes, (byte)0);
+			}
 		}
 	}
 

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/PBKDF2PasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/PBKDF2PasswordEncryptor.java
@@ -23,6 +23,7 @@ import java.nio.ByteBuffer;
 
 import java.security.GeneralSecurityException;
 
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -58,21 +59,28 @@ public class PBKDF2PasswordEncryptor implements PasswordEncryptor {
 
 		byte[] saltBytes = pbkdf2EncryptionConfiguration.getSaltBytes();
 
-		byte[] secretKeyBytes = _generateDerivedKey(
-			pbkdf2EncryptionConfiguration.getKeySize(),
-			pbkdf2EncryptionConfiguration.getMacAlgorithm(),
-			plaintextPassword.getBytes(),
-			pbkdf2EncryptionConfiguration.getRounds(), saltBytes);
+		byte[] plaintextPasswordBytes = plaintextPassword.getBytes();
 
-		ByteBuffer byteBuffer = ByteBuffer.allocate(
-			(2 * 4) + saltBytes.length + secretKeyBytes.length);
+		try {
+			byte[] secretKeyBytes = _generateDerivedKey(
+				pbkdf2EncryptionConfiguration.getKeySize(),
+				pbkdf2EncryptionConfiguration.getMacAlgorithm(),
+				plaintextPasswordBytes,
+				pbkdf2EncryptionConfiguration.getRounds(), saltBytes);
 
-		byteBuffer.putInt(pbkdf2EncryptionConfiguration.getKeySize());
-		byteBuffer.putInt(pbkdf2EncryptionConfiguration.getRounds());
-		byteBuffer.put(saltBytes);
-		byteBuffer.put(secretKeyBytes);
+			ByteBuffer byteBuffer = ByteBuffer.allocate(
+				(2 * 4) + saltBytes.length + secretKeyBytes.length);
 
-		return Base64.encode(byteBuffer.array());
+			byteBuffer.putInt(pbkdf2EncryptionConfiguration.getKeySize());
+			byteBuffer.putInt(pbkdf2EncryptionConfiguration.getRounds());
+			byteBuffer.put(saltBytes);
+			byteBuffer.put(secretKeyBytes);
+
+			return Base64.encode(byteBuffer.array());
+		}
+		finally {
+			Arrays.fill(plaintextPasswordBytes, (byte)0);
+		}
 	}
 
 	@Override
@@ -112,6 +120,8 @@ public class PBKDF2PasswordEncryptor implements PasswordEncryptor {
 
 		byte[] derivedKeyBytes = new byte[derivedKeyLength];
 
+		byte[] nextMacBytes = null;
+
 		try {
 			Mac mac = Mac.getInstance(macAlgorithm);
 
@@ -130,8 +140,9 @@ public class PBKDF2PasswordEncryptor implements PasswordEncryptor {
 
 			int blockCount = (int)Math.ceil(
 				(double)derivedKeyLength / macLength);
-			byte[] nextMacBytes = new byte[macLength];
 			int offset = 0;
+
+			nextMacBytes = new byte[macLength];
 
 			for (int i = 1; i <= blockCount; i++) {
 				BigEndianCodec.putInt(blockBytes, saltBytes.length, i);
@@ -140,34 +151,45 @@ public class PBKDF2PasswordEncryptor implements PasswordEncryptor {
 
 				byte[] derivedBlockBytes = macBytes.clone();
 
-				for (int j = 1; j < rounds; j++) {
-					mac.update(macBytes);
+				try {
+					for (int j = 1; j < rounds; j++) {
+						mac.update(macBytes);
 
-					mac.doFinal(nextMacBytes, 0);
+						mac.doFinal(nextMacBytes, 0);
 
-					for (int k = 0; k < derivedBlockBytes.length; k++) {
-						derivedBlockBytes[k] ^= nextMacBytes[k];
+						for (int k = 0; k < derivedBlockBytes.length; k++) {
+							derivedBlockBytes[k] ^= nextMacBytes[k];
+						}
+
+						byte[] tempBytes = macBytes;
+
+						macBytes = nextMacBytes;
+
+						nextMacBytes = tempBytes;
 					}
 
-					byte[] tempBytes = macBytes;
+					int length = Math.min(macLength, derivedKeyLength - offset);
 
-					macBytes = nextMacBytes;
+					System.arraycopy(
+						derivedBlockBytes, 0, derivedKeyBytes, offset, length);
 
-					nextMacBytes = tempBytes;
+					offset += length;
 				}
-
-				int length = Math.min(macLength, derivedKeyLength - offset);
-
-				System.arraycopy(
-					derivedBlockBytes, 0, derivedKeyBytes, offset, length);
-
-				offset += length;
+				finally {
+					Arrays.fill(derivedBlockBytes, (byte)0);
+					Arrays.fill(macBytes, (byte)0);
+				}
 			}
 		}
 		catch (GeneralSecurityException generalSecurityException) {
 			throw new PwdEncryptorException.InvalidAlgorithm(
 				"Unable to derive key using " + macAlgorithm,
 				generalSecurityException);
+		}
+		finally {
+			if (nextMacBytes != null) {
+				Arrays.fill(nextMacBytes, (byte)0);
+			}
 		}
 
 		return derivedKeyBytes;

--- a/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/SSHAPasswordEncryptor.java
+++ b/modules/apps/portal-security/portal-security-password-encryptor-impl/src/main/java/com/liferay/portal/security/password/encryptor/internal/SSHAPasswordEncryptor.java
@@ -20,6 +20,8 @@ import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
+import java.util.Arrays;
+
 import org.osgi.service.component.annotations.Component;
 
 /**
@@ -44,16 +46,22 @@ public class SSHAPasswordEncryptor implements PasswordEncryptor {
 
 		byte[] saltBytes = getSaltBytes(encryptedPassword);
 
+		byte[] plaintextPasswordBytes = null;
+		byte[] saltedPlaintextPasswordBytes = null;
+
 		try {
 			MessageDigest messageDigest = MessageDigest.getInstance(
 				PropsValues.FIPS_ENABLED ? DigesterUtil.SHA_256 :
 					DigesterUtil.SHA_1);
 
-			byte[] plaintextPasswordBytes = plaintextPassword.getBytes(
+			plaintextPasswordBytes = plaintextPassword.getBytes(
 				DigesterUtil.ENCODING);
 
+			saltedPlaintextPasswordBytes = ArrayUtil.append(
+				plaintextPasswordBytes, saltBytes);
+
 			byte[] messageDigestBytes = messageDigest.digest(
-				ArrayUtil.append(plaintextPasswordBytes, saltBytes));
+				saltedPlaintextPasswordBytes);
 
 			return Base64.encode(
 				ArrayUtil.append(messageDigestBytes, saltBytes));
@@ -67,6 +75,15 @@ public class SSHAPasswordEncryptor implements PasswordEncryptor {
 			throw new PwdEncryptorException.UnsupportedEncoding(
 				unsupportedEncodingException.getMessage(),
 				unsupportedEncodingException);
+		}
+		finally {
+			if (plaintextPasswordBytes != null) {
+				Arrays.fill(plaintextPasswordBytes, (byte)0);
+			}
+
+			if (saltedPlaintextPasswordBytes != null) {
+				Arrays.fill(saltedPlaintextPasswordBytes, (byte)0);
+			}
 		}
 	}
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/DLKeyStoreManagerImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/DLKeyStoreManagerImpl.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
@@ -46,7 +47,15 @@ public class DLKeyStoreManagerImpl extends BaseKeyStoreManagerImpl {
 
 			String samlKeyStorePassword = getSamlKeyStorePassword();
 
-			keyStore.load(inputStream, samlKeyStorePassword.toCharArray());
+			char[] samlKeyStorePasswordChars =
+				samlKeyStorePassword.toCharArray();
+
+			try {
+				keyStore.load(inputStream, samlKeyStorePasswordChars);
+			}
+			finally {
+				Arrays.fill(samlKeyStorePasswordChars, '\0');
+			}
 		}
 		catch (NoSuchFileException noSuchFileException) {
 
@@ -88,8 +97,14 @@ public class DLKeyStoreManagerImpl extends BaseKeyStoreManagerImpl {
 
 		String samlKeyStorePassword = getSamlKeyStorePassword();
 
-		keyStore.store(
-			byteArrayOutputStream, samlKeyStorePassword.toCharArray());
+		char[] samlKeyStorePasswordChars = samlKeyStorePassword.toCharArray();
+
+		try {
+			keyStore.store(byteArrayOutputStream, samlKeyStorePasswordChars);
+		}
+		finally {
+			Arrays.fill(samlKeyStorePasswordChars, '\0');
+		}
 
 		if (_store.hasFile(
 				getCompanyId(), CompanyConstants.SYSTEM, _SAML_KEYSTORE_PATH,

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/FileSystemKeyStoreManagerImpl.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/credential/FileSystemKeyStoreManagerImpl.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 
+import java.util.Arrays;
 import java.util.Map;
 
 import org.osgi.service.component.annotations.Activate;
@@ -69,11 +70,15 @@ public class FileSystemKeyStoreManagerImpl extends BaseKeyStoreManagerImpl {
 
 		String samlKeyStorePassword = getSamlKeyStorePassword();
 
+		char[] samlKeyStorePasswordChars = samlKeyStorePassword.toCharArray();
+
 		try (FileOutputStream fileOutputStream = new FileOutputStream(
 				samlKeyStoreFile)) {
 
-			_keyStore.store(
-				fileOutputStream, samlKeyStorePassword.toCharArray());
+			_keyStore.store(fileOutputStream, samlKeyStorePasswordChars);
+		}
+		finally {
+			Arrays.fill(samlKeyStorePasswordChars, '\0');
 		}
 	}
 
@@ -135,8 +140,13 @@ public class FileSystemKeyStoreManagerImpl extends BaseKeyStoreManagerImpl {
 	private void _doLoadKeyStore() throws Exception {
 		String samlKeyStorePassword = getSamlKeyStorePassword();
 
+		char[] samlKeyStorePasswordChars = samlKeyStorePassword.toCharArray();
+
 		try (InputStream inputStream = _getInputStream()) {
-			_keyStore.load(inputStream, samlKeyStorePassword.toCharArray());
+			_keyStore.load(inputStream, samlKeyStorePasswordChars);
+		}
+		finally {
+			Arrays.fill(samlKeyStorePasswordChars, '\0');
 		}
 	}
 

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/KeyStoreLocalEntityManager.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/metadata/KeyStoreLocalEntityManager.java
@@ -26,6 +26,7 @@ import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 
+import java.util.Arrays;
 import java.util.List;
 
 import net.shibboleth.utilities.java.support.resolver.CriteriaSet;
@@ -175,13 +176,25 @@ public class KeyStoreLocalEntityManager implements LocalEntityManager {
 
 		KeyStore keyStore = _keyStoreManager.getKeyStore();
 
-		keyStore.setEntry(
-			KeyStoreUtil.getAlias(
-				getLocalEntityId(), _getUsageType(certificateUsage)),
-			new KeyStore.PrivateKeyEntry(
-				privateKey, new Certificate[] {x509Certificate}),
-			new KeyStore.PasswordProtection(
-				certificateKeyPassword.toCharArray()));
+		char[] certificateKeyPasswordChars =
+			certificateKeyPassword.toCharArray();
+
+		KeyStore.PasswordProtection keyStorePasswordProtection =
+			new KeyStore.PasswordProtection(certificateKeyPasswordChars);
+
+		try {
+			keyStore.setEntry(
+				KeyStoreUtil.getAlias(
+					getLocalEntityId(), _getUsageType(certificateUsage)),
+				new KeyStore.PrivateKeyEntry(
+					privateKey, new Certificate[] {x509Certificate}),
+				keyStorePasswordProtection);
+		}
+		finally {
+			Arrays.fill(certificateKeyPasswordChars, '\0');
+
+			KeyStoreUtil.destroyPasswordProtection(keyStorePasswordProtection);
+		}
 
 		_keyStoreManager.saveKeyStore(keyStore);
 	}

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/util/KeyStoreUtil.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/main/java/com/liferay/saml/opensaml/integration/internal/util/KeyStoreUtil.java
@@ -5,6 +5,8 @@
 
 package com.liferay.saml.opensaml.integration.internal.util;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.saml.runtime.credential.KeyStoreManager;
 import com.liferay.saml.runtime.exception.CredentialAuthException;
@@ -14,12 +16,33 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.UnrecoverableKeyException;
 
+import java.util.Arrays;
+
+import javax.security.auth.DestroyFailedException;
+
 import org.opensaml.security.credential.UsageType;
 
 /**
  * @author João Victor Alves
  */
 public class KeyStoreUtil {
+
+	public static void destroyPasswordProtection(
+		KeyStore.PasswordProtection keyStorePasswordProtection) {
+
+		if (keyStorePasswordProtection == null) {
+			return;
+		}
+
+		try {
+			keyStorePasswordProtection.destroy();
+		}
+		catch (DestroyFailedException destroyFailedException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(destroyFailedException);
+			}
+		}
+	}
 
 	public static String getAlias(String entityId, UsageType usageType) {
 		if (usageType.equals(UsageType.SIGNING)) {
@@ -37,11 +60,14 @@ public class KeyStoreUtil {
 			KeyStoreManager keyStoreManager)
 		throws CredentialAuthException {
 
+		char[] certificateKeyPasswordChars = null;
 		KeyStore.PasswordProtection keyStorePasswordProtection = null;
 
 		if (certificateKeyPassword != null) {
+			certificateKeyPasswordChars = certificateKeyPassword.toCharArray();
+
 			keyStorePasswordProtection = new KeyStore.PasswordProtection(
-				certificateKeyPassword.toCharArray());
+				certificateKeyPasswordChars);
 		}
 
 		try {
@@ -92,6 +118,13 @@ public class KeyStoreUtil {
 					companyId, clazz.getSimpleName()),
 				generalSecurityException);
 		}
+		finally {
+			if (certificateKeyPasswordChars != null) {
+				Arrays.fill(certificateKeyPasswordChars, '\0');
+			}
+
+			destroyPasswordProtection(keyStorePasswordProtection);
+		}
 	}
 
 	private static <T> T _getCauseThrowable(
@@ -113,5 +146,7 @@ public class KeyStoreUtil {
 
 		return null;
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(KeyStoreUtil.class);
 
 }

--- a/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/util/KeyStoreUtilTest.java
+++ b/modules/dxp/apps/saml/saml-opensaml-integration/src/test/java/com/liferay/saml/opensaml/integration/internal/util/KeyStoreUtilTest.java
@@ -1,0 +1,139 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.saml.opensaml.integration.internal.util;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.saml.opensaml.integration.internal.certificate.CertificateToolImpl;
+import com.liferay.saml.runtime.certificate.CertificateEntityId;
+import com.liferay.saml.runtime.certificate.CertificateTool;
+import com.liferay.saml.runtime.credential.KeyStoreManager;
+import com.liferay.saml.runtime.exception.CredentialAuthException;
+
+import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+
+import java.util.Arrays;
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Pedro Victor Silvestre
+ */
+public class KeyStoreUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() throws Exception {
+		_alias = RandomTestUtil.randomString();
+		_password = RandomTestUtil.randomString();
+
+		KeyPair keyPair = _certificateTool.generateKeyPair("RSA", 2048);
+
+		CertificateEntityId certificateEntityId = new CertificateEntityId(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
+
+		Date startDate = new Date();
+
+		X509Certificate x509Certificate = _certificateTool.generateCertificate(
+			keyPair, certificateEntityId, certificateEntityId, startDate,
+			new Date(startDate.getTime() + (365L * 24 * 60 * 60 * 1000)),
+			"SHA256withRSA");
+
+		_keyStore = KeyStore.getInstance("PKCS12");
+
+		_keyStore.load(null, null);
+
+		_keyStore.setEntry(
+			_alias,
+			new KeyStore.PrivateKeyEntry(
+				keyPair.getPrivate(), new Certificate[] {x509Certificate}),
+			new KeyStore.PasswordProtection(_password.toCharArray()));
+
+		_keyStoreManager = new KeyStoreManager() {
+
+			@Override
+			public KeyStore getKeyStore() {
+				return _keyStore;
+			}
+
+			@Override
+			public void saveKeyStore(KeyStore keyStore) {
+			}
+
+		};
+	}
+
+	@Test
+	public void testDestroyPasswordProtection() {
+		char[] passwordChars = _password.toCharArray();
+
+		KeyStore.PasswordProtection keyStorePasswordProtection =
+			new KeyStore.PasswordProtection(passwordChars);
+
+		char[] clonedPasswordChars = keyStorePasswordProtection.getPassword();
+
+		KeyStoreUtil.destroyPasswordProtection(keyStorePasswordProtection);
+
+		Assert.assertTrue(keyStorePasswordProtection.isDestroyed());
+
+		Assert.assertFalse(
+			Arrays.equals(_password.toCharArray(), clonedPasswordChars));
+
+		Assert.assertArrayEquals(_password.toCharArray(), passwordChars);
+	}
+
+	@Test
+	public void testDestroyPasswordProtectionWithNullPasswordProtection() {
+		KeyStoreUtil.destroyPasswordProtection(null);
+	}
+
+	@Test
+	public void testGetKeyStoreEntryWithCorrectPassword() throws Exception {
+		KeyStore.Entry entry = KeyStoreUtil.getKeyStoreEntry(
+			_alias, _password, _keyStoreManager);
+
+		Assert.assertTrue(entry instanceof KeyStore.PrivateKeyEntry);
+	}
+
+	@Test
+	public void testGetKeyStoreEntryWithIncorrectPassword() {
+		Assert.assertThrows(
+			CredentialAuthException.class,
+			() -> KeyStoreUtil.getKeyStoreEntry(
+				_alias, RandomTestUtil.randomString(), _keyStoreManager));
+	}
+
+	@Test
+	public void testGetKeyStoreEntryWithRepeatedCalls() throws Exception {
+		for (int i = 0; i < 3; i++) {
+			Assert.assertTrue(
+				KeyStoreUtil.getKeyStoreEntry(
+					_alias, _password, _keyStoreManager) instanceof
+						KeyStore.PrivateKeyEntry);
+		}
+	}
+
+	private String _alias;
+	private final CertificateTool _certificateTool = new CertificateToolImpl();
+	private KeyStore _keyStore;
+	private KeyStoreManager _keyStoreManager;
+	private String _password;
+
+}

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/UpdateCertificateMVCActionCommand.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/portlet/action/UpdateCertificateMVCActionCommand.java
@@ -54,7 +54,10 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.security.interfaces.RSAKey;
 
+import java.util.Arrays;
 import java.util.Calendar;
+
+import javax.security.auth.DestroyFailedException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -182,6 +185,7 @@ public class UpdateCertificateMVCActionCommand extends BaseMVCActionCommand {
 			"selectKeyStoreAlias");
 
 		KeyStore keyStore = null;
+		KeyStore.PasswordProtection keyStorePasswordProtection = null;
 		KeyStore.PrivateKeyEntry privateKeyEntry = null;
 
 		try {
@@ -201,8 +205,11 @@ public class UpdateCertificateMVCActionCommand extends BaseMVCActionCommand {
 				throw new IllegalArgumentException();
 			}
 
+			keyStorePasswordProtection = new KeyStore.PasswordProtection(
+				password);
+
 			privateKeyEntry = (KeyStore.PrivateKeyEntry)keyStore.getEntry(
-				selectKeyStoreAlias, new KeyStore.PasswordProtection(password));
+				selectKeyStoreAlias, keyStorePasswordProtection);
 		}
 		catch (IOException ioException) {
 			if (ioException.getCause() instanceof UnrecoverableKeyException) {
@@ -247,6 +254,20 @@ public class UpdateCertificateMVCActionCommand extends BaseMVCActionCommand {
 			SessionErrors.add(actionRequest, "certificateException");
 
 			return;
+		}
+		finally {
+			Arrays.fill(password, '\0');
+
+			if (keyStorePasswordProtection != null) {
+				try {
+					keyStorePasswordProtection.destroy();
+				}
+				catch (DestroyFailedException destroyFailedException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(destroyFailedException);
+					}
+				}
+			}
 		}
 
 		X509Certificate x509Certificate =

--- a/portal-impl/src/com/liferay/portal/security/auth/PortalCallbackHandler.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/PortalCallbackHandler.java
@@ -7,6 +7,8 @@ package com.liferay.portal.security.auth;
 
 import java.io.Serializable;
 
+import java.util.Arrays;
+
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.CallbackHandler;
 import javax.security.auth.callback.NameCallback;
@@ -31,9 +33,16 @@ public class PortalCallbackHandler implements CallbackHandler, Serializable {
 				nameCallback.setName(_name);
 			}
 			else if (callback instanceof PasswordCallback) {
-				PasswordCallback passCallback = (PasswordCallback)callback;
+				PasswordCallback passwordCallback = (PasswordCallback)callback;
 
-				passCallback.setPassword(_password.toCharArray());
+				char[] passwordChars = _password.toCharArray();
+
+				try {
+					passwordCallback.setPassword(passwordChars);
+				}
+				finally {
+					Arrays.fill(passwordChars, '\0');
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Jira: [LPD-102580](https://liferay.atlassian.net/browse/LPD-102580) (Technical Task under [LPD-93280](https://liferay.atlassian.net/browse/LPD-93280) Active Memory Zeroization, epic [LPD-93270](https://liferay.atlassian.net/browse/LPD-93270) FIPS Level 1 Requirements)

## What this does

Java's immutable `String` cannot be wiped, so a secret held in one stays in the heap until GC and can survive into a heap dump. This clears the secret buffers DXP itself allocates, uses, and abandons.

It deliberately does **not** try to eliminate `String` for secrets. That is not satisfiable while OSGi Config Admin, Service Builder, the Servlet API, and the `PasswordEncryptor` / `Authenticator` `@ProviderType` SPIs are all String typed. The story's acceptance criteria were refined to match, and the forced-`String` boundaries are enumerated in a comment on LPD-93280 rather than in code.

## The JDK detail that drove the design

`java.security.KeyStore.PasswordProtection` **clones** the `char[]` handed to its constructor. Verified by running the case:

- clearing our own array does **not** clear its copy
- `destroy()` does **not** clear our array

So both are required at every such site; doing only one looks correct and silently leaves plaintext behind. `KeyStoreUtil.destroyPasswordProtection` centralizes the destroy half, since `DestroyFailedException` has to be swallowed. `KeyStoreUtilTest` asserts each half separately so a future change that drops either one fails.

Every buffer is cleared in a `finally`, not on the happy path — several of these methods return early or return from a `catch`.

## Changes

**`portal-security-password-encryptor-impl`** — `PBKDF2PasswordEncryptor`, `SSHAPasswordEncryptor`, `CryptPasswordEncryptor`. Derived byte arrays are cleared, and in PBKDF2 so are the intermediate PRF outputs, which are key material derived from the secret.

Not cleared, deliberately: `derivedKeyBytes` is the returned stored hash rather than a secret input, and `blockBytes` holds only the salt and the block counter, neither of which is secret.

**`saml-opensaml-integration` / `saml-web`** — `KeyStoreUtil`, `KeyStoreLocalEntityManager`, `DLKeyStoreManagerImpl`, `FileSystemKeyStoreManagerImpl` (both load and store paths), and `UpdateCertificateMVCActionCommand`.

Already clean, left alone: `portal-security-key` (`Secret` is `Destroyable`, `CryptoManagerImpl` already fills), and `SamlConfigurationUpgradeProcess`.

## Testing

- `portal-security-password-encryptor-impl`: **28 tests, 0 failures.** `PasswordEncryptorUtilTest` has hardcoded expected hashes for nine PBKDF2 variants, SSHA in both SHA-1 and FIPS SHA-256 modes, and UFC-Crypt — this is the real safety net, since the main risk in this change is clearing a buffer a callee still needs.
- `saml-opensaml-integration`: 5 new tests in `KeyStoreUtilTest`, using a real PKCS12 key store with a `PrivateKeyEntry` so the fixture matches production. The module has 14 pre-existing failures (`NoClassDefFoundError` in the XXE and WebSSO tests); I stashed this work and confirmed the identical 14 fail on a clean tree — 99 baseline vs 104 here, zero new.
- `formatSource` clean on all three modules.

Not run: deploy plus login and SAML certificate-import smoke tests against a bundle. Per the ticket refinement, FIPS CI verification (LPD-80674) is out of scope for this story.

## Answers to the questions this will raise

- **Why does `saml-web` inline the try/catch instead of using `KeyStoreUtil.destroyPasswordProtection`?** `com.liferay.saml.opensaml.integration.internal.util` is not in that bundle's `Export-Package`, so the helper is not reachable from `saml-web`.
- **Why not use `Secret` from `portal-security-key-api`?** Every constructor requires a non-null `KeyReference`. It targets decrypted key material flowing through `SecretManager`, not ad-hoc "I derived a `char[]` from a configuration String" sites.
- **Why are SSHA and UFC-Crypt in scope when they are not FIPS-approved?** The asset being wiped is the plaintext, which is equally sensitive regardless of which hash consumes it. `CryptPasswordEncryptor` is `@Component(enabled = false)` and SSHA is the legacy default, so this is defensive coverage of a disabled and a legacy path. Splitting a three-line `finally` per file into a second ticket would be churn.
- **What about `SecretKeySpec`?** It clones the key bytes and its `clear()` is package private, so there is no public way to wipe it — unlike `PBEKeySpec`, which exposes `clearPassword()`. Recorded as a known limitation on LPD-93280.

## Known residual exposure

Clearing derived buffers reduces the number of live plaintext copies; it does not remove the plaintext. The largest remaining item is OSGi metatype configuration (for example `SamlConfiguration.keyStorePassword()`), where Config Admin holds the value as a `String` for the lifetime of the configuration. Full list, with reasons and residual risk, is on LPD-93280.

Two incidental findings are recorded there too, both out of scope here: `PortalCallbackHandler` in `portal-impl` is dead code that builds an uncleared `char[]` and is referenced nowhere in the repository, and `Secret.getBytes()` / `getChars()` return their internal arrays rather than copies.
