### PR TITLE
LPD-101833 Escape unescaped values in the OAuth 2 provider JSPs

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotatedApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotatedApplicationClientTest.java
@@ -11,6 +11,7 @@ import com.liferay.oauth2.provider.internal.test.TestInterfaceAnnotatedApplicati
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -74,7 +75,7 @@ public class AnnotatedApplicationClientTest extends BaseClientTestCase {
 		invocationBuilder = authorize(
 			invocationBuilder,
 			getToken(
-				"oauthTestApplication", null,
+				_CLIENT_ID, null,
 				getClientCredentialsResponseBiFunction(StringPool.BLANK),
 				this::parseTokenString));
 
@@ -95,7 +96,7 @@ public class AnnotatedApplicationClientTest extends BaseClientTestCase {
 		invocationBuilder = authorize(
 			webTarget.request(),
 			getToken(
-				"oauthTestApplication", null,
+				_CLIENT_ID, null,
 				getClientCredentialsResponseBiFunction("everything.write"),
 				this::parseTokenString));
 
@@ -106,7 +107,7 @@ public class AnnotatedApplicationClientTest extends BaseClientTestCase {
 		invocationBuilder = authorize(
 			webTarget.request(),
 			getToken(
-				"oauthTestApplication", null,
+				_CLIENT_ID, null,
 				getClientCredentialsResponseBiFunction("everything.read"),
 				this::parseTokenString));
 
@@ -115,6 +116,8 @@ public class AnnotatedApplicationClientTest extends BaseClientTestCase {
 		Assert.assertEquals(
 			"everything.read", invocationBuilder.get(String.class));
 	}
+
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
 
 	private class AnnotatedApplicationTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
@@ -140,7 +143,7 @@ public class AnnotatedApplicationClientTest extends BaseClientTestCase {
 				new TestAnnotatedApplication(), "annotated-impl", properties);
 
 			createOAuth2Application(
-				companyId, user, "oauthTestApplication",
+				companyId, user, _CLIENT_ID,
 				Arrays.asList(
 					"everything", "everything.read", "everything.write"));
 		}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotatedApplicationPrefixHandlerClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotatedApplicationPrefixHandlerClientTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.internal.test.TestAnnotatedApplication;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -45,7 +46,7 @@ public class AnnotatedApplicationPrefixHandlerClientTest
 		WebTarget webTarget = getWebTarget("/annotated");
 
 		Invocation.Builder builder = authorize(
-			webTarget.request(), getToken("oauthTestApplication"));
+			webTarget.request(), getToken(_CLIENT_ID));
 
 		Assert.assertEquals("everything.read", builder.get(String.class));
 	}
@@ -54,6 +55,8 @@ public class AnnotatedApplicationPrefixHandlerClientTest
 	protected BundleActivator getBundleActivator() {
 		return new AnnotatedApplicationPrefixHandlerTestPreparatorBundleActivator();
 	}
+
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
 
 	private class AnnotatedApplicationPrefixHandlerTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
@@ -77,7 +80,7 @@ public class AnnotatedApplicationPrefixHandlerClientTest
 				new TestAnnotatedApplication(), "annotated", properties);
 
 			createOAuth2Application(
-				companyId, user, "oauthTestApplication",
+				companyId, user, _CLIENT_ID,
 				Collections.singletonList("test/everything"));
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotationsAndHttpApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotationsAndHttpApplicationClientTest.java
@@ -10,6 +10,7 @@ import com.liferay.oauth2.provider.internal.test.TestAnnotatedApplication;
 import com.liferay.oauth2.provider.internal.test.TestApplication;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -43,7 +44,7 @@ public class AnnotationsAndHttpApplicationClientTest
 
 	@Test
 	public void test() throws Exception {
-		String tokenString = getToken("oauthTestApplication");
+		String tokenString = getToken(_CLIENT_ID);
 
 		WebTarget webTarget = getWebTarget("/methods");
 
@@ -63,6 +64,8 @@ public class AnnotationsAndHttpApplicationClientTest
 	protected BundleActivator getBundleActivator() {
 		return new AnnotationsAndHttpTestPreparatorBundleActivator();
 	}
+
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
 
 	private class AnnotationsAndHttpTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
@@ -104,7 +107,7 @@ public class AnnotationsAndHttpApplicationClientTest
 				properties);
 
 			createOAuth2Application(
-				companyId, user, "oauthTestApplication",
+				companyId, user, _CLIENT_ID,
 				Collections.singletonList("everything"));
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotationsAndHttpPrefixApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotationsAndHttpPrefixApplicationClientTest.java
@@ -62,7 +62,7 @@ public class AnnotationsAndHttpPrefixApplicationClientTest
 
 		Assert.assertEquals("everything.read", builder.get(String.class));
 
-		tokenString = getToken("oauthTestApplicationWrong");
+		tokenString = getToken(_CLIENT_ID_WRONG);
 
 		webTarget = getWebTarget("/methods");
 
@@ -93,6 +93,9 @@ public class AnnotationsAndHttpPrefixApplicationClientTest
 	}
 
 	private static final String _CLIENT_ID = RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_WRONG =
+		RandomTestUtil.randomString();
 
 	private class AnnotationsAndHttpPrefixTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
