### PR TITLE
LPD-98129 Fix groupId and timestamp in audit log serialization

### DIFF
--- a/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventLocalServiceImpl.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-storage-service/src/main/java/com/liferay/portal/security/audit/storage/service/impl/AuditEventLocalServiceImpl.java
@@ -280,7 +280,7 @@ public class AuditEventLocalServiceImpl extends AuditEventLocalServiceBaseImpl {
 		auditEvent.setCompanyId(auditMessage.getCompanyId());
 		auditEvent.setUserId(auditMessage.getUserId());
 		auditEvent.setUserName(auditMessage.getUserName());
-		auditEvent.setCreateDate(auditMessage.getTimestamp());
+		auditEvent.setCreateDate(auditMessage.getTimestampDate());
 		auditEvent.setAccountEntryId(auditMessage.getAccountEntryId());
 		auditEvent.setAdditionalInfo(
 			String.valueOf(auditMessage.getAdditionalInfo()));

--- a/portal-impl/test/unit/com/liferay/portal/kernel/audit/AuditMessageTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/audit/AuditMessageTest.java
@@ -33,11 +33,11 @@ public class AuditMessageTest {
 	@Test
 	public void testToJSONObject() throws Exception {
 		long groupId = RandomTestUtil.randomLong();
-		Date timestamp = RandomTestUtil.nextDate();
+		Date timestampDate = RandomTestUtil.nextDate();
 
 		AuditMessage auditMessage = new AuditMessage(
 			groupId, RandomTestUtil.randomLong(), RandomTestUtil.randomLong(),
-			RandomTestUtil.randomString(), timestamp,
+			RandomTestUtil.randomString(), timestampDate,
 			JSONFactoryUtil.createJSONObject(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString());
@@ -49,9 +49,10 @@ public class AuditMessageTest {
 
 		Assert.assertEquals(groupId, jsonObject.getLong("groupId"));
 		Assert.assertEquals(
-			dateFormat.format(timestamp), jsonObject.getString("timestamp"));
+			dateFormat.format(timestampDate),
+			jsonObject.getString("timestamp"));
 
-		auditMessage.setTimestamp(null);
+		auditMessage.setTimestampDate(null);
 
 		jsonObject = auditMessage.toJSONObject();
 
@@ -60,7 +61,7 @@ public class AuditMessageTest {
 		auditMessage = new AuditMessage(jsonObject.toString());
 
 		Assert.assertEquals(groupId, auditMessage.getGroupId());
-		Assert.assertNotNull(auditMessage.getTimestamp());
+		Assert.assertNotNull(auditMessage.getTimestampDate());
 	}
 
 }

--- a/portal-impl/test/unit/com/liferay/portal/kernel/audit/AuditMessageTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/audit/AuditMessageTest.java
@@ -1,0 +1,66 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.audit;
+
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.text.DateFormat;
+
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Regisson Aguiar
+ */
+public class AuditMessageTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testToJSONObject() throws Exception {
+		long groupId = RandomTestUtil.randomLong();
+		Date timestamp = RandomTestUtil.nextDate();
+
+		AuditMessage auditMessage = new AuditMessage(
+			groupId, RandomTestUtil.randomLong(), RandomTestUtil.randomLong(),
+			RandomTestUtil.randomString(), timestamp,
+			JSONFactoryUtil.createJSONObject(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString());
+
+		JSONObject jsonObject = auditMessage.toJSONObject();
+
+		DateFormat dateFormat = DateFormatFactoryUtil.getSimpleDateFormat(
+			"yyyyMMddkkmmssSSS");
+
+		Assert.assertEquals(groupId, jsonObject.getLong("groupId"));
+		Assert.assertEquals(
+			dateFormat.format(timestamp), jsonObject.getString("timestamp"));
+
+		auditMessage.setTimestamp(null);
+
+		jsonObject = auditMessage.toJSONObject();
+
+		Assert.assertNotNull(jsonObject.getString("timestamp"));
+
+		auditMessage = new AuditMessage(jsonObject.toString());
+
+		Assert.assertEquals(groupId, auditMessage.getGroupId());
+		Assert.assertNotNull(auditMessage.getTimestamp());
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessage.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessage.java
@@ -377,6 +377,8 @@ public class AuditMessage implements Serializable {
 		).put(
 			_EVENT_TYPE, _eventType
 		).put(
+			_GROUP_ID, _groupId
+		).put(
 			_MESSAGE, _message
 		).put(
 			_SERVER_NAME, _serverName
@@ -385,7 +387,9 @@ public class AuditMessage implements Serializable {
 		).put(
 			_SESSION_ID, _sessionID
 		).put(
-			_TIMESTAMP, _getDateFormat().format(new Date())
+			_TIMESTAMP,
+			_getDateFormat().format(
+				(_timestamp != null) ? _timestamp : new Date())
 		).put(
 			_USER_EMAIL_ADDRESS, _userEmailAddress
 		).put(

--- a/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessage.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/audit/AuditMessage.java
@@ -34,18 +34,18 @@ public class AuditMessage implements Serializable {
 
 	public AuditMessage(
 		long groupId, long companyId, long userId, String userName,
-		Date timestamp, JSONObject additionalInfoJSONObject, String className,
-		String classPK, String eventType, String message) {
+		Date timestampDate, JSONObject additionalInfoJSONObject,
+		String className, String classPK, String eventType, String message) {
 
 		this(
-			groupId, companyId, userId, userName, timestamp, 0,
+			groupId, companyId, userId, userName, timestampDate, 0,
 			additionalInfoJSONObject, className, classPK, null, eventType,
 			message);
 	}
 
 	public AuditMessage(
 		long groupId, long companyId, long userId, String userName,
-		Date timestamp, long accountEntryId,
+		Date timestampDate, long accountEntryId,
 		JSONObject additionalInfoJSONObject, String className, String classPK,
 		String contextName, String eventType, String message) {
 
@@ -53,7 +53,7 @@ public class AuditMessage implements Serializable {
 		_companyId = companyId;
 		_userId = userId;
 		_userName = userName;
-		_timestamp = (timestamp != null) ? timestamp : new Date();
+		_timestampDate = (timestampDate != null) ? timestampDate : new Date();
 		_accountEntryId = accountEntryId;
 		_additionalInfoJSONObject =
 			(additionalInfoJSONObject != null) ? additionalInfoJSONObject :
@@ -109,12 +109,12 @@ public class AuditMessage implements Serializable {
 	}
 
 	public AuditMessage(
-		long companyId, long userId, String userName, Date timestamp,
+		long companyId, long userId, String userName, Date timestampDate,
 		JSONObject additionalInfoJSONObject, String className, String classPK,
 		String eventType, String message) {
 
 		this(
-			0, companyId, userId, userName, timestamp, 0,
+			0, companyId, userId, userName, timestampDate, 0,
 			additionalInfoJSONObject, className, classPK, null, eventType,
 			message);
 	}
@@ -193,7 +193,7 @@ public class AuditMessage implements Serializable {
 			_sessionID = jsonObject.getString(_SESSION_ID);
 		}
 
-		_timestamp = GetterUtil.getDate(
+		_timestampDate = GetterUtil.getDate(
 			jsonObject.getString(_TIMESTAMP), _getDateFormat());
 		_userEmailAddress = jsonObject.getString(_USER_EMAIL_ADDRESS);
 		_userId = jsonObject.getLong(_USER_ID);
@@ -257,8 +257,8 @@ public class AuditMessage implements Serializable {
 		return _sessionID;
 	}
 
-	public Date getTimestamp() {
-		return _timestamp;
+	public Date getTimestampDate() {
+		return _timestampDate;
 	}
 
 	public String getUserEmailAddress() {
@@ -337,8 +337,8 @@ public class AuditMessage implements Serializable {
 		_sessionID = sessionID;
 	}
 
-	public void setTimestamp(Date timestamp) {
-		_timestamp = timestamp;
+	public void setTimestampDate(Date timestampDate) {
+		_timestampDate = timestampDate;
 	}
 
 	public void setUserEmailAddress(String userEmailAddress) {
@@ -389,7 +389,7 @@ public class AuditMessage implements Serializable {
 		).put(
 			_TIMESTAMP,
 			_getDateFormat().format(
-				(_timestamp != null) ? _timestamp : new Date())
+				(_timestampDate != null) ? _timestampDate : new Date())
 		).put(
 			_USER_EMAIL_ADDRESS, _userEmailAddress
 		).put(
@@ -461,7 +461,7 @@ public class AuditMessage implements Serializable {
 	private String _serverName;
 	private int _serverPort;
 	private String _sessionID;
-	private Date _timestamp;
+	private Date _timestampDate;
 	private String _userEmailAddress;
 	private long _userId = -1;
 	private String _userLogin;

--- a/portal-kernel/src/com/liferay/portal/kernel/audit/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/audit/packageinfo
@@ -1,1 +1,1 @@
-version 10.0.0
+version 11.0.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98129

## What Is Being Fixed

AuditMessage.toJSONObject() never wrote the groupId key even though the JSON round-trip constructor already read it back, so groupId was missing from JSON and CSV audit log output and came back as 0 after a round trip. The method also formatted a fresh new Date() instead of the message's own timestamp, so the logged time was when the log line was written rather than when the audited action happened.

## How It Is Being Fixed

AuditMessage.toJSONObject() now writes groupId and formats the message's own timestamp instead of a fresh Date(). AuditMessageTest exercises toJSONObject() directly, covering the groupId and timestamp assertions, the JSON round trip, and the null-timestamp fallback path.

Per review feedback, a separate commit renames AuditMessage#getTimestamp()/setTimestamp(Date) to getTimestampDate()/setTimestampDate(Date) for clarity, since they operate on a Date. This is a breaking change to AuditMessage's public API, so its commit carries a "# breaking" note describing the rename, per Liferay's [breaking change process](https://liferay.atlassian.net/wiki/spaces/ENGR/pages/2489483265/Process+to+register+breaking+changes+in+commits). A final, dedicated commit bumps the com.liferay.portal.kernel.audit package's major version from 10.0.0 to 11.0.0 accordingly.

## PR Check

**pr-check: PASS** — tested on `3a3ceec479ff96191bc3b757993710cdae97f69f`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3a3ceec479ff96191bc3b757993710cdae97f69f"} -->
