### PR TITLE
[FIPS] LPD-102682 Add a source formatter check for unclearable credential buffers

### DIFF
--- a/modules/util/source-formatter/source-formatter.properties
+++ b/modules/util/source-formatter/source-formatter.properties
@@ -30,6 +30,8 @@
 
     source.check.BouncyCastleFIPSCheck.enabled=true
 
+    source.check.CredentialBufferCheck.enabled=true
+
     source.check.IfStatementCheck.enabled=true
 
     source.check.JavaClassNameCheck.enabled=false

--- a/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/CredentialBufferCheck.java
+++ b/modules/util/source-formatter/src/main/java/com/liferay/source/formatter/check/CredentialBufferCheck.java
@@ -1,0 +1,65 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.check;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Pedro Victor Silvestre
+ */
+public class CredentialBufferCheck extends BaseFileCheck {
+
+	@Override
+	public boolean isLiferaySourceCheck() {
+		return true;
+	}
+
+	@Override
+	protected String doProcess(
+		String fileName, String absolutePath, String content) {
+
+		if (absolutePath.contains("/modules/third-party/") ||
+			absolutePath.contains("/src/test/") ||
+			absolutePath.contains("/src/testIntegration/") ||
+			absolutePath.contains("/test/unit/")) {
+
+			return content;
+		}
+
+		_check(fileName, content, _constructorPattern);
+		_check(fileName, content, _methodPattern);
+
+		return content;
+	}
+
+	private void _check(String fileName, String content, Pattern pattern) {
+		Matcher matcher = pattern.matcher(content);
+
+		while (matcher.find()) {
+			addMessage(
+				fileName,
+				"Assign the buffer to a local variable so that it can be " +
+					"cleared after use, see LPD-93280",
+				getLineNumber(content, matcher.start()));
+		}
+	}
+
+	private static final String _DERIVED_BUFFER =
+		"[\\w.]+(?:\\([^()]*\\))?\\.(?:getBytes|toCharArray)\\([^()]*\\)";
+
+	private static final String _METHOD_PREFIX =
+		"\\.(?:getKey|init|load|loadKeyMaterial|loadTrustMaterial|" +
+			"setKeyEntry|setPassword|store)\\(" +
+				"(?:(?:[^();]|\\([^()]*\\))*?,\\s*)?";
+
+	private static final Pattern _constructorPattern = Pattern.compile(
+		"new (?:KeyStore\\.PasswordProtection|PBEKeySpec|SecretKeySpec)" +
+			"\\(\\s*" + _DERIVED_BUFFER);
+	private static final Pattern _methodPattern = Pattern.compile(
+		_METHOD_PREFIX + _DERIVED_BUFFER);
+
+}