@@ -161,7 +164,7 @@ public class AnnotationsAndHttpPrefixApplicationClientTest
 				Arrays.asList("annotations/everything", "methods/everything"));
 
 			createOAuth2Application(
-				companyId, user, "oauthTestApplicationWrong",
+				companyId, user, _CLIENT_ID_WRONG,
 				Collections.singletonList("everything"));
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotationsAndHttpPrefixApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/AnnotationsAndHttpPrefixApplicationClientTest.java
@@ -10,6 +10,7 @@ import com.liferay.oauth2.provider.internal.test.TestAnnotatedApplication;
 import com.liferay.oauth2.provider.internal.test.TestApplication;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -46,7 +47,7 @@ public class AnnotationsAndHttpPrefixApplicationClientTest
 
 	@Test
 	public void test() throws Exception {
-		String tokenString = getToken("oauthTestApplication");
+		String tokenString = getToken(_CLIENT_ID);
 
 		WebTarget webTarget = getWebTarget("/methods");
 
@@ -90,6 +91,8 @@ public class AnnotationsAndHttpPrefixApplicationClientTest
 	protected BundleActivator getBundleActivator() {
 		return new AnnotationsAndHttpPrefixTestPreparatorBundleActivator();
 	}
+
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
 
 	private class AnnotationsAndHttpPrefixTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
@@ -154,7 +157,7 @@ public class AnnotationsAndHttpPrefixApplicationClientTest
 				annotatedApplicationProperties);
 
 			createOAuth2Application(
-				companyId, user, "oauthTestApplication",
+				companyId, user, _CLIENT_ID,
 				Arrays.asList("annotations/everything", "methods/everything"));
 
 			createOAuth2Application(

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseClientTestCase.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseClientTestCase.java
@@ -341,7 +341,7 @@ public abstract class BaseClientTestCase {
 		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
 
 		formData.add("client_id", clientId);
-		formData.add("client_secret", "oauthTestApplicationSecret");
+		formData.add("client_secret", CLIENT_SECRET);
 		formData.add("grant_type", "client_credentials");
 
 		return invocationBuilder.post(Entity.form(formData));
@@ -355,7 +355,7 @@ public abstract class BaseClientTestCase {
 				new MultivaluedHashMap<>();
 
 			formData.add("client_id", clientId);
-			formData.add("client_secret", "oauthTestApplicationSecret");
+			formData.add("client_secret", CLIENT_SECRET);
 			formData.add("grant_type", "client_credentials");
 			formData.add("scope", scope);
 
@@ -463,7 +463,7 @@ public abstract class BaseClientTestCase {
 				new MultivaluedHashMap<>();
 
 			formData.add("client_id", clientId);
-			formData.add("client_secret", "oauthTestApplicationSecret");
+			formData.add("client_secret", CLIENT_SECRET);
 			formData.add("code", authorizationCode);
 			formData.add("grant_type", "authorization_code");
 
@@ -542,7 +542,7 @@ public abstract class BaseClientTestCase {
 				new MultivaluedHashMap<>();
 
 			formData.add("client_id", clientId);
-			formData.add("client_secret", "oauthTestApplicationSecret");
+			formData.add("client_secret", CLIENT_SECRET);
 			formData.add("grant_type", "password");
 			formData.add("password", password);
 			formData.add("username", userName);
@@ -560,7 +560,7 @@ public abstract class BaseClientTestCase {
 				new MultivaluedHashMap<>();
 
 			formData.add("client_id", clientId);
-			formData.add("client_secret", "oauthTestApplicationSecret");
+			formData.add("client_secret", CLIENT_SECRET);
 			formData.add("grant_type", "password");
 			formData.add("password", password);
 			formData.add("scope", scope);
@@ -699,6 +699,8 @@ public abstract class BaseClientTestCase {
 		return _oAuth2AuthorizationLocalService.updateOAuth2Authorization(
 			oAuth2Authorization);
 	}
+
+	protected static final String CLIENT_SECRET = RandomTestUtil.randomString();
 
 	private static Set<String> _originalRestrictedHeaderSet;
 	private static final Pattern _pAuthTokenPattern = Pattern.compile(

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionary;
@@ -290,7 +291,7 @@ public abstract class BaseTestPreparatorBundleActivator
 
 		return createOAuth2Application(
 			companyId, user, clientId, clientSecret, allowedGrantTypesList,
-			clientAuthenticationMethod, jwks, "test application",
+			clientAuthenticationMethod, jwks, RandomTestUtil.randomString(),
 			redirectURIsList, rememberDevice, scopeAliasesList,
 			trustedApplication);
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
@@ -238,11 +238,10 @@ public abstract class BaseTestPreparatorBundleActivator
 
 		return createOAuth2Application(
 			companyId, user, clientId, BaseClientTestCase.CLIENT_SECRET,
-			allowedGrantTypesList, OAuthConstants.TOKEN_ENDPOINT_AUTH_POST,
-			null, name,
+			allowedGrantTypesList, name,
 			Collections.singletonList(
 				"http://redirecturi:" + PortalUtil.getPortalServerPort(false)),
-			false, scopeAliasesList, false);
+			scopeAliasesList);
 	}
 
 	protected OAuth2Application createOAuth2Application(
@@ -279,6 +278,18 @@ public abstract class BaseTestPreparatorBundleActivator
 
 		return createOAuth2Application(
 			companyId, user, clientId, clientSecret, allowedGrantTypesList,
+			redirectURIsList, false, scopeAliasesList, false);
+	}
+
+	protected OAuth2Application createOAuth2Application(
+			long companyId, User user, String clientId, String clientSecret,
+			List<GrantType> allowedGrantTypesList, String name,
+			List<String> redirectURIsList, List<String> scopeAliasesList)
+		throws PortalException {
+
+		return createOAuth2Application(
+			companyId, user, clientId, clientSecret, allowedGrantTypesList,
+			OAuthConstants.TOKEN_ENDPOINT_AUTH_POST, null, name,
 			redirectURIsList, false, scopeAliasesList, false);
 	}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
@@ -11,6 +11,7 @@ import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.scope.spi.prefix.handler.PrefixHandler;
 import com.liferay.oauth2.provider.scope.spi.prefix.handler.PrefixHandlerFactory;
+import com.liferay.oauth2.provider.scope.spi.scope.descriptor.ScopeDescriptor;
 import com.liferay.oauth2.provider.scope.spi.scope.finder.ScopeFinder;
 import com.liferay.oauth2.provider.scope.spi.scope.mapper.ScopeMapper;
 import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
@@ -451,6 +452,19 @@ public abstract class BaseTestPreparatorBundleActivator
 		ServiceRegistration<PrefixHandlerFactory> serviceRegistration =
 			bundleContext.registerService(
 				PrefixHandlerFactory.class, a -> prefixHandler, properties);
+
+		autoCloseables.add(serviceRegistration::unregister);
+
+		return serviceRegistration;
+	}
+
+	protected ServiceRegistration<ScopeDescriptor> registerScopeDescriptor(
+		ScopeDescriptor scopeDescriptor,
+		Dictionary<String, Object> properties) {
+
+		ServiceRegistration<ScopeDescriptor> serviceRegistration =
+			bundleContext.registerService(
+				ScopeDescriptor.class, scopeDescriptor, properties);
 
 		autoCloseables.add(serviceRegistration::unregister);
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
@@ -330,7 +330,7 @@ public abstract class BaseTestPreparatorBundleActivator
 				companyId, user.getUserId(), user.getFullName(),
 				allowedGrantTypesList, clientAuthenticationMethod,
 				user.getUserId(), clientId, 0, clientSecret,
-				"test oauth application",
+				RandomTestUtil.randomString(),
 				Collections.singletonList("token.introspection"),
 				"http://localhost:" + PortalUtil.getPortalServerPort(false), 0,
 				jwks, name,

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
@@ -230,6 +230,21 @@ public abstract class BaseTestPreparatorBundleActivator
 
 	protected OAuth2Application createOAuth2Application(
 			long companyId, User user, String clientId,
+			List<GrantType> allowedGrantTypesList, String name,
+			List<String> scopeAliasesList)
+		throws PortalException {
+
+		return createOAuth2Application(
+			companyId, user, clientId, "oauthTestApplicationSecret",
+			allowedGrantTypesList, OAuthConstants.TOKEN_ENDPOINT_AUTH_POST,
+			null, name,
+			Collections.singletonList(
+				"http://redirecturi:" + PortalUtil.getPortalServerPort(false)),
+			false, scopeAliasesList, false);
+	}
+
+	protected OAuth2Application createOAuth2Application(
+			long companyId, User user, String clientId,
 			List<String> scopeAliasesList)
 		throws PortalException {
 
@@ -273,6 +288,21 @@ public abstract class BaseTestPreparatorBundleActivator
 			List<String> scopeAliasesList, boolean trustedApplication)
 		throws PortalException {
 
+		return createOAuth2Application(
+			companyId, user, clientId, clientSecret, allowedGrantTypesList,
+			clientAuthenticationMethod, jwks, "test application",
+			redirectURIsList, rememberDevice, scopeAliasesList,
+			trustedApplication);
+	}
+
+	protected OAuth2Application createOAuth2Application(
+			long companyId, User user, String clientId, String clientSecret,
+			List<GrantType> allowedGrantTypesList,
+			String clientAuthenticationMethod, String jwks, String name,
+			List<String> redirectURIsList, boolean rememberDevice,
+			List<String> scopeAliasesList, boolean trustedApplication)
+		throws PortalException {
+
 		ServiceReference<OAuth2ApplicationLocalService> serviceReference =
 			bundleContext.getServiceReference(
 				OAuth2ApplicationLocalService.class);
@@ -290,7 +320,7 @@ public abstract class BaseTestPreparatorBundleActivator
 				"test oauth application",
 				Collections.singletonList("token.introspection"),
 				"http://localhost:" + PortalUtil.getPortalServerPort(false), 0,
-				jwks, "test application",
+				jwks, name,
 				"http://localhost:" + PortalUtil.getPortalServerPort(false),
 				redirectURIsList, rememberDevice, scopeAliasesList,
 				trustedApplication, new ServiceContext());

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/BaseTestPreparatorBundleActivator.java
@@ -209,7 +209,7 @@ public abstract class BaseTestPreparatorBundleActivator
 		throws PortalException {
 
 		return createOAuth2Application(
-			companyId, user, clientId, "oauthTestApplicationSecret",
+			companyId, user, clientId, BaseClientTestCase.CLIENT_SECRET,
 			allowedGrantTypesList,
 			Collections.singletonList(
 				"http://redirecturi:" + PortalUtil.getPortalServerPort(false)),
@@ -223,7 +223,7 @@ public abstract class BaseTestPreparatorBundleActivator
 		throws PortalException {
 
 		return createOAuth2Application(
-			companyId, user, clientId, "oauthTestApplicationSecret",
+			companyId, user, clientId, BaseClientTestCase.CLIENT_SECRET,
 			allowedGrantTypesList,
 			Collections.singletonList(
 				"http://redirecturi:" + PortalUtil.getPortalServerPort(false)),
@@ -237,7 +237,7 @@ public abstract class BaseTestPreparatorBundleActivator
 		throws PortalException {
 
 		return createOAuth2Application(
-			companyId, user, clientId, "oauthTestApplicationSecret",
+			companyId, user, clientId, BaseClientTestCase.CLIENT_SECRET,
 			allowedGrantTypesList, OAuthConstants.TOKEN_ENDPOINT_AUTH_POST,
 			null, name,
 			Collections.singletonList(

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/CORSApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/CORSApplicationClientTest.java
@@ -54,7 +54,7 @@ public class CORSApplicationClientTest extends BaseClientTestCase {
 
 		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
 
-		formData.add("client_id", "oauthTestApplicationRO");
+		formData.add("client_id", _CLIENT_ID_RO);
 		formData.add("client_secret", CLIENT_SECRET);
 		formData.add("grant_type", "password");
 		formData.add("password", PropsValues.DEFAULT_ADMIN_PASSWORD);
@@ -73,7 +73,7 @@ public class CORSApplicationClientTest extends BaseClientTestCase {
 		WebTarget webTarget = getJsonWebTarget("user", "get-current-user");
 
 		String tokenString = getToken(
-			"oauthTestApplicationRO", null,
+			_CLIENT_ID_RO, null,
 			getResourceOwnerPasswordBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD),
 			this::parseTokenString);
@@ -128,7 +128,7 @@ public class CORSApplicationClientTest extends BaseClientTestCase {
 		WebTarget webTarget = getJsonWebTarget("user", "get-current-user");
 
 		String tokenString = getToken(
-			"oauthTestApplicationRO", null,
+			_CLIENT_ID_RO, null,
 			getResourceOwnerPasswordBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD),
 			this::parseTokenString);
@@ -167,6 +167,8 @@ public class CORSApplicationClientTest extends BaseClientTestCase {
 		return new CORSApplicationTestPreparatorBundleActivator();
 	}
 
+	private static final String _CLIENT_ID_RO = RandomTestUtil.randomString();
+
 	private User _user;
 
 	private class CORSApplicationTestPreparatorBundleActivator
@@ -179,7 +181,7 @@ public class CORSApplicationClientTest extends BaseClientTestCase {
 			_user = UserTestUtil.getAdminUser(companyId);
 
 			createOAuth2Application(
-				companyId, _user, "oauthTestApplicationRO",
+				companyId, _user, _CLIENT_ID_RO,
 				Collections.singletonList("everything.read"));
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/CORSApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/CORSApplicationClientTest.java
@@ -55,7 +55,7 @@ public class CORSApplicationClientTest extends BaseClientTestCase {
 		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
 
 		formData.add("client_id", "oauthTestApplicationRO");
-		formData.add("client_secret", "oauthTestApplicationSecret");
+		formData.add("client_secret", CLIENT_SECRET);
 		formData.add("grant_type", "password");
 		formData.add("password", PropsValues.DEFAULT_ADMIN_PASSWORD);
 		formData.add("username", _user.getEmailAddress());

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/DenyAccessToAdminScopeTononAdminUserTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/DenyAccessToAdminScopeTononAdminUserTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.model.OAuth2Application;
 import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.test.rule.Inject;
@@ -48,8 +49,8 @@ public class DenyAccessToAdminScopeTononAdminUserTest
 			"o/headless-admin-workflow/v1.0/workflow-definitions");
 
 		String tokenString = getToken(
-			"oauthTestApplicationAdmin", null,
-			this::getClientCredentialsResponse, this::parseTokenString);
+			_CLIENT_ID_ADMIN, null, this::getClientCredentialsResponse,
+			this::parseTokenString);
 
 		Invocation.Builder invocationBuilder = authorize(
 			webTarget.request(), tokenString);
@@ -58,7 +59,7 @@ public class DenyAccessToAdminScopeTononAdminUserTest
 
 		Assert.assertEquals(200, response.getStatus());
 
-		tokenString = getToken("oauthTestApplicationNonAdmin");
+		tokenString = getToken(_CLIENT_ID_NONADMIN);
 
 		invocationBuilder = authorize(webTarget.request(), tokenString);
 
@@ -71,6 +72,12 @@ public class DenyAccessToAdminScopeTononAdminUserTest
 	protected BundleActivator getBundleActivator() {
 		return new DenyAccessToAdminScopeTononAdminUserTestPreparatorBundleActivator();
 	}
+
+	private static final String _CLIENT_ID_ADMIN =
+		RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_NONADMIN =
+		RandomTestUtil.randomString();
 
 	@Inject
 	private OAuth2ScopeGrantLocalService _oAuth2ScopeGrantLocalService;
@@ -85,7 +92,7 @@ public class DenyAccessToAdminScopeTononAdminUserTest
 
 			OAuth2Application oauth2AdminApp = createOAuth2Application(
 				companyId, UserTestUtil.getAdminUser(companyId),
-				"oauthTestApplicationAdmin",
+				_CLIENT_ID_ADMIN,
 				Collections.singletonList(
 					"Liferay.Headless.Admin.Workflow.everything"));
 
@@ -98,8 +105,7 @@ public class DenyAccessToAdminScopeTononAdminUserTest
 					"Liferay.Headless.Admin.Workflow.everything"));
 
 			OAuth2Application oauth2RegularUserApp = createOAuth2Application(
-				companyId, UserTestUtil.addUser(),
-				"oauthTestApplicationNonAdmin",
+				companyId, UserTestUtil.addUser(), _CLIENT_ID_NONADMIN,
 				Collections.singletonList(
 					"Liferay.Headless.Admin.Workflow.everything"));
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/DisabledUserClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/DisabledUserClientTest.java
@@ -56,8 +56,7 @@ public class DisabledUserClientTest extends BaseClientTestCase {
 
 		webTarget = getWebTarget("/users");
 
-		builder = authorize(
-			webTarget.request(), getToken("oauthTestApplicationDisabled"));
+		builder = authorize(webTarget.request(), getToken(_CLIENT_ID_DISABLED));
 
 		response = builder.get();
 
@@ -70,6 +69,9 @@ public class DisabledUserClientTest extends BaseClientTestCase {
 	}
 
 	private static final String _CLIENT_ID = RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_DISABLED =
+		RandomTestUtil.randomString();
 
 	private class DisabledUserTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
@@ -92,7 +94,7 @@ public class DisabledUserClientTest extends BaseClientTestCase {
 			createOAuth2Application(
 				companyId, user, _CLIENT_ID, Arrays.asList("GET"));
 			createOAuth2Application(
-				companyId, disabledUser, "oauthTestApplicationDisabled",
+				companyId, disabledUser, _CLIENT_ID_DISABLED,
 				Arrays.asList("GET"));
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/DisabledUserClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/DisabledUserClientTest.java
@@ -12,6 +12,7 @@ import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -47,7 +48,7 @@ public class DisabledUserClientTest extends BaseClientTestCase {
 		WebTarget webTarget = getWebTarget("/users");
 
 		Invocation.Builder builder = authorize(
-			webTarget.request(), getToken("oauthTestApplication"));
+			webTarget.request(), getToken(_CLIENT_ID));
 
 		Response response = builder.get();
 
@@ -68,6 +69,8 @@ public class DisabledUserClientTest extends BaseClientTestCase {
 		return new DisabledUserTestPreparatorBundleActivator();
 	}
 
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
+
 	private class DisabledUserTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
 
@@ -87,7 +90,7 @@ public class DisabledUserClientTest extends BaseClientTestCase {
 			registerJaxRsApplication(new TestApplication(), "users", null);
 
 			createOAuth2Application(
-				companyId, user, "oauthTestApplication", Arrays.asList("GET"));
+				companyId, user, _CLIENT_ID, Arrays.asList("GET"));
 			createOAuth2Application(
 				companyId, disabledUser, "oauthTestApplicationDisabled",
 				Arrays.asList("GET"));

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ExpiredAuthorizationsAfterlifeTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ExpiredAuthorizationsAfterlifeTest.java
@@ -11,6 +11,7 @@ import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.oauth2.provider.service.OAuth2AuthorizationLocalService;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -68,6 +69,8 @@ public class ExpiredAuthorizationsAfterlifeTest extends BaseClientTestCase {
 		return new ExpiredAuthorizationsAfterlifeTestPreparatorBundleActivator();
 	}
 
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
+
 	@Inject
 	private OAuth2AuthorizationLocalService _oAuth2AuthorizationLocalService;
 
@@ -86,8 +89,7 @@ public class ExpiredAuthorizationsAfterlifeTest extends BaseClientTestCase {
 			User user = UserTestUtil.getAdminUser(companyId);
 
 			OAuth2Application oAuth2Application = createOAuth2Application(
-				companyId, user, "oauthTestApplication",
-				Arrays.asList("everything.read"));
+				companyId, user, _CLIENT_ID, Arrays.asList("everything.read"));
 
 			addOAuth2Authorization(
 				companyId, user, oAuth2Application, "accessToken1", new Date(),

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/GrantAuthorizationCodeKillSwitchTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/GrantAuthorizationCodeKillSwitchTest.java
@@ -10,6 +10,7 @@ import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.internal.test.TestAnnotatedApplication;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -48,7 +49,7 @@ public class GrantAuthorizationCodeKillSwitchTest extends BaseClientTestCase {
 					null,
 					getCodeFunction(
 						webTarget -> webTarget.queryParam(
-							"client_id", "oauthTestApplicationCode"
+							"client_id", _CLIENT_ID_CODE
 						).queryParam(
 							"response_type", "code"
 						)))));
@@ -58,6 +59,8 @@ public class GrantAuthorizationCodeKillSwitchTest extends BaseClientTestCase {
 	protected BundleActivator getBundleActivator() {
 		return new GrantKillClientCredentialsSwitchTestPreparatorBundleActivator();
 	}
+
+	private static final String _CLIENT_ID_CODE = RandomTestUtil.randomString();
 
 	private User _user;
 
@@ -81,7 +84,7 @@ public class GrantAuthorizationCodeKillSwitchTest extends BaseClientTestCase {
 				).build());
 
 			createOAuth2Application(
-				companyId, _user, "oauthTestApplicationCode",
+				companyId, _user, _CLIENT_ID_CODE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
 				Collections.singletonList("everything"));
 		}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/GrantAuthorizationCodePKCEKillSwitchTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/GrantAuthorizationCodePKCEKillSwitchTest.java
@@ -10,6 +10,7 @@ import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.internal.test.TestAnnotatedApplication;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -50,7 +51,7 @@ public class GrantAuthorizationCodePKCEKillSwitchTest
 					null,
 					getCodeFunction(
 						webTarget -> webTarget.queryParam(
-							"client_id", "oauthTestApplicationCodePKCE"
+							"client_id", _CLIENT_ID_CODE_PKCE
 						).queryParam(
 							"code_challenge", "NotChecked"
 						).queryParam(
@@ -62,6 +63,9 @@ public class GrantAuthorizationCodePKCEKillSwitchTest
 	protected BundleActivator getBundleActivator() {
 		return new GrantKillClientCredentialsSwitchTestPreparatorBundleActivator();
 	}
+
+	private static final String _CLIENT_ID_CODE_PKCE =
+		RandomTestUtil.randomString();
 
 	private User _user;
 
@@ -85,7 +89,7 @@ public class GrantAuthorizationCodePKCEKillSwitchTest
 				).build());
 
 			createOAuth2ApplicationWithNone(
-				companyId, _user, "oauthTestApplicationCodePKCE",
+				companyId, _user, _CLIENT_ID_CODE_PKCE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE_PKCE),
 				Collections.singletonList(
 					"http://redirecturi:" +

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/GrantClientKillSwitchTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/GrantClientKillSwitchTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.internal.test.TestAnnotatedApplication;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -39,14 +40,16 @@ public class GrantClientKillSwitchTest extends BaseClientTestCase {
 		Assert.assertEquals(
 			"unauthorized_client",
 			getToken(
-				"oauthTestApplication", null,
-				this::getClientCredentialsResponse, this::parseError));
+				_CLIENT_ID, null, this::getClientCredentialsResponse,
+				this::parseError));
 	}
 
 	@Override
 	protected BundleActivator getBundleActivator() {
 		return new GrantKillClientCredentialsSwitchTestPreparatorBundleActivator();
 	}
+
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
 
 	private class GrantKillClientCredentialsSwitchTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
@@ -67,7 +70,7 @@ public class GrantClientKillSwitchTest extends BaseClientTestCase {
 					"oauth2.scope.checker.type", "annotations"
 				).build());
 
-			createOAuth2Application(companyId, user, "oauthTestApplication");
+			createOAuth2Application(companyId, user, _CLIENT_ID);
 		}
 
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/GrantResourceOwnerKillSwitchTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/GrantResourceOwnerKillSwitchTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.internal.test.TestAnnotatedApplication;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -40,7 +41,7 @@ public class GrantResourceOwnerKillSwitchTest extends BaseClientTestCase {
 		Assert.assertEquals(
 			"unauthorized_client",
 			getToken(
-				"oauthTestApplication", null,
+				_CLIENT_ID, null,
 				getResourceOwnerPasswordBiFunction(
 					"test@liferay.com", PropsValues.DEFAULT_ADMIN_PASSWORD),
 				this::parseError));
@@ -50,6 +51,8 @@ public class GrantResourceOwnerKillSwitchTest extends BaseClientTestCase {
 	protected BundleActivator getBundleActivator() {
 		return new GrantKillClientCredentialsSwitchTestPreparatorBundleActivator();
 	}
+
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
 
 	private class GrantKillClientCredentialsSwitchTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
@@ -71,7 +74,7 @@ public class GrantResourceOwnerKillSwitchTest extends BaseClientTestCase {
 					"oauth2.scope.checker.type", "annotations"
 				).build());
 
-			createOAuth2Application(companyId, user, "oauthTestApplication");
+			createOAuth2Application(companyId, user, _CLIENT_ID);
 		}
 
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/GrantedFlowsTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/GrantedFlowsTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -76,7 +77,7 @@ public class GrantedFlowsTest extends BaseClientTestCase {
 		Assert.assertEquals("unauthorized_client", errorString);
 
 		tokenString = getToken(
-			"oauthTestApplicationCode", null,
+			_CLIENT_ID_CODE, null,
 			getAuthorizationCodeBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
 				null),
@@ -94,7 +95,7 @@ public class GrantedFlowsTest extends BaseClientTestCase {
 		Assert.assertEquals("unauthorized_client", errorString);
 
 		tokenString = getToken(
-			"oauthTestApplicationCodePKCE", null,
+			_CLIENT_ID_CODE_PKCE, null,
 			getAuthorizationCodePKCEBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
 				null),
@@ -108,6 +109,11 @@ public class GrantedFlowsTest extends BaseClientTestCase {
 		return new AnnotatedApplicationTestPreparatorBundleActivator();
 	}
 
+	private static final String _CLIENT_ID_CODE = RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_CODE_PKCE =
+		RandomTestUtil.randomString();
+
 	private User _user;
 
 	private class AnnotatedApplicationTestPreparatorBundleActivator
@@ -120,12 +126,12 @@ public class GrantedFlowsTest extends BaseClientTestCase {
 			_user = UserTestUtil.getAdminUser(companyId);
 
 			createOAuth2Application(
-				companyId, _user, "oauthTestApplicationCode",
+				companyId, _user, _CLIENT_ID_CODE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
 				Collections.singletonList("everything"));
 
 			createOAuth2ApplicationWithNone(
-				companyId, _user, "oauthTestApplicationCodePKCE",
+				companyId, _user, _CLIENT_ID_CODE_PKCE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE_PKCE),
 				Collections.singletonList(
 					"http://redirecturi:" +

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/GrantedFlowsTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/GrantedFlowsTest.java
@@ -40,13 +40,13 @@ public class GrantedFlowsTest extends BaseClientTestCase {
 	@Test
 	public void test() throws Exception {
 		String errorString = getToken(
-			"oauthTestApplicationPassword", null,
-			this::getClientCredentialsResponse, this::parseError);
+			_CLIENT_ID_PASSWORD, null, this::getClientCredentialsResponse,
+			this::parseError);
 
 		Assert.assertEquals("unauthorized_client", errorString);
 
 		String tokenString = getToken(
-			"oauthTestApplicationPassword", null,
+			_CLIENT_ID_PASSWORD, null,
 			getResourceOwnerPasswordBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD),
 			this::parseTokenString);
@@ -54,7 +54,7 @@ public class GrantedFlowsTest extends BaseClientTestCase {
 		Assert.assertNotNull(tokenString);
 
 		errorString = getToken(
-			"oauthTestApplicationClient", null,
+			_CLIENT_ID_CLIENT, null,
 			getResourceOwnerPasswordBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD),
 			this::parseError);
@@ -62,13 +62,13 @@ public class GrantedFlowsTest extends BaseClientTestCase {
 		Assert.assertEquals("unauthorized_client", errorString);
 
 		tokenString = getToken(
-			"oauthTestApplicationClient", null,
-			this::getClientCredentialsResponse, this::parseTokenString);
+			_CLIENT_ID_CLIENT, null, this::getClientCredentialsResponse,
+			this::parseTokenString);
 
 		Assert.assertNotNull(tokenString);
 
 		errorString = getToken(
-			"oauthTestApplicationNoGrants", null,
+			_CLIENT_ID_NO_GRANTS, null,
 			getAuthorizationCodePKCEBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
 				null),
@@ -86,7 +86,7 @@ public class GrantedFlowsTest extends BaseClientTestCase {
 		Assert.assertNotNull(tokenString);
 
 		errorString = getToken(
-			"oauthTestApplicationPassword", null,
+			_CLIENT_ID_PASSWORD, null,
 			getAuthorizationCodeBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
 				null),
@@ -109,9 +109,18 @@ public class GrantedFlowsTest extends BaseClientTestCase {
 		return new AnnotatedApplicationTestPreparatorBundleActivator();
 	}
 
+	private static final String _CLIENT_ID_CLIENT =
+		RandomTestUtil.randomString();
+
 	private static final String _CLIENT_ID_CODE = RandomTestUtil.randomString();
 
 	private static final String _CLIENT_ID_CODE_PKCE =
+		RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_NO_GRANTS =
+		RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_PASSWORD =
 		RandomTestUtil.randomString();
 
 	private User _user;
@@ -139,20 +148,19 @@ public class GrantedFlowsTest extends BaseClientTestCase {
 				false, Collections.singletonList("everything"), false);
 
 			createOAuth2Application(
-				companyId, _user, "oauthTestApplicationClient",
+				companyId, _user, _CLIENT_ID_CLIENT,
 				Collections.singletonList(GrantType.CLIENT_CREDENTIALS),
 				Collections.singletonList("everything"));
 
 			createOAuth2ApplicationWithNone(
-				companyId, _user, "oauthTestApplicationNoGrants",
-				Collections.emptyList(),
+				companyId, _user, _CLIENT_ID_NO_GRANTS, Collections.emptyList(),
 				Collections.singletonList(
 					"http://redirecturi:" +
 						PortalUtil.getPortalServerPort(false)),
 				false, Collections.singletonList("everything"), false);
 
 			createOAuth2Application(
-				companyId, _user, "oauthTestApplicationPassword",
+				companyId, _user, _CLIENT_ID_PASSWORD,
 				Collections.singletonList(GrantType.RESOURCE_OWNER_PASSWORD),
 				Collections.singletonList("everything"));
 		}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/HttpMethodApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/HttpMethodApplicationClientTest.java
@@ -10,6 +10,7 @@ import com.liferay.oauth2.provider.internal.test.TestApplication;
 import com.liferay.oauth2.provider.internal.test.TestHeadHandlingApplication;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -50,7 +51,7 @@ public class HttpMethodApplicationClientTest extends BaseClientTestCase {
 		WebTarget webTarget = getWebTarget("/methods");
 
 		Invocation.Builder builder = authorize(
-			webTarget.request(), getToken("oauthTestApplicationAfter"));
+			webTarget.request(), getToken(_CLIENT_ID_AFTER));
 
 		Assert.assertEquals("get", builder.get(String.class));
 
@@ -59,8 +60,7 @@ public class HttpMethodApplicationClientTest extends BaseClientTestCase {
 
 		Assert.assertEquals("post", response.readEntity(String.class));
 
-		builder = authorize(
-			webTarget.request(), getToken("oauthTestApplicationBefore"));
+		builder = authorize(webTarget.request(), getToken(_CLIENT_ID_BEFORE));
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 				"portal_web.docroot.errors.code_jsp", LoggerTestUtil.WARN)) {
@@ -70,7 +70,7 @@ public class HttpMethodApplicationClientTest extends BaseClientTestCase {
 			Assert.assertEquals(403, response.getStatus());
 
 			builder = authorize(
-				webTarget.request(), getToken("oauthTestApplicationWrong"));
+				webTarget.request(), getToken(_CLIENT_ID_WRONG));
 
 			response = builder.get();
 
@@ -83,7 +83,7 @@ public class HttpMethodApplicationClientTest extends BaseClientTestCase {
 		WebTarget webTarget = getWebTarget("/methods");
 
 		Invocation.Builder builder = authorize(
-			webTarget.request(), getToken("oauthTestApplicationBefore"));
+			webTarget.request(), getToken(_CLIENT_ID_BEFORE));
 
 		Response response = builder.head();
 
@@ -91,15 +91,13 @@ public class HttpMethodApplicationClientTest extends BaseClientTestCase {
 
 		webTarget = getWebTarget("/methods-with-ignore-missing-scopes-empty");
 
-		builder = authorize(
-			webTarget.request(), getToken("oauthTestApplicationBefore"));
+		builder = authorize(webTarget.request(), getToken(_CLIENT_ID_BEFORE));
 
 		response = builder.head();
 
 		Assert.assertEquals(403, response.getStatus());
 
-		builder = authorize(
-			webTarget.request(), getToken("oauthTestApplicationAfter"));
+		builder = authorize(webTarget.request(), getToken(_CLIENT_ID_AFTER));
 
 		response = builder.head();
 
@@ -107,22 +105,21 @@ public class HttpMethodApplicationClientTest extends BaseClientTestCase {
 
 		webTarget = getWebTarget("/methods-with-head");
 
-		builder = authorize(
-			webTarget.request(), getToken("oauthTestApplicationAfter"));
+		builder = authorize(webTarget.request(), getToken(_CLIENT_ID_AFTER));
 
 		response = builder.head();
 
 		Assert.assertEquals(403, response.getStatus());
 
 		builder = authorize(
-			webTarget.request(), getToken("oauthTestApplicationWithHead"));
+			webTarget.request(), getToken(_CLIENT_ID_WITH_HEAD));
 
 		response = builder.head();
 
 		Assert.assertEquals(200, response.getStatus());
 
 		builder = authorize(
-			webTarget.request(), getToken("oauthTestApplicationWithHead"));
+			webTarget.request(), getToken(_CLIENT_ID_WITH_HEAD));
 
 		response = builder.method("CUSTOM");
 
@@ -134,6 +131,18 @@ public class HttpMethodApplicationClientTest extends BaseClientTestCase {
 		return new MethodApplicationTestPreparatorBundleActivator();
 	}
 
+	private static final String _CLIENT_ID_AFTER =
+		RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_BEFORE =
+		RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_WITH_HEAD =
+		RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_WRONG =
+		RandomTestUtil.randomString();
+
 	private class MethodApplicationTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
 
@@ -144,7 +153,7 @@ public class HttpMethodApplicationClientTest extends BaseClientTestCase {
 			User user = UserTestUtil.getAdminUser(companyId);
 
 			createOAuth2Application(
-				companyId, user, "oauthTestApplicationBefore",
+				companyId, user, _CLIENT_ID_BEFORE,
 				Arrays.asList("GET", "POST"));
 
 			registerJaxRsApplication(new TestApplication(), "methods", null);
@@ -160,15 +169,14 @@ public class HttpMethodApplicationClientTest extends BaseClientTestCase {
 				).build());
 
 			createOAuth2Application(
-				companyId, user, "oauthTestApplicationAfter",
+				companyId, user, _CLIENT_ID_AFTER,
 				Arrays.asList("GET", "POST"));
 
 			createOAuth2Application(
-				companyId, user, "oauthTestApplicationWithHead",
-				Arrays.asList("HEAD"));
+				companyId, user, _CLIENT_ID_WITH_HEAD, Arrays.asList("HEAD"));
 
 			createOAuth2Application(
-				companyId, user, "oauthTestApplicationWrong",
+				companyId, user, _CLIENT_ID_WRONG,
 				Collections.singletonList("everything"));
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/IsolationAcrossCompaniesTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/IsolationAcrossCompaniesTest.java
@@ -11,6 +11,7 @@ import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.test.log.LogCapture;
@@ -45,7 +46,7 @@ public class IsolationAcrossCompaniesTest extends BaseClientTestCase {
 	public void testAnnotated() throws Exception {
 		WebTarget webTarget = getWebTarget("/annotated");
 
-		String tokenString = getToken("oauthTestApplication", "host1.xyz");
+		String tokenString = getToken(_CLIENT_ID, "host1.xyz");
 
 		Invocation.Builder builder = authorize(
 			webTarget.request(), tokenString);
@@ -73,7 +74,7 @@ public class IsolationAcrossCompaniesTest extends BaseClientTestCase {
 	public void testNoScopes() throws Exception {
 		WebTarget webTarget = getWebTarget("/no-scopes");
 
-		String tokenString = getToken("oauthTestApplication", "host1.xyz");
+		String tokenString = getToken(_CLIENT_ID, "host1.xyz");
 
 		Invocation.Builder builder = authorize(
 			webTarget.request(), tokenString);
@@ -102,6 +103,8 @@ public class IsolationAcrossCompaniesTest extends BaseClientTestCase {
 		return new IsolationAccrossCompaniesTestPreparatorBundleActivator();
 	}
 
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
+
 	private class IsolationAccrossCompaniesTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
 
@@ -128,7 +131,7 @@ public class IsolationAcrossCompaniesTest extends BaseClientTestCase {
 				createOAuth2Application(
 					company1.getCompanyId(),
 					UserTestUtil.getAdminUser(company1.getCompanyId()),
-					"oauthTestApplication");
+					_CLIENT_ID);
 			}
 
 			Company company2 = createCompany("host2");
@@ -140,7 +143,7 @@ public class IsolationAcrossCompaniesTest extends BaseClientTestCase {
 				createOAuth2Application(
 					company2.getCompanyId(),
 					UserTestUtil.getAdminUser(company2.getCompanyId()),
-					"oauthTestApplication");
+					_CLIENT_ID);
 			}
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/JsonWebServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/JsonWebServiceTest.java
@@ -10,6 +10,7 @@ import com.liferay.portal.json.JSONObjectImpl;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -71,7 +72,7 @@ public class JsonWebServiceTest extends BaseClientTestCase {
 		}
 
 		String tokenString = getToken(
-			"oauthTestApplicationRO", null,
+			_CLIENT_ID_RO, null,
 			getResourceOwnerPasswordBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD),
 			this::parseTokenString);
@@ -106,7 +107,7 @@ public class JsonWebServiceTest extends BaseClientTestCase {
 		}
 
 		String token = getToken(
-			"oauthTestApplicationRW", null,
+			_CLIENT_ID_RW, null,
 			getResourceOwnerPasswordBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
 				"everything.write"),
@@ -142,6 +143,10 @@ public class JsonWebServiceTest extends BaseClientTestCase {
 		return new JsonWebServiceTestPreparatorBundleActivator();
 	}
 
+	private static final String _CLIENT_ID_RO = RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_RW = RandomTestUtil.randomString();
+
 	private User _user;
 
 	private class JsonWebServiceTestPreparatorBundleActivator
@@ -156,11 +161,11 @@ public class JsonWebServiceTest extends BaseClientTestCase {
 			createCompany("testcompany");
 
 			createOAuth2Application(
-				companyId, _user, "oauthTestApplicationRO",
+				companyId, _user, _CLIENT_ID_RO,
 				Collections.singletonList("everything.read"));
 
 			createOAuth2Application(
-				companyId, _user, "oauthTestApplicationRW",
+				companyId, _user, _CLIENT_ID_RW,
 				Arrays.asList("everything.read", "everything.write"));
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/JsonWebServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/JsonWebServiceTest.java
@@ -72,7 +72,7 @@ public class JsonWebServiceTest extends BaseClientTestCase {
 		}
 
 		String tokenString = getToken(
-			_CLIENT_ID_RO, null,
+			_CLIENT_ID_READ_ONLY, null,
 			getResourceOwnerPasswordBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD),
 			this::parseTokenString);
@@ -107,7 +107,7 @@ public class JsonWebServiceTest extends BaseClientTestCase {
 		}
 
 		String token = getToken(
-			_CLIENT_ID_RW, null,
+			_CLIENT_ID_READ_WRITE, null,
 			getResourceOwnerPasswordBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
 				"everything.write"),
@@ -143,9 +143,11 @@ public class JsonWebServiceTest extends BaseClientTestCase {
 		return new JsonWebServiceTestPreparatorBundleActivator();
 	}
 
-	private static final String _CLIENT_ID_RO = RandomTestUtil.randomString();
+	private static final String _CLIENT_ID_READ_ONLY =
+		RandomTestUtil.randomString();
 
-	private static final String _CLIENT_ID_RW = RandomTestUtil.randomString();
+	private static final String _CLIENT_ID_READ_WRITE =
+		RandomTestUtil.randomString();
 
 	private User _user;
 
@@ -161,11 +163,11 @@ public class JsonWebServiceTest extends BaseClientTestCase {
 			createCompany("testcompany");
 
 			createOAuth2Application(
-				companyId, _user, _CLIENT_ID_RO,
+				companyId, _user, _CLIENT_ID_READ_ONLY,
 				Collections.singletonList("everything.read"));
 
 			createOAuth2Application(
-				companyId, _user, _CLIENT_ID_RW,
+				companyId, _user, _CLIENT_ID_READ_WRITE,
 				Arrays.asList("everything.read", "everything.write"));
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/NarrowDownScopeClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/NarrowDownScopeClientTest.java
@@ -11,6 +11,7 @@ import com.liferay.oauth2.provider.internal.test.TestApplication;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -51,7 +52,7 @@ public class NarrowDownScopeClientTest extends BaseClientTestCase {
 		Assert.assertEquals(
 			"GET",
 			getToken(
-				"oauthTestApplication", null,
+				_CLIENT_ID, null,
 				getAuthorizationCodeBiFunction(
 					_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
 					null, "GET"),
@@ -60,12 +61,11 @@ public class NarrowDownScopeClientTest extends BaseClientTestCase {
 		Assert.assertEquals(
 			"GET",
 			getToken(
-				"oauthTestApplication", null,
-				getClientCredentialsResponseBiFunction("GET"),
+				_CLIENT_ID, null, getClientCredentialsResponseBiFunction("GET"),
 				this::parseScopeString));
 
 		Response response = getToken(
-			"oauthTestApplication", null,
+			_CLIENT_ID, null,
 			getResourceOwnerPasswordBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
 				"GET"),
@@ -86,7 +86,7 @@ public class NarrowDownScopeClientTest extends BaseClientTestCase {
 		Assert.assertEquals(403, postResponse.getStatus());
 
 		String scopeString = getToken(
-			"oauthTestApplication", null,
+			_CLIENT_ID, null,
 			getResourceOwnerPasswordBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD),
 			this::parseScopeString);
@@ -98,7 +98,7 @@ public class NarrowDownScopeClientTest extends BaseClientTestCase {
 		Assert.assertEquals(
 			"invalid_grant",
 			getToken(
-				"oauthTestApplication", null,
+				_CLIENT_ID, null,
 				getResourceOwnerPasswordBiFunction(
 					_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
 					"GET POST PUT"),
@@ -109,6 +109,8 @@ public class NarrowDownScopeClientTest extends BaseClientTestCase {
 	protected BundleActivator getBundleActivator() {
 		return new NarrowDownScopeTestPreparatorBundleActivator();
 	}
+
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
 
 	private User _user;
 
@@ -128,7 +130,7 @@ public class NarrowDownScopeClientTest extends BaseClientTestCase {
 				).build());
 
 			createOAuth2Application(
-				companyId, _user, "oauthTestApplication",
+				companyId, _user, _CLIENT_ID,
 				Arrays.asList(
 					GrantType.AUTHORIZATION_CODE, GrantType.CLIENT_CREDENTIALS,
 					GrantType.RESOURCE_OWNER_PASSWORD),

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/OAuth2AuthorizationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/OAuth2AuthorizationClientTest.java
@@ -55,7 +55,7 @@ public class OAuth2AuthorizationClientTest extends BaseClientTestCase {
 		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
 
 		formData.add("client_id", "oauthTestApplication");
-		formData.add("client_secret", "oauthTestApplicationSecret");
+		formData.add("client_secret", CLIENT_SECRET);
 		formData.add("grant_type", "client_credentials");
 
 		String tokenString = parseTokenString(

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/OAuth2AuthorizationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/OAuth2AuthorizationClientTest.java
@@ -10,6 +10,7 @@ import com.liferay.oauth2.provider.internal.test.TestAnnotatedApplication;
 import com.liferay.oauth2.provider.model.OAuth2Authorization;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -54,7 +55,7 @@ public class OAuth2AuthorizationClientTest extends BaseClientTestCase {
 
 		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
 
-		formData.add("client_id", "oauthTestApplication");
+		formData.add("client_id", _CLIENT_ID);
 		formData.add("client_secret", CLIENT_SECRET);
 		formData.add("grant_type", "client_credentials");
 
@@ -85,6 +86,8 @@ public class OAuth2AuthorizationClientTest extends BaseClientTestCase {
 		return new ExpiredAuthorizationTestPreparator();
 	}
 
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
+
 	private class ExpiredAuthorizationTestPreparator
 		extends BaseTestPreparatorBundleActivator {
 
@@ -102,7 +105,7 @@ public class OAuth2AuthorizationClientTest extends BaseClientTestCase {
 					"oauth2.scope.checker.type", "annotations"
 				).build());
 
-			createOAuth2Application(companyId, user, "oauthTestApplication");
+			createOAuth2Application(companyId, user, _CLIENT_ID);
 		}
 
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/OAuth2WebServerServletTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/OAuth2WebServerServletTest.java
@@ -17,6 +17,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -59,7 +60,7 @@ public class OAuth2WebServerServletTest extends BaseClientTestCase {
 
 	@Test
 	public void test() throws Exception {
-		String tokenString = getToken("oauthTestApplication");
+		String tokenString = getToken(_CLIENT_ID);
 
 		WebTarget webTarget = getWebTarget("/preview-url");
 
@@ -108,6 +109,8 @@ public class OAuth2WebServerServletTest extends BaseClientTestCase {
 					PortalUtil.getPortalServerPort(false), path)));
 	}
 
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
+
 	private static final String _TEST_FILE_CONTENT = "Test File Content";
 
 	@Inject
@@ -140,7 +143,7 @@ public class OAuth2WebServerServletTest extends BaseClientTestCase {
 				).build());
 
 			createOAuth2Application(
-				TestPropsValues.getCompanyId(), user, "oauthTestApplication",
+				TestPropsValues.getCompanyId(), user, _CLIENT_ID,
 				Collections.singletonList(GrantType.CLIENT_CREDENTIALS),
 				Arrays.asList("GET", "everything.read.documents.download"));
 		}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/RememberDeviceApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/RememberDeviceApplicationClientTest.java
@@ -50,7 +50,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 
 	@Test
 	public void testCookieResponseApplicationCode() {
-		String applicationClientId = "oauthTestApplicationCode";
+		String applicationClientId = _CLIENT_ID_CODE;
 
 		Response response = getCodeResponse(
 			_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD, null,
@@ -74,7 +74,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 
 	@Test
 	public void testCookieResponseApplicationCodePKCE() {
-		String applicationClientId = "oauthTestApplicationCodePKCE";
+		String applicationClientId = _CLIENT_ID_CODE_PKCE;
 
 		Response response = getCodeResponse(
 			_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD, null,
@@ -816,6 +816,11 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 		return multivaluedMap;
 	}
 
+	private static final String _CLIENT_ID_CODE = RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_CODE_PKCE =
+		RandomTestUtil.randomString();
+
 	private static final String _COOKIE_NAME_PREFIX = "OAUTH2_REMEMBER_DEVICE_";
 
 	@Inject
@@ -833,11 +838,11 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 			_user = UserTestUtil.getAdminUser(companyId);
 
 			createOAuth2Application(
-				companyId, _user, "oauthTestApplicationCode",
+				companyId, _user, _CLIENT_ID_CODE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE), false,
 				Collections.singletonList("everything"), false);
 			createOAuth2ApplicationWithNone(
-				companyId, _user, "oauthTestApplicationCodePKCE",
+				companyId, _user, _CLIENT_ID_CODE_PKCE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE_PKCE),
 				Collections.singletonList(
 					"http://redirecturi:" +

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/RememberDeviceApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/RememberDeviceApplicationClientTest.java
@@ -136,7 +136,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 					new MultivaluedHashMap<>();
 
 				formData.add("client_id", applicationClientId);
-				formData.add("client_secret", "oauthTestApplicationSecret");
+				formData.add("client_secret", CLIENT_SECRET);
 				formData.add("code", authorizationCodeString);
 				formData.add("grant_type", "authorization_code");
 
@@ -276,7 +276,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 					new MultivaluedHashMap<>();
 
 				formData.add("client_id", applicationClientId);
-				formData.add("client_secret", "oauthTestApplicationSecret");
+				formData.add("client_secret", CLIENT_SECRET);
 				formData.add("code", parseAuthorizationCodeString(response1));
 				formData.add("grant_type", "authorization_code");
 
@@ -309,7 +309,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 					new MultivaluedHashMap<>();
 
 				formData.add("client_id", applicationClientId);
-				formData.add("client_secret", "oauthTestApplicationSecret");
+				formData.add("client_secret", CLIENT_SECRET);
 				formData.add("code", parseAuthorizationCodeString(response2));
 				formData.add("grant_type", "authorization_code");
 
@@ -392,7 +392,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 					new MultivaluedHashMap<>();
 
 				formData.add("client_id", applicationClientId);
-				formData.add("client_secret", "oauthTestApplicationSecret");
+				formData.add("client_secret", CLIENT_SECRET);
 				formData.add("code", parseAuthorizationCodeString(response2));
 				formData.add("grant_type", "authorization_code");
 
@@ -439,7 +439,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 						new MultivaluedHashMap<>();
 
 					formData.add("client_id", applicationClientId);
-					formData.add("client_secret", "oauthTestApplicationSecret");
+					formData.add("client_secret", CLIENT_SECRET);
 					formData.add(
 						"code", parseAuthorizationCodeString(response));
 					formData.add("grant_type", "authorization_code");
@@ -569,7 +569,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 					new MultivaluedHashMap<>();
 
 				formData1.add("client_id", applicationClientId);
-				formData1.add("client_secret", "oauthTestApplicationSecret");
+				formData1.add("client_secret", CLIENT_SECRET);
 				formData1.add("code", parseAuthorizationCodeString(response1));
 				formData1.add("grant_type", "authorization_code");
 
@@ -601,7 +601,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 						new MultivaluedHashMap<>();
 
 					formData.add("client_id", applicationClientId);
-					formData.add("client_secret", "oauthTestApplicationSecret");
+					formData.add("client_secret", CLIENT_SECRET);
 					formData.add(
 						"code", parseAuthorizationCodeString(response2));
 					formData.add("grant_type", "authorization_code");
@@ -767,7 +767,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 					new MultivaluedHashMap<>();
 
 				formData.add("client_id", applicationClientId);
-				formData.add("client_secret", "oauthTestApplicationSecret");
+				formData.add("client_secret", CLIENT_SECRET);
 				formData.add("grant_type", "authorization_code");
 				formData.add("code", authorizationCodeString);
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/RememberDeviceApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/RememberDeviceApplicationClientTest.java
@@ -101,7 +101,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 
 	@Test
 	public void testRememberApplicationCode() {
-		String applicationClientId = "oauthTestRememberApplicationCode";
+		String applicationClientId = _CLIENT_ID_REMEMBER_CODE;
 
 		String cookieName = _COOKIE_NAME_PREFIX.concat(applicationClientId);
 
@@ -171,7 +171,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 
 	@Test
 	public void testRememberApplicationCodePKCE() {
-		String applicationClientId = "oauthTestRememberApplicationCodePKCE";
+		String applicationClientId = _CLIENT_ID_REMEMBER_CODE_PKCE;
 
 		String cookieName = _COOKIE_NAME_PREFIX.concat(applicationClientId);
 
@@ -247,7 +247,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 
 	@Test
 	public void testRequestTokenInvalidatePreviousTokenRememberApplicationCode() {
-		String applicationClientId = "oauthTestRememberApplicationCode";
+		String applicationClientId = _CLIENT_ID_REMEMBER_CODE;
 
 		String cookieName = _COOKIE_NAME_PREFIX.concat(applicationClientId);
 
@@ -324,7 +324,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 
 	@Test
 	public void testRequestTokenInvalidatePreviousTokenRememberApplicationCodePKCE() {
-		String applicationClientId = "oauthTestRememberApplicationCodePKCE";
+		String applicationClientId = _CLIENT_ID_REMEMBER_CODE_PKCE;
 
 		String cookieName = _COOKIE_NAME_PREFIX.concat(applicationClientId);
 
@@ -409,7 +409,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 	public void testRevokeTokenInvalidateCookieRememberApplicationCode()
 		throws PortalException {
 
-		String applicationClientId = "oauthTestRememberApplicationCode";
+		String applicationClientId = _CLIENT_ID_REMEMBER_CODE;
 
 		String cookieName = _COOKIE_NAME_PREFIX.concat(applicationClientId);
 
@@ -472,7 +472,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 	public void testRevokeTokenInvalidateCookieRememberApplicationCodePKCE()
 		throws PortalException {
 
-		String applicationClientId = "oauthTestRememberApplicationCodePKCE";
+		String applicationClientId = _CLIENT_ID_REMEMBER_CODE_PKCE;
 
 		String cookieName = _COOKIE_NAME_PREFIX.concat(applicationClientId);
 
@@ -540,7 +540,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 
 	@Test
 	public void testSingleUseCookieRememberApplicationCode() {
-		String applicationClientId = "oauthTestRememberApplicationCode";
+		String applicationClientId = _CLIENT_ID_REMEMBER_CODE;
 
 		String cookieName = _COOKIE_NAME_PREFIX.concat(applicationClientId);
 
@@ -632,7 +632,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 
 	@Test
 	public void testSingleUseCookieRememberApplicationCodePKCE() {
-		String applicationClientId = "oauthTestRememberApplicationCodePKCE";
+		String applicationClientId = _CLIENT_ID_REMEMBER_CODE_PKCE;
 
 		String cookieName = _COOKIE_NAME_PREFIX.concat(applicationClientId);
 
@@ -736,7 +736,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 
 	@Test
 	public void testUseExistingDifferentCookieRememberApplicationCode() {
-		String applicationClientId = "oauthTestRememberApplicationCode";
+		String applicationClientId = _CLIENT_ID_REMEMBER_CODE;
 
 		String cookieName = _COOKIE_NAME_PREFIX.concat(applicationClientId);
 
@@ -775,7 +775,7 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 			},
 			this::parseTokenString);
 
-		String applicationClientIdPKCE = "oauthTestRememberApplicationCodePKCE";
+		String applicationClientIdPKCE = _CLIENT_ID_REMEMBER_CODE_PKCE;
 
 		Assert.assertNull(
 			parseAuthorizationCodeString(
@@ -821,6 +821,12 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 	private static final String _CLIENT_ID_CODE_PKCE =
 		RandomTestUtil.randomString();
 
+	private static final String _CLIENT_ID_REMEMBER_CODE =
+		RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_REMEMBER_CODE_PKCE =
+		RandomTestUtil.randomString();
+
 	private static final String _COOKIE_NAME_PREFIX = "OAUTH2_REMEMBER_DEVICE_";
 
 	@Inject
@@ -849,11 +855,11 @@ public class RememberDeviceApplicationClientTest extends BaseClientTestCase {
 						PortalUtil.getPortalServerPort(false)),
 				false, Collections.singletonList("everything"), false);
 			createOAuth2Application(
-				companyId, _user, "oauthTestRememberApplicationCode",
+				companyId, _user, _CLIENT_ID_REMEMBER_CODE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE), true,
 				Collections.singletonList("everything"), false);
 			createOAuth2ApplicationWithNone(
-				companyId, _user, "oauthTestRememberApplicationCodePKCE",
+				companyId, _user, _CLIENT_ID_REMEMBER_CODE_PKCE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE_PKCE),
 				Collections.singletonList(
 					"http://redirecturi:" +

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/RevokedTokenTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/RevokedTokenTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -44,7 +45,7 @@ public class RevokedTokenTest extends BaseClientTestCase {
 		WebTarget webTarget = getJsonWebTarget("user", "get-current-user");
 
 		String tokenString = getToken(
-			"oauthTestApplication", null,
+			_CLIENT_ID, null,
 			getResourceOwnerPasswordBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD),
 			this::parseTokenString);
@@ -74,6 +75,8 @@ public class RevokedTokenTest extends BaseClientTestCase {
 		return new RevokedTokenTestPreparatorBundleActivator();
 	}
 
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
+
 	private User _user;
 
 	private class RevokedTokenTestPreparatorBundleActivator
@@ -86,7 +89,7 @@ public class RevokedTokenTest extends BaseClientTestCase {
 			_user = UserTestUtil.getAdminUser(companyId);
 
 			createOAuth2Application(
-				companyId, _user, "oauthTestApplication",
+				companyId, _user, _CLIENT_ID,
 				Collections.singletonList("everything.read"));
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SAPClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SAPClientTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.internal.test.TestSAPApplication;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -43,28 +44,25 @@ public class SAPClientTest extends BaseClientTestCase {
 		WebTarget webTarget = getWebTarget("SAP/AUTHORIZED_OAUTH2_SAP");
 
 		Invocation.Builder builder = authorize(
-			webTarget.request(), getToken("oauthTestApplication"));
+			webTarget.request(), getToken(_CLIENT_ID));
 
 		Assert.assertTrue(builder.get(Boolean.class));
 
 		webTarget = getWebTarget("SAP/CUSTOM_SAP");
 
-		builder = authorize(
-			webTarget.request(), getToken("oauthTestApplication"));
+		builder = authorize(webTarget.request(), getToken(_CLIENT_ID));
 
 		Assert.assertFalse(builder.get(Boolean.class));
 
 		webTarget = getWebTarget("CUSTOM_SAP/AUTHORIZED_OAUTH2_SAP");
 
-		builder = authorize(
-			webTarget.request(), getToken("oauthTestApplication"));
+		builder = authorize(webTarget.request(), getToken(_CLIENT_ID));
 
 		Assert.assertFalse(builder.get(Boolean.class));
 
 		webTarget = getWebTarget("CUSTOM_SAP/CUSTOM_SAP");
 
-		builder = authorize(
-			webTarget.request(), getToken("oauthTestApplication"));
+		builder = authorize(webTarget.request(), getToken(_CLIENT_ID));
 
 		Assert.assertTrue(builder.get(Boolean.class));
 	}
@@ -73,6 +71,8 @@ public class SAPClientTest extends BaseClientTestCase {
 	protected BundleActivator getBundleActivator() {
 		return new SAPTestPreparatorBundleActivator();
 	}
+
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
 
 	private class SAPTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
@@ -98,8 +98,7 @@ public class SAPClientTest extends BaseClientTestCase {
 				).build());
 
 			createOAuth2Application(
-				companyId, user, "oauthTestApplication",
-				Collections.singletonList("GET"));
+				companyId, user, _CLIENT_ID, Collections.singletonList("GET"));
 
 			createServiceAccessProfile(
 				user.getUserId(), "#is*", false, true, "CUSTOM_SAP");

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeCheckerGuestAllowedTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeCheckerGuestAllowedTest.java
@@ -13,6 +13,7 @@ import com.liferay.oauth2.provider.internal.test.TestApplication;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
@@ -122,11 +123,13 @@ public class ScopeCheckerGuestAllowedTest extends BaseClientTestCase {
 		}
 
 		invocationBuilder = authorize(
-			webTarget.request(), getToken("oauthTestApplication"));
+			webTarget.request(), getToken(_CLIENT_ID));
 
 		Assert.assertEquals(
 			expectedValidTokenResponse, invocationBuilder.get(String.class));
 	}
+
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
 
 	private static final String[] _INVALID_TOKENS = {
 		OAuth2AuthorizationConstants.ACCESS_TOKEN_CONTENT_EXPIRED_TOKEN,
@@ -203,7 +206,7 @@ public class ScopeCheckerGuestAllowedTest extends BaseClientTestCase {
 			User user = UserTestUtil.getAdminUser(companyId);
 
 			createOAuth2Application(
-				companyId, user, "oauthTestApplication",
+				companyId, user, _CLIENT_ID,
 				Collections.singletonList(GrantType.CLIENT_CREDENTIALS),
 				Arrays.asList("everything.read", "GET"));
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeFinderTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeFinderTest.java
@@ -49,7 +49,7 @@ public class ScopeFinderTest extends BaseClientTestCase {
 	@Test
 	public void testUnavailableAssignedScopeAliases() throws Exception {
 		String token = getToken(
-			"oauthTestClientCredentials", null,
+			_CLIENT_ID_CLIENT_CREDENTIALS, null,
 			this::getClientCredentialsResponse, this::parseTokenString);
 
 		Assert.assertNotNull(token);
@@ -78,7 +78,7 @@ public class ScopeFinderTest extends BaseClientTestCase {
 		invocationBuilder = authorize(
 			webTarget.request(),
 			getToken(
-				"oauthTestClientCredentials", null,
+				_CLIENT_ID_CLIENT_CREDENTIALS, null,
 				this::getClientCredentialsResponse, this::parseTokenString));
 
 		Assert.assertEquals(
@@ -129,6 +129,9 @@ public class ScopeFinderTest extends BaseClientTestCase {
 
 	private static final String _CLIENT_ID = RandomTestUtil.randomString();
 
+	private static final String _CLIENT_ID_CLIENT_CREDENTIALS =
+		RandomTestUtil.randomString();
+
 	private long _oAuth2ApplicationId;
 
 	@Inject
@@ -168,7 +171,7 @@ public class ScopeFinderTest extends BaseClientTestCase {
 			User user = UserTestUtil.getAdminUser(companyId);
 
 			createOAuth2Application(
-				companyId, user, "oauthTestClientCredentials",
+				companyId, user, _CLIENT_ID_CLIENT_CREDENTIALS,
 				Collections.singletonList(GrantType.CLIENT_CREDENTIALS),
 				Collections.singletonList("everything.read"));
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeFinderTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeFinderTest.java
@@ -14,6 +14,7 @@ import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -92,8 +93,8 @@ public class ScopeFinderTest extends BaseClientTestCase {
 		invocationBuilder = authorize(
 			webTarget.request(),
 			getToken(
-				"oauthTestApplication", null,
-				this::getClientCredentialsResponse, this::parseTokenString));
+				_CLIENT_ID, null, this::getClientCredentialsResponse,
+				this::parseTokenString));
 
 		Assert.assertEquals(
 			200,
@@ -112,8 +113,8 @@ public class ScopeFinderTest extends BaseClientTestCase {
 		invocationBuilder = authorize(
 			webTarget.request(),
 			getToken(
-				"oauthTestApplication", null,
-				this::getClientCredentialsResponse, this::parseTokenString));
+				_CLIENT_ID, null, this::getClientCredentialsResponse,
+				this::parseTokenString));
 
 		Assert.assertEquals(
 			403,
@@ -125,6 +126,8 @@ public class ScopeFinderTest extends BaseClientTestCase {
 	protected BundleActivator getBundleActivator() {
 		return new ScopeFinderTestPreparatorBundleActivator();
 	}
+
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
 
 	private long _oAuth2ApplicationId;
 
@@ -170,7 +173,7 @@ public class ScopeFinderTest extends BaseClientTestCase {
 				Collections.singletonList("everything.read"));
 
 			OAuth2Application oAuth2Application = createOAuth2Application(
-				companyId, user, "oauthTestApplication",
+				companyId, user, _CLIENT_ID,
 				Collections.singletonList(
 					"Liferay.Captcha.REST.everything.read"));
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeMapperNarrowDownClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeMapperNarrowDownClientTest.java
@@ -64,7 +64,7 @@ public class ScopeMapperNarrowDownClientTest extends BaseClientTestCase {
 		Assert.assertEquals("invalid_grant", error);
 
 		String scopeString = getToken(
-			"oauthTestApplicationNarrowed", null,
+			_CLIENT_ID_NARROWED, null,
 			getClientCredentialsResponseBiFunction("everything"),
 			this::parseScopeString);
 
@@ -73,7 +73,7 @@ public class ScopeMapperNarrowDownClientTest extends BaseClientTestCase {
 		invocationBuilder = authorize(
 			webTarget.request(),
 			getToken(
-				"oauthTestApplicationNarrowed", null,
+				_CLIENT_ID_NARROWED, null,
 				getClientCredentialsResponseBiFunction("everything"),
 				this::parseTokenString));
 
@@ -81,7 +81,7 @@ public class ScopeMapperNarrowDownClientTest extends BaseClientTestCase {
 			"everything.read", invocationBuilder.get(String.class));
 
 		scopeString = getToken(
-			"oauthTestApplicationNarrowed", null,
+			_CLIENT_ID_NARROWED, null,
 			getClientCredentialsResponseBiFunction("everything.read"),
 			this::parseScopeString);
 
@@ -90,7 +90,7 @@ public class ScopeMapperNarrowDownClientTest extends BaseClientTestCase {
 		invocationBuilder = authorize(
 			webTarget.request(),
 			getToken(
-				"oauthTestApplicationNarrowed", null,
+				_CLIENT_ID_NARROWED, null,
 				getClientCredentialsResponseBiFunction("everything.read"),
 				this::parseTokenString));
 
@@ -104,6 +104,9 @@ public class ScopeMapperNarrowDownClientTest extends BaseClientTestCase {
 	}
 
 	private static final String _CLIENT_ID = RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_NARROWED =
+		RandomTestUtil.randomString();
 
 	private class ScopeMapperNarrowDownClientTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
@@ -135,7 +138,7 @@ public class ScopeMapperNarrowDownClientTest extends BaseClientTestCase {
 				Collections.singletonList("everything"));
 
 			createOAuth2Application(
-				companyId, user, "oauthTestApplicationNarrowed",
+				companyId, user, _CLIENT_ID_NARROWED,
 				Arrays.asList("everything", "everything.read"));
 		}
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeMapperNarrowDownClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/ScopeMapperNarrowDownClientTest.java
@@ -10,6 +10,7 @@ import com.liferay.oauth2.provider.internal.test.TestAnnotatedApplication;
 import com.liferay.oauth2.provider.internal.test.TestApplication;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -48,7 +49,7 @@ public class ScopeMapperNarrowDownClientTest extends BaseClientTestCase {
 		Invocation.Builder invocationBuilder = authorize(
 			webTarget.request(),
 			getToken(
-				"oauthTestApplication", null,
+				_CLIENT_ID, null,
 				getClientCredentialsResponseBiFunction("everything"),
 				this::parseTokenString));
 
@@ -56,7 +57,7 @@ public class ScopeMapperNarrowDownClientTest extends BaseClientTestCase {
 			"everything.read", invocationBuilder.get(String.class));
 
 		String error = getToken(
-			"oauthTestApplication", null,
+			_CLIENT_ID, null,
 			getClientCredentialsResponseBiFunction("everything.read"),
 			this::parseError);
 
@@ -102,6 +103,8 @@ public class ScopeMapperNarrowDownClientTest extends BaseClientTestCase {
 		return new ScopeMapperNarrowDownClientTestPreparatorBundleActivator();
 	}
 
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
+
 	private class ScopeMapperNarrowDownClientTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
 
@@ -128,7 +131,7 @@ public class ScopeMapperNarrowDownClientTest extends BaseClientTestCase {
 				applicationProperties);
 
 			createOAuth2Application(
-				companyId, user, "oauthTestApplication",
+				companyId, user, _CLIENT_ID,
 				Collections.singletonList("everything"));
 
 			createOAuth2Application(

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
@@ -13,17 +13,21 @@ import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 
 import java.net.URI;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.junit.Assert;
 import org.junit.ClassRule;
@@ -44,6 +48,54 @@ public class SecurityTest extends BaseClientTestCase {
 	@Rule
 	public static final AggregateTestRule aggregateTestRule =
 		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testEscapeOAuth2ApplicationName() {
+		Function<WebTarget, Invocation.Builder> invocationBuilderFunction =
+			getAuthenticatedInvocationBuilderFunction(
+				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
+				null);
+
+		Response response = getCodeFunction(
+			webTarget -> webTarget.queryParam(
+				"client_id", "oauthTestApplicationUnescapedName"
+			).queryParam(
+				"response_type", "code"
+			),
+			true
+		).apply(
+			invocationBuilderFunction
+		);
+
+		URI uri = response.getLocation();
+
+		if (uri == null) {
+			throw new IllegalArgumentException(
+				"Authorization service response missing \"Location\" header " +
+					"from which the authorization page URL is extracted");
+		}
+
+		WebTarget webTarget = getWebTarget();
+
+		webTarget = webTarget.path(uri.getPath());
+
+		Map<String, String[]> parameterMap = HttpComponentsUtil.getParameterMap(
+			uri.getRawQuery());
+
+		for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
+			webTarget = webTarget.queryParam(
+				entry.getKey(), (Object[])entry.getValue());
+		}
+
+		Invocation.Builder invocationBuilder = invocationBuilderFunction.apply(
+			webTarget);
+
+		String bodyString = getBodyAsString(invocationBuilder.get());
+
+		Assert.assertFalse(bodyString.contains(_APPLICATION_NAME));
+		Assert.assertTrue(
+			bodyString.contains(HtmlUtil.escape(_APPLICATION_NAME)));
+	}
 
 	@Test
 	public void testGuestOwnerCreateTokenPermission() {
@@ -234,6 +286,8 @@ public class SecurityTest extends BaseClientTestCase {
 		return response.getHeaderString("x-frame-options");
 	}
 
+	private static final String _APPLICATION_NAME = "<script>alert(1)</script>";
+
 	private User _user;
 
 	private class SecurityTestPreparatorBundleActivator
@@ -249,6 +303,11 @@ public class SecurityTest extends BaseClientTestCase {
 				companyId, _user, "oauthTestApplicationCode",
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
 				Collections.singletonList("everything"));
+
+			createOAuth2Application(
+				companyId, _user, "oauthTestApplicationUnescapedName",
+				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
+				_APPLICATION_NAME, Collections.singletonList("everything"));
 
 			createOAuth2ApplicationWithNone(
 				companyId, _user, "oauthTestApplicationCodePKCE",

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
@@ -106,7 +106,7 @@ public class SecurityTest extends BaseClientTestCase {
 					null,
 					getCodeFunction(
 						webTarget -> webTarget.queryParam(
-							"client_id", "oauthTestApplicationCode"
+							"client_id", _CLIENT_ID_CODE
 						).queryParam(
 							"response_type", "code"
 						)))));
@@ -126,7 +126,7 @@ public class SecurityTest extends BaseClientTestCase {
 					null,
 					getCodeFunction(
 						webTarget -> webTarget.queryParam(
-							"client_id", "oauthTestApplicationCode"
+							"client_id", _CLIENT_ID_CODE
 						).queryParam(
 							"response_type", "code"
 						)))));
@@ -143,7 +143,7 @@ public class SecurityTest extends BaseClientTestCase {
 				null,
 				getCodeFunction(
 					webTarget -> webTarget.queryParam(
-						"client_id", "oauthTestApplicationCodePKCE"
+						"client_id", _CLIENT_ID_CODE_PKCE
 					).queryParam(
 						"code_challenge", "correctCodeChallenge"
 					).queryParam(
@@ -155,7 +155,7 @@ public class SecurityTest extends BaseClientTestCase {
 		Assert.assertEquals(
 			"invalid_grant",
 			getToken(
-				"oauthTestApplicationCodePKCE", null,
+				_CLIENT_ID_CODE_PKCE, null,
 				getExchangeAuthorizationCodePKCEBiFunction(
 					authorizationCode, null, "wrongCodeVerifier"),
 				this::parseError));
@@ -174,7 +174,7 @@ public class SecurityTest extends BaseClientTestCase {
 				null,
 				getCodeFunction(
 					webTarget -> webTarget.queryParam(
-						"client_id", "oauthTestApplicationCode"
+						"client_id", _CLIENT_ID_CODE
 					).queryParam(
 						"response_type", "code"
 					).queryParam(
@@ -193,7 +193,7 @@ public class SecurityTest extends BaseClientTestCase {
 			_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD, null,
 			getCodeFunction(
 				webTarget -> webTarget.queryParam(
-					"client_id", "oauthTestApplicationCode"
+					"client_id", _CLIENT_ID_CODE
 				).queryParam(
 					"redirect_uri",
 					"http://invalid:" + PortalUtil.getPortalServerPort(false)
@@ -216,7 +216,7 @@ public class SecurityTest extends BaseClientTestCase {
 				null,
 				getCodeFunction(
 					webTarget -> webTarget.queryParam(
-						"client_id", "oauthTestApplicationCode"
+						"client_id", _CLIENT_ID_CODE
 					).queryParam(
 						"redirect_uri",
 						"http://redirecturi:" +
@@ -230,7 +230,7 @@ public class SecurityTest extends BaseClientTestCase {
 		Assert.assertEquals(
 			"invalid_grant",
 			getToken(
-				"oauthTestApplicationCode", null,
+				_CLIENT_ID_CODE, null,
 				getExchangeAuthorizationCodeBiFunction(
 					authorizationCode,
 					"http://invalid:" + PortalUtil.getPortalServerPort(false)),
@@ -313,6 +313,11 @@ public class SecurityTest extends BaseClientTestCase {
 		return response.getHeaderString("x-frame-options");
 	}
 
+	private static final String _CLIENT_ID_CODE = RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_CODE_PKCE =
+		RandomTestUtil.randomString();
+
 	private static final String _CLIENT_ID_DEFAULT_USER =
 		RandomTestUtil.randomString();
 
@@ -345,12 +350,12 @@ public class SecurityTest extends BaseClientTestCase {
 			_user = UserTestUtil.getAdminUser(companyId);
 
 			createOAuth2Application(
-				companyId, _user, "oauthTestApplicationCode",
+				companyId, _user, _CLIENT_ID_CODE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
 				Collections.singletonList("everything"));
 
 			createOAuth2ApplicationWithNone(
-				companyId, _user, "oauthTestApplicationCodePKCE",
+				companyId, _user, _CLIENT_ID_CODE_PKCE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE_PKCE),
 				Collections.singletonList(
 					"http://redirecturi:" +

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
@@ -304,11 +304,6 @@ public class SecurityTest extends BaseClientTestCase {
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
 				Collections.singletonList("everything"));
 
-			createOAuth2Application(
-				companyId, _user, "oauthTestApplicationUnescapedName",
-				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
-				_APPLICATION_NAME, Collections.singletonList("everything"));
-
 			createOAuth2ApplicationWithNone(
 				companyId, _user, "oauthTestApplicationCodePKCE",
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE_PKCE),
@@ -322,6 +317,11 @@ public class SecurityTest extends BaseClientTestCase {
 			createOAuth2Application(
 				companyId, company.getGuestUser(),
 				"oauthTestApplicationDefaultUser");
+
+			createOAuth2Application(
+				companyId, _user, "oauthTestApplicationUnescapedName",
+				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
+				_APPLICATION_NAME, Collections.singletonList("everything"));
 		}
 
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
@@ -7,16 +7,20 @@ package com.liferay.oauth2.provider.client.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.constants.GrantType;
+import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
 import jakarta.ws.rs.client.Invocation;
@@ -51,46 +55,28 @@ public class SecurityTest extends BaseClientTestCase {
 
 	@Test
 	public void testEscapeOAuth2ApplicationName() {
-		Function<WebTarget, Invocation.Builder> invocationBuilderFunction =
-			getAuthenticatedInvocationBuilderFunction(
-				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
-				null);
-
-		Response response = getCodeFunction(
+		String bodyString = getAuthorizationPageBodyString(
 			webTarget -> webTarget.queryParam(
 				"client_id", "oauthTestApplicationUnescapedName"
 			).queryParam(
 				"response_type", "code"
-			),
-			true
-		).apply(
-			invocationBuilderFunction
-		);
+			));
 
-		URI uri = response.getLocation();
+		Assert.assertFalse(bodyString.contains(_INJECTED_SCRIPT));
+		Assert.assertTrue(
+			bodyString.contains(HtmlUtil.escape(_INJECTED_SCRIPT)));
+	}
 
-		if (uri == null) {
-			throw new IllegalArgumentException(
-				"Authorization service response missing \"Location\" header " +
-					"from which the authorization page URL is extracted");
-		}
-
-		WebTarget webTarget = getWebTarget();
-
-		webTarget = webTarget.path(uri.getPath());
-
-		Map<String, String[]> parameterMap = HttpComponentsUtil.getParameterMap(
-			uri.getRawQuery());
-
-		for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
-			webTarget = webTarget.queryParam(
-				entry.getKey(), (Object[])entry.getValue());
-		}
-
-		Invocation.Builder invocationBuilder = invocationBuilderFunction.apply(
-			webTarget);
-
-		String bodyString = getBodyAsString(invocationBuilder.get());
+	@Test
+	public void testEscapeOAuth2ScopeDescription() {
+		String bodyString = getAuthorizationPageBodyString(
+			webTarget -> webTarget.queryParam(
+				"client_id", "oauthTestApplicationUnescapedScope"
+			).queryParam(
+				"response_type", "code"
+			).queryParam(
+				"scope", _SCOPE_ALIAS
+			));
 
 		Assert.assertFalse(bodyString.contains(_INJECTED_SCRIPT));
 		Assert.assertTrue(
@@ -250,6 +236,46 @@ public class SecurityTest extends BaseClientTestCase {
 				this::parseError));
 	}
 
+	protected String getAuthorizationPageBodyString(
+		Function<WebTarget, WebTarget> authorizeRequestFunction) {
+
+		Function<WebTarget, Invocation.Builder> invocationBuilderFunction =
+			getAuthenticatedInvocationBuilderFunction(
+				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
+				null);
+
+		Response response = getCodeFunction(
+			authorizeRequestFunction, true
+		).apply(
+			invocationBuilderFunction
+		);
+
+		URI uri = response.getLocation();
+
+		if (uri == null) {
+			throw new IllegalArgumentException(
+				"Authorization service response missing \"Location\" header " +
+					"from which the authorization page URL is extracted");
+		}
+
+		WebTarget webTarget = getWebTarget();
+
+		webTarget = webTarget.path(uri.getPath());
+
+		Map<String, String[]> parameterMap = HttpComponentsUtil.getParameterMap(
+			uri.getRawQuery());
+
+		for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
+			webTarget = webTarget.queryParam(
+				entry.getKey(), (Object[])entry.getValue());
+		}
+
+		Invocation.Builder invocationBuilder = invocationBuilderFunction.apply(
+			webTarget);
+
+		return getBodyAsString(invocationBuilder.get());
+	}
+
 	protected String getBodyAsString(Response response) {
 		return response.readEntity(String.class);
 	}
@@ -288,6 +314,15 @@ public class SecurityTest extends BaseClientTestCase {
 
 	private static final String _INJECTED_SCRIPT = "<script>alert(1)</script>";
 
+	private static final String _SCOPE_ALIAS =
+		SecurityTest._SCOPE_APPLICATION_NAME + ".everything.read";
+
+	private static final String _SCOPE_APPLICATION_NAME =
+		"Liferay.Captcha.REST";
+
+	@Inject
+	private OAuth2ScopeGrantLocalService _oAuth2ScopeGrantLocalService;
+
 	private User _user;
 
 	private class SecurityTestPreparatorBundleActivator
@@ -322,6 +357,25 @@ public class SecurityTest extends BaseClientTestCase {
 				companyId, _user, "oauthTestApplicationUnescapedName",
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
 				_INJECTED_SCRIPT, Collections.singletonList("everything"));
+
+			OAuth2Application oAuth2Application = createOAuth2Application(
+				companyId, _user, "oauthTestApplicationUnescapedScope",
+				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
+				Collections.singletonList(_SCOPE_ALIAS));
+
+			_oAuth2ScopeGrantLocalService.createOAuth2ScopeGrant(
+				companyId,
+				oAuth2Application.getOAuth2ApplicationScopeAliasesId(),
+				_SCOPE_APPLICATION_NAME, "com.liferay.captcha.rest.impl", "GET",
+				Collections.singletonList(_SCOPE_ALIAS));
+
+			registerScopeDescriptor(
+				(scope, locale) -> _INJECTED_SCRIPT,
+				HashMapDictionaryBuilder.<String, Object>put(
+					"osgi.jaxrs.name", _SCOPE_APPLICATION_NAME
+				).put(
+					"service.ranking", Integer.MAX_VALUE
+				).build());
 		}
 
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
@@ -13,6 +13,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -57,7 +58,7 @@ public class SecurityTest extends BaseClientTestCase {
 	public void testEscapeOAuth2ApplicationName() {
 		String bodyString = getAuthorizationPageBodyString(
 			webTarget -> webTarget.queryParam(
-				"client_id", "oauthTestApplicationUnescapedName"
+				"client_id", _CLIENT_ID_UNESCAPED_NAME
 			).queryParam(
 				"response_type", "code"
 			));
@@ -71,7 +72,7 @@ public class SecurityTest extends BaseClientTestCase {
 	public void testEscapeOAuth2ScopeDescription() {
 		String bodyString = getAuthorizationPageBodyString(
 			webTarget -> webTarget.queryParam(
-				"client_id", "oauthTestApplicationUnescapedScope"
+				"client_id", _CLIENT_ID_UNESCAPED_SCOPE
 			).queryParam(
 				"response_type", "code"
 			).queryParam(
@@ -88,7 +89,7 @@ public class SecurityTest extends BaseClientTestCase {
 		Assert.assertEquals(
 			"invalid_grant",
 			getToken(
-				"oauthTestApplicationDefaultUser", null,
+				_CLIENT_ID_DEFAULT_USER, null,
 				this::getClientCredentialsResponse, this::parseError));
 	}
 
@@ -312,6 +313,15 @@ public class SecurityTest extends BaseClientTestCase {
 		return response.getHeaderString("x-frame-options");
 	}
 
+	private static final String _CLIENT_ID_DEFAULT_USER =
+		RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_UNESCAPED_NAME =
+		RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_UNESCAPED_SCOPE =
+		RandomTestUtil.randomString();
+
 	private static final String _INJECTED_SCRIPT = "<script>alert(1)</script>";
 
 	private static final String _SCOPE_ALIAS =
@@ -350,16 +360,15 @@ public class SecurityTest extends BaseClientTestCase {
 			Company company = CompanyLocalServiceUtil.getCompany(companyId);
 
 			createOAuth2Application(
-				companyId, company.getGuestUser(),
-				"oauthTestApplicationDefaultUser");
+				companyId, company.getGuestUser(), _CLIENT_ID_DEFAULT_USER);
 
 			createOAuth2Application(
-				companyId, _user, "oauthTestApplicationUnescapedName",
+				companyId, _user, _CLIENT_ID_UNESCAPED_NAME,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
 				_INJECTED_SCRIPT, Collections.singletonList("everything"));
 
 			OAuth2Application oAuth2Application = createOAuth2Application(
-				companyId, _user, "oauthTestApplicationUnescapedScope",
+				companyId, _user, _CLIENT_ID_UNESCAPED_SCOPE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
 				Collections.singletonList(_SCOPE_ALIAS));
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
@@ -56,21 +56,17 @@ public class SecurityTest extends BaseClientTestCase {
 
 	@Test
 	public void testEscapeOAuth2ApplicationName() {
-		String bodyString = getAuthorizationPageBodyString(
+		_assertAuthorizationPageEscapesInjectedScript(
 			webTarget -> webTarget.queryParam(
 				"client_id", _CLIENT_ID_UNESCAPED_NAME
 			).queryParam(
 				"response_type", "code"
 			));
-
-		Assert.assertFalse(bodyString.contains(_INJECTED_SCRIPT));
-		Assert.assertTrue(
-			bodyString.contains(HtmlUtil.escape(_INJECTED_SCRIPT)));
 	}
 
 	@Test
 	public void testEscapeOAuth2ScopeDescription() {
-		String bodyString = getAuthorizationPageBodyString(
+		_assertAuthorizationPageEscapesInjectedScript(
 			webTarget -> webTarget.queryParam(
 				"client_id", _CLIENT_ID_UNESCAPED_SCOPE
 			).queryParam(
@@ -78,10 +74,6 @@ public class SecurityTest extends BaseClientTestCase {
 			).queryParam(
 				"scope", _SCOPE_ALIAS
 			));
-
-		Assert.assertFalse(bodyString.contains(_INJECTED_SCRIPT));
-		Assert.assertTrue(
-			bodyString.contains(HtmlUtil.escape(_INJECTED_SCRIPT)));
 	}
 
 	@Test
@@ -237,46 +229,6 @@ public class SecurityTest extends BaseClientTestCase {
 				this::parseError));
 	}
 
-	protected String getAuthorizationPageBodyString(
-		Function<WebTarget, WebTarget> authorizeRequestFunction) {
-
-		Function<WebTarget, Invocation.Builder> invocationBuilderFunction =
-			getAuthenticatedInvocationBuilderFunction(
-				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
-				null);
-
-		Response response = getCodeFunction(
-			authorizeRequestFunction, true
-		).apply(
-			invocationBuilderFunction
-		);
-
-		URI uri = response.getLocation();
-
-		if (uri == null) {
-			throw new IllegalArgumentException(
-				"Authorization service response missing \"Location\" header " +
-					"from which the authorization page URL is extracted");
-		}
-
-		WebTarget webTarget = getWebTarget();
-
-		webTarget = webTarget.path(uri.getPath());
-
-		Map<String, String[]> parameterMap = HttpComponentsUtil.getParameterMap(
-			uri.getRawQuery());
-
-		for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
-			webTarget = webTarget.queryParam(
-				entry.getKey(), (Object[])entry.getValue());
-		}
-
-		Invocation.Builder invocationBuilder = invocationBuilderFunction.apply(
-			webTarget);
-
-		return getBodyAsString(invocationBuilder.get());
-	}
-
 	protected String getBodyAsString(Response response) {
 		return response.readEntity(String.class);
 	}
@@ -313,6 +265,50 @@ public class SecurityTest extends BaseClientTestCase {
 		return response.getHeaderString("x-frame-options");
 	}
 
+	private void _assertAuthorizationPageEscapesInjectedScript(
+		Function<WebTarget, WebTarget> authorizeRequestFunction) {
+
+		Function<WebTarget, Invocation.Builder> invocationBuilderFunction =
+			getAuthenticatedInvocationBuilderFunction(
+				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
+				null);
+
+		Response response = getCodeFunction(
+			authorizeRequestFunction, true
+		).apply(
+			invocationBuilderFunction
+		);
+
+		URI uri = response.getLocation();
+
+		if (uri == null) {
+			throw new IllegalArgumentException(
+				"Authorization service response missing \"Location\" header " +
+					"from which the authorization page URL is extracted");
+		}
+
+		WebTarget webTarget = getWebTarget();
+
+		webTarget = webTarget.path(uri.getPath());
+
+		Map<String, String[]> parameterMap = HttpComponentsUtil.getParameterMap(
+			uri.getRawQuery());
+
+		for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
+			webTarget = webTarget.queryParam(
+				entry.getKey(), (Object[])entry.getValue());
+		}
+
+		Invocation.Builder invocationBuilder = invocationBuilderFunction.apply(
+			webTarget);
+
+		String bodyString = getBodyAsString(invocationBuilder.get());
+
+		Assert.assertFalse(bodyString.contains(_INJECTED_SCRIPT));
+		Assert.assertTrue(
+			bodyString.contains(HtmlUtil.escape(_INJECTED_SCRIPT)));
+	}
+
 	private static final String _CLIENT_ID_CODE = RandomTestUtil.randomString();
 
 	private static final String _CLIENT_ID_CODE_PKCE =
@@ -330,7 +326,7 @@ public class SecurityTest extends BaseClientTestCase {
 	private static final String _INJECTED_SCRIPT = "<script>alert(1)</script>";
 
 	private static final String _SCOPE_ALIAS =
-		SecurityTest._SCOPE_APPLICATION_NAME + ".everything.read";
+		"Liferay.Captcha.REST.everything.read";
 
 	private static final String _SCOPE_APPLICATION_NAME =
 		"Liferay.Captcha.REST";

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
@@ -92,9 +92,9 @@ public class SecurityTest extends BaseClientTestCase {
 
 		String bodyString = getBodyAsString(invocationBuilder.get());
 
-		Assert.assertFalse(bodyString.contains(_APPLICATION_NAME));
+		Assert.assertFalse(bodyString.contains(_INJECTED_SCRIPT));
 		Assert.assertTrue(
-			bodyString.contains(HtmlUtil.escape(_APPLICATION_NAME)));
+			bodyString.contains(HtmlUtil.escape(_INJECTED_SCRIPT)));
 	}
 
 	@Test
@@ -286,7 +286,7 @@ public class SecurityTest extends BaseClientTestCase {
 		return response.getHeaderString("x-frame-options");
 	}
 
-	private static final String _APPLICATION_NAME = "<script>alert(1)</script>";
+	private static final String _INJECTED_SCRIPT = "<script>alert(1)</script>";
 
 	private User _user;
 
@@ -321,7 +321,7 @@ public class SecurityTest extends BaseClientTestCase {
 			createOAuth2Application(
 				companyId, _user, "oauthTestApplicationUnescapedName",
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
-				_APPLICATION_NAME, Collections.singletonList("everything"));
+				_INJECTED_SCRIPT, Collections.singletonList("everything"));
 		}
 
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TOCTOUTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TOCTOUTest.java
@@ -14,6 +14,7 @@ import com.liferay.oauth2.provider.service.OAuth2ApplicationScopeAliasesLocalSer
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -63,7 +64,7 @@ public class TOCTOUTest extends BaseClientTestCase {
 		WebTarget webTarget1 = getWebTarget("/annotated");
 
 		String token = getToken(
-			"oauthTestApplicationCode", null,
+			_CLIENT_ID_CODE, null,
 			getAuthorizationCodeBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
 				null),
@@ -108,7 +109,7 @@ public class TOCTOUTest extends BaseClientTestCase {
 		webTarget2InvocationBuilder = authorize(
 			webTarget2.request(),
 			getToken(
-				"oauthTestApplicationCode", null,
+				_CLIENT_ID_CODE, null,
 				getAuthorizationCodeBiFunction(
 					_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
 					null, "everything.read"),
@@ -157,7 +158,7 @@ public class TOCTOUTest extends BaseClientTestCase {
 		webTarget2InvocationBuilder = authorize(
 			webTarget2.request(),
 			getToken(
-				"oauthTestApplicationCode", null,
+				_CLIENT_ID_CODE, null,
 				getAuthorizationCodeBiFunction(
 					_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
 					null),
@@ -171,6 +172,8 @@ public class TOCTOUTest extends BaseClientTestCase {
 	protected BundleActivator getBundleActivator() {
 		return new SecurityTestPreparatorBundleActivator();
 	}
+
+	private static final String _CLIENT_ID_CODE = RandomTestUtil.randomString();
 
 	private User _user;
 
@@ -226,7 +229,7 @@ public class TOCTOUTest extends BaseClientTestCase {
 			_user = UserTestUtil.getAdminUser(companyId);
 
 			OAuth2Application oAuth2Application = createOAuth2Application(
-				companyId, _user, "oauthTestApplicationCode",
+				companyId, _user, _CLIENT_ID_CODE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
 				Collections.singletonList("everything.read"));
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenExpeditionTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenExpeditionTest.java
@@ -105,7 +105,7 @@ public class TokenExpeditionTest extends BaseClientTestCase {
 			formData = new MultivaluedHashMap<>();
 
 			formData.add("client_id", "wrong");
-			formData.add("client_secret", "oauthTestApplicationSecret");
+			formData.add("client_secret", CLIENT_SECRET);
 			formData.add("grant_type", "client_credentials");
 
 			errorString = parseError(
@@ -117,7 +117,7 @@ public class TokenExpeditionTest extends BaseClientTestCase {
 		formData = new MultivaluedHashMap<>();
 
 		formData.add("client_id", "oauthTestApplication");
-		formData.add("client_secret", "oauthTestApplicationSecret");
+		formData.add("client_secret", CLIENT_SECRET);
 		formData.add("grant_type", "client_credentials");
 
 		WebTarget webTarget = getWebTarget("/annotated");

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenExpeditionTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenExpeditionTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.oauth2.provider.internal.test.TestAnnotatedApplication;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -83,7 +84,7 @@ public class TokenExpeditionTest extends BaseClientTestCase {
 
 			formData = new MultivaluedHashMap<>();
 
-			formData.add("client_id", "oauthTestApplication");
+			formData.add("client_id", _CLIENT_ID);
 			formData.add("client_secret", "");
 			formData.add("grant_type", "client_credentials");
 
@@ -93,7 +94,7 @@ public class TokenExpeditionTest extends BaseClientTestCase {
 
 			formData = new MultivaluedHashMap<>();
 
-			formData.add("client_id", "oauthTestApplication");
+			formData.add("client_id", _CLIENT_ID);
 			formData.add("client_secret", "wrong");
 			formData.add("grant_type", "client_credentials");
 
@@ -116,7 +117,7 @@ public class TokenExpeditionTest extends BaseClientTestCase {
 
 		formData = new MultivaluedHashMap<>();
 
-		formData.add("client_id", "oauthTestApplication");
+		formData.add("client_id", _CLIENT_ID);
 		formData.add("client_secret", CLIENT_SECRET);
 		formData.add("grant_type", "client_credentials");
 
@@ -158,6 +159,8 @@ public class TokenExpeditionTest extends BaseClientTestCase {
 		return new TokenExpeditionTestPreparatorBundleActivator();
 	}
 
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
+
 	private class TokenExpeditionTestPreparatorBundleActivator
 		extends BaseTestPreparatorBundleActivator {
 
@@ -175,7 +178,7 @@ public class TokenExpeditionTest extends BaseClientTestCase {
 					"oauth2.scope.checker.type", "annotations"
 				).build());
 
-			createOAuth2Application(companyId, user, "oauthTestApplication");
+			createOAuth2Application(companyId, user, _CLIENT_ID);
 		}
 
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenIntrospectionTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenIntrospectionTest.java
@@ -70,7 +70,7 @@ public class TokenIntrospectionTest extends BaseClientTestCase {
 					HashMapBuilder.put(
 						"client_id", applicationClientId
 					).put(
-						"client_secret", "oauthTestApplicationSecret"
+						"client_secret", CLIENT_SECRET
 					).put(
 						"token", token
 					).build())));

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenIntrospectionTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TokenIntrospectionTest.java
@@ -47,7 +47,7 @@ public class TokenIntrospectionTest extends BaseClientTestCase {
 
 	@Test
 	public void testTokenIntrospectionApplicationCode() {
-		String applicationClientId = "oauthTestApplicationCode";
+		String applicationClientId = _CLIENT_ID_CODE;
 
 		String token = getToken(
 			applicationClientId, null,
@@ -87,7 +87,7 @@ public class TokenIntrospectionTest extends BaseClientTestCase {
 
 	@Test
 	public void testTokenIntrospectionApplicationCodePKCE() {
-		String applicationClientId = "oauthTestApplicationCodePKCE";
+		String applicationClientId = _CLIENT_ID_CODE_PKCE;
 
 		String token = getToken(
 			applicationClientId, null,
@@ -126,6 +126,11 @@ public class TokenIntrospectionTest extends BaseClientTestCase {
 			TokenIntrospectionTestPreparatorBundleActivator();
 	}
 
+	private static final String _CLIENT_ID_CODE = RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_CODE_PKCE =
+		RandomTestUtil.randomString();
+
 	private User _user;
 
 	private class TokenIntrospectionTestPreparatorBundleActivator
@@ -138,11 +143,11 @@ public class TokenIntrospectionTest extends BaseClientTestCase {
 			_user = UserTestUtil.getAdminUser(companyId);
 
 			createOAuth2Application(
-				companyId, _user, "oauthTestApplicationCode",
+				companyId, _user, _CLIENT_ID_CODE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE), false,
 				Collections.singletonList("everything"), false);
 			createOAuth2ApplicationWithNone(
-				companyId, _user, "oauthTestApplicationCodePKCE",
+				companyId, _user, _CLIENT_ID_CODE_PKCE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE_PKCE),
 				Collections.singletonList(
 					"http://redirecturi:" +

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TrustedApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TrustedApplicationClientTest.java
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -48,7 +49,7 @@ public class TrustedApplicationClientTest extends BaseClientTestCase {
 			_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD, null,
 			getCodeFunction(
 				webTarget -> webTarget.queryParam(
-					"client_id", "oauthTestApplicationCode"
+					"client_id", _CLIENT_ID_CODE
 				).queryParam(
 					"redirect_uri",
 					"http://redirecturi:" +
@@ -66,7 +67,7 @@ public class TrustedApplicationClientTest extends BaseClientTestCase {
 			_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD, null,
 			getCodeFunction(
 				webTarget -> webTarget.queryParam(
-					"client_id", "oauthTestApplicationCodePKCE"
+					"client_id", _CLIENT_ID_CODE_PKCE
 				).queryParam(
 					"redirect_uri",
 					"http://redirecturi:" +
@@ -126,6 +127,11 @@ public class TrustedApplicationClientTest extends BaseClientTestCase {
 			TrustedApplicationClientTestPreparatorBundleActivator();
 	}
 
+	private static final String _CLIENT_ID_CODE = RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_CODE_PKCE =
+		RandomTestUtil.randomString();
+
 	private String _host;
 	private User _user;
 
@@ -143,11 +149,11 @@ public class TrustedApplicationClientTest extends BaseClientTestCase {
 			_user = UserTestUtil.getAdminUser(companyId);
 
 			createOAuth2Application(
-				companyId, _user, "oauthTestApplicationCode",
+				companyId, _user, _CLIENT_ID_CODE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE), false,
 				Collections.singletonList("everything"), false);
 			createOAuth2ApplicationWithNone(
-				companyId, _user, "oauthTestApplicationCodePKCE",
+				companyId, _user, _CLIENT_ID_CODE_PKCE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE_PKCE),
 				Collections.singletonList(
 					"http://redirecturi:" +

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TrustedApplicationClientTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/TrustedApplicationClientTest.java
@@ -88,7 +88,7 @@ public class TrustedApplicationClientTest extends BaseClientTestCase {
 			_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD, null,
 			getCodeFunction(
 				webTarget -> webTarget.queryParam(
-					"client_id", "oauthTestTrustedApplicationCode"
+					"client_id", _CLIENT_ID_TRUSTED_CODE
 				).queryParam(
 					"redirect_uri",
 					"http://redirecturi:" +
@@ -106,7 +106,7 @@ public class TrustedApplicationClientTest extends BaseClientTestCase {
 			_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD, null,
 			getCodeFunction(
 				webTarget -> webTarget.queryParam(
-					"client_id", "oauthTestTrustedApplicationCodePKCE"
+					"client_id", _CLIENT_ID_TRUSTED_CODE_PKCE
 				).queryParam(
 					"redirect_uri",
 					"http://redirecturi:" +
@@ -130,6 +130,12 @@ public class TrustedApplicationClientTest extends BaseClientTestCase {
 	private static final String _CLIENT_ID_CODE = RandomTestUtil.randomString();
 
 	private static final String _CLIENT_ID_CODE_PKCE =
+		RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_TRUSTED_CODE =
+		RandomTestUtil.randomString();
+
+	private static final String _CLIENT_ID_TRUSTED_CODE_PKCE =
 		RandomTestUtil.randomString();
 
 	private String _host;
@@ -160,11 +166,11 @@ public class TrustedApplicationClientTest extends BaseClientTestCase {
 						PortalUtil.getPortalServerPort(false)),
 				false, Collections.singletonList("everything"), false);
 			createOAuth2Application(
-				companyId, _user, "oauthTestTrustedApplicationCode",
+				companyId, _user, _CLIENT_ID_TRUSTED_CODE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE), false,
 				Collections.singletonList("everything"), true);
 			createOAuth2ApplicationWithNone(
-				companyId, _user, "oauthTestTrustedApplicationCodePKCE",
+				companyId, _user, _CLIENT_ID_TRUSTED_CODE_PKCE,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE_PKCE),
 				Collections.singletonList(
 					"http://redirecturi:" +

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/BaseTokenEndpointTestCase.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/BaseTokenEndpointTestCase.java
@@ -16,6 +16,7 @@ import com.liferay.oauth2.provider.internal.test.JWTAssertionClientAuthenticatio
 import com.liferay.oauth2.provider.internal.test.util.JWTAssertionUtil;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.Base64;
@@ -177,17 +178,23 @@ public abstract class BaseTokenEndpointTestCase extends BaseClientTestCase {
 		return parseJsonField(response, "refresh_token");
 	}
 
-	protected static final String TEST_CLIENT_ID_1 = "test_client_id_1";
+	protected static final String TEST_CLIENT_ID_1 =
+		RandomTestUtil.randomString();
 
-	protected static final String TEST_CLIENT_ID_2 = "test_client_id_2";
+	protected static final String TEST_CLIENT_ID_2 =
+		RandomTestUtil.randomString();
 
-	protected static final String TEST_CLIENT_ID_3 = "test_client_id_3";
+	protected static final String TEST_CLIENT_ID_3 =
+		RandomTestUtil.randomString();
 
-	protected static final String TEST_CLIENT_ID_4 = "test_client_id_4";
+	protected static final String TEST_CLIENT_ID_4 =
+		RandomTestUtil.randomString();
 
-	protected static final String TEST_CLIENT_ID_5 = "test_client_id_5";
+	protected static final String TEST_CLIENT_ID_5 =
+		RandomTestUtil.randomString();
 
-	protected static final String TEST_CLIENT_ID_6 = "test_client_id_6";
+	protected static final String TEST_CLIENT_ID_6 =
+		RandomTestUtil.randomString();
 
 	protected static final Map<String, ClientAuthentication>
 		clientAuthentications = new HashMap<>();

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/BaseTokenEndpointTestCase.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/BaseTokenEndpointTestCase.java
@@ -60,12 +60,12 @@ public abstract class BaseTokenEndpointTestCase extends BaseClientTestCase {
 			clientAuthentications.put(
 				TEST_CLIENT_ID_1,
 				new ClientPasswordClientAuthentication(
-					TEST_CLIENT_ID_1, _TEST_CLIENT_SECRET));
+					TEST_CLIENT_ID_1, CLIENT_SECRET));
 			clientAuthentications.put(
 				TEST_CLIENT_ID_2,
 				new JWTAssertionClientAuthentication(
 					getTokenWebTarget(), TEST_CLIENT_ID_2, false,
-					TEST_CLIENT_ID_2, _TEST_CLIENT_SECRET, true));
+					TEST_CLIENT_ID_2, CLIENT_SECRET, true));
 			clientAuthentications.put(
 				TEST_CLIENT_ID_3,
 				new JWTAssertionClientAuthentication(
@@ -83,23 +83,21 @@ public abstract class BaseTokenEndpointTestCase extends BaseClientTestCase {
 			clientAuthentications.put(
 				TEST_CLIENT_ID_5,
 				new ClientPasswordClientAuthentication(
-					TEST_CLIENT_ID_5, _TEST_CLIENT_SECRET));
+					TEST_CLIENT_ID_5, CLIENT_SECRET));
 			clientAuthentications.put(
 				TEST_CLIENT_ID_6,
 				new ClientPasswordClientAuthentication(
-					TEST_CLIENT_ID_6, _TEST_CLIENT_SECRET));
+					TEST_CLIENT_ID_6, CLIENT_SECRET));
 
 			createOAuth2ApplicationWithClientSecretPost(
-				user.getCompanyId(), user, TEST_CLIENT_ID_1,
-				_TEST_CLIENT_SECRET,
+				user.getCompanyId(), user, TEST_CLIENT_ID_1, CLIENT_SECRET,
 				Arrays.asList(
 					GrantType.RESOURCE_OWNER_PASSWORD, GrantType.REFRESH_TOKEN,
 					GrantType.JWT_BEARER),
 				Arrays.asList(
 					"everything", "everything.read", "everything.write"));
 			createOAuth2ApplicationWithClientSecretJWT(
-				user.getCompanyId(), user, TEST_CLIENT_ID_2,
-				_TEST_CLIENT_SECRET,
+				user.getCompanyId(), user, TEST_CLIENT_ID_2, CLIENT_SECRET,
 				Arrays.asList(
 					GrantType.RESOURCE_OWNER_PASSWORD, GrantType.REFRESH_TOKEN,
 					GrantType.JWT_BEARER),
@@ -121,16 +119,14 @@ public abstract class BaseTokenEndpointTestCase extends BaseClientTestCase {
 				Arrays.asList(
 					"everything", "everything.read", "everything.write"));
 			createOAuth2ApplicationWithClientSecretPost(
-				user.getCompanyId(), user, TEST_CLIENT_ID_5,
-				_TEST_CLIENT_SECRET,
+				user.getCompanyId(), user, TEST_CLIENT_ID_5, CLIENT_SECRET,
 				Arrays.asList(
 					GrantType.RESOURCE_OWNER_PASSWORD, GrantType.REFRESH_TOKEN,
 					GrantType.JWT_BEARER),
 				Arrays.asList(
 					"everything", "everything.read", "everything.write"));
 			createOAuth2ApplicationWithClientSecretPost(
-				user.getCompanyId(), user, TEST_CLIENT_ID_6,
-				_TEST_CLIENT_SECRET,
+				user.getCompanyId(), user, TEST_CLIENT_ID_6, CLIENT_SECRET,
 				Arrays.asList(
 					GrantType.RESOURCE_OWNER_PASSWORD, GrantType.REFRESH_TOKEN,
 					GrantType.JWT_BEARER),
@@ -200,9 +196,6 @@ public abstract class BaseTokenEndpointTestCase extends BaseClientTestCase {
 		return getInvocationBuilder(
 			null, getTokenWebTarget(), Function.identity());
 	}
-
-	private static final String _TEST_CLIENT_SECRET =
-		"oauthTestApplicationSecret";
 
 	private static final String _TEST_CLIENT_SECRET_NOT_BASE64 =
 		"secret-2527c3ad-be54-dcea-18a3-ab349ff637ac";

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/RefreshTokenAuthorizationGrantTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/RefreshTokenAuthorizationGrantTest.java
@@ -68,7 +68,7 @@ public class RefreshTokenAuthorizationGrantTest
 		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
 
 		formData.add("client_id", "oauthTestApplication");
-		formData.add("client_secret", "oauthTestApplicationSecret");
+		formData.add("client_secret", CLIENT_SECRET);
 		formData.add("grant_type", "refresh_token");
 		formData.add("refresh_token", jsonObject.getString("refresh_token"));
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/RefreshTokenAuthorizationGrantTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/RefreshTokenAuthorizationGrantTest.java
@@ -13,6 +13,7 @@ import com.liferay.oauth2.provider.internal.test.RefreshTokenAuthorizationGrant;
 import com.liferay.oauth2.provider.internal.test.TestAnnotatedApplication;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
@@ -46,7 +47,7 @@ public class RefreshTokenAuthorizationGrantTest
 	@Test
 	public void test() throws Exception {
 		JSONObject jsonObject = getToken(
-			"oauthTestApplication", null,
+			_CLIENT_ID, null,
 			getResourceOwnerPasswordBiFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD),
 			this::parseJSONObject);
@@ -67,7 +68,7 @@ public class RefreshTokenAuthorizationGrantTest
 
 		MultivaluedMap<String, String> formData = new MultivaluedHashMap<>();
 
-		formData.add("client_id", "oauthTestApplication");
+		formData.add("client_id", _CLIENT_ID);
 		formData.add("client_secret", CLIENT_SECRET);
 		formData.add("grant_type", "refresh_token");
 		formData.add("refresh_token", jsonObject.getString("refresh_token"));
@@ -108,6 +109,8 @@ public class RefreshTokenAuthorizationGrantTest
 		return new TokenExpeditionTestPreparatorBundleActivator();
 	}
 
+	private static final String _CLIENT_ID = RandomTestUtil.randomString();
+
 	private User _user;
 
 	private class TokenExpeditionTestPreparatorBundleActivator
@@ -128,7 +131,7 @@ public class RefreshTokenAuthorizationGrantTest
 				).build());
 
 			createOAuth2Application(
-				companyId, _user, "oauthTestApplication",
+				companyId, _user, _CLIENT_ID,
 				Arrays.asList(
 					GrantType.RESOURCE_OWNER_PASSWORD, GrantType.REFRESH_TOKEN),
 				Collections.singletonList("everything"));

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_left_column.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_left_column.jsp
@@ -188,7 +188,7 @@ OAuth2Application oAuth2Application = oAuth2AdminPortletDisplayContext.getOAuth2
 								'<%= user.getUserId() %>'
 							);
 							A.one('#<portlet:namespace />clientCredentialUserName').val(
-								'<%= user.getScreenName() %>'
+								'<%= HtmlUtil.escapeJS(user.getScreenName()) %>'
 							);
 						});
 					}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/authorize/authorize.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/authorize/authorize.jsp
@@ -79,7 +79,7 @@ if (Validator.isNotNull(replyTo) && !replyTo.startsWith(PortalUtil.getPortalURL(
 										messageArguments[0] = LanguageUtil.format(request, "x,-y", messageArguments);
 									}
 
-									messageArguments[1] = messageArguments[0];
+									messageArguments[1] = HtmlUtil.escape(messageArguments[0]);
 									messageArguments[0] = HtmlUtil.escape(assignableScopes.getApplicationDescription(applicationName));
 								%>
 

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/authorize/authorize.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/authorize/authorize.jsp
@@ -53,7 +53,7 @@ if (Validator.isNotNull(replyTo) && !replyTo.startsWith(PortalUtil.getPortalURL(
 						</c:when>
 						<c:otherwise>
 							<h1>
-								<%= LanguageUtil.format(request, "authorize-x", new String[] {oAuth2Application.getName()}) %>
+								<%= LanguageUtil.format(request, "authorize-x", new String[] {HtmlUtil.escape(oAuth2Application.getName())}) %>
 							</h1>
 
 							<p class="application-wants-permissions text-truncate">

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view_application.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/connected_applications/view_application.jsp
@@ -87,7 +87,7 @@ renderResponse.setTitle(oAuth2Application.getName());
 								>
 									<div class="list-group-title text-truncate"><%= HtmlUtil.escape(assignableScopes.getApplicationDescription(applicationName)) %></div>
 
-									<p class="list-group-subtitle text-truncate"><%= StringUtil.merge(assignableScopes.getApplicationScopeDescription(themeDisplay.getCompanyId(), applicationName), ", ") %></p>
+									<p class="list-group-subtitle text-truncate"><%= HtmlUtil.escape(StringUtil.merge(assignableScopes.getApplicationScopeDescription(themeDisplay.getCompanyId(), applicationName), ", ")) %></p>
 								</clay:content-col>
 							</li>
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-101833

Supersedes #3203, whose forward was closed with review feedback.

## What Is Being Fixed

Several values are rendered into `oauth2-provider-web` JSPs without being escaped first, so stored content is interpreted as markup instead of text. In `authorize/authorize.jsp` the OAuth 2 application name is passed straight into the `authorize-x` message that titles the consent screen, and `LanguageUtil.format` does not escape its arguments; the accumulated scope descriptions reach a message argument unescaped as well. In `admin/edit_application_left_column.jsp` the selected user's screen name is injected into a JavaScript string literal, and `connected_applications/view_application.jsp` merges the scope descriptions into markup.

All of them are part of the set collected in LPD-97914, which was never merged into master.

## How It Is Being Fixed

Each value is wrapped in the escaper that matches the sink it lands in: `HtmlUtil.escape` for HTML text and `HtmlUtil.escapeJS` for the JavaScript string.

Two integration tests in `SecurityTest` cover the authorization page, which already hosts the other hardening tests for this flow. Both drive the real authorization endpoint, keep the redirect to the consent page, then rebuild that page's URL and fetch it with the same authenticated session, asserting that the escaped form of the payload is present while the raw payload is not. The query is carried over through `getRawQuery`, because `URI.getQuery` is already decoded and `HttpComponentsUtil` decodes again. Reaching the scope description needs a scope the scope locator actually knows, because the page drops any grant whose application name and scope it cannot resolve, so that test hangs its grant on Liferay.Captcha.REST the way ScopeFinderTest does and registers a scope descriptor that describes it with markup.

Every test value that no assertion depends on is randomized: the application name, its description, the client credential and all eleven client IDs the module used to spell out. Two assertions gain from it — token introspection compares the client ID it returns against the one the test registered, and isolation across companies registers the same client in two companies on purpose, so each constant is declared once per class rather than once per registration. What stays literal cannot follow: the asserted payload, the deliberately wrong inputs, and the scope alias, application name, bundle symbolic name and scope that have to match the application the scope locator already knows.

The rendering in `connected_applications/view_application.jsp` is left uncovered: it needs a granted authorization and a visit to that widget, which is a different flow. The screen name is not reachable with the default configuration either, because `DefaultScreenNameValidator` restricts screen names to `[A-Za-z0-9-._]+`, so that escape is defense in depth.

## Test Results

The whole `oauth2-provider-test` integration suite was run against a portal built from this branch with `ant all`: **91 tests, 5 failures**, and both new tests pass.

The 5 failures are master's own. They were confirmed by running the same suite on plain `master` in the same portal and comparing the failing sets: every failure the branch shows, master shows too, and the branch adds none.

- `CORSApplicationClientTest.testCORSRequest`
- `JsonWebServiceTest.test`
- `RevokedTokenTest.test`
- `OAuth2ApplicationIndexedColumnSizeUpgradeProcessTest.testUpgrade`
- `OAuth2ApplicationIndexedColumnSizeUpgradeProcessTest.testUpgradeWithDuplicateUniqueIndexEntries`

## Follow Up, Not This Pull Request

- `connected_applications/view_application.jsp:39` renders `getThumbnailURL()` unescaped, while `authorize.jsp:26` escapes the same call.
- `admin/edit_application_left_column.jsp:169,174` escape twice: `HtmlUtil.escapeAttribute(...)` into an `aui:input value` the tag escapes again.

## PR Check

**pr-check: PASS** — tested on `574d522ed38782a858aa1298841ee8d51f291c0b`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| JSP Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "574d522ed38782a858aa1298841ee8d51f291c0b"} -->
