### PR TITLE
LPD-99746 Give audit events a stable, opaque session ID

### DIFF
--- a/modules/apps/portal-security-audit/portal-security-audit-wiring-test/bnd.bnd
+++ b/modules/apps/portal-security-audit/portal-security-audit-wiring-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Portal Security Audit Wiring Test
+Bundle-SymbolicName: com.liferay.portal.security.audit.wiring.test
+Bundle-Version: 1.0.0

--- a/modules/apps/portal-security-audit/portal-security-audit-wiring-test/build.gradle
+++ b/modules/apps/portal-security-audit/portal-security-audit-wiring-test/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+	testIntegrationImplementation group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/apps/portal-security-audit/portal-security-audit-wiring-test/src/testIntegration/java/com/liferay/portal/security/audit/wiring/internal/servlet/filter/test/AuditFilterTest.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-wiring-test/src/testIntegration/java/com/liferay/portal/security/audit/wiring/internal/servlet/filter/test/AuditFilterTest.java
@@ -1,0 +1,110 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.audit.wiring.internal.servlet.filter.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.audit.AuditRequestThreadLocal;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterChain;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.http.HttpSession;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Álvaro Saugar
+ */
+@RunWith(Arquillian.class)
+public class AuditFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@After
+	public void tearDown() throws Exception {
+		AuditRequestThreadLocal.removeAuditThreadLocal();
+	}
+
+	@Test
+	public void testDoFilterCapturesAuditSessionIdWhenAuthenticated()
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		HttpSession httpSession = mockHttpServletRequest.getSession();
+
+		String auditSessionId = RandomTestUtil.randomString();
+
+		httpSession.setAttribute(WebKeys.AUDIT_SESSION_ID, auditSessionId);
+
+		httpSession.setAttribute(WebKeys.USER_ID, TestPropsValues.getUserId());
+
+		_runAuditFilter(mockHttpServletRequest);
+
+		AuditRequestThreadLocal auditRequestThreadLocal =
+			AuditRequestThreadLocal.getAuditThreadLocal();
+
+		Assert.assertEquals(
+			auditSessionId, auditRequestThreadLocal.getSessionID());
+		Assert.assertNotEquals(
+			httpSession.getId(), auditRequestThreadLocal.getSessionID());
+	}
+
+	@Test
+	public void testDoFilterCapturesNoAuditSessionIdBeforeAuthentication()
+		throws Exception {
+
+		_runAuditFilter(new MockHttpServletRequest());
+
+		AuditRequestThreadLocal auditRequestThreadLocal =
+			AuditRequestThreadLocal.getAuditThreadLocal();
+
+		Assert.assertNull(auditRequestThreadLocal.getSessionID());
+	}
+
+	private void _runAuditFilter(MockHttpServletRequest mockHttpServletRequest)
+		throws Exception {
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					TestPropsValues.getCompanyId())) {
+
+			InvokerFilterChain invokerFilterChain = new InvokerFilterChain(
+				(servletRequest, servletResponse) -> {
+				});
+
+			invokerFilterChain.addFilter(_filter);
+
+			invokerFilterChain.doFilter(
+				mockHttpServletRequest, new MockHttpServletResponse());
+		}
+	}
+
+	@Inject(
+		filter = "component.name=com.liferay.portal.security.audit.wiring.internal.servlet.filter.AuditFilter"
+	)
+	private Filter _filter;
+
+}

--- a/modules/apps/portal-security-audit/portal-security-audit-wiring/src/main/java/com/liferay/portal/security/audit/wiring/internal/servlet/filter/AuditFilter.java
+++ b/modules/apps/portal-security-audit/portal-security-audit-wiring/src/main/java/com/liferay/portal/security/audit/wiring/internal/servlet/filter/AuditFilter.java
@@ -115,7 +115,8 @@ public class AuditFilter extends BaseFilter implements TryFilter {
 			httpServletRequest.getServerName());
 		auditRequestThreadLocal.setServerPort(
 			httpServletRequest.getServerPort());
