### PR TITLE
LPD-102679 Skip the nonce lifecycle on nested filter passes

### DIFF
--- a/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/main/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilter.java
@@ -48,10 +48,17 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class ContentSecurityPolicyFilter extends BasePortalFilter {
 
+	public static final String SKIP_FILTER =
+		ContentSecurityPolicyFilter.class.getName() + "#SKIP_FILTER";
+
 	@Override
 	public boolean isFilterEnabled(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {
+
+		if (httpServletRequest.getAttribute(SKIP_FILTER) != null) {
+			return false;
+		}
 
 		if (CompanyThreadLocal.getCompanyId() == 0) {
 			if (_log.isDebugEnabled()) {
@@ -84,6 +91,8 @@ public class ContentSecurityPolicyFilter extends BasePortalFilter {
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse, FilterChain filterChain)
 		throws Exception {
+
+		httpServletRequest.setAttribute(SKIP_FILTER, Boolean.TRUE);
 
 		String nonce = _contentSecurityPolicyNonceManager.setNonce(
 			httpServletRequest);

--- a/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
+++ b/modules/apps/portal-security/portal-security-content-security-policy/src/test/java/com/liferay/portal/security/content/security/policy/internal/servlet/filter/ContentSecurityPolicyFilterTest.java
@@ -11,6 +11,7 @@ import com.liferay.portal.security.content.security.policy.internal.configuratio
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -48,6 +49,23 @@ public class ContentSecurityPolicyFilterTest {
 		_testIsExcludedURIPath(
 			new String[] {"/group"}, true, null, "/group/guest/home");
 		_testIsExcludedURIPath(new String[0], true, null, "/GROUP/guest/home");
+	}
+
+	@Test
+	public void testIsFilterEnabledSkipsAlreadyFilteredRequest() {
+		HttpServletRequest httpServletRequest = Mockito.mock(
+			HttpServletRequest.class);
+
+		Mockito.when(
+			httpServletRequest.getAttribute(
+				ContentSecurityPolicyFilter.SKIP_FILTER)
+		).thenReturn(
+			Boolean.TRUE
+		);
+
+		Assert.assertFalse(
+			_contentSecurityPolicyFilter.isFilterEnabled(
+				httpServletRequest, Mockito.mock(HttpServletResponse.class)));
 	}
 
 	private void _testIsExcludedURIPath(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102679

## What Is Being Fixed

On Web Content Display pages, some server-rendered inline scripts lose their CSP nonce under concurrent load, so the browser blocks them. The content security policy filter is registered for both REQUEST and FORWARD dispatch, so a nested forward re-enters the filter on the same request. On the nested pass the filter tears down the request-scoped nonce (and its ThreadLocal) while the outer pass is still rendering, so scripts emitted afterward carry no nonce that matches the already-sent Content-Security-Policy header.

## How It Is Being Fixed

The filter now guards against re-entry the same way the other BasePortalFilter subclasses do (ETagFilter, I18nFilter, StripFilter, GZipFilter, FragmentFilter): it marks the request with a SKIP_FILTER attribute on the first pass and returns early from isFilterEnabled on any nested dispatch. The nested pass no longer runs the nonce lifecycle, so the single nonce set by the outermost pass survives the whole render and matches the header. The nonce manager is left unchanged.

## PR Check

**pr-check: PASS** — tested on `19ad56b69acc444657927ac63a97cdce47d18da3`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "19ad56b69acc444657927ac63a97cdce47d18da3"} -->
