### PR TITLE
LPD-92156 Add the AWS key manager module utilities and FIPS validators

### DIFF
--- a/modules/apps/portal-security/portal-security-key-provider-aws/bnd.bnd
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/bnd.bnd
@@ -1,0 +1,8 @@
+Bundle-Name: Liferay Portal Security Key Provider AWS
+Bundle-SymbolicName: com.liferay.portal.security.key.provider.aws
+Bundle-Version: 1.0.0
+Import-Package:\
+	!javax.xml.bind,\
+	\
+	*
+Liferay-Releng-Module-Group-Title: Portal Security Key

--- a/modules/apps/portal-security/portal-security-key-provider-aws/build.gradle
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/build.gradle
@@ -1,0 +1,20 @@
+dependencies {
+	compileInclude group: "com.amazonaws", name: "aws-java-sdk-core", version: "1.12.719"
+	compileInclude group: "com.amazonaws", name: "aws-java-sdk-kms", version: "1.12.719"
+	compileInclude group: "com.amazonaws", name: "aws-java-sdk-secretsmanager", version: "1.12.778"
+	compileInclude group: "com.amazonaws", name: "aws-java-sdk-sts", version: "1.12.778"
+	compileInclude group: "com.amazonaws", name: "jmespath-java", version: "1.12.778"
+	compileInclude group: "software.amazon.ion", name: "ion-java", version: "1.0.2"
+	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "6.4.0"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "org.osgi", name: "org.osgi.framework", version: "1.9.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.cm", version: "1.6.0"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly project(":apps:portal-security:portal-security-key-api")
+	compileOnly project(":apps:portal-security:portal-security-key-spi")
+	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
+	compileOnly project(":core:petra:petra-string")
+	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.test", version: "default"
+	testImplementation group: "junit", name: "junit", version: "4.13.1"
+	testImplementation group: "org.mockito", name: "mockito-core", version: "4.4.0"
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/fips/AWSKMSFIPSValidator.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/fips/AWSKMSFIPSValidator.java
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.fips;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.security.key.ServiceIndicator;
+import com.liferay.portal.security.key.crypto.exception.CryptoException;
+
+import java.util.Set;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSKMSFIPSValidator {
+
+	public AWSKMSFIPSValidator(String cipherMode, boolean fipsEnforced) {
+		_cipherMode = cipherMode;
+		_fipsEnforced = fipsEnforced;
+	}
+
+	public boolean isFIPSApprovedKeyOrigin(String keyOrigin) {
+		return _approvedKeyOrigins.contains(keyOrigin);
+	}
+
+	public boolean isFIPSEnforced() {
+		return _fipsEnforced;
+	}
+
+	public ServiceIndicator toServiceIndicator(
+			boolean fipsApproved, String securityFunctionName)
+		throws CryptoException {
+
+		if (_fipsEnforced && !fipsApproved) {
+			throw new CryptoException(
+				"Security function \"" + securityFunctionName +
+					"\" is not FIPS approved under strict mode");
+		}
+
+		return new ServiceIndicator(fipsApproved, securityFunctionName);
+	}
+
+	public ServiceIndicator toServiceIndicator(
+			String keyOrigin, String securityFunctionName)
+		throws CryptoException {
+
+		return toServiceIndicator(
+			isFIPSApprovedKeyOrigin(keyOrigin), securityFunctionName);
+	}
+
+	public void validateCipherMode() throws CryptoException {
+		if (_fipsEnforced &&
+			(Validator.isNull(_cipherMode) ||
+			 !_aeadCipherModes.contains(StringUtil.toUpperCase(_cipherMode)))) {
+
+			throw new CryptoException(
+				"FIPS enforcement requires an AEAD cipher mode but \"" +
+					_cipherMode + "\" is not AEAD");
+		}
+	}
+
+	public void validateKeyOrigin(String keyOrigin) throws CryptoException {
+		if (_fipsEnforced && !isFIPSApprovedKeyOrigin(keyOrigin)) {
+			throw new CryptoException(
+				StringBundler.concat(
+					"FIPS enforcement requires a CMK within the AWS FIPS ",
+					"boundary (origin AWS_CLOUDHSM or AWS_KMS) but the key ",
+					"origin is \"", keyOrigin, "\""));
+		}
+	}
+
+	private static final Set<String> _aeadCipherModes = SetUtil.fromArray(
+		"AES_256_GCM", "AES_GCM", "SYMMETRIC_DEFAULT");
+	private static final Set<String> _approvedKeyOrigins = SetUtil.fromArray(
+		"AWS_CLOUDHSM", "AWS_KMS");
+
+	private final String _cipherMode;
+	private final boolean _fipsEnforced;
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSARNUtil.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSARNUtil.java
@@ -1,0 +1,57 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.util;
+
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSARNUtil {
+
+	public static String resolve(
+		String accountId, String arnTemplate, long companyId, String identifier,
+		String region) {
+
+		if (Validator.isNull(arnTemplate) || (identifier == null) ||
+			identifier.startsWith("arn:") || identifier.startsWith("alias/")) {
+
+			return identifier;
+		}
+
+		if (Validator.isNull(accountId)) {
+			if (arnTemplate.contains("{accountId}")) {
+				throw new IllegalArgumentException(
+					"Unable to resolve AWS account ID for ARN template \"" +
+						arnTemplate + "\"");
+			}
+		}
+		else {
+			arnTemplate = StringUtil.replace(
+				arnTemplate, "{accountId}", accountId);
+		}
+
+		arnTemplate = StringUtil.replace(
+			arnTemplate, "{companyId}", String.valueOf(companyId));
+		arnTemplate = StringUtil.replace(
+			arnTemplate, "{identifier}", identifier);
+
+		if (Validator.isNull(region)) {
+			if (arnTemplate.contains("{region}")) {
+				throw new IllegalArgumentException(
+					"Unable to resolve AWS region for ARN template \"" +
+						arnTemplate + "\"");
+			}
+		}
+		else {
+			arnTemplate = StringUtil.replace(arnTemplate, "{region}", region);
+		}
+
+		return arnTemplate;
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSAccountUtil.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSAccountUtil.java
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.util;
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest;
+import com.amazonaws.services.securitytoken.model.GetCallerIdentityResult;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSAccountUtil {
+
+	public static String getAccountId() {
+		AWSSecurityTokenService awsSecurityTokenService =
+			_getAWSSecurityTokenService();
+
+		try {
+			GetCallerIdentityResult getCallerIdentityResult =
+				awsSecurityTokenService.getCallerIdentity(
+					new GetCallerIdentityRequest());
+
+			return getCallerIdentityResult.getAccount();
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to get AWS account ID via STS", exception);
+			}
+		}
+		finally {
+			awsSecurityTokenService.shutdown();
+		}
+
+		return null;
+	}
+
+	private static AWSSecurityTokenService _getAWSSecurityTokenService() {
+		AWSSecurityTokenServiceClientBuilder
+			awsSecurityTokenServiceClientBuilder =
+				AWSSecurityTokenServiceClientBuilder.standard(
+				).withCredentials(
+					DefaultAWSCredentialsProviderChain.getInstance()
+				);
+
+		return awsSecurityTokenServiceClientBuilder.build();
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(AWSAccountUtil.class);
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSByteBufferUtil.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSByteBufferUtil.java
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.util;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+import java.nio.ByteBuffer;
+
+import java.util.Arrays;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSByteBufferUtil {
+
+	public static byte[] getBytes(ByteBuffer byteBuffer) {
+		if (byteBuffer == null) {
+			throw new IllegalArgumentException("AWS response buffer is null");
+		}
+
+		byte[] bytes = new byte[byteBuffer.remaining()];
+
+		byteBuffer.get(bytes);
+
+		if (byteBuffer.hasArray() && !byteBuffer.isReadOnly()) {
+			int arrayOffset = byteBuffer.arrayOffset();
+
+			Arrays.fill(
+				byteBuffer.array(), arrayOffset,
+				arrayOffset + byteBuffer.limit(), (byte)0);
+		}
+		else if (_log.isWarnEnabled()) {
+			_log.warn(
+				"Unable to zero AWS response buffer (direct or read only); " +
+					"sensitive bytes remain until JVM reclaims them");
+		}
+
+		return bytes;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AWSByteBufferUtil.class);
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSClientManager.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSClientManager.java
@@ -1,0 +1,199 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.util;
+
+import com.amazonaws.AmazonWebServiceClient;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.client.builder.AwsClientBuilder;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSClientManager<T> {
+
+	public AWSClientManager(
+		ClientFactory<T> clientFactory, String fipsEndpointTemplate,
+		String region, boolean useFIPSEndpoint) {
+
+		_clientFactory = clientFactory;
+		_fipsEndpointTemplate = fipsEndpointTemplate;
+		_region = _resolveRegion(region);
+		_useFIPSEndpoint = useFIPSEndpoint;
+
+		_awsCredentialsProvider =
+			DefaultAWSCredentialsProviderChain.getInstance();
+
+		ReentrantReadWriteLock reentrantReadWriteLock =
+			new ReentrantReadWriteLock();
+
+		_readLock = reentrantReadWriteLock.readLock();
+		_writeLock = reentrantReadWriteLock.writeLock();
+	}
+
+	public void close() {
+		_writeLock.lock();
+
+		try {
+			_closed = true;
+
+			_closeClient();
+		}
+		finally {
+			_writeLock.unlock();
+		}
+	}
+
+	public <R> R execute(AWSOperation<T, R> awsOperation) throws Exception {
+		while (true) {
+			_readLock.lock();
+
+			try {
+				if (_closed) {
+					throw new IllegalStateException(
+						"AWS client manager is closed");
+				}
+
+				if (_client != null) {
+					return awsOperation.apply(_client);
+				}
+			}
+			finally {
+				_readLock.unlock();
+			}
+
+			_writeLock.lock();
+
+			try {
+				if (_closed) {
+					throw new IllegalStateException(
+						"AWS client manager is closed");
+				}
+
+				if (_client == null) {
+					_client = _clientFactory.build(
+						_awsCredentialsProvider, _getEndpointConfiguration(),
+						_region);
+				}
+			}
+			finally {
+				_writeLock.unlock();
+			}
+		}
+	}
+
+	public String getRegion() {
+		return _region;
+	}
+
+	public void updateConfiguration(String region, boolean useFIPSEndpoint) {
+		region = _resolveRegion(region);
+
+		if (Validator.isNull(region)) {
+			throw new IllegalArgumentException(
+				"AWS region could not be resolved");
+		}
+
+		_writeLock.lock();
+
+		try {
+			if (!region.equals(_region) ||
+				(useFIPSEndpoint != _useFIPSEndpoint)) {
+
+				_region = region;
+				_useFIPSEndpoint = useFIPSEndpoint;
+
+				_closeClient();
+			}
+		}
+		finally {
+			_writeLock.unlock();
+		}
+	}
+
+	@FunctionalInterface
+	public interface AWSOperation<T, R> {
+
+		public R apply(T client) throws Exception;
+
+	}
+
+	@FunctionalInterface
+	public interface ClientFactory<T> {
+
+		public T build(
+				AWSCredentialsProvider awsCredentialsProvider,
+				AwsClientBuilder.EndpointConfiguration endpointConfiguration,
+				String region)
+			throws Exception;
+
+	}
+
+	private void _closeClient() {
+		if (_client == null) {
+			return;
+		}
+
+		try {
+			if (_client instanceof AmazonWebServiceClient) {
+				AmazonWebServiceClient amazonWebServiceClient =
+					(AmazonWebServiceClient)_client;
+
+				amazonWebServiceClient.shutdown();
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to cleanly shut down AWS client", exception);
+			}
+		}
+
+		_client = null;
+	}
+
+	private AwsClientBuilder.EndpointConfiguration _getEndpointConfiguration() {
+		if (!_useFIPSEndpoint || Validator.isNull(_fipsEndpointTemplate) ||
+			Validator.isNull(_region)) {
+
+			return null;
+		}
+
+		String endpoint = StringUtil.replace(
+			_fipsEndpointTemplate, "{region}", _region);
+
+		return new AwsClientBuilder.EndpointConfiguration(endpoint, _region);
+	}
+
+	private String _resolveRegion(String region) {
+		if (Validator.isNull(region)) {
+			return AWSRegionUtil.getRegion();
+		}
+
+		return region;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AWSClientManager.class);
+
+	private final AWSCredentialsProvider _awsCredentialsProvider;
+	private volatile T _client;
+	private final ClientFactory<T> _clientFactory;
+	private volatile boolean _closed;
+	private final String _fipsEndpointTemplate;
+	private final Lock _readLock;
+	private volatile String _region;
+	private volatile boolean _useFIPSEndpoint;
+	private final Lock _writeLock;
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSRegionUtil.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSRegionUtil.java
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.util;
+
+import com.amazonaws.regions.DefaultAwsRegionProviderChain;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSRegionUtil {
+
+	public static String getRegion() {
+		try {
+			DefaultAwsRegionProviderChain defaultAwsRegionProviderChain =
+				new DefaultAwsRegionProviderChain();
+
+			return defaultAwsRegionProviderChain.getRegion();
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to get AWS region from environment", exception);
+			}
+		}
+
+		return null;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(AWSRegionUtil.class);
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/fips/AWSKMSFIPSValidatorTest.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/fips/AWSKMSFIPSValidatorTest.java
@@ -1,0 +1,101 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.fips;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.security.key.ServiceIndicator;
+import com.liferay.portal.security.key.crypto.exception.CryptoException;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSKMSFIPSValidatorTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testIsFIPSApprovedKeyOrigin() {
+		AWSKMSFIPSValidator awsKMSFIPSValidator = new AWSKMSFIPSValidator(
+			RandomTestUtil.randomString(), true);
+
+		Assert.assertTrue(
+			awsKMSFIPSValidator.isFIPSApprovedKeyOrigin("AWS_CLOUDHSM"));
+		Assert.assertTrue(
+			awsKMSFIPSValidator.isFIPSApprovedKeyOrigin("AWS_KMS"));
+		Assert.assertFalse(
+			awsKMSFIPSValidator.isFIPSApprovedKeyOrigin("EXTERNAL"));
+	}
+
+	@Test
+	public void testToServiceIndicator() throws Exception {
+		AWSKMSFIPSValidator enforcedAWSKMSFIPSValidator =
+			new AWSKMSFIPSValidator(RandomTestUtil.randomString(), true);
+
+		ServiceIndicator approvedServiceIndicator =
+			enforcedAWSKMSFIPSValidator.toServiceIndicator(
+				true, "AWS.KMS.Encrypt");
+
+		Assert.assertEquals(
+			"AWS.KMS.Encrypt",
+			approvedServiceIndicator.getSecurityFunctionName());
+		Assert.assertTrue(approvedServiceIndicator.isApproved());
+
+		Assert.assertThrows(
+			CryptoException.class,
+			() -> enforcedAWSKMSFIPSValidator.toServiceIndicator(
+				false, RandomTestUtil.randomString()));
+
+		AWSKMSFIPSValidator unenforcedAWSKMSFIPSValidator =
+			new AWSKMSFIPSValidator(RandomTestUtil.randomString(), false);
+
+		ServiceIndicator unapprovedServiceIndicator =
+			unenforcedAWSKMSFIPSValidator.toServiceIndicator(
+				false, RandomTestUtil.randomString());
+
+		Assert.assertFalse(unapprovedServiceIndicator.isApproved());
+	}
+
+	@Test
+	public void testValidateCipherMode() throws Exception {
+		AWSKMSFIPSValidator awsKMSFIPSValidator = new AWSKMSFIPSValidator(
+			"AES_256_GCM", true);
+
+		awsKMSFIPSValidator.validateCipherMode();
+
+		AWSKMSFIPSValidator cbcAWSKMSFIPSValidator = new AWSKMSFIPSValidator(
+			"AES_CBC", true);
+
+		Assert.assertThrows(
+			CryptoException.class, cbcAWSKMSFIPSValidator::validateCipherMode);
+	}
+
+	@Test
+	public void testValidateKeyOrigin() throws Exception {
+		AWSKMSFIPSValidator enforcedAWSKMSFIPSValidator =
+			new AWSKMSFIPSValidator(RandomTestUtil.randomString(), true);
+
+		enforcedAWSKMSFIPSValidator.validateKeyOrigin("AWS_CLOUDHSM");
+
+		Assert.assertThrows(
+			CryptoException.class,
+			() -> enforcedAWSKMSFIPSValidator.validateKeyOrigin("EXTERNAL"));
+
+		AWSKMSFIPSValidator unenforcedAWSKMSFIPSValidator =
+			new AWSKMSFIPSValidator(RandomTestUtil.randomString(), false);
+
+		unenforcedAWSKMSFIPSValidator.validateKeyOrigin("EXTERNAL");
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSARNUtilTest.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSARNUtilTest.java
@@ -1,0 +1,124 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.util;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSARNUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testResolveCompanyTemplate() {
+		long companyId = RandomTestUtil.randomLong();
+		String identifier = RandomTestUtil.randomString();
+		String prefix = RandomTestUtil.randomString() + StringPool.SLASH;
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				prefix, companyId, StringPool.SLASH, identifier),
+			AWSARNUtil.resolve(
+				RandomTestUtil.randomString(),
+				prefix + "{companyId}/{identifier}", companyId, identifier,
+				RandomTestUtil.randomString()));
+	}
+
+	@Test
+	public void testResolveNullAccountIdWithoutPlaceholder() {
+		String identifier = RandomTestUtil.randomString();
+		String prefix = RandomTestUtil.randomString() + StringPool.SLASH;
+
+		Assert.assertEquals(
+			prefix + identifier,
+			AWSARNUtil.resolve(
+				null, prefix + "{identifier}", RandomTestUtil.randomLong(),
+				identifier, RandomTestUtil.randomString()));
+	}
+
+	@Test
+	public void testResolveNullTemplateFallsBackToIdentifier() {
+		String identifier = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			identifier,
+			AWSARNUtil.resolve(
+				RandomTestUtil.randomString(), null,
+				RandomTestUtil.randomLong(), identifier,
+				RandomTestUtil.randomString()));
+	}
+
+	@Test
+	public void testResolvePassesThroughAliasIdentifier() {
+		String identifier = "alias/" + RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			identifier,
+			AWSARNUtil.resolve(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomLong(), identifier,
+				RandomTestUtil.randomString()));
+	}
+
+	@Test
+	public void testResolvePassesThroughARNIdentifier() {
+		String identifier = "arn:" + RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			identifier,
+			AWSARNUtil.resolve(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomLong(), identifier,
+				RandomTestUtil.randomString()));
+	}
+
+	@Test
+	public void testResolveSystemTemplate() {
+		String accountId = RandomTestUtil.randomString();
+		String identifier = RandomTestUtil.randomString();
+		String prefix = RandomTestUtil.randomString() + StringPool.SLASH;
+		String region = RandomTestUtil.randomString();
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				prefix, region, StringPool.SLASH, accountId, StringPool.SLASH,
+				identifier),
+			AWSARNUtil.resolve(
+				accountId, prefix + "{region}/{accountId}/{identifier}",
+				RandomTestUtil.randomLong(), identifier, region));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testResolveThrowsForBlankAccountIdWithPlaceholder() {
+		AWSARNUtil.resolve(
+			StringPool.BLANK,
+			RandomTestUtil.randomString() + "/{accountId}/{identifier}",
+			RandomTestUtil.randomLong(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testResolveThrowsForNullAccountIdWithPlaceholder() {
+		AWSARNUtil.resolve(
+			null, RandomTestUtil.randomString() + "/{accountId}/{identifier}",
+			RandomTestUtil.randomLong(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString());
+	}
+
+}


### PR DESCRIPTION
Layer 1 of the LPD-92156 AWS key manager stack: module utilities (AWS client manager, ARN, region, account, byte buffer) and the FIPS validator.

Addressed Brian's review: lowercased "origin" in the FIPS enforcement message.