-		auditRequestThreadLocal.setSessionID(httpSession.getId());
+		auditRequestThreadLocal.setSessionID(
+			(String)httpSession.getAttribute(WebKeys.AUDIT_SESSION_ID));
 
 		if (!_auditLogContextConfiguration.enabled()) {
 			return null;

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/build.gradle
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/build.gradle
@@ -1,4 +1,7 @@
 dependencies {
+	testIntegrationImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
+	testIntegrationImplementation group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
+	testIntegrationImplementation group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-api")
 	testIntegrationImplementation project(":apps:portal-security-audit:portal-security-audit-event-generators-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/events/test/LoginPostActionTest.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators-test/src/testIntegration/java/com/liferay/portal/security/audit/event/generators/internal/events/test/LoginPostActionTest.java
@@ -1,0 +1,296 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.audit.event.generators.internal.events.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.audit.AuditMessage;
+import com.liferay.portal.kernel.audit.AuditRequestThreadLocal;
+import com.liferay.portal.kernel.events.LifecycleAction;
+import com.liferay.portal.kernel.events.LifecycleEvent;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterChain;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.security.audit.AuditMessageProcessor;
+import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
+import com.liferay.portal.security.auth.session.AuthenticatedSessionManagerUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.http.HttpSession;
+
+import java.util.ArrayList;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceRegistration;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Álvaro Saugar
+ */
+@RunWith(Arquillian.class)
+public class LoginPostActionTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_user = UserTestUtil.addUser();
+
+		Bundle bundle = FrameworkUtil.getBundle(getClass());
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		Dictionary<String, Object> properties = new Hashtable<>();
+
+		properties.put("eventTypes", "*");
+
+		_serviceRegistration = bundleContext.registerService(
+			AuditMessageProcessor.class,
+			auditMessage -> _auditMessages.add(auditMessage), properties);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		AuditRequestThreadLocal.removeAuditThreadLocal();
+
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
+	@Test
+	public void testDoRunGeneratesOpaqueAuditSessionId() throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			_createMockHttpServletRequest();
+
+		_runLoginPostAction(mockHttpServletRequest);
+
+		MockHttpServletRequest secondMockHttpServletRequest =
+			_createMockHttpServletRequest();
+
+		_runLoginPostAction(secondMockHttpServletRequest);
+
+		String auditSessionId = _getAuditSessionId(mockHttpServletRequest);
+		String secondAuditSessionId = _getAuditSessionId(
+			secondMockHttpServletRequest);
+
+		HttpSession httpSession = mockHttpServletRequest.getSession();
+		HttpSession secondHttpSession =
+			secondMockHttpServletRequest.getSession();
+
+		Assert.assertNotEquals(httpSession.getId(), auditSessionId);
+		Assert.assertNotEquals(secondHttpSession.getId(), secondAuditSessionId);
+		Assert.assertNotEquals(auditSessionId, secondAuditSessionId);
+	}
+
+	@Test
+	public void testDoRunKeepsAuditSessionIdAcrossRequests() throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			_createMockHttpServletRequest();
+
+		_runLoginPostAction(mockHttpServletRequest);
+
+		AuditMessage auditMessage = _fetchAuditMessage(EventTypes.LOGIN);
+
+		String auditSessionId = auditMessage.getSessionID();
+
+		Assert.assertNotNull(auditSessionId);
+
+		MockHttpServletRequest secondMockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		secondMockHttpServletRequest.setSession(
+			mockHttpServletRequest.getSession());
+
+		_runAuditFilter(secondMockHttpServletRequest);
+
+		AuditRequestThreadLocal auditRequestThreadLocal =
+			AuditRequestThreadLocal.getAuditThreadLocal();
+
+		Assert.assertEquals(
+			auditSessionId, auditRequestThreadLocal.getSessionID());
+	}
+
+	@Test
+	public void testDoRunKeepsAuditSessionIdAcrossSessionRenewal()
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			_createMockHttpServletRequest();
+
+		_runLoginPostAction(mockHttpServletRequest);
+
+		String auditSessionId = _getAuditSessionId(mockHttpServletRequest);
+
+		HttpSession httpSession = mockHttpServletRequest.getSession();
+
+		String containerSessionId = httpSession.getId();
+
+		AuthenticatedSessionManagerUtil.renewSession(
+			mockHttpServletRequest, httpSession);
+
+		_runLoginPostAction(mockHttpServletRequest);
+
+		HttpSession renewedHttpSession = mockHttpServletRequest.getSession();
+
+		Assert.assertNotEquals(containerSessionId, renewedHttpSession.getId());
+
+		Assert.assertEquals(
+			auditSessionId, _getAuditSessionId(mockHttpServletRequest));
+
+		AuditMessage auditMessage = _fetchAuditMessage(EventTypes.LOGIN);
+
+		Assert.assertEquals(auditSessionId, auditMessage.getSessionID());
+
+		String[] sessionPhishingProtectedAttributes =
+			PropsValues.SESSION_PHISHING_PROTECTED_ATTRIBUTES;
+
+		PropsValues.SESSION_PHISHING_PROTECTED_ATTRIBUTES = ArrayUtil.remove(
+			sessionPhishingProtectedAttributes, WebKeys.AUDIT_SESSION_ID);
+
+		try {
+			MockHttpServletRequest unprotectedMockHttpServletRequest =
+				_createMockHttpServletRequest();
+
+			_runLoginPostAction(unprotectedMockHttpServletRequest);
+
+			String unprotectedAuditSessionId = _getAuditSessionId(
+				unprotectedMockHttpServletRequest);
+
+			AuthenticatedSessionManagerUtil.renewSession(
+				unprotectedMockHttpServletRequest,
+				unprotectedMockHttpServletRequest.getSession());
+
+			_runLoginPostAction(unprotectedMockHttpServletRequest);
+
+			Assert.assertNotEquals(
+				unprotectedAuditSessionId,
+				_getAuditSessionId(unprotectedMockHttpServletRequest));
+		}
+		finally {
+			PropsValues.SESSION_PHISHING_PROTECTED_ATTRIBUTES =
+				sessionPhishingProtectedAttributes;
+		}
+	}
+
+	private MockHttpServletRequest _createMockHttpServletRequest()
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.COMPANY_ID, TestPropsValues.getCompanyId());
+		mockHttpServletRequest.setAttribute(WebKeys.USER, _user);
+
+		HttpSession httpSession = mockHttpServletRequest.getSession();
+
+		httpSession.setAttribute(WebKeys.USER_ID, _user.getUserId());
+
+		return mockHttpServletRequest;
+	}
+
+	private AuditMessage _fetchAuditMessage(String eventType) {
+		for (AuditMessage auditMessage : _auditMessages) {
+			if (Objects.equals(auditMessage.getEventType(), eventType)) {
+				return auditMessage;
+			}
+		}
+
+		return null;
+	}
+
+	private String _getAuditSessionId(
+		MockHttpServletRequest mockHttpServletRequest) {
+
+		HttpSession httpSession = mockHttpServletRequest.getSession();
+
+		return (String)httpSession.getAttribute(WebKeys.AUDIT_SESSION_ID);
+	}
+
+	private void _runAuditFilter(MockHttpServletRequest mockHttpServletRequest)
+		throws Exception {
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					TestPropsValues.getCompanyId())) {
+
+			InvokerFilterChain invokerFilterChain = new InvokerFilterChain(
+				(servletRequest, servletResponse) -> {
+				});
+
+			invokerFilterChain.addFilter(_filter);
+
+			invokerFilterChain.doFilter(
+				mockHttpServletRequest, new MockHttpServletResponse());
+		}
+	}
+
+	private void _runLoginPostAction(
+			MockHttpServletRequest mockHttpServletRequest)
+		throws Exception {
+
+		_auditMessages.clear();
+
+		try (SafeCloseable safeCloseable =
+				CompanyThreadLocal.setCompanyIdWithSafeCloseable(
+					TestPropsValues.getCompanyId())) {
+
+			_lifecycleAction.processLifecycleEvent(
+				new LifecycleEvent(
+					mockHttpServletRequest, new MockHttpServletResponse()));
+		}
+	}
+
+	private final List<AuditMessage> _auditMessages = new ArrayList<>();
+
+	@Inject(
+		filter = "component.name=com.liferay.portal.security.audit.wiring.internal.servlet.filter.AuditFilter"
+	)
+	private Filter _filter;
+
+	@Inject(
+		filter = "component.name=com.liferay.portal.security.audit.event.generators.internal.events.LoginPostAction"
+	)
+	private LifecycleAction _lifecycleAction;
+
+	private ServiceRegistration<AuditMessageProcessor> _serviceRegistration;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+}