--- a/modules/util/source-formatter/src/main/resources/documentation/all_checks.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/all_checks.md
@@ -73,6 +73,7 @@ ContractionsCheck | [Styling](styling_checks.md#styling-checks) | .java, .jsp, .
 [CopyrightCheck](check/copyright_check.md#copyrightcheck) | [Styling](styling_checks.md#styling-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl, or .vm | Validates `copyright` header. |
 [CreatingThreadsForDBAccessCheck](check/creating_threads_for_db_access_check.md#creatingthreadsfordbaccesscheck) | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Finds cases where `CompanyInheritableThreadLocalCallable` should be used when creating threads for DB access. |
 [CreationMenuBuilderCheck](check/builder_check.md#buildercheck) | [Miscellaneous](miscellaneous_checks.md#miscellaneous-checks) | .java | Checks that `CreationMenuBuilder` is used when possible. |
+CredentialBufferCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Finds buffers that are derived from a `String` and passed straight into a credential API, leaving no reference to clear. |
 DTOEnumCreationCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Checks the creation of DTO enum. |
 DatabaseMetaDataCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | .java | Checks usages of `java.sql.DatabaseMetaData`. |
 [DefaultComesLastCheck](https://checkstyle.sourceforge.io/checks/coding/defaultcomeslast.html) | [Styling](styling_checks.md#styling-checks) | .java, .jsp, .jspf, .jspx, .tag, .tpl, or .vm | Checks that the `default` is after all the cases in a `switch` statement. |

--- a/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/bug_prevention_checks.md
@@ -38,6 +38,7 @@ ComponentAnnotationCheck | .java | Performs several checks on classes with @Comp
 [ComponentExposureCheck](check/component_exposure_check.md#componentexposurecheck) | .java | Avoid exposing static component. |
 ConsumerTypeAnnotationCheck | .java | Performs several checks on classes with @ConsumerType annotation. |
 [CreatingThreadsForDBAccessCheck](check/creating_threads_for_db_access_check.md#creatingthreadsfordbaccesscheck) | .java | Finds cases where `CompanyInheritableThreadLocalCallable` should be used when creating threads for DB access. |
+CredentialBufferCheck | .java | Finds buffers that are derived from a `String` and passed straight into a credential API, leaving no reference to clear. |
 DTOEnumCreationCheck | .java | Checks the creation of DTO enum. |
 DatabaseMetaDataCheck | .java | Checks usages of `java.sql.DatabaseMetaData`. |
 DeprecatedAPICheck | .java | Finds calls to deprecated classes, constructors, fields or methods. |

--- a/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.md
+++ b/modules/util/source-formatter/src/main/resources/documentation/java_source_processor_checks.md
@@ -35,6 +35,7 @@ ContractionsCheck | [Styling](styling_checks.md#styling-checks) | Finds contract
 [CopyrightCheck](check/copyright_check.md#copyrightcheck) | [Styling](styling_checks.md#styling-checks) | Validates `copyright` header. |
 [CreatingThreadsForDBAccessCheck](check/creating_threads_for_db_access_check.md#creatingthreadsfordbaccesscheck) | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Finds cases where `CompanyInheritableThreadLocalCallable` should be used when creating threads for DB access. |
 [CreationMenuBuilderCheck](check/builder_check.md#buildercheck) | [Miscellaneous](miscellaneous_checks.md#miscellaneous-checks) | Checks that `CreationMenuBuilder` is used when possible. |
+CredentialBufferCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Finds buffers that are derived from a `String` and passed straight into a credential API, leaving no reference to clear. |
 DTOEnumCreationCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Checks the creation of DTO enum. |
 DatabaseMetaDataCheck | [Bug Prevention](bug_prevention_checks.md#bug-prevention-checks) | Checks usages of `java.sql.DatabaseMetaData`. |
 [DefaultComesLastCheck](https://checkstyle.sourceforge.io/checks/coding/defaultcomeslast.html) | [Styling](styling_checks.md#styling-checks) | Checks that the `default` is after all the cases in a `switch` statement. |

--- a/modules/util/source-formatter/src/main/resources/sourcechecks.xml
+++ b/modules/util/source-formatter/src/main/resources/sourcechecks.xml
@@ -482,6 +482,11 @@
 			<description name="Finds imports of non-FIPS BouncyCastle packages." />
 			<property name="enabled" value="false" />
 		</check>
+		<check name="CredentialBufferCheck">
+			<category name="Bug Prevention" />
+			<description name="Finds buffers that are derived from a `String` and passed straight into a credential API, leaving no reference to clear." />
+			<property name="enabled" value="false" />
+		</check>
 		<check name="EmptyCollectionCheck">
 			<category name="Styling" />
 			<description name="Checks that there are no calls to `Collections.EMPTY_LIST`, `Collections.EMPTY_MAP` or `Collections.EMPTY_SET`." />

--- a/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
+++ b/modules/util/source-formatter/src/test/java/com/liferay/source/formatter/processor/JavaSourceProcessorTest.java
@@ -137,6 +137,38 @@ public class JavaSourceProcessorTest extends BaseSourceProcessorTestCase {
 	}
 
 	@Test
+	public void testCredentialBuffer() throws Exception {
+		test(
+			SourceProcessorTestParameters.create(
+				"CredentialBuffer.testjava"
+			).addExpectedMessage(
+				"Assign the buffer to a local variable so that it can be " +
+					"cleared after use, see LPD-93280",
+				34
+			).addExpectedMessage(
+				"Assign the buffer to a local variable so that it can be " +
+					"cleared after use, see LPD-93280",
+				38
+			).addExpectedMessage(
+				"Assign the buffer to a local variable so that it can be " +
+					"cleared after use, see LPD-93280",
+				42
+			).addExpectedMessage(
+				"Assign the buffer to a local variable so that it can be " +
+					"cleared after use, see LPD-93280",
+				46
+			).addExpectedMessage(
+				"Assign the buffer to a local variable so that it can be " +
+					"cleared after use, see LPD-93280",
+				61
+			).addExpectedMessage(
+				"Assign the buffer to a local variable so that it can be " +
+					"cleared after use, see LPD-93280",
+				65
+			));
+	}
+
+	@Test
 	public void testDeserializationSecurity() throws Exception {
 		test(
 			"DeserializationSecurity.testjava",

--- a/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/CredentialBuffer.testjava
+++ b/modules/util/source-formatter/src/test/resources/com/liferay/source/formatter/dependencies/CredentialBuffer.testjava
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.source.formatter.dependencies;
+
+import com.liferay.portal.kernel.util.ArrayUtil;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import java.security.KeyStore;
+
+import java.util.Arrays;
+import java.util.Map;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import javax.net.ssl.KeyManagerFactory;
+
+/**
+ * @author Pedro Victor Silvestre
+ */
+public class CredentialBuffer {
+
+	public byte[] appendEntry(Map.Entry<String, byte[]> entry) {
+		return ArrayUtil.append(entry.getKey(), _credential.getBytes());
+	}
+
+	public KeyStore.Entry getEntry(String alias) throws Exception {
+		return _keyStore.getEntry(
+			alias, new KeyStore.PasswordProtection(_credential.toCharArray()));
+	}
+
+	public void initKeyManagerFactory() throws Exception {
+		_keyManagerFactory.init(_keyStore, _getCredential().toCharArray());
+	}
+
+	public void initMac() throws Exception {
+		_mac.init(new SecretKeySpec(_credential.getBytes(), "HmacSHA512"));
+	}
+
+	public void loadKeyStore() throws Exception {
+		_keyStore.load(_inputStream, _credential.toCharArray());
+	}
+
+	public void loadKeyStoreCorrectly() throws Exception {
+		char[] credentialChars = _credential.toCharArray();
+
+		try {
+			_keyStore.load(_inputStream, credentialChars);
+		}
+		finally {
+			Arrays.fill(credentialChars, '\0');
+		}
+	}
+
+	public void loadKeyStoreWithGetter() throws Exception {
+		_keyStore.load(_inputStream, _getCredential().toCharArray());
+	}
+
+	public void storeKeyStore() throws Exception {
+		_keyStore.store(_outputStream, _credential.toCharArray());
+	}
+
+	private String _getCredential() {
+		return null;
+	}
+
+	private String _credential;
+	private InputStream _inputStream;
+	private KeyManagerFactory _keyManagerFactory;
+	private KeyStore _keyStore;
+	private Mac _mac;
+	private OutputStream _outputStream;
+
+}

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -585,6 +585,8 @@
 
     source.check.BouncyCastleFIPSCheck.enabled=true
 
+    source.check.CredentialBufferCheck.enabled=true
+
     source.check.CSPIllegalTagsCheck.ftlAndVmIllegalTagNames=\
         embed,\
         object


### PR DESCRIPTION
Jira: [LPD-102682](https://liferay.atlassian.net/browse/LPD-102682) (Technical Task under [LPD-93280](https://liferay.atlassian.net/browse/LPD-93280) Active Memory Zeroization)

> **Stacked on #3215** (LPD-102580), which is this PR's base. Review that one first, and merge it first — the check cannot go green until its fixes land, so this will not apply on its own.

Answers @rafaprax's question on #3215: can a source formatter rule stop new cases like the ones fixed there?

## What is checkable, and what is not

**Not checkable: "every derived buffer is cleared."** The source formatter has regular expressions and a light Java term model — no control flow graph, no type resolution, no data flow. Worse, the actual defect in #3215 was a buffer cleared on the happy path but *not* in a `finally`, and that is precisely the distinction a non-CFG checker cannot make. A rule claiming to verify "is cleared" would have passed the bug we shipped, while false-positiving wherever ownership is legitimately transferred. That is worse than no rule.

**Checkable: the inline form.** A buffer derived from a `String` and passed straight into a credential API retains no reference, so nothing can ever overwrite it. It is unclearable *by construction*, and that is decidable from the source alone.

```java
// flagged - no reference is kept, so this can never be cleared
keyStore.load(inputStream, credential.toCharArray());

// not flagged
char[] credentialChars = credential.toCharArray();

try {
	keyStore.load(inputStream, credentialChars);
}
finally {
	Arrays.fill(credentialChars, '\0');
}
```

**So a green check does not mean buffers are wiped.** The rule enforces a necessary precondition — the buffer has a name — not the security property. Its value is that it makes the omission reviewable: a named buffer with no `finally` is visible in a diff, whereas an inline temporary hides the problem entirely.

## What the check matches

`CredentialBufferCheck` flags an inline `toCharArray()` / `getBytes()` in a credential argument position, for the constructors `KeyStore.PasswordProtection`, `PBEKeySpec` and `SecretKeySpec`, and for the `getKey`, `init`, `load`, `loadKeyMaterial`, `loadTrustMaterial`, `setKeyEntry`, `setPassword` and `store` sinks. The buffer may be the first argument or a later one, and the receiver may itself be a call, so a value read straight from configuration through a getter is covered:

```java
keyStore.load(inputStream, getSamlKeyStorePassword().toCharArray());   // flagged
```

That last shape matters: `BaseKeyStoreManagerImpl` has exactly such a getter, so it was one refactor away from slipping through.

It anchors on the **argument**, not the receiving method name, which is what keeps ordinary calls like `Properties.load(inputStream)` and `user.setPassword(encrypted)` out of it.

Exempt: `modules/third-party`, and test sources (`/src/test/`, `/src/testIntegration/`, `/test/unit/`) — their values are throwaway fixtures, and the ceremony would cost readability for no protection. Without the test exemption the check fires on 7 fixture sites.

## Scored against the defect it is meant to prevent

Of the 12 sites #3215 repairs, this catches **6**. The rest split into:

- **bound to a local but never cleared** — undecidable per above
- **cleared, but not on every path** — the dangerous shape, and the one a careless fix to a flagged site would produce
- **inline into a callee not on the sink list** — a private helper or a third-party call; adding unknown method names would blow up the false-positive rate

A rule for the "bound but never cleared" case would need to key on variable *names* rather than an API, which is a heuristic, and it fires on roughly 69 existing sites (24 in `headless`, 12 in `commerce`). It cannot ship as an error until that backlog is cleared. Worth its own ticket.

## Testing

- `JavaSourceProcessorTest`: **117 tests, 0 failures**, including `testCredentialBuffer` asserting six violations. The fixture also contains a deliberately correct method and a `Map.Entry.getKey()` collision case, so a regression that over-matches fails too.
- **Repo-wide, with the compiled check: 0 violations.** Running only this check over the whole tree, report-only so nothing is rewritten:

	```bash
	ant format-source-all -Dsource.check.names=CredentialBufferCheck -Dsource.auto.fix=false
	```

	`BUILD SUCCESSFUL`, no findings.

- **Control, so that clean result means something.** A pass with no output could equally mean the check never reached any Java source. Restoring the pre-fix version of one tracked file makes the identical command fail with the real message, then `git checkout --` restores it:

	```
	Assign the buffer to a local variable so that it can be cleared after use, see LPD-93280: ./portal-impl/src/com/liferay/portal/security/auth/PortalCallbackHandler.java 36 (SourceCheck:CredentialBufferCheck)
	```

- **Fires on every site this is meant to prevent.** Against the *pre-fix* versions of the 13 files #3215 repairs, the patterns hit **all 12** sites — the check is not silently dead.
- The regexes were validated on 22 hand-built cases (12 must-match, 10 must-skip) before being wired up.

Note that CI's own `ci:test:sf` has **not** run on this PR. It did not auto-trigger because the base is `LPD-102580` rather than `master`, and `ci:test:sf` is not a valid comment trigger on this repository — only `ci:test[:SHA|nocompile|norebase|gist-SHA]` is. It should trigger normally once #3215 merges and this PR's base becomes `master`, which will independently corroborate the local run above. This matters because the branch *enables* the check for master, so a false positive would break master's build rather than just this PR.

## Review note on the regex

An earlier revision used `[^;]*?` to skip preceding arguments. Because `[^;]` matches parentheses, that could escape the sink's own argument list and pair a `getKey(` from one call with a `getBytes(` from an unrelated argument — `ArrayUtil.append(entry.getKey(), value.getBytes())` was wrongly flagged, and `Map.Entry.getKey()` is everywhere. It now uses `(?:(?:[^();]|\([^()]*\))*?,\s*)?`, which allows one nested paren level but never leaves the argument list.

One residual is known and accepted: because a buffer may legitimately be a later argument, a *payload* in a credential-shaped position — say `store(structure, fields, json.getBytes(UTF_8))` — would match. That is a semantic false positive rather than a structural one, and there are no occurrences today. Note there is no `source.check.<Name>.excludes` precedent in `source-formatter.properties`, so the first real false positive needs a check change rather than a config line.

## Shipping

Registered in `sourcechecks.xml` under Bug Prevention with `enabled=false`, then turned on for master via `source-formatter.properties` — the same pattern as [LPD-96649](https://liferay.atlassian.net/browse/LPD-96649), which kept that check off older release branches. Documentation is regenerated by the formatter itself.

---

**pr-check: PASS** — tested on `887e07d946011160ae08881509b7de05c2b7d8fe`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "887e07d946011160ae08881509b7de05c2b7d8fe"} -->
