### PR TITLE
LPD-103030 Upgrade jose4j to 0.9.6

### DIFF
--- a/lib/versions-complete.xml
+++ b/lib/versions-complete.xml
@@ -1953,7 +1953,7 @@
 			</library>
 			<library>
 				<file-name>com.liferay.oauth2.provider.rest.jar!jose4j.jar</file-name>
-				<version>0.9.4</version>
+				<version>0.9.6</version>
 				<project-name>jose4j</project-name>
 				<project-url>https://bitbucket.org/b_c/jose4j/</project-url>
 				<licenses>

--- a/lib/versions.html
+++ b/lib/versions.html
@@ -1053,7 +1053,7 @@
                 </tr>
                 			
                 <tr>
-                    <td nowrap="nowrap">com.liferay.oauth2.provider.rest.jar!jose4j.jar</td><td nowrap="nowrap">0.9.4</td><td nowrap="nowrap"><a href="https://bitbucket.org/b_c/jose4j/">jose4j</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
+                    <td nowrap="nowrap">com.liferay.oauth2.provider.rest.jar!jose4j.jar</td><td nowrap="nowrap">0.9.6</td><td nowrap="nowrap"><a href="https://bitbucket.org/b_c/jose4j/">jose4j</a></td><td nowrap><a href="http://www.apache.org/licenses/LICENSE-2.0.txt">The Apache Software License, Version 2.0</a>
                         <br>
                     </td><td></td>
                 </tr>

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/build.gradle
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
 	compileInclude group: "jakarta.annotation", name: "jakarta.annotation-api", version: "2.1.1"
-	compileInclude group: "org.bitbucket.b_c", name: "jose4j", version: "0.9.4"
+	compileInclude group: "org.bitbucket.b_c", name: "jose4j", version: "0.9.6"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-annotations", version: "2.18.9"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.18.9"
 	compileOnly group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.18.9"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103030

## What Is Being Fixed

`modules/apps/oauth2-provider/oauth2-provider-rest` embeds jose4j 0.9.4, which is affected by CVE-2024-29371: a crafted JSON Web Encryption token with an exceptionally high compression ratio makes the decompression step allocate a large amount of memory and processing time, so a denial of service is possible. NVD scores it 7.5 and it is fixed in jose4j 0.9.6, which is also the latest release.

LSV-1584 closed the report as not exploitable, and the code agrees. `OAuth2AuthorizationServerConfigurationGenerator` is the only consumer of jose4j in the portal, and it uses only `JsonWebKey`, `RsaJsonWebKey` and `RsaJwkGenerator` to generate the RSA JWK of the authorization server, so no attacker supplied token is ever decompressed. Per the InfoSec and Engineering agreement a library that is not exploitable still receives the version bump, and LPP-65255 asks for it in 2025.Q1.27, which needs the fix on master first.

## How It Is Being Fixed

The `compileInclude` declaration moves to 0.9.6, and `lib/versions-complete.xml` and `lib/versions.html` record the new version for the embedded jar.

jose4j is declared in exactly that one place and consumed by exactly one class, so nothing else has to move with it. Its POM is unchanged between the two versions, carrying `slf4j-api` 1.7.36 at compile scope in both, so the bundle keeps the same embedded content and the same imports.

## Why Are There No Tests?

This is a third party version bump that changes no portal code. The behavior the upgrade fixes lives in jose4j's own JWE decompression path, which this module never reaches, so a test here would exercise the library rather than the portal. It was verified by running it instead.

`oauth2-provider-rest` compiles and jars from scratch against 0.9.6, and `LibraryReferenceTest` covers the changed `lib/` metadata. The eight `oauth2-provider` unit test classes pass, 31 tests, with one exception: `ConfigurationFactoryTest#testOAuth2ProviderApplicationHeadlessServerConfigurationFactory`, which fails identically on a clean master checkout.

On a running portal the bundle starts with `Bundle-ClassPath: .,lib/jakarta.annotation-api-2.1.1.jar,lib/jose4j-0.9.6.jar` and serves `/o/oauth2/jwks`. Clearing the stored `OAuth2AuthorizationServerConfiguration` and restarting had `RsaJwkGenerator` regenerate the signing key under 0.9.6, rotating the modulus, so the one line of portal code that reaches jose4j is exercised inside the container.

The `oauth2-provider` integration suite reports 40 failures against my local bundle, and none of them belong to this change. Twenty eight are a single cascade from a login response that carries no cookie. The JWT specific ones, `IssueJWTAccessTokenTest` with `INVALID_COMPACT_JWS` and `RefreshTokenAuthorizationGrantTest` with 401, reproduce identically after redeploying the same module built with 0.9.4, while `JWTAssertAuthorizationGrantTest` passes 8 of 8 either way. That bundle is also running cookie and consent modules from an unrelated branch, so its integration results are not a clean signal for anything right now.

## PR Check

**pr-check: PASS** — tested on `b02802be75791de151ffde24e574789643cfff2f`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |

Only three validations match a diff made of one `build.gradle` and two `lib/` files. Per-Module Compile does not fire, because its pattern does not cover `build.gradle`, so `oauth2-provider-rest` was compiled and jarred separately with `--rerun-tasks` (132 of 132 tasks executed) and passes.

Structural Smoke ran both applicable scanners: `ModulesStructureTest` for the changed `.gradle` file (8 tests) and `LibraryReferenceTest` for the changed `lib/` metadata (14 tests). Baseline reported no warnings of any kind and left the tree unchanged.

One note on the generated files: `ant build-lib-versions` also wanted to add AWS SDK entries for `com.liferay.portal.security.key.provider.aws.jar`, which master is missing. Those are unrelated to this branch and were left out, so the commit carries only the two jose4j lines.

<!-- pr-check {"result": "success", "sha": "b02802be75791de151ffde24e574789643cfff2f"} -->