--- a/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/events/LoginPostAction.java
+++ b/modules/dxp/apps/portal-security-audit/portal-security-audit-event-generators/src/main/java/com/liferay/portal/security/audit/event/generators/internal/events/LoginPostAction.java
@@ -13,11 +13,14 @@ import com.liferay.portal.kernel.events.LifecycleAction;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.servlet.filters.invoker.InvokerFilterChain;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portal.security.audit.event.generators.constants.EventTypes;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -51,6 +54,13 @@ public class LoginPostAction extends Action {
 		throws Exception {
 
 		User user = _portal.getUser(httpServletRequest);
+
+		HttpSession httpSession = httpServletRequest.getSession();
+
+		if (httpSession.getAttribute(WebKeys.AUDIT_SESSION_ID) == null) {
+			httpSession.setAttribute(
+				WebKeys.AUDIT_SESSION_ID, PortalUUIDUtil.generate());
+		}
 
 		InvokerFilterChain invokerFilterChain = new InvokerFilterChain(
 			(servletRequest, servletResponse) -> {

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3264,6 +3264,7 @@
     # Env: LIFERAY_SESSION_PERIOD_PHISHING_PERIOD_PROTECTED_PERIOD_ATTRIBUTES
     #
     session.phishing.protected.attributes=\
+        AUDIT_SESSION_ID,\
         HTTPS_INITIAL,\
         LAST_PATH,\
         SAML_SP_SESSION_KEY,\

--- a/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
@@ -45,6 +45,8 @@ public interface WebKeys {
 
 	public static final String ASSET_VOCABULARY = "ASSET_VOCABULARY";
 
+	public static final String AUDIT_SESSION_ID = "AUDIT_SESSION_ID";
+
 	public static final String AUI_SCRIPT_DATA =
 		"LIFERAY_SHARED_AUI_SCRIPT_DATA";
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99746

## What Is Being Fixed

The audit `sessionID` column stored the raw container session identifier (`httpSession.getId()`), which is both unstable and unsafe to store.

It is unstable because `AuthenticatedSessionManagerUtil.renewSession` invalidates the session and creates a new one, so the container mints a fresh JSESSIONID. That path runs on every sign in under the default `session.enable.phishing.protection=true`, and a mid-session password change re-enters `login()` through `UpdatePasswordMVCActionCommand` and `UpdatePasswordActionUtil`. A user who changed their password therefore started a second audit session, and an auditor could no longer reconstruct the full chain of events for a single session.

It is unsafe because a live session token ended up in an audit row that is meant to be read, searched, and exported.

## How It Is Being Fixed

An opaque UUID is minted at authentication in the audit `LoginPostAction`, stored on the HTTP session under a new `WebKeys.AUDIT_SESSION_ID`, and read by `AuditFilter` in place of `httpSession.getId()`. The attribute is added to `session.phishing.protected.attributes` so `renewSession` carries it across the invalidate-and-recreate pair, which is what keeps the identifier stable for the lifetime of the session. The CSP nonce is preserved the same way.

The mint is conditional. A password change renews the session — which has already copied the identifier forward — and then re-fires `LOGIN_EVENTS_POST`, so an unconditional mint would overwrite the value that `renewSession` just preserved and reintroduce the defect with a differently shaped value. Both the property entry and the guard are load-bearing, which is why `testAuditSessionIdIsLostWithoutPhishingProtectedAttribute` exists as a negative control: it runs the same scenario with the entry removed and asserts the identifier changes, so `testAuditSessionIdSurvivesSessionRenewal` cannot pass vacuously.

Events emitted before the user is known carry no identifier, since there is no authenticated session to trace; those are linked by `requestId` under LPD-97721 instead. The persistence path, the `sessionID` column, and its consumers are unchanged, so there is no Service Builder, schema, or upgrade work.

Two limitations are left deliberately.

`UserWorkflowHandler` still captures a raw `httpSession.getId()` for non-HTTP execution paths. LPD-97724 owns those paths and is expected to propagate the derived identifier defined here rather than the container identifier, so until it lands the "never equals the raw container session id" criterion holds for the HTTP filter path but not repository wide.

A CE deployment gets no identifier at all. The mint lives in `LoginPostAction` under the DXP-only `portal-security-audit-event-generators`, while `AuditFilter` and the `portal-security-audit-event-generators-user-management` listeners are CE, so without the DXP bundle nothing writes the session attribute and those events move from carrying a JSESSIONID to carrying null. That follows from the epic's refined design rather than from a choice made here; closing it would mean moving the mint into the CE filter, minting when the session already carries a `WebKeys.USER_ID`, which would also cover authentication paths that do not run this action. Worth confirming in refinement whether the CE split is intended.

## PR Check

**pr-check: PASS** — tested on `3294d719c779b369b1b5c19861ec5a901bccb0f2`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "3294d719c779b369b1b5c19861ec5a901bccb0f2"} -->
