### PR TITLE
LPD-103042 Apply a configured AntiSamy policy only to its own class name

### DIFF
--- a/modules/apps/portal-security/portal-security-antisamy-test/build.gradle
+++ b/modules/apps/portal-security/portal-security-antisamy-test/build.gradle
@@ -1,3 +1,4 @@
 dependencies {
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/portal-security/portal-security-antisamy-test/src/testIntegration/java/com/liferay/portal/security/antisamy/internal/test/AntiSamySanitizerImplTest.java
+++ b/modules/apps/portal-security/portal-security-antisamy-test/src/testIntegration/java/com/liferay/portal/security/antisamy/internal/test/AntiSamySanitizerImplTest.java
@@ -7,10 +7,14 @@ package com.liferay.portal.security.antisamy.internal.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -48,6 +52,41 @@ public class AntiSamySanitizerImplTest {
 				"right here.",
 			"This little text should not have a space removed but it happens " +
 				"right here.");
+	}
+
+	@Test
+	@TestInfo("LPD-103042")
+	public void testSanitizeWithConfiguredClassName() throws Exception {
+		String className = RandomTestUtil.randomString();
+		String factoryPid =
+			"com.liferay.portal.security.antisamy.configuration." +
+				"AntiSamyClassNameConfiguration";
+
+		String pid = ConfigurationTestUtil.createFactoryConfiguration(
+			factoryPid,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"className", className
+			).put(
+				"configurationFileURL",
+				"/META-INF/resources/fragment-sanitizer-configuration.xml"
+			).build());
+
+		String svg = "<svg><circle cx=\"1\"></circle></svg>";
+
+		try {
+			Assert.assertEquals(svg, _sanitize(className, svg));
+			Assert.assertEquals(
+				StringPool.BLANK, _sanitize(className + "Rel", svg));
+		}
+		finally {
+			ConfigurationTestUtil.deleteFactoryConfiguration(pid, factoryPid);
+		}
+	}
+
+	private String _sanitize(String className, String value) throws Exception {
+		return _sanitizer.sanitize(
+			TestPropsValues.getCompanyId(), 0, 0, className, 0,
+			ContentTypes.TEXT_HTML, new String[0], value, new HashMap<>());
 	}
 
 	private void _testSanitize(String expectedValue, String value)

--- a/modules/apps/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/internal/AntiSamySanitizerImpl.java
+++ b/modules/apps/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/internal/AntiSamySanitizerImpl.java
@@ -109,9 +109,9 @@ public class AntiSamySanitizerImpl implements Sanitizer {
 
 			AntiSamy antiSamy = new AntiSamy();
 
-			if (_isConfigured(className, classPK)) {
-				Policy policy = _policies.get(className);
+			Policy policy = _policies.get(className);
 
+			if (policy != null) {
 				cleanResults = antiSamy.scan(content, policy, AntiSamy.SAX);
 			}
 			else {
@@ -143,18 +143,6 @@ public class AntiSamySanitizerImpl implements Sanitizer {
 			throw new IllegalStateException(
 				"Unable to initialize policy", exception);
 		}
-	}
-
-	private boolean _isConfigured(String className, long classPK) {
-		String classNameAndClassPK = className + StringPool.POUND + classPK;
-
-		for (String policyClassName : _policies.keySet()) {
-			if (classNameAndClassPK.startsWith(policyClassName)) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	private boolean _isWhitelisted(String className, long classPK) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103042

@jgarcialr as you reviewed the original pull, can you please check? Thanks!

## What Is Being Fixed

`AntiSamySanitizerImpl` picks a configured policy by prefix but looks it up exactly, so any sanitized class name that starts with a registered one selects a policy that then resolves to null, and every write of that entity fails.

`_isConfigured` walks `_policies.keySet()` and returns true when `className + "#" + classPK` starts with a registered class name. `sanitize` then does `_policies.get(className)`, an exact lookup. When the two disagree the policy is null, `antiSamy.scan(content, null, AntiSamy.SAX)` throws `PolicyException: No policy loaded`, and `sanitize` wraps it in a `SanitizerException`.

The shipped `configurator/configurations.json` registers `BlogsEntry`, `FragmentEntryLink` and `KBArticle`, and none of the three is a prefix of another sanitized class name, so a stock instance is not affected. Any further registration can be, whether an administrator adds one in System Settings or a module ships one. Sanitized class names that already form such a prefix pair include `FragmentEntry`/`FragmentEntryVersion`, `DLFileEntry`/`DLFileEntryType`, `AssetCategory`/`AssetCategoryProperty`, `Layout`/`LayoutPageTemplateEntry` and `User`/`UserGroup`.

## How It Is Being Fixed

`_isConfigured` is deleted and the branch is taken on the exact lookup itself, so a class name with no policy of its own falls through to the default policy instead of selecting a null one.

`AntiSamySanitizerImplTest.testSanitizeWithConfiguredClassName` registers an `AntiSamyClassNameConfiguration` for a random class name, then sanitizes that class name and the same name with `Rel` appended. It fails without the fix with `PolicyException: No policy loaded`.

## Where It Came From

Found while working https://liferay.atlassian.net/browse/LPD-102184, which registers a fourth class name policy, for `LayoutPageTemplateStructureRelElementVariation`. That registration broke every external reference code write of `LayoutPageTemplateStructureRelElementVariationAudienceEntryRel`: 14 integration test failures. That pull was discarded, so the fix and its test are extracted here to be reviewed and land on their own.

## PR Check

**pr-check: PASS** — tested on `82850f737da291e19a0fac4d5b1ffdf9cfb7cf80`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Java Unit Tests | PASS (no unit test counterpart) |
| Structural Smoke | PASS |
| Baseline | PASS |

<!-- pr-check {"result": "success", "sha": "82850f737da291e19a0fac4d5b1ffdf9cfb7cf80"} -->
