### PR TITLE
LPD-102990 Do not cache permission-denied Document Library redirects

### DIFF
--- a/modules/apps/portal/portal-webserver-test/src/testIntegration/java/com/liferay/portal/webserver/test/WebServerServletTest.java
+++ b/modules/apps/portal/portal-webserver-test/src/testIntegration/java/com/liferay/portal/webserver/test/WebServerServletTest.java
@@ -158,7 +158,12 @@ public class WebServerServletTest {
 						"promptEnabled", false
 					).build())) {
 
-			_testGetStatus(HttpServletResponse.SC_NOT_FOUND);
+			MockHttpServletResponse mockHttpServletResponse =
+				_serviceRestrictedDocumentRequest();
+
+			Assert.assertEquals(
+				HttpServletResponse.SC_NOT_FOUND,
+				mockHttpServletResponse.getStatus());
 		}
 
 		try (ConfigurationTemporarySwapper configurationTemporarySwapper =
@@ -169,7 +174,15 @@ public class WebServerServletTest {
 						"promptEnabled", true
 					).build())) {
 
-			_testGetStatus(HttpServletResponse.SC_MOVED_TEMPORARILY);
+			MockHttpServletResponse mockHttpServletResponse =
+				_serviceRestrictedDocumentRequest();
+
+			Assert.assertEquals(
+				HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE,
+				mockHttpServletResponse.getHeader(HttpHeaders.CACHE_CONTROL));
+			Assert.assertEquals(
+				HttpServletResponse.SC_MOVED_TEMPORARILY,
+				mockHttpServletResponse.getStatus());
 		}
 	}
 
@@ -410,7 +423,9 @@ public class WebServerServletTest {
 		return mockHttpServletResponse;
 	}
 
-	private void _testGetStatus(int status) throws Exception {
+	private MockHttpServletResponse _serviceRestrictedDocumentRequest()
+		throws Exception {
+
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
 
@@ -462,7 +477,7 @@ public class WebServerServletTest {
 		_webServerServlet.service(
 			mockHttpServletRequest, mockHttpServletResponse);
 
-		Assert.assertEquals(status, mockHttpServletResponse.getStatus());
+		return mockHttpServletResponse;
 	}
 
 	private void _testService(String requestURI) throws Exception {

--- a/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
+++ b/portal-impl/src/com/liferay/portal/webserver/WebServerServlet.java
@@ -908,6 +908,10 @@ public class WebServerServlet extends HttpServlet {
 			HttpServletResponse httpServletResponse)
 		throws IOException, ServletException {
 
+		httpServletResponse.setHeader(
+			HttpHeaders.CACHE_CONTROL,
+			HttpHeaders.CACHE_CONTROL_NO_CACHE_VALUE);
+
 		if (!user.isGuestUser()) {
 			PortalUtil.sendError(
 				HttpServletResponse.SC_UNAUTHORIZED, (Exception)throwable,


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102990

## What Is Being Fixed

An unauthenticated guest requesting a private Document Library file whose URL ends in a cacheable extension (.css, .gif, .ico, .jpg, .js, .png) received a 302 redirect to the sign-in page carrying `Cache-Control: max-age=315360000, public`. CDNs and browsers cached that public redirect, so after Guest view permission was restored on the file, guests kept receiving the cached redirect instead of the file.

## How It Is Being Fixed

The extension-based Header Filter stamps the long-lived public `Cache-Control` header for any non-new session, and `WebServerServlet.processPrincipalException` redirected the guest without clearing it. The filter sets headers before the servlet runs and cannot modify them after the redirect commits, so the reset belongs at the redirect. `processPrincipalException` now sets `Cache-Control` to a non-cacheable value before both the redirect and the 401 branch, so a permission-denied response is never cached. `WebServerServletTest` asserts the 302 now carries the no-cache value.

## PR Check

**pr-check: PASS** — tested on `90a416024b46cdbb71659638b9cda4e59c7a412d`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "90a416024b46cdbb71659638b9cda4e59c7a412d"} -->
