### PR TITLE
LPD-93284 Log every FIPS state transition as NDJSON

### DIFF
--- a/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
+++ b/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
@@ -1,0 +1,183 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.fips.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jorge García Jiménez
+ */
+@RunWith(Arquillian.class)
+public class FIPSAuditUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() {
+		Assume.assumeTrue(PropsValues.FIPS_ENABLED);
+	}
+
+	@Test
+	public void testAuditLogFileExists() {
+		Path path = _getAuditLogPath();
+
+		Assert.assertTrue(
+			"Unable to find the FIPS audit log " + path, Files.exists(path));
+	}
+
+	@Test
+	public void testAuditLogFileIsReadableByTheOwnerOnly() throws Exception {
+		Path path = _getAuditLogPath();
+
+		FileSystem fileSystem = path.getFileSystem();
+
+		Set<String> supportedFileAttributeViews =
+			fileSystem.supportedFileAttributeViews();
+
+		Assume.assumeTrue(supportedFileAttributeViews.contains("posix"));
+
+		Assert.assertEquals(
+			PosixFilePermissions.fromString("rw-------"),
+			Files.getPosixFilePermissions(path));
+	}
+
+	@Test
+	public void testAuditLogRecordsAreParseable() throws Exception {
+		for (String line : Files.readAllLines(_getAuditLogPath())) {
+			Assert.assertTrue(
+				"Blank line in the FIPS audit log", Validator.isNotNull(line));
+
+			JSONFactoryUtil.createJSONObject(line);
+		}
+	}
+
+	@Test
+	public void testAuditLogRecordsCarryACanonicalTimestamp() throws Exception {
+		for (JSONObject jsonObject : _getRecordJSONObjects()) {
+			String timestamp = jsonObject.getString("timestamp");
+
+			Assert.assertTrue(
+				StringBundler.concat(
+					"Noncanonical timestamp \"", timestamp,
+					"\" in the FIPS audit record ", jsonObject),
+				timestamp.matches(
+					"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"));
+		}
+	}
+
+	@Test
+	public void testAuditLogRecordsCarryAMonotonicSequence() throws Exception {
+		long previousEventSequence = 0;
+
+		for (JSONObject jsonObject : _getRecordJSONObjects()) {
+			long eventSequence = jsonObject.getLong("event-sequence");
+
+			if (eventSequence > previousEventSequence) {
+				Assert.assertEquals(
+					String.valueOf(jsonObject), previousEventSequence + 1,
+					eventSequence);
+			}
+
+			previousEventSequence = eventSequence;
+		}
+	}
+
+	@Test
+	public void testAuditLogRecordsCarryTheCommonEnvelope() throws Exception {
+		for (JSONObject jsonObject : _getRecordJSONObjects()) {
+			for (String envelopeKey : _ENVELOPE_KEYS) {
+				Assert.assertTrue(
+					StringBundler.concat(
+						"Unable to find \"", envelopeKey,
+						"\" in the FIPS audit record ", jsonObject),
+					jsonObject.has(envelopeKey));
+			}
+		}
+	}
+
+	@Test
+	public void testAuditLogRecordsTheBootStateTransitions() throws Exception {
+		List<String> transitions = new ArrayList<>();
+
+		for (JSONObject jsonObject : _getRecordJSONObjects()) {
+			String eventType = jsonObject.getString("event-type");
+
+			if (!eventType.equals("fips-state-transition")) {
+				continue;
+			}
+
+			JSONObject fieldsJSONObject = jsonObject.getJSONObject("fields");
+
+			transitions.add(
+				StringBundler.concat(
+					fieldsJSONObject.getString("from-state"), " to ",
+					fieldsJSONObject.getString("to-state")));
+		}
+
+		Assert.assertTrue(
+			transitions.toString(),
+			transitions.contains("INITIALIZING to SELF_TEST"));
+		Assert.assertTrue(
+			transitions.toString(),
+			transitions.contains("SELF_TEST to OPERATIONAL"));
+	}
+
+	private Path _getAuditLogPath() {
+		LocalDate localDate = LocalDate.now(ZoneOffset.UTC);
+
+		return Paths.get(
+			PropsValues.LIFERAY_HOME, "logs",
+			StringBundler.concat("fips-audit.", localDate, ".ndjson"));
+	}
+
+	private List<JSONObject> _getRecordJSONObjects() throws Exception {
+		List<JSONObject> jsonObjects = new ArrayList<>();
+
+		for (String line : Files.readAllLines(_getAuditLogPath())) {
+			jsonObjects.add(JSONFactoryUtil.createJSONObject(line));
+		}
+
+		return jsonObjects;
+	}
+
+	private static final String[] _ENVELOPE_KEYS = {
+		"cmvp-certificate-id", "deployment-instance-id", "event-schema-version",
+		"event-sequence", "event-type", "fields", "provider-name",
+		"provider-version", "severity", "timestamp"
+	};
+
+}

--- a/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
+++ b/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
@@ -60,7 +60,7 @@ public class FIPSAuditUtilTest {
 	}
 
 	@Test
-	public void testAuditLogFileIsReadableByTheOwnerOnly() throws Exception {
+	public void testAuditLogFileIsAccessibleByTheOwnerOnly() throws Exception {
 		Path path = _getAuditLogPath();
 
 		FileSystem fileSystem = path.getFileSystem();
@@ -100,7 +100,7 @@ public class FIPSAuditUtilTest {
 	}
 
 	@Test
-	public void testAuditLogRecordsCarryAMonotonicSequence() throws Exception {
+	public void testAuditLogRecordsCarryAContiguousSequence() throws Exception {
 		long previousEventSequence = 0;
 
 		for (JSONObject jsonObject : _getRecordJSONObjects()) {

--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -356,6 +356,10 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 		if (Boolean.parseBoolean(System.getenv("LIFERAY_CLEAN_OSGI_STATE"))) {
 			_cleanOSGiStateFolder();
 		}
+
+		if (PropsValues.FIPS_ENABLED) {
+			FIPSApplicationStateMachineUtil.powerOff("Server shutdown");
+		}
 	}
 
 	@Override

--- a/portal-impl/src/META-INF/portal-log4j.xml
+++ b/portal-impl/src/META-INF/portal-log4j.xml
@@ -31,6 +31,14 @@
 				<Layout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p [%t][%c{1}:%L] %m%n" type="PatternLayout" />
 			</FilePattern>
 		</Appender>
+
+		<Appender filePattern="@liferay.home@/logs/fips-audit.%d{yyyy-MM-dd}{UTC}.ndjson" filePermissions="rw-------" ignoreExceptions="false" immediateFlush="true" name="FIPS_AUDIT_FILE" type="RollingFile">
+			<Layout type="FIPSAuditNDJSONLayout" />
+
+			<TimeBasedTriggeringPolicy />
+
+			<DirectWriteRolloverStrategy />
+		</Appender>
 	</Appenders>
 
 	<Loggers>
@@ -83,6 +91,11 @@
 		<Logger level="INFO" name="com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil" />
 		<Logger level="INFO" name="com.liferay.portal.kernel.deploy" />
 		<Logger level="WARN" name="com.liferay.portal.kernel.internal.configuration.ConfigurationImpl" />
+
+		<Logger additivity="false" level="INFO" name="com.liferay.portal.kernel.internal.log4j.Log4jFIPSAuditUtil">
+			<AppenderRef ref="FIPS_AUDIT_FILE" />
+		</Logger>
+
 		<Logger level="ERROR" name="com.liferay.portal.kernel.lar" />
 		<Logger level="INFO" name="com.liferay.portal.kernel.messaging.config.DefaultMessagingConfigurator" />
 		<Logger level="ERROR" name="com.liferay.portal.kernel.model.Image" />

--- a/portal-impl/src/META-INF/portal-log4j.xml
+++ b/portal-impl/src/META-INF/portal-log4j.xml
@@ -33,6 +33,8 @@
 		</Appender>
 
 		<Appender filePattern="@liferay.home@/logs/fips-audit.%d{yyyy-MM-dd}{UTC}.ndjson" filePermissions="rw-------" ignoreExceptions="false" immediateFlush="true" name="FIPS_AUDIT_FILE" type="RollingFile">
+			<Filter type="FIPSAuditFilter" />
+
 			<Layout type="FIPSAuditNDJSONLayout" />
 
 			<TimeBasedTriggeringPolicy />

--- a/portal-impl/src/META-INF/portal-log4j.xml
+++ b/portal-impl/src/META-INF/portal-log4j.xml
@@ -92,7 +92,7 @@
 		<Logger level="INFO" name="com.liferay.portal.kernel.deploy" />
 		<Logger level="WARN" name="com.liferay.portal.kernel.internal.configuration.ConfigurationImpl" />
 
-		<Logger additivity="false" level="INFO" name="com.liferay.portal.kernel.internal.log4j.Log4jFIPSAuditUtil">
+		<Logger additivity="false" level="INFO" name="com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil">
 			<AppenderRef ref="FIPS_AUDIT_FILE" />
 		</Logger>
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7737,20 +7737,20 @@
 ##
 
     #
-    # Set the deployment instance ID recorded in the common envelope of every
-    # FIPS audit event. Leave blank to derive a stable per install identifier.
+    # Set the deployment instance ID written in the common envelope of every
+    # FIPS audit record. Leave blank to derive a stable per install identifier.
     # In a cluster, set a distinct value per node so that downstream SIEM
-    # correlation can attribute each event to the node that emitted it.
+    # correlation can attribute each record to the node that wrote it.
     #
     # Env: LIFERAY_FIPS_PERIOD_AUDIT_PERIOD_DEPLOYMENT_PERIOD_INSTANCE_PERIOD_ID
     #
     fips.audit.deployment.instance.id=
 
     #
-    # Set the CMVP certificate ID of the validated cryptographic module,
-    # recorded in the common envelope of every FIPS audit event. This is
-    # deployment metadata that the JCE provider does not expose. Leave blank if
-    # it is unset.
+    # Set the CMVP certificate ID of the validated cryptographic module, written
+    # in the common envelope of every FIPS audit record. This is deployment
+    # metadata that the JCE provider does not expose. Leave blank if it is
+    # unset.
     #
     # Env: LIFERAY_FIPS_PERIOD_AUDIT_PERIOD_PROVIDER_PERIOD_CMVP_PERIOD_CERTIFICATE_PERIOD_ID
     #

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7737,6 +7737,26 @@
 ##
 
     #
+    # Set the deployment instance ID recorded in the common envelope of every
+    # FIPS audit event. Leave blank to derive a stable per install identifier.
+    # In a cluster, set a distinct value per node so that downstream SIEM
+    # correlation can attribute each event to the node that emitted it.
+    #
+    # Env: LIFERAY_FIPS_PERIOD_AUDIT_PERIOD_DEPLOYMENT_PERIOD_INSTANCE_PERIOD_ID
+    #
+    fips.audit.deployment.instance.id=
+
+    #
+    # Set the CMVP certificate ID of the validated cryptographic module,
+    # recorded in the common envelope of every FIPS audit event. This is
+    # deployment metadata that the JCE provider does not expose. Leave blank if
+    # it is unset.
+    #
+    # Env: LIFERAY_FIPS_PERIOD_AUDIT_PERIOD_PROVIDER_PERIOD_CMVP_PERIOD_CERTIFICATE_PERIOD_ID
+    #
+    fips.audit.provider.cmvp.certificate.id=
+
+    #
     # Set this to true to operate the portal in FIPS mode. When enabled, the
     # portal validates that the security providers configured in the JVM's
     # java.security file are registered in the order required to route

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
@@ -59,21 +59,22 @@ public class FIPSAuditFilterTest {
 		Marker marker = MarkerManager.getMarker(FIPSLog4jUtil.MARKER_NAME);
 
 		_testFilterDenies(
-			marker, new ObjectMessage("not-a-map"),
-			"does not carry a FIPS audit record");
+			"does not carry a FIPS audit record", marker,
+			new ObjectMessage("not-a-map"));
 		_testFilterDenies(
-			marker, new SimpleMessage("Not a record"),
-			"does not carry a FIPS audit record");
+			"does not carry a FIPS audit record", marker,
+			new SimpleMessage("Not a record"));
 	}
 
 	@Test
 	public void testFilterDeniesAnEventWithoutTheMarker() {
 		_testFilterDenies(
+			"carries no \"FIPS_AUDIT\" marker",
 			MarkerManager.getMarker(RandomTestUtil.randomString()),
-			new ObjectMessage(_record), "carries no \"FIPS_AUDIT\" marker");
+			new ObjectMessage(_record));
 		_testFilterDenies(
-			null, new ObjectMessage(_record),
-			"carries no \"FIPS_AUDIT\" marker");
+			"carries no \"FIPS_AUDIT\" marker", null,
+			new ObjectMessage(_record));
 	}
 
 	private FIPSAuditFilter _createFIPSAuditFilter() {
@@ -94,7 +95,7 @@ public class FIPSAuditFilterTest {
 	}
 
 	private void _testFilterDenies(
-		Marker marker, Message message, String expectedMessage) {
+		String expectedMessage, Marker marker, Message message) {
 
 		FIPSAuditFilter fipsAuditFilter = _createFIPSAuditFilter();
 
@@ -117,6 +118,6 @@ public class FIPSAuditFilterTest {
 	}
 
 	private final Map<String, Object> _record = Collections.singletonMap(
-		"event-type", "fips-state-transition");
+		RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
 }

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
@@ -1,0 +1,122 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.internal.log4j;
+
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.ObjectMessage;
+import org.apache.logging.log4j.message.SimpleMessage;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSAuditFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			CodeCoverageAssertor.INSTANCE, LiferayUnitTestRule.INSTANCE);
+
+	@Test
+	public void testFilterAcceptsARecord() {
+		FIPSAuditFilter fipsAuditFilter = _createFIPSAuditFilter();
+
+		Assert.assertEquals(
+			Filter.Result.ACCEPT,
+			fipsAuditFilter.filter(
+				_createLogEvent(
+					MarkerManager.getMarker(FIPSLog4jUtil.MARKER_NAME),
+					new ObjectMessage(_record))));
+	}
+
+	@Test
+	public void testFilterDeniesAnEventWithoutARecord() {
+		Marker marker = MarkerManager.getMarker(FIPSLog4jUtil.MARKER_NAME);
+
+		_testFilterDenies(
+			marker, new ObjectMessage("not-a-map"),
+			"does not carry a FIPS audit record");
+		_testFilterDenies(
+			marker, new SimpleMessage("Not a record"),
+			"does not carry a FIPS audit record");
+	}
+
+	@Test
+	public void testFilterDeniesAnEventWithoutTheMarker() {
+		_testFilterDenies(
+			MarkerManager.getMarker(RandomTestUtil.randomString()),
+			new ObjectMessage(_record), "carries no \"FIPS_AUDIT\" marker");
+		_testFilterDenies(
+			null, new ObjectMessage(_record),
+			"carries no \"FIPS_AUDIT\" marker");
+	}
+
+	private FIPSAuditFilter _createFIPSAuditFilter() {
+		FIPSAuditFilter.Builder builder = FIPSAuditFilter.newBuilder();
+
+		return builder.build();
+	}
+
+	private LogEvent _createLogEvent(Marker marker, Message message) {
+		Log4jLogEvent.Builder builder = Log4jLogEvent.newBuilder();
+
+		builder.setLevel(Level.INFO);
+		builder.setLoggerName(RandomTestUtil.randomString());
+		builder.setMarker(marker);
+		builder.setMessage(message);
+
+		return builder.build();
+	}
+
+	private void _testFilterDenies(
+		Marker marker, Message message, String expectedMessage) {
+
+		FIPSAuditFilter fipsAuditFilter = _createFIPSAuditFilter();
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				FIPSAuditFilter.class.getName(), LoggerTestUtil.ERROR)) {
+
+			Assert.assertEquals(
+				Filter.Result.DENY,
+				fipsAuditFilter.filter(_createLogEvent(marker, message)));
+
+			List<String> messages = logCapture.getMessages();
+
+			Assert.assertEquals(messages.toString(), 1, messages.size());
+
+			String errorMessage = messages.get(0);
+
+			Assert.assertTrue(
+				errorMessage, errorMessage.contains(expectedMessage));
+		}
+	}
+
+	private final Map<String, Object> _record = Collections.singletonMap(
+		"event-type", "fips-state-transition");
+
+}

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
@@ -59,10 +59,10 @@ public class FIPSAuditFilterTest {
 		Marker marker = MarkerManager.getMarker(FIPSLog4jUtil.MARKER_NAME);
 
 		_testFilterDenies(
-			"does not carry a FIPS audit record", marker,
+			"carries no FIPS audit record", marker,
 			new ObjectMessage("not-a-map"));
 		_testFilterDenies(
-			"does not carry a FIPS audit record", marker,
+			"carries no FIPS audit record", marker,
 			new SimpleMessage("Not a record"));
 	}
 

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
@@ -93,12 +93,11 @@ public class FIPSAuditNDJSONLayoutTest {
 
 	@Test
 	public void testToSerializableEndsWithASingleNewLine() {
-		String ndjson = _toSerializable(
-			Collections.singletonMap("event-type", "fips-state-transition"));
-
 		Assert.assertEquals(
-			"{\"event-type\":\"fips-state-transition\"}\n", ndjson);
-		Assert.assertEquals(ndjson.length() - 1, ndjson.indexOf('\n'));
+			"{\"event-type\":\"fips-state-transition\"}\n",
+			_toSerializable(
+				Collections.singletonMap(
+					"event-type", "fips-state-transition")));
 	}
 
 	@Test

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
@@ -1,0 +1,257 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.internal.log4j;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.ByteArrayOutputStream;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.core.layout.ByteBufferDestination;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.ObjectMessage;
+import org.apache.logging.log4j.message.SimpleMessage;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Rafael Praxedes
+ */
+public class FIPSAuditNDJSONLayoutTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			CodeCoverageAssertor.INSTANCE, LiferayUnitTestRule.INSTANCE);
+
+	@Before
+	public void setUp() {
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+	}
+
+	@Test
+	public void testEncode() {
+		Map<String, Object> record = LinkedHashMapBuilder.<String, Object>put(
+			"event-type", "fips-state-transition"
+		).put(
+			"severity", "CRITICAL"
+		).build();
+
+		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
+			_createFIPSAuditNDJSONLayout();
+
+		TestByteBufferDestination testByteBufferDestination =
+			new TestByteBufferDestination();
+
+		fipsAuditNDJSONLayout.encode(
+			_createLogEvent(new ObjectMessage(record)),
+			testByteBufferDestination);
+
+		Assert.assertEquals(
+			_toSerializable(record), testByteBufferDestination.toString());
+	}
+
+	@Test
+	public void testGetContentType() {
+		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
+			_createFIPSAuditNDJSONLayout();
+
+		Assert.assertEquals(
+			"application/x-ndjson; charset=UTF-8",
+			fipsAuditNDJSONLayout.getContentType());
+	}
+
+	@Test
+	public void testToSerializableEndsWithASingleNewLine() {
+		String ndjson = _toSerializable(
+			Collections.singletonMap("event-type", "fips-state-transition"));
+
+		Assert.assertEquals(
+			"{\"event-type\":\"fips-state-transition\"}\n", ndjson);
+		Assert.assertEquals(ndjson.length() - 1, ndjson.indexOf('\n'));
+	}
+
+	@Test
+	public void testToSerializableEscapesReservedCharacters() {
+		Assert.assertEquals(
+			"{\"provider-error-message\":\"a\\\\b\\\"c\\nd\\re\\tf\\u0001g" +
+				"\\u2028h\\u2029i\"}\n",
+			_toSerializable(
+				Collections.singletonMap(
+					"provider-error-message",
+					new String(
+						new char[] {
+							'a', '\\', 'b', '"', 'c', '\n', 'd', '\r', 'e',
+							'\t', 'f', 0x01, 'g', 0x2028, 'h', 0x2029, 'i'
+						}))));
+	}
+
+	@Test
+	public void testToSerializableWritesEveryEntry() throws Exception {
+		Map<String, Object> record = LinkedHashMapBuilder.<String, Object>put(
+			"event-type", "fips-state-transition"
+		).put(
+			"severity", "INFO"
+		).put(
+			"timestamp", "2026-08-04T12:00:00.000Z"
+		).build();
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			_toSerializable(record));
+
+		Assert.assertEquals(record.size(), jsonObject.length());
+
+		for (Map.Entry<String, Object> entry : record.entrySet()) {
+			Assert.assertEquals(
+				entry.getValue(), jsonObject.getString(entry.getKey()));
+		}
+	}
+
+	@Test
+	public void testToSerializableWritesMessageKeyForUnreadableMessages() {
+		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
+			_createFIPSAuditNDJSONLayout();
+
+		Assert.assertEquals(
+			"{\"message\":\"Unable to \\\"parse\\\" the record\"}\n",
+			fipsAuditNDJSONLayout.toSerializable(
+				_createLogEvent(
+					new SimpleMessage("Unable to \"parse\" the record"))));
+
+		Assert.assertEquals(
+			"{\"message\":\"not-a-map\"}\n",
+			fipsAuditNDJSONLayout.toSerializable(
+				_createLogEvent(new ObjectMessage("not-a-map"))));
+	}
+
+	@Test
+	public void testToSerializableWritesNestedMaps() {
+		Assert.assertEquals(
+			"{\"fields\":{\"from-state\":\"SELF_TEST\"}}\n",
+			_toSerializable(
+				Collections.singletonMap(
+					"fields",
+					Collections.singletonMap("from-state", "SELF_TEST"))));
+	}
+
+	@Test
+	public void testToSerializableWritesValueTypes() {
+		_testToSerializable(
+			"array", new String[] {"first", "second"},
+			"[\"first\",\"second\"]");
+		_testToSerializable("boolean", Boolean.TRUE, "true");
+		_testToSerializable("decimal", 1.5D, "1.5");
+		_testToSerializable("iterable", Arrays.asList("one", 2), "[\"one\",2]");
+		_testToSerializable("number", 42, "42");
+		_testToSerializable("string", "text", "\"text\"");
+	}
+
+	private FIPSAuditNDJSONLayout _createFIPSAuditNDJSONLayout() {
+		FIPSAuditNDJSONLayout.Builder builder =
+			FIPSAuditNDJSONLayout.newBuilder();
+
+		return builder.build();
+	}
+
+	private LogEvent _createLogEvent(Message message) {
+		Log4jLogEvent.Builder builder = Log4jLogEvent.newBuilder();
+
+		builder.setLevel(Level.INFO);
+		builder.setLoggerName(RandomTestUtil.randomString());
+		builder.setMessage(message);
+
+		return builder.build();
+	}
+
+	private void _testToSerializable(
+		String key, Object value, String valueJSON) {
+
+		Assert.assertEquals(
+			StringBundler.concat("{\"", key, "\":", valueJSON, "}\n"),
+			_toSerializable(Collections.singletonMap(key, value)));
+	}
+
+	private String _toSerializable(Map<String, Object> record) {
+		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
+			_createFIPSAuditNDJSONLayout();
+
+		return fipsAuditNDJSONLayout.toSerializable(
+			_createLogEvent(new ObjectMessage(record)));
+	}
+
+	private static class TestByteBufferDestination
+		implements ByteBufferDestination {
+
+		@Override
+		public ByteBuffer drain(ByteBuffer byteBuffer) {
+			byteBuffer.flip();
+
+			writeBytes(byteBuffer);
+
+			byteBuffer.clear();
+
+			return byteBuffer;
+		}
+
+		@Override
+		public ByteBuffer getByteBuffer() {
+			return _byteBuffer;
+		}
+
+		@Override
+		public String toString() {
+			drain(_byteBuffer);
+
+			byte[] bytes = _byteArrayOutputStream.toByteArray();
+
+			return new String(bytes, StandardCharsets.UTF_8);
+		}
+
+		@Override
+		public void writeBytes(byte[] bytes, int offset, int length) {
+			_byteArrayOutputStream.write(bytes, offset, length);
+		}
+
+		@Override
+		public void writeBytes(ByteBuffer byteBuffer) {
+			byte[] bytes = new byte[byteBuffer.remaining()];
+
+			byteBuffer.get(bytes);
+
+			writeBytes(bytes, 0, bytes.length);
+		}
+
+		private final ByteArrayOutputStream _byteArrayOutputStream =
+			new ByteArrayOutputStream();
+		private final ByteBuffer _byteBuffer = ByteBuffer.allocate(4096);
+
+	}
+
+}

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
@@ -138,8 +138,7 @@ public class FIPSAuditNDJSONLayoutTest {
 
 			for (String message : messages) {
 				Assert.assertTrue(
-					message,
-					message.contains("does not carry a FIPS audit record"));
+					message, message.contains("carries no FIPS audit record"));
 			}
 		}
 	}

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
@@ -13,6 +13,8 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.io.ByteArrayOutputStream;
@@ -22,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.Level;
@@ -114,6 +117,35 @@ public class FIPSAuditNDJSONLayoutTest {
 	}
 
 	@Test
+	public void testToSerializableRejectsAForeignEvent() {
+		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
+			_createFIPSAuditNDJSONLayout();
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				FIPSAuditNDJSONLayout.class.getName(), LoggerTestUtil.ERROR)) {
+
+			Assert.assertEquals(
+				"",
+				fipsAuditNDJSONLayout.toSerializable(
+					_createLogEvent(new SimpleMessage("Not a record"))));
+			Assert.assertEquals(
+				"",
+				fipsAuditNDJSONLayout.toSerializable(
+					_createLogEvent(new ObjectMessage("not-a-map"))));
+
+			List<String> messages = logCapture.getMessages();
+
+			Assert.assertEquals(messages.toString(), 2, messages.size());
+
+			for (String message : messages) {
+				Assert.assertTrue(
+					message,
+					message.contains("does not carry a FIPS audit record"));
+			}
+		}
+	}
+
+	@Test
 	public void testToSerializableWritesEveryEntry() throws Exception {
 		Map<String, Object> record = LinkedHashMapBuilder.<String, Object>put(
 			"event-type", "fips-state-transition"
@@ -132,23 +164,6 @@ public class FIPSAuditNDJSONLayoutTest {
 			Assert.assertEquals(
 				entry.getValue(), jsonObject.getString(entry.getKey()));
 		}
-	}
-
-	@Test
-	public void testToSerializableWritesMessageKeyForUnreadableMessages() {
-		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
-			_createFIPSAuditNDJSONLayout();
-
-		Assert.assertEquals(
-			"{\"message\":\"Unable to \\\"parse\\\" the record\"}\n",
-			fipsAuditNDJSONLayout.toSerializable(
-				_createLogEvent(
-					new SimpleMessage("Unable to \"parse\" the record"))));
-
-		Assert.assertEquals(
-			"{\"message\":\"not-a-map\"}\n",
-			fipsAuditNDJSONLayout.toSerializable(
-				_createLogEvent(new ObjectMessage("not-a-map"))));
 	}
 
 	@Test

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilter.java
@@ -1,0 +1,102 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.internal.log4j;
+
+import com.liferay.petra.string.StringBundler;
+
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
+import org.apache.logging.log4j.core.filter.AbstractFilter;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.ObjectMessage;
+
+/**
+ * @author Jorge García Jiménez
+ */
+@Plugin(
+	category = Node.CATEGORY, elementType = Filter.ELEMENT_TYPE,
+	name = FIPSAuditFilter.PLUGIN_NAME, printObject = true
+)
+public final class FIPSAuditFilter extends AbstractFilter {
+
+	public static final String PLUGIN_NAME = "FIPSAuditFilter";
+
+	@PluginBuilderFactory
+	public static Builder newBuilder() {
+		return new Builder();
+	}
+
+	@Override
+	public Result filter(LogEvent logEvent) {
+		Marker marker = logEvent.getMarker();
+
+		if ((marker == null) ||
+			!marker.isInstanceOf(FIPSLog4jUtil.MARKER_NAME)) {
+
+			_logger.error(
+				StringBundler.concat(
+					"Unable to write the event from the logger \"",
+					logEvent.getLoggerName(),
+					"\" to the FIPS audit trail because it carries no \"",
+					FIPSLog4jUtil.MARKER_NAME, "\" marker"));
+
+			return Result.DENY;
+		}
+
+		if (!_hasRecord(logEvent.getMessage())) {
+			_logger.error(
+				StringBundler.concat(
+					"Unable to write the event from the logger \"",
+					logEvent.getLoggerName(),
+					"\" to the FIPS audit trail because its message does not ",
+					"carry a FIPS audit record"));
+
+			return Result.DENY;
+		}
+
+		return Result.ACCEPT;
+	}
+
+	public static class Builder
+		implements org.apache.logging.log4j.core.util.Builder<FIPSAuditFilter> {
+
+		@Override
+		public FIPSAuditFilter build() {
+			return new FIPSAuditFilter();
+		}
+
+	}
+
+	private FIPSAuditFilter() {
+		super(Result.ACCEPT, Result.DENY);
+	}
+
+	private boolean _hasRecord(Message message) {
+		if (!(message instanceof ObjectMessage)) {
+			return false;
+		}
+
+		ObjectMessage objectMessage = (ObjectMessage)message;
+
+		if (objectMessage.getParameter() instanceof Map) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static final Logger _logger = LogManager.getLogger(
+		FIPSAuditFilter.class);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilter.java
@@ -46,9 +46,9 @@ public final class FIPSAuditFilter extends AbstractFilter {
 
 			_logger.error(
 				StringBundler.concat(
-					"Unable to write the event from the logger \"",
+					"Unable to write the log event from the logger \"",
 					logEvent.getLoggerName(),
-					"\" to the FIPS audit trail because it carries no \"",
+					"\" to the FIPS audit log because it carries no \"",
 					FIPSLog4jUtil.MARKER_NAME, "\" marker"));
 
 			return Result.DENY;
@@ -57,10 +57,10 @@ public final class FIPSAuditFilter extends AbstractFilter {
 		if (!_hasRecord(logEvent.getMessage())) {
 			_logger.error(
 				StringBundler.concat(
-					"Unable to write the event from the logger \"",
+					"Unable to write the log event from the logger \"",
 					logEvent.getLoggerName(),
-					"\" to the FIPS audit trail because its message does not ",
-					"carry a FIPS audit record"));
+					"\" to the FIPS audit log because its message carries no ",
+					"FIPS audit record"));
 
 			return Result.DENY;
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
@@ -1,0 +1,107 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.internal.log4j;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.Map;
+
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
+import org.apache.logging.log4j.core.layout.AbstractStringLayout;
+import org.apache.logging.log4j.core.layout.ByteBufferDestination;
+import org.apache.logging.log4j.core.layout.Encoder;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.ObjectMessage;
+
+/**
+ * @author Rafael Praxedes
+ * @see    LiferayXmlLayout
+ */
+@Plugin(
+	category = Node.CATEGORY, elementType = Layout.ELEMENT_TYPE,
+	name = FIPSAuditNDJSONLayout.PLUGIN_NAME, printObject = true
+)
+public final class FIPSAuditNDJSONLayout extends AbstractStringLayout {
+
+	public static final String PLUGIN_NAME = "FIPSAuditNDJSONLayout";
+
+	@PluginBuilderFactory
+	public static Builder newBuilder() {
+		return new Builder();
+	}
+
+	@Override
+	public void encode(
+		LogEvent logEvent, ByteBufferDestination byteBufferDestination) {
+
+		StringBuilder sb = getStringBuilder();
+
+		_generateNDJSON(logEvent, sb);
+
+		Encoder<StringBuilder> encoder = getStringBuilderEncoder();
+
+		encoder.encode(sb, byteBufferDestination);
+	}
+
+	@Override
+	public String getContentType() {
+		return "application/x-ndjson; charset=UTF-8";
+	}
+
+	@Override
+	public String toSerializable(LogEvent logEvent) {
+		StringBuilder sb = getStringBuilder();
+
+		_generateNDJSON(logEvent, sb);
+
+		return sb.toString();
+	}
+
+	public static class Builder
+		implements org.apache.logging.log4j.core.util.Builder
+			<FIPSAuditNDJSONLayout> {
+
+		@Override
+		public FIPSAuditNDJSONLayout build() {
+			return new FIPSAuditNDJSONLayout();
+		}
+
+	}
+
+	private FIPSAuditNDJSONLayout() {
+		super(StandardCharsets.UTF_8);
+	}
+
+	private void _generateNDJSON(LogEvent logEvent, StringBuilder sb) {
+		Message message = logEvent.getMessage();
+
+		Object record = null;
+
+		if (message instanceof ObjectMessage) {
+			ObjectMessage objectMessage = (ObjectMessage)message;
+
+			record = objectMessage.getParameter();
+		}
+
+		if (record instanceof Map) {
+			sb.append(JSONFactoryUtil.createJSONObject((Map<?, ?>)record));
+		}
+		else {
+			sb.append(JSONUtil.put("message", message.getFormattedMessage()));
+		}
+
+		sb.append(CharPool.NEW_LINE);
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
@@ -99,10 +99,10 @@ public final class FIPSAuditNDJSONLayout extends AbstractStringLayout {
 		if (!(record instanceof Map)) {
 			_logger.error(
 				StringBundler.concat(
-					"Unable to write the event from the logger \"",
+					"Unable to write the log event from the logger \"",
 					logEvent.getLoggerName(),
-					"\" to the FIPS audit trail because its message does not ",
-					"carry a FIPS audit record"));
+					"\" to the FIPS audit log because its message carries no ",
+					"FIPS audit record"));
 
 			return;
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
@@ -6,13 +6,15 @@
 package com.liferay.portal.kernel.internal.log4j;
 
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
-import com.liferay.portal.kernel.json.JSONUtil;
 
 import java.nio.charset.StandardCharsets;
 
 import java.util.Map;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Node;
@@ -94,14 +96,23 @@ public final class FIPSAuditNDJSONLayout extends AbstractStringLayout {
 			record = objectMessage.getParameter();
 		}
 
-		if (record instanceof Map) {
-			sb.append(JSONFactoryUtil.createJSONObject((Map<?, ?>)record));
+		if (!(record instanceof Map)) {
+			_logger.error(
+				StringBundler.concat(
+					"Unable to write the event from the logger \"",
+					logEvent.getLoggerName(),
+					"\" to the FIPS audit trail because its message does not ",
+					"carry a FIPS audit record"));
+
+			return;
 		}
-		else {
-			sb.append(JSONUtil.put("message", message.getFormattedMessage()));
-		}
+
+		sb.append(JSONFactoryUtil.createJSONObject((Map<?, ?>)record));
 
 		sb.append(CharPool.NEW_LINE);
 	}
+
+	private static final Logger _logger = LogManager.getLogger(
+		FIPSAuditNDJSONLayout.class);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.message.ObjectMessage;
  * @author Jorge García Jiménez
  * @author Rafael Praxedes
  */
-public class Log4jFIPSAuditUtil {
+public class FIPSLog4jUtil {
 
 	public static void write(
 		Map<String, Object> fields, FIPSAuditEvent.Severity severity) {
@@ -56,7 +56,7 @@ public class Log4jFIPSAuditUtil {
 			throw new IllegalStateException(
 				StringBundler.concat(
 					"Unable to write a FIPS audit record because the logger \"",
-					Log4jFIPSAuditUtil.class.getName(),
+					FIPSLog4jUtil.class.getName(),
 					"\" is disabled for the level \"", level,
 					"\". Check that the portal property ",
 					"\"log4j.configure.on.startup\" is enabled and that no ",
@@ -97,6 +97,6 @@ public class Log4jFIPSAuditUtil {
 	private static final String _APPENDER_NAME = "FIPS_AUDIT_FILE";
 
 	private static final Logger _logger = LogManager.getLogger(
-		Log4jFIPSAuditUtil.class);
+		FIPSLog4jUtil.class);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
@@ -15,6 +15,8 @@ import java.util.Map;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
@@ -27,6 +29,8 @@ import org.apache.logging.log4j.message.ObjectMessage;
  */
 public class FIPSLog4jUtil {
 
+	public static final String MARKER_NAME = "FIPS_AUDIT";
+
 	public static void write(
 		Map<String, Object> fields, FIPSAuditEvent.Severity severity) {
 
@@ -34,7 +38,7 @@ public class FIPSLog4jUtil {
 
 		_validate(level);
 
-		_logger.log(level, new ObjectMessage(fields));
+		_logger.log(level, _marker, new ObjectMessage(fields));
 	}
 
 	private static Level _getLevel(FIPSAuditEvent.Severity severity) {
@@ -98,5 +102,7 @@ public class FIPSLog4jUtil {
 
 	private static final Logger _logger = LogManager.getLogger(
 		FIPSLog4jUtil.class);
+
+	private static final Marker _marker = MarkerManager.getMarker(MARKER_NAME);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
@@ -67,8 +67,6 @@ public class FIPSLog4jUtil {
 					"configuration lowers the level of that logger"));
 		}
 
-		RollingFileAppender rollingFileAppender = null;
-
 		LoggerContext loggerContext = (LoggerContext)LogManager.getContext(
 			false);
 
@@ -76,20 +74,14 @@ public class FIPSLog4jUtil {
 
 		Appender appender = configuration.getAppender(_APPENDER_NAME);
 
-		if (appender instanceof RollingFileAppender) {
-			rollingFileAppender = (RollingFileAppender)appender;
-		}
-
-		if (rollingFileAppender == null) {
+		if (!(appender instanceof RollingFileAppender)) {
 			throw new IllegalStateException(
 				StringBundler.concat(
 					"Unable to write a FIPS audit record because the appender ",
 					"\"", _APPENDER_NAME, "\" is not configured"));
 		}
 
-		if (!(rollingFileAppender.getLayout() instanceof
-				FIPSAuditNDJSONLayout)) {
-
+		if (!(appender.getLayout() instanceof FIPSAuditNDJSONLayout)) {
 			throw new IllegalStateException(
 				StringBundler.concat(
 					"Unable to write a FIPS audit record because the appender ",

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/Log4jFIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/Log4jFIPSAuditUtil.java
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.internal.log4j;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.security.fips.FIPSAuditEvent;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.ServerDetector;
+
+import java.util.Map;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.message.ObjectMessage;
+
+/**
+ * @author Jorge García Jiménez
+ * @author Rafael Praxedes
+ */
+public class Log4jFIPSAuditUtil {
+
+	public static void write(
+		Map<String, Object> record, FIPSAuditEvent.Severity severity) {
+
+		Level level = _getLevel(severity);
+
+		_validateDeliverable(level);
+
+		_logger.log(level, new ObjectMessage(record));
+	}
+
+	private static Level _getLevel(FIPSAuditEvent.Severity severity) {
+		if (severity == FIPSAuditEvent.Severity.CRITICAL) {
+			return Level.ERROR;
+		}
+
+		return Level.INFO;
+	}
+
+	private static RollingFileAppender _getRollingFileAppender() {
+		LoggerContext loggerContext = (LoggerContext)LogManager.getContext(
+			false);
+
+		Configuration configuration = loggerContext.getConfiguration();
+
+		Appender appender = configuration.getAppender(_APPENDER_NAME);
+
+		if (appender instanceof RollingFileAppender) {
+			return (RollingFileAppender)appender;
+		}
+
+		return null;
+	}
+
+	private static void _validateDeliverable(Level level) {
+		if (!PropsValues.FIPS_ENABLED ||
+			(ServerDetector.getServerId() == null)) {
+
+			return;
+		}
+
+		if (!_logger.isEnabled(level)) {
+			throw new IllegalStateException(
+				StringBundler.concat(
+					"Unable to write a FIPS audit record because the logger \"",
+					Log4jFIPSAuditUtil.class.getName(),
+					"\" is disabled for the level \"", level,
+					"\". Check that the portal property ",
+					"\"log4j.configure.on.startup\" is enabled and that no ",
+					"configuration lowers the level of that logger"));
+		}
+
+		RollingFileAppender rollingFileAppender = _getRollingFileAppender();
+
+		if (rollingFileAppender == null) {
+			throw new IllegalStateException(
+				StringBundler.concat(
+					"Unable to write a FIPS audit record because the appender ",
+					"\"", _APPENDER_NAME, "\" is not configured"));
+		}
+
+		if (!(rollingFileAppender.getLayout() instanceof
+				FIPSAuditNDJSONLayout)) {
+
+			throw new IllegalStateException(
+				StringBundler.concat(
+					"Unable to write a FIPS audit record because the appender ",
+					"\"", _APPENDER_NAME, "\" does not render it with \"",
+					FIPSAuditNDJSONLayout.PLUGIN_NAME, "\""));
+		}
+	}
+
+	private static final String _APPENDER_NAME = "FIPS_AUDIT_FILE";
+
+	private static final Logger _logger = LogManager.getLogger(
+		Log4jFIPSAuditUtil.class);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/Log4jFIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/Log4jFIPSAuditUtil.java
@@ -28,13 +28,13 @@ import org.apache.logging.log4j.message.ObjectMessage;
 public class Log4jFIPSAuditUtil {
 
 	public static void write(
-		Map<String, Object> record, FIPSAuditEvent.Severity severity) {
+		Map<String, Object> fields, FIPSAuditEvent.Severity severity) {
 
 		Level level = _getLevel(severity);
 
-		_validateDeliverable(level);
+		_validate(level);
 
-		_logger.log(level, new ObjectMessage(record));
+		_logger.log(level, new ObjectMessage(fields));
 	}
 
 	private static Level _getLevel(FIPSAuditEvent.Severity severity) {
@@ -45,22 +45,7 @@ public class Log4jFIPSAuditUtil {
 		return Level.INFO;
 	}
 
-	private static RollingFileAppender _getRollingFileAppender() {
-		LoggerContext loggerContext = (LoggerContext)LogManager.getContext(
-			false);
-
-		Configuration configuration = loggerContext.getConfiguration();
-
-		Appender appender = configuration.getAppender(_APPENDER_NAME);
-
-		if (appender instanceof RollingFileAppender) {
-			return (RollingFileAppender)appender;
-		}
-
-		return null;
-	}
-
-	private static void _validateDeliverable(Level level) {
+	private static void _validate(Level level) {
 		if (!PropsValues.FIPS_ENABLED ||
 			(ServerDetector.getServerId() == null)) {
 
@@ -78,7 +63,18 @@ public class Log4jFIPSAuditUtil {
 					"configuration lowers the level of that logger"));
 		}
 
-		RollingFileAppender rollingFileAppender = _getRollingFileAppender();
+		RollingFileAppender rollingFileAppender = null;
+
+		LoggerContext loggerContext = (LoggerContext)LogManager.getContext(
+			false);
+
+		Configuration configuration = loggerContext.getConfiguration();
+
+		Appender appender = configuration.getAppender(_APPENDER_NAME);
+
+		if (appender instanceof RollingFileAppender) {
+			rollingFileAppender = (RollingFileAppender)appender;
+		}
 
 		if (rollingFileAppender == null) {
 			throw new IllegalStateException(

--- a/portal-kernel/src/com/liferay/portal/kernel/log4j/Log4JUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/log4j/Log4JUtil.java
@@ -76,7 +76,7 @@ public class Log4JUtil {
 		}
 		else {
 			priorities = Log4jConfigUtil.configureLog4J(
-				urlContent, "TEXT_FILE", "XML_FILE");
+				urlContent, "FIPS_AUDIT_FILE", "TEXT_FILE", "XML_FILE");
 		}
 
 		for (Map.Entry<String, String> entry : priorities.entrySet()) {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationState.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationState.java
@@ -10,6 +10,7 @@ package com.liferay.portal.kernel.security.fips;
  */
 public enum FIPSApplicationState {
 
-	ERROR, INITIALIZING, OPERATIONAL, POWER_OFF, SELF_TEST
+	ERROR, INITIALIZING, KEY_CSP_ENTRY, OPERATIONAL, POWER_OFF, QUIESCENT,
+	SELF_TEST
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
@@ -6,66 +6,228 @@
 package com.liferay.portal.kernel.security.fips;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 /**
  * @author Jorge García Jiménez
  */
 public class FIPSApplicationStateMachineUtil {
 
+	public static void error(String failedStep, Throwable throwable) {
+		_transition(
+			FIPSApplicationState.ERROR,
+			fipsAuditEvent -> {
+				fipsAuditEvent.put("failed-step", failedStep);
+				fipsAuditEvent.put(
+					"provider-error-message", _getMessage(throwable));
+			});
+	}
+
 	public static FIPSApplicationState getFIPSApplicationState() {
 		return _fipsApplicationStateAtomicReference.get();
 	}
 
+	public static void keyCSPEntry(
+		String cryptoOfficerUserId, String operationType, Runnable runnable) {
+
+		_transition(
+			FIPSApplicationState.KEY_CSP_ENTRY,
+			fipsAuditEvent -> {
+				fipsAuditEvent.put(
+					"crypto-officer-user-id", cryptoOfficerUserId);
+				fipsAuditEvent.put("operation-type", operationType);
+			});
+
+		_runAndTransitionToOperational(
+			"Key or CSP entry", "The operation was completed successfully",
+			runnable);
+	}
+
+	public static void operational(String cryptoOfficerUserId, String reason) {
+		_transition(
+			FIPSApplicationState.OPERATIONAL,
+			fipsAuditEvent -> {
+				fipsAuditEvent.put(
+					"crypto-officer-user-id", cryptoOfficerUserId);
+				fipsAuditEvent.put("reason", reason);
+			});
+	}
+
+	public static void powerOff(String initiatingActor) {
+		_transition(
+			FIPSApplicationState.POWER_OFF,
+			fipsAuditEvent -> fipsAuditEvent.put(
+				"initiating-actor", initiatingActor));
+	}
+
+	public static void quiescent(String cryptoOfficerUserId, String reason) {
+		_transition(
+			FIPSApplicationState.QUIESCENT,
+			fipsAuditEvent -> {
+				fipsAuditEvent.put(
+					"crypto-officer-user-id", cryptoOfficerUserId);
+				fipsAuditEvent.put("reason", reason);
+			});
+	}
+
 	public static void selfTest(Runnable runnable) {
-		_transition(FIPSApplicationState.SELF_TEST);
+		_transition(
+			FIPSApplicationState.SELF_TEST,
+			fipsAuditEvent -> fipsAuditEvent.put(
+				"message", "The integrity checks were started"));
+
+		_runSelfTest(runnable);
+	}
+
+	public static void selfTest(
+		String cryptoOfficerUserId, String recoveryAction, Runnable runnable) {
+
+		_transition(
+			FIPSApplicationState.SELF_TEST,
+			fipsAuditEvent -> {
+				fipsAuditEvent.put(
+					"crypto-officer-user-id", cryptoOfficerUserId);
+				fipsAuditEvent.put("recovery-action", recoveryAction);
+			});
+
+		_runSelfTest(runnable);
+	}
+
+	private static String _getMessage(Throwable throwable) {
+		String message = throwable.getMessage();
+
+		if (message == null) {
+			return throwable.toString();
+		}
+
+		return message;
+	}
+
+	private static FIPSAuditEvent.Severity _getSeverity(
+		FIPSApplicationState fipsApplicationState) {
+
+		if (fipsApplicationState == FIPSApplicationState.ERROR) {
+			return FIPSAuditEvent.Severity.CRITICAL;
+		}
+
+		return FIPSAuditEvent.Severity.INFO;
+	}
+
+	private static void _registerShutdownHook() {
+		Runtime runtime = Runtime.getRuntime();
+
+		runtime.addShutdownHook(
+			new Thread(
+				() -> {
+					if (getFIPSApplicationState() ==
+							FIPSApplicationState.POWER_OFF) {
+
+						return;
+					}
+
+					try {
+						powerOff("OS signal");
+					}
+					catch (Throwable throwable) {
+						if (_log.isDebugEnabled()) {
+							_log.debug(throwable);
+						}
+					}
+				}));
+	}
+
+	private static void _runAndTransitionToOperational(
+		String failedStep, String message, Runnable runnable) {
 
 		try {
 			runnable.run();
 		}
 		catch (Throwable throwable) {
-			_transition(FIPSApplicationState.ERROR);
+			error(failedStep, throwable);
 
 			throw throwable;
 		}
 
-		_transition(FIPSApplicationState.OPERATIONAL);
+		_transition(
+			FIPSApplicationState.OPERATIONAL,
+			fipsAuditEvent -> fipsAuditEvent.put("message", message));
 	}
 
-	private static void _transition(FIPSApplicationState fipsApplicationState) {
-		_fipsApplicationStateAtomicReference.updateAndGet(
-			currentFIPSApplicationState -> {
-				Set<FIPSApplicationState> nextFIPSApplicationStates =
-					_allowedTransitions.getOrDefault(
-						currentFIPSApplicationState, Set.of());
-
-				if (!nextFIPSApplicationStates.contains(fipsApplicationState)) {
-					throw new IllegalStateException(
-						StringBundler.concat(
-							"Unable to transition the FIPS application state ",
-							"from \"", currentFIPSApplicationState, "\" to \"",
-							fipsApplicationState, "\""));
-				}
-
-				return fipsApplicationState;
-			});
+	private static void _runSelfTest(Runnable runnable) {
+		_runAndTransitionToOperational(
+			"Self test",
+			"All checks and the validated provider self tests passed",
+			runnable);
 	}
+
+	private static void _transition(
+		FIPSApplicationState fipsApplicationState,
+		Consumer<FIPSAuditEvent> fipsAuditEventConsumer) {
+
+		FIPSApplicationState previousFIPSApplicationState =
+			_fipsApplicationStateAtomicReference.getAndUpdate(
+				currentFIPSApplicationState -> {
+					Set<FIPSApplicationState> nextFIPSApplicationStates =
+						_allowedTransitions.getOrDefault(
+							currentFIPSApplicationState, Set.of());
+
+					if (!nextFIPSApplicationStates.contains(
+							fipsApplicationState)) {
+
+						throw new IllegalStateException(
+							StringBundler.concat(
+								"Unable to transition the FIPS application ",
+								"state from \"", currentFIPSApplicationState,
+								"\" to \"", fipsApplicationState, "\""));
+					}
+
+					return fipsApplicationState;
+				});
+
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			"fips-state-transition", _getSeverity(fipsApplicationState));
+
+		fipsAuditEvent.put("from-state", previousFIPSApplicationState.name());
+		fipsAuditEvent.put("to-state", fipsApplicationState.name());
+
+		fipsAuditEventConsumer.accept(fipsAuditEvent);
+
+		FIPSAuditUtil.write(fipsAuditEvent);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FIPSApplicationStateMachineUtil.class);
 
 	private static final Map<FIPSApplicationState, Set<FIPSApplicationState>>
 		_allowedTransitions = Map.of(
-			FIPSApplicationState.ERROR, Set.of(FIPSApplicationState.POWER_OFF),
+			FIPSApplicationState.ERROR,
+			Set.of(
+				FIPSApplicationState.POWER_OFF, FIPSApplicationState.SELF_TEST),
 			FIPSApplicationState.INITIALIZING,
 			Set.of(
 				FIPSApplicationState.ERROR, FIPSApplicationState.POWER_OFF,
 				FIPSApplicationState.SELF_TEST),
+			FIPSApplicationState.KEY_CSP_ENTRY,
+			Set.of(
+				FIPSApplicationState.ERROR, FIPSApplicationState.OPERATIONAL,
+				FIPSApplicationState.POWER_OFF),
 			FIPSApplicationState.OPERATIONAL,
 			Set.of(
-				FIPSApplicationState.ERROR, FIPSApplicationState.POWER_OFF,
+				FIPSApplicationState.ERROR, FIPSApplicationState.KEY_CSP_ENTRY,
+				FIPSApplicationState.POWER_OFF, FIPSApplicationState.QUIESCENT,
 				FIPSApplicationState.SELF_TEST),
 			FIPSApplicationState.POWER_OFF, Set.of(),
+			FIPSApplicationState.QUIESCENT,
+			Set.of(
+				FIPSApplicationState.ERROR, FIPSApplicationState.KEY_CSP_ENTRY,
+				FIPSApplicationState.OPERATIONAL,
+				FIPSApplicationState.POWER_OFF),
 			FIPSApplicationState.SELF_TEST,
 			Set.of(
 				FIPSApplicationState.ERROR, FIPSApplicationState.OPERATIONAL,
@@ -73,5 +235,9 @@ public class FIPSApplicationStateMachineUtil {
 	private static final AtomicReference<FIPSApplicationState>
 		_fipsApplicationStateAtomicReference = new AtomicReference<>(
 			FIPSApplicationState.INITIALIZING);
+
+	static {
+		_registerShutdownHook();
+	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.petra.string.StringBundler;
+
+import java.security.Key;
+import java.security.spec.KeySpec;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSAuditEvent {
+
+	public FIPSAuditEvent(String eventType, Severity severity) {
+		_eventType = eventType;
+		_severity = severity;
+	}
+
+	public String getEventType() {
+		return _eventType;
+	}
+
+	public Map<String, Object> getFields() {
+		return Collections.unmodifiableMap(_fields);
+	}
+
+	public Severity getSeverity() {
+		return _severity;
+	}
+
+	public FIPSAuditEvent put(String key, Object value) {
+		_validate(key, value);
+
+		_fields.put(key, value);
+
+		return this;
+	}
+
+	public enum Severity {
+
+		CRITICAL, INFO
+
+	}
+
+	private boolean _isNonfiniteNumber(Object value) {
+		if (value instanceof Double) {
+			return !Double.isFinite((Double)value);
+		}
+
+		if (value instanceof Float) {
+			return !Float.isFinite((Float)value);
+		}
+
+		return false;
+	}
+
+	private boolean _isSensitiveSecurityParameter(Object value) {
+		if (value instanceof byte[] || value instanceof char[] ||
+			value instanceof Key || value instanceof KeySpec) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private void _validate(String key, Object value) {
+		if (value == null) {
+			throw new IllegalArgumentException(
+				StringBundler.concat(
+					"Unable to record the FIPS audit field \"", key,
+					"\" because a null value is dropped from an audit record ",
+					"instead of being written"));
+		}
+
+		if (value instanceof Iterable) {
+			for (Object curValue : (Iterable<?>)value) {
+				_validate(key, curValue);
+			}
+
+			return;
+		}
+
+		if (value instanceof Map) {
+			Map<?, ?> map = (Map<?, ?>)value;
+
+			for (Map.Entry<?, ?> entry : map.entrySet()) {
+				_validate(key, entry.getValue());
+			}
+
+			return;
+		}
+
+		if (_isNonfiniteNumber(value)) {
+			throw new IllegalArgumentException(
+				StringBundler.concat(
+					"Unable to record the FIPS audit field \"", key,
+					"\" because the number \"", value,
+					"\" is not finite and cannot be written as JSON"));
+		}
+
+		if (_isSensitiveSecurityParameter(value)) {
+			throw new IllegalArgumentException(
+				StringBundler.concat(
+					"Unable to record the FIPS audit field \"", key,
+					"\" because a sensitive security parameter must never ",
+					"reach an audit record"));
+		}
+	}
+
+	private final String _eventType;
+	private final Map<String, Object> _fields = new LinkedHashMap<>();
+	private final Severity _severity;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
@@ -76,9 +76,9 @@ public class FIPSAuditEvent {
 		if (value == null) {
 			throw new IllegalArgumentException(
 				StringBundler.concat(
-					"Unable to record the FIPS audit field \"", key,
-					"\" because a null value is dropped from an audit record ",
-					"instead of being written"));
+					"Unable to write the FIPS audit field \"", key,
+					"\" because a null value is dropped from a FIPS audit ",
+					"record"));
 		}
 
 		if (value instanceof Iterable) {
@@ -102,17 +102,17 @@ public class FIPSAuditEvent {
 		if (_isNonfiniteNumber(value)) {
 			throw new IllegalArgumentException(
 				StringBundler.concat(
-					"Unable to record the FIPS audit field \"", key,
+					"Unable to write the FIPS audit field \"", key,
 					"\" because the number \"", value,
-					"\" is not finite and cannot be written as JSON"));
+					"\" is not finite and has no JSON representation"));
 		}
 
 		if (_isSensitiveSecurityParameter(value)) {
 			throw new IllegalArgumentException(
 				StringBundler.concat(
-					"Unable to record the FIPS audit field \"", key,
+					"Unable to write the FIPS audit field \"", key,
 					"\" because a sensitive security parameter must never ",
-					"reach an audit record"));
+					"reach a FIPS audit record"));
 		}
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
@@ -160,7 +160,9 @@ public class FIPSAuditUtil {
 			return _normalizeTimestamps((Map<?, ?>)value);
 		}
 
-		if (value instanceof TemporalAccessor temporalAccessor) {
+		if (value instanceof TemporalAccessor) {
+			TemporalAccessor temporalAccessor = (TemporalAccessor)value;
+
 			try {
 				return _formatTimestamp(Instant.from(temporalAccessor));
 			}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
@@ -1,0 +1,199 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.internal.log4j.Log4jFIPSAuditUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.security.Provider;
+import java.security.Security;
+
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author Jorge García Jiménez
+ * @author Rafael Praxedes
+ */
+public class FIPSAuditUtil {
+
+	public static void write(FIPSAuditEvent fipsAuditEvent) {
+		FIPSAuditEvent.Severity severity = fipsAuditEvent.getSeverity();
+
+		Log4jFIPSAuditUtil.write(
+			LinkedHashMapBuilder.<String, Object>put(
+				"cmvp-certificate-id",
+				PropsValues.FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID
+			).put(
+				"deployment-instance-id", _getDeploymentInstanceId()
+			).put(
+				"event-schema-version", "1.0"
+			).put(
+				"event-sequence", _eventSequence.incrementAndGet()
+			).put(
+				"event-type", fipsAuditEvent.getEventType()
+			).put(
+				"fields", _normalizeTimestamps(fipsAuditEvent.getFields())
+			).put(
+				"provider-name",
+				() -> {
+					Provider provider = _getProvider();
+
+					if (provider == null) {
+						return "";
+					}
+
+					return provider.getName();
+				}
+			).put(
+				"provider-version",
+				() -> {
+					Provider provider = _getProvider();
+
+					if (provider == null) {
+						return "";
+					}
+
+					return provider.getVersionStr();
+				}
+			).put(
+				"severity", severity.name()
+			).put(
+				"timestamp", () -> _formatTimestamp(Instant.now())
+			).build(),
+			severity);
+	}
+
+	private static String _formatTimestamp(Instant instant) {
+		return _dateTimeFormatter.format(instant.atZone(ZoneOffset.UTC));
+	}
+
+	private static String _getDeploymentInstanceId() {
+		String deploymentInstanceId =
+			PropsValues.FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID;
+
+		if (Validator.isNotNull(deploymentInstanceId)) {
+			return deploymentInstanceId;
+		}
+
+		Path path = Paths.get(
+			PropsValues.LIFERAY_HOME, "data",
+			"fips-audit-deployment-instance-id");
+
+		try {
+			if (Files.exists(path)) {
+				String persistedId = new String(
+					Files.readAllBytes(path), StandardCharsets.UTF_8);
+
+				return persistedId.trim();
+			}
+
+			String generatedId = String.valueOf(UUID.randomUUID());
+
+			Files.createDirectories(path.getParent());
+
+			Files.write(path, generatedId.getBytes(StandardCharsets.UTF_8));
+
+			return generatedId;
+		}
+		catch (IOException ioException) {
+			throw new UncheckedIOException(
+				"Unable to resolve the FIPS deployment instance ID",
+				ioException);
+		}
+	}
+
+	private static Provider _getProvider() {
+		Provider[] providers = Security.getProviders();
+
+		if (ArrayUtil.isEmpty(providers)) {
+			return null;
+		}
+
+		return providers[0];
+	}
+
+	private static Object _normalizeTimestamp(Object value) {
+		if (value instanceof Date) {
+			Date date = (Date)value;
+
+			return _formatTimestamp(date.toInstant());
+		}
+
+		if (value instanceof Iterable) {
+			List<Object> normalizedValues = new ArrayList<>();
+
+			for (Object curValue : (Iterable<?>)value) {
+				normalizedValues.add(_normalizeTimestamp(curValue));
+			}
+
+			return normalizedValues;
+		}
+
+		if (value instanceof Map) {
+			return _normalizeTimestamps((Map<?, ?>)value);
+		}
+
+		if (value instanceof TemporalAccessor) {
+			return _formatTimestamp(_toInstant((TemporalAccessor)value));
+		}
+
+		return value;
+	}
+
+	private static Map<String, Object> _normalizeTimestamps(Map<?, ?> map) {
+		Map<String, Object> normalizedMap = new LinkedHashMap<>();
+
+		for (Map.Entry<?, ?> entry : map.entrySet()) {
+			normalizedMap.put(
+				String.valueOf(entry.getKey()),
+				_normalizeTimestamp(entry.getValue()));
+		}
+
+		return normalizedMap;
+	}
+
+	private static Instant _toInstant(TemporalAccessor temporalAccessor) {
+		try {
+			return Instant.from(temporalAccessor);
+		}
+		catch (DateTimeException dateTimeException) {
+			throw new IllegalArgumentException(
+				StringBundler.concat(
+					"Unable to normalize the FIPS audit timestamp \"",
+					temporalAccessor, "\" because it carries no time zone"),
+				dateTimeException);
+		}
+	}
+
+	private static final DateTimeFormatter _dateTimeFormatter =
+		DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+	private static final AtomicLong _eventSequence = new AtomicLong();
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
@@ -6,7 +6,7 @@
 package com.liferay.portal.kernel.security.fips;
 
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.internal.log4j.Log4jFIPSAuditUtil;
+import com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -46,7 +46,7 @@ public class FIPSAuditUtil {
 	public static void write(FIPSAuditEvent fipsAuditEvent) {
 		FIPSAuditEvent.Severity severity = fipsAuditEvent.getSeverity();
 
-		Log4jFIPSAuditUtil.write(
+		FIPSLog4jUtil.write(
 			LinkedHashMapBuilder.<String, Object>put(
 				"cmvp-certificate-id",
 				PropsValues.FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
@@ -160,8 +160,17 @@ public class FIPSAuditUtil {
 			return _normalizeTimestamps((Map<?, ?>)value);
 		}
 
-		if (value instanceof TemporalAccessor) {
-			return _formatTimestamp(_toInstant((TemporalAccessor)value));
+		if (value instanceof TemporalAccessor temporalAccessor) {
+			try {
+				return _formatTimestamp(Instant.from(temporalAccessor));
+			}
+			catch (DateTimeException dateTimeException) {
+				throw new IllegalArgumentException(
+					StringBundler.concat(
+						"Unable to normalize the FIPS audit timestamp \"",
+						temporalAccessor, "\" because it carries no time zone"),
+					dateTimeException);
+			}
 		}
 
 		return value;
@@ -177,19 +186,6 @@ public class FIPSAuditUtil {
 		}
 
 		return normalizedMap;
-	}
-
-	private static Instant _toInstant(TemporalAccessor temporalAccessor) {
-		try {
-			return Instant.from(temporalAccessor);
-		}
-		catch (DateTimeException dateTimeException) {
-			throw new IllegalArgumentException(
-				StringBundler.concat(
-					"Unable to normalize the FIPS audit timestamp \"",
-					temporalAccessor, "\" because it carries no time zone"),
-				dateTimeException);
-		}
 	}
 
 	private static final DateTimeFormatter _dateTimeFormatter =

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1079,6 +1079,12 @@ public interface PropsKeys {
 		FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS =
 			"field.enable.com.liferay.portal.kernel.model.Organization.status";
 
+	public static final String FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID =
+		"fips.audit.deployment.instance.id";
+
+	public static final String FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID =
+		"fips.audit.provider.cmvp.certificate.id";
+
 	public static final String FIPS_ENABLED = "fips.enabled";
 
 	public static final String FULL_PAGE_DISPLAYABLE = "full.page.displayable";

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -888,6 +888,12 @@ public class PropsValues {
 					PropsKeys.
 						FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS));
 
+	public static final String FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID =
+		PropsUtil.get(PropsKeys.FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID);
+
+	public static final String FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID =
+		PropsUtil.get(PropsKeys.FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID);
+
 	public static final boolean FIPS_ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.FIPS_ENABLED));
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 100.0.0
+version 100.1.0

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -6,7 +6,7 @@
 package com.liferay.portal.kernel.security.fips;
 
 import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.portal.kernel.internal.log4j.Log4jFIPSAuditUtil;
+import com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -51,7 +51,7 @@ public class FIPSApplicationStateMachineUtilTest {
 			LogManager.class, Mockito.CALLS_REAL_METHODS);
 
 		_logManagerMockedStatic.when(
-			() -> LogManager.getLogger(Log4jFIPSAuditUtil.class)
+			() -> LogManager.getLogger(FIPSLog4jUtil.class)
 		).thenReturn(
 			_logger
 		);

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ObjectMessage;
 
@@ -71,7 +72,7 @@ public class FIPSApplicationStateMachineUtilTest {
 
 		Mockito.doAnswer(
 			invocation -> {
-				ObjectMessage objectMessage = invocation.getArgument(1);
+				ObjectMessage objectMessage = invocation.getArgument(2);
 
 				_records.add((Map<String, Object>)objectMessage.getParameter());
 
@@ -80,7 +81,8 @@ public class FIPSApplicationStateMachineUtilTest {
 		).when(
 			_logger
 		).log(
-			Mockito.any(Level.class), Mockito.any(Message.class)
+			Mockito.any(Level.class), Mockito.any(Marker.class),
+			Mockito.any(Message.class)
 		);
 
 		_setFIPSApplicationState(FIPSApplicationState.INITIALIZING);

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -5,22 +5,269 @@
 
 package com.liferay.portal.kernel.security.fips;
 
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.internal.log4j.Log4jFIPSAuditUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.ObjectMessage;
+
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * @author Jorge García Jiménez
+ * @author Rafael Praxedes
  */
 public class FIPSApplicationStateMachineUtilTest {
 
+	@BeforeClass
+	public static void setUpClass() {
+		PropsUtil.get("fips.enabled");
+
+		_logger = Mockito.mock(Logger.class);
+
+		_logManagerMockedStatic = Mockito.mockStatic(
+			LogManager.class, Mockito.CALLS_REAL_METHODS);
+
+		_logManagerMockedStatic.when(
+			() -> LogManager.getLogger(Log4jFIPSAuditUtil.class)
+		).thenReturn(
+			_logger
+		);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_logManagerMockedStatic.close();
+	}
+
 	@Before
 	public void setUp() {
+		Mockito.reset(_logger);
+
+		_safeCloseable = PropsValuesTestUtil.swapWithSafeCloseable(
+			"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", RandomTestUtil.randomString());
+
+		Mockito.doAnswer(
+			invocation -> {
+				ObjectMessage objectMessage = invocation.getArgument(1);
+
+				_records.add((Map<String, Object>)objectMessage.getParameter());
+
+				return null;
+			}
+		).when(
+			_logger
+		).log(
+			Mockito.any(Level.class), Mockito.any(Message.class)
+		);
+
 		_setFIPSApplicationState(FIPSApplicationState.INITIALIZING);
+	}
+
+	@After
+	public void tearDown() {
+		_safeCloseable.close();
+	}
+
+	@Test
+	public void testError() {
+		_setFIPSApplicationState(FIPSApplicationState.OPERATIONAL);
+
+		String failedStep = RandomTestUtil.randomString();
+
+		FIPSApplicationStateMachineUtil.error(
+			failedStep, new SecurityException("The provider is unhappy"));
+
+		Assert.assertEquals(
+			FIPSApplicationState.ERROR,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Map<String, Object> record = _getRecord();
+
+		_assertEnvelope("event-type", record, "fips-state-transition");
+		_assertEnvelope("severity", record, "CRITICAL");
+		_assertField("failed-step", record, failedStep);
+		_assertField("from-state", record, "OPERATIONAL");
+		_assertField(
+			"provider-error-message", record, "The provider is unhappy");
+		_assertField("to-state", record, "ERROR");
+	}
+
+	@Test
+	public void testKeyCSPEntry() {
+		_setFIPSApplicationState(FIPSApplicationState.OPERATIONAL);
+
+		String cryptoOfficerUserId = RandomTestUtil.randomString();
+		String operationType = RandomTestUtil.randomString();
+
+		FIPSApplicationStateMachineUtil.keyCSPEntry(
+			cryptoOfficerUserId, operationType,
+			() -> {
+			});
+
+		Assert.assertEquals(
+			FIPSApplicationState.OPERATIONAL,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Assert.assertEquals(_records.toString(), 2, _records.size());
+
+		_assertEnvelope("severity", _records.get(0), "INFO");
+		_assertField(
+			"crypto-officer-user-id", _records.get(0), cryptoOfficerUserId);
+		_assertField("operation-type", _records.get(0), operationType);
+		_assertField("to-state", _records.get(0), "KEY_CSP_ENTRY");
+		_assertField("from-state", _records.get(1), "KEY_CSP_ENTRY");
+		_assertField(
+			"message", _records.get(1),
+			"The operation was completed successfully");
+		_assertField("to-state", _records.get(1), "OPERATIONAL");
+	}
+
+	@Test
+	public void testKeyCSPEntryWithFailedOperation() {
+		_setFIPSApplicationState(FIPSApplicationState.OPERATIONAL);
+
+		Assert.assertThrows(
+			SecurityException.class,
+			() -> FIPSApplicationStateMachineUtil.keyCSPEntry(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				() -> {
+					throw new SecurityException("The key is unusable");
+				}));
+
+		Assert.assertEquals(
+			FIPSApplicationState.ERROR,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Assert.assertEquals(_records.toString(), 2, _records.size());
+
+		_assertEnvelope("severity", _records.get(1), "CRITICAL");
+		_assertField("failed-step", _records.get(1), "Key or CSP entry");
+		_assertField(
+			"provider-error-message", _records.get(1), "The key is unusable");
+		_assertField("to-state", _records.get(1), "ERROR");
+	}
+
+	@Test
+	public void testOperational() {
+		_setFIPSApplicationState(FIPSApplicationState.QUIESCENT);
+
+		String cryptoOfficerUserId = RandomTestUtil.randomString();
+		String reason = RandomTestUtil.randomString();
+
+		FIPSApplicationStateMachineUtil.operational(
+			cryptoOfficerUserId, reason);
+
+		Assert.assertEquals(
+			FIPSApplicationState.OPERATIONAL,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Map<String, Object> record = _getRecord();
+
+		_assertEnvelope("severity", record, "INFO");
+		_assertField("crypto-officer-user-id", record, cryptoOfficerUserId);
+		_assertField("from-state", record, "QUIESCENT");
+		_assertField("reason", record, reason);
+		_assertField("to-state", record, "OPERATIONAL");
+	}
+
+	@Test
+	public void testPowerOff() {
+		_setFIPSApplicationState(FIPSApplicationState.OPERATIONAL);
+
+		String initiatingActor = RandomTestUtil.randomString();
+
+		FIPSApplicationStateMachineUtil.powerOff(initiatingActor);
+
+		Assert.assertEquals(
+			FIPSApplicationState.POWER_OFF,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Map<String, Object> record = _getRecord();
+
+		_assertEnvelope("severity", record, "INFO");
+		_assertField("from-state", record, "OPERATIONAL");
+		_assertField("initiating-actor", record, initiatingActor);
+		_assertField("to-state", record, "POWER_OFF");
+	}
+
+	@Test
+	public void testQuiescent() {
+		_setFIPSApplicationState(FIPSApplicationState.OPERATIONAL);
+
+		String cryptoOfficerUserId = RandomTestUtil.randomString();
+		String reason = RandomTestUtil.randomString();
+
+		FIPSApplicationStateMachineUtil.quiescent(cryptoOfficerUserId, reason);
+
+		Assert.assertEquals(
+			FIPSApplicationState.QUIESCENT,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Map<String, Object> record = _getRecord();
+
+		_assertEnvelope("severity", record, "INFO");
+		_assertField("crypto-officer-user-id", record, cryptoOfficerUserId);
+		_assertField("from-state", record, "OPERATIONAL");
+		_assertField("reason", record, reason);
+		_assertField("to-state", record, "QUIESCENT");
+	}
+
+	@Test
+	public void testRegisterShutdownHook() {
+		_setFIPSApplicationState(FIPSApplicationState.OPERATIONAL);
+
+		Thread thread = _registerShutdownHook();
+
+		thread.run();
+
+		Assert.assertEquals(
+			FIPSApplicationState.POWER_OFF,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Map<String, Object> record = _getRecord();
+
+		_assertEnvelope("severity", record, "INFO");
+		_assertField("from-state", record, "OPERATIONAL");
+		_assertField("initiating-actor", record, "OS signal");
+		_assertField("to-state", record, "POWER_OFF");
+	}
+
+	@Test
+	public void testRegisterShutdownHookWithPowerOffState() {
+		_setFIPSApplicationState(FIPSApplicationState.POWER_OFF);
+
+		Thread thread = _registerShutdownHook();
+
+		thread.run();
+
+		Assert.assertEquals(
+			FIPSApplicationState.POWER_OFF,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Assert.assertTrue(_records.toString(), _records.isEmpty());
 	}
 
 	@Test
@@ -33,8 +280,45 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.OPERATIONAL,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
+		Assert.assertEquals(_records.toString(), 2, _records.size());
+
+		_assertField("from-state", _records.get(0), "INITIALIZING");
+		_assertField(
+			"message", _records.get(0), "The integrity checks were started");
+		_assertField("to-state", _records.get(0), "SELF_TEST");
+		_assertField(
+			"message", _records.get(1),
+			"All checks and the validated provider self tests passed");
+		_assertField("to-state", _records.get(1), "OPERATIONAL");
+
 		_testSelfTest(new RuntimeException());
 		_testSelfTest(new SecurityException());
+	}
+
+	@Test
+	public void testSelfTestWithRecovery() {
+		_setFIPSApplicationState(FIPSApplicationState.ERROR);
+
+		String cryptoOfficerUserId = RandomTestUtil.randomString();
+		String recoveryAction = RandomTestUtil.randomString();
+
+		FIPSApplicationStateMachineUtil.selfTest(
+			cryptoOfficerUserId, recoveryAction,
+			() -> {
+			});
+
+		Assert.assertEquals(
+			FIPSApplicationState.OPERATIONAL,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Assert.assertEquals(_records.toString(), 2, _records.size());
+
+		_assertField(
+			"crypto-officer-user-id", _records.get(0), cryptoOfficerUserId);
+		_assertField("from-state", _records.get(0), "ERROR");
+		_assertField("recovery-action", _records.get(0), recoveryAction);
+		_assertField("to-state", _records.get(0), "SELF_TEST");
+		_assertField("to-state", _records.get(1), "OPERATIONAL");
 	}
 
 	@Test
@@ -42,17 +326,39 @@ public class FIPSApplicationStateMachineUtilTest {
 		_testTransition(
 			FIPSApplicationState.ERROR, FIPSApplicationState.POWER_OFF);
 		_testTransition(
+			FIPSApplicationState.ERROR, FIPSApplicationState.SELF_TEST);
+		_testTransition(
 			FIPSApplicationState.INITIALIZING, FIPSApplicationState.ERROR);
 		_testTransition(
 			FIPSApplicationState.INITIALIZING, FIPSApplicationState.POWER_OFF);
 		_testTransition(
 			FIPSApplicationState.INITIALIZING, FIPSApplicationState.SELF_TEST);
 		_testTransition(
+			FIPSApplicationState.KEY_CSP_ENTRY, FIPSApplicationState.ERROR);
+		_testTransition(
+			FIPSApplicationState.KEY_CSP_ENTRY,
+			FIPSApplicationState.OPERATIONAL);
+		_testTransition(
+			FIPSApplicationState.KEY_CSP_ENTRY, FIPSApplicationState.POWER_OFF);
+		_testTransition(
 			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.ERROR);
+		_testTransition(
+			FIPSApplicationState.OPERATIONAL,
+			FIPSApplicationState.KEY_CSP_ENTRY);
 		_testTransition(
 			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.POWER_OFF);
 		_testTransition(
+			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.QUIESCENT);
+		_testTransition(
 			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.SELF_TEST);
+		_testTransition(
+			FIPSApplicationState.QUIESCENT, FIPSApplicationState.ERROR);
+		_testTransition(
+			FIPSApplicationState.QUIESCENT, FIPSApplicationState.KEY_CSP_ENTRY);
+		_testTransition(
+			FIPSApplicationState.QUIESCENT, FIPSApplicationState.OPERATIONAL);
+		_testTransition(
+			FIPSApplicationState.QUIESCENT, FIPSApplicationState.POWER_OFF);
 		_testTransition(
 			FIPSApplicationState.SELF_TEST, FIPSApplicationState.ERROR);
 		_testTransition(
@@ -68,15 +374,32 @@ public class FIPSApplicationStateMachineUtilTest {
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.ERROR, FIPSApplicationState.INITIALIZING);
 		_testTransitionWithIllegalState(
+			FIPSApplicationState.ERROR, FIPSApplicationState.KEY_CSP_ENTRY);
+		_testTransitionWithIllegalState(
 			FIPSApplicationState.ERROR, FIPSApplicationState.OPERATIONAL);
 		_testTransitionWithIllegalState(
-			FIPSApplicationState.ERROR, FIPSApplicationState.SELF_TEST);
+			FIPSApplicationState.ERROR, FIPSApplicationState.QUIESCENT);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.INITIALIZING,
 			FIPSApplicationState.INITIALIZING);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.INITIALIZING,
+			FIPSApplicationState.KEY_CSP_ENTRY);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.INITIALIZING,
 			FIPSApplicationState.OPERATIONAL);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.INITIALIZING, FIPSApplicationState.QUIESCENT);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.KEY_CSP_ENTRY,
+			FIPSApplicationState.INITIALIZING);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.KEY_CSP_ENTRY,
+			FIPSApplicationState.KEY_CSP_ENTRY);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.KEY_CSP_ENTRY, FIPSApplicationState.QUIESCENT);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.KEY_CSP_ENTRY, FIPSApplicationState.SELF_TEST);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.OPERATIONAL,
 			FIPSApplicationState.INITIALIZING);
@@ -87,15 +410,76 @@ public class FIPSApplicationStateMachineUtilTest {
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.POWER_OFF, FIPSApplicationState.INITIALIZING);
 		_testTransitionWithIllegalState(
+			FIPSApplicationState.POWER_OFF, FIPSApplicationState.KEY_CSP_ENTRY);
+		_testTransitionWithIllegalState(
 			FIPSApplicationState.POWER_OFF, FIPSApplicationState.OPERATIONAL);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.POWER_OFF, FIPSApplicationState.POWER_OFF);
 		_testTransitionWithIllegalState(
+			FIPSApplicationState.POWER_OFF, FIPSApplicationState.QUIESCENT);
+		_testTransitionWithIllegalState(
 			FIPSApplicationState.POWER_OFF, FIPSApplicationState.SELF_TEST);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.QUIESCENT, FIPSApplicationState.INITIALIZING);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.QUIESCENT, FIPSApplicationState.QUIESCENT);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.QUIESCENT, FIPSApplicationState.SELF_TEST);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.SELF_TEST, FIPSApplicationState.INITIALIZING);
 		_testTransitionWithIllegalState(
+			FIPSApplicationState.SELF_TEST, FIPSApplicationState.KEY_CSP_ENTRY);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.SELF_TEST, FIPSApplicationState.QUIESCENT);
+		_testTransitionWithIllegalState(
 			FIPSApplicationState.SELF_TEST, FIPSApplicationState.SELF_TEST);
+	}
+
+	private void _assertEnvelope(
+		String key, Map<String, Object> record, String value) {
+
+		Assert.assertEquals(String.valueOf(record), value, record.get(key));
+	}
+
+	private void _assertField(
+		String key, Map<String, Object> record, String value) {
+
+		Map<?, ?> fields = (Map<?, ?>)record.get("fields");
+
+		Assert.assertEquals(String.valueOf(record), value, fields.get(key));
+	}
+
+	private Map<String, Object> _getRecord() {
+		return _records.get(_records.size() - 1);
+	}
+
+	private Thread _registerShutdownHook() {
+		try (MockedStatic<Runtime> runtimeMockedStatic = Mockito.mockStatic(
+				Runtime.class)) {
+
+			Runtime runtime = Mockito.mock(Runtime.class);
+
+			runtimeMockedStatic.when(
+				Runtime::getRuntime
+			).thenReturn(
+				runtime
+			);
+
+			ReflectionTestUtil.invoke(
+				FIPSApplicationStateMachineUtil.class, "_registerShutdownHook",
+				new Class<?>[0]);
+
+			ArgumentCaptor<Thread> argumentCaptor = ArgumentCaptor.forClass(
+				Thread.class);
+
+			Mockito.verify(
+				runtime
+			).addShutdownHook(
+				argumentCaptor.capture()
+			);
+
+			return argumentCaptor.getValue();
+		}
 	}
 
 	private void _setFIPSApplicationState(
@@ -111,6 +495,8 @@ public class FIPSApplicationStateMachineUtilTest {
 	}
 
 	private void _testSelfTest(RuntimeException runtimeException) {
+		_records.clear();
+
 		_setFIPSApplicationState(FIPSApplicationState.INITIALIZING);
 
 		Assert.assertThrows(
@@ -123,11 +509,20 @@ public class FIPSApplicationStateMachineUtilTest {
 		Assert.assertEquals(
 			FIPSApplicationState.ERROR,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Assert.assertEquals(_records.toString(), 2, _records.size());
+
+		_assertEnvelope("severity", _records.get(1), "CRITICAL");
+		_assertField("failed-step", _records.get(1), "Self test");
+		_assertField("from-state", _records.get(1), "SELF_TEST");
+		_assertField("to-state", _records.get(1), "ERROR");
 	}
 
 	private void _testTransition(
 		FIPSApplicationState fromFIPSApplicationState,
 		FIPSApplicationState toFIPSApplicationState) {
+
+		_records.clear();
 
 		_setFIPSApplicationState(fromFIPSApplicationState);
 
@@ -136,11 +531,21 @@ public class FIPSApplicationStateMachineUtilTest {
 		Assert.assertEquals(
 			toFIPSApplicationState,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Assert.assertEquals(_records.toString(), 1, _records.size());
+
+		_assertEnvelope("event-type", _records.get(0), "fips-state-transition");
+		_assertField(
+			"from-state", _records.get(0), fromFIPSApplicationState.name());
+		_assertField(
+			"to-state", _records.get(0), toFIPSApplicationState.name());
 	}
 
 	private void _testTransitionWithIllegalState(
 		FIPSApplicationState fromFIPSApplicationState,
 		FIPSApplicationState toFIPSApplicationState) {
+
+		_records.clear();
 
 		_setFIPSApplicationState(fromFIPSApplicationState);
 
@@ -151,12 +556,24 @@ public class FIPSApplicationStateMachineUtilTest {
 		Assert.assertEquals(
 			fromFIPSApplicationState,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Assert.assertTrue(_records.toString(), _records.isEmpty());
 	}
 
 	private void _transition(FIPSApplicationState fipsApplicationState) {
 		ReflectionTestUtil.invoke(
 			FIPSApplicationStateMachineUtil.class, "_transition",
-			new Class<?>[] {FIPSApplicationState.class}, fipsApplicationState);
+			new Class<?>[] {FIPSApplicationState.class, Consumer.class},
+			fipsApplicationState,
+			(Consumer<FIPSAuditEvent>)fipsAuditEvent -> {
+			});
 	}
+
+	private static Logger _logger;
+
+	private static MockedStatic<LogManager> _logManagerMockedStatic;
+
+	private final List<Map<String, Object>> _records = new ArrayList<>();
+	private SafeCloseable _safeCloseable;
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventTest.java
@@ -1,0 +1,90 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.crypto.spec.PBEKeySpec;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSAuditEventTest {
+
+	@Test
+	public void testPut() {
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
+
+		String reason = RandomTestUtil.randomString();
+
+		fipsAuditEvent.put("reason", reason);
+
+		Map<String, Object> fields = fipsAuditEvent.getFields();
+
+		Assert.assertEquals(reason, fields.get("reason"));
+	}
+
+	@Test
+	public void testPutRejectsANonfiniteNumber() {
+		_testPutRejects(Double.NaN);
+		_testPutRejects(Double.POSITIVE_INFINITY);
+		_testPutRejects(Float.NEGATIVE_INFINITY);
+		_testPutRejects(Float.NaN);
+	}
+
+	@Test
+	public void testPutRejectsANullValue() {
+		_testPutRejects(null);
+	}
+
+	@Test
+	public void testPutRejectsASensitiveSecurityParameter() throws Exception {
+		KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+
+		KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+		_testPutRejects(keyPair.getPrivate());
+		_testPutRejects(keyPair.getPublic());
+
+		char[] chars = RandomTestUtil.randomString(
+		).toCharArray();
+
+		_testPutRejects(RandomTestUtil.randomBytes());
+		_testPutRejects(chars);
+		_testPutRejects(new PBEKeySpec(chars));
+	}
+
+	private void _testPutRejects(Object value) {
+		_testPutRejectsValue(value);
+		_testPutRejectsValue(Arrays.asList(value));
+		_testPutRejectsValue(Collections.singletonMap("nested", value));
+	}
+
+	private void _testPutRejectsValue(Object value) {
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
+
+		Assert.assertThrows(
+			IllegalArgumentException.class,
+			() -> fipsAuditEvent.put(RandomTestUtil.randomString(), value));
+
+		Map<String, Object> fields = fipsAuditEvent.getFields();
+
+		Assert.assertTrue(String.valueOf(fields), fields.isEmpty());
+	}
+
+}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
@@ -6,7 +6,7 @@
 package com.liferay.portal.kernel.security.fips;
 
 import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.portal.kernel.internal.log4j.Log4jFIPSAuditUtil;
+import com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -72,7 +72,7 @@ public class FIPSAuditUtilTest {
 			LogManager.class, Mockito.CALLS_REAL_METHODS);
 
 		_logManagerMockedStatic.when(
-			() -> LogManager.getLogger(Log4jFIPSAuditUtil.class)
+			() -> LogManager.getLogger(FIPSLog4jUtil.class)
 		).thenReturn(
 			_logger
 		);

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
@@ -38,6 +38,7 @@ import java.util.TimeZone;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.MarkerManager;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
@@ -421,7 +422,9 @@ public class FIPSAuditUtilTest {
 		Mockito.verify(
 			_logger, Mockito.atLeastOnce()
 		).log(
-			Mockito.eq(level), argumentCaptor.capture()
+			Mockito.eq(level),
+			Mockito.eq(MarkerManager.getMarker(FIPSLog4jUtil.MARKER_NAME)),
+			argumentCaptor.capture()
 		);
 
 		for (Message message : argumentCaptor.getAllValues()) {

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
@@ -1,0 +1,517 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.internal.log4j.Log4jFIPSAuditUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.ServerDetector;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import java.security.Provider;
+import java.security.Security;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.ObjectMessage;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Jorge García Jiménez
+ * @author Rafael Praxedes
+ */
+public class FIPSAuditUtilTest {
+
+	@BeforeClass
+	public static void setUpClass() {
+		PropsUtil.get("fips.enabled");
+
+		_logger = Mockito.mock(Logger.class);
+
+		_logManagerMockedStatic = Mockito.mockStatic(
+			LogManager.class, Mockito.CALLS_REAL_METHODS);
+
+		_logManagerMockedStatic.when(
+			() -> LogManager.getLogger(Log4jFIPSAuditUtil.class)
+		).thenReturn(
+			_logger
+		);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_logManagerMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() {
+		Mockito.reset(_logger);
+
+		_safeCloseable = PropsValuesTestUtil.swapWithSafeCloseable(
+			"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", RandomTestUtil.randomString());
+
+		_mockLogManager(null);
+	}
+
+	@After
+	public void tearDown() {
+		_safeCloseable.close();
+	}
+
+	@Test
+	public void testWrite() {
+		try (SafeCloseable safeCloseable1 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", "instance-1");
+			SafeCloseable safeCloseable2 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID", "4743")) {
+
+			String eventType = RandomTestUtil.randomString();
+
+			FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+				eventType, FIPSAuditEvent.Severity.CRITICAL);
+
+			String fromState = RandomTestUtil.randomString();
+			String toState = RandomTestUtil.randomString();
+
+			fipsAuditEvent.put("from-state", fromState);
+			fipsAuditEvent.put("to-state", toState);
+
+			FIPSAuditUtil.write(fipsAuditEvent);
+
+			Map<String, Object> record = _getRecord(Level.ERROR);
+
+			Assert.assertEquals("4743", record.get("cmvp-certificate-id"));
+			Assert.assertEquals(
+				"instance-1", record.get("deployment-instance-id"));
+			Assert.assertEquals("1.0", record.get("event-schema-version"));
+			Assert.assertEquals(eventType, record.get("event-type"));
+
+			Map<?, ?> fields = (Map<?, ?>)record.get("fields");
+
+			Assert.assertEquals(fromState, fields.get("from-state"));
+			Assert.assertEquals(toState, fields.get("to-state"));
+
+			Provider provider = _getProvider();
+
+			Assert.assertEquals(
+				provider.getName(), record.get("provider-name"));
+			Assert.assertEquals(
+				provider.getVersionStr(), record.get("provider-version"));
+
+			Assert.assertEquals("CRITICAL", record.get("severity"));
+
+			String timestamp = String.valueOf(record.get("timestamp"));
+
+			Assert.assertTrue(
+				timestamp,
+				timestamp.matches(
+					"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"));
+		}
+	}
+
+	@Test
+	public void testWriteDerivesStableDeploymentInstanceIdWhenUnset()
+		throws Exception {
+
+		Path liferayHome = Files.createTempDirectory("fips-audit-test");
+
+		try (SafeCloseable safeCloseable1 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"LIFERAY_HOME", liferayHome.toString());
+			SafeCloseable safeCloseable2 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", "");
+			SafeCloseable safeCloseable3 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID", "")) {
+
+			FIPSAuditUtil.write(
+				new FIPSAuditEvent(
+					RandomTestUtil.randomString(),
+					FIPSAuditEvent.Severity.INFO));
+			FIPSAuditUtil.write(
+				new FIPSAuditEvent(
+					RandomTestUtil.randomString(),
+					FIPSAuditEvent.Severity.INFO));
+
+			List<Map<String, Object>> records = _getRecords(Level.INFO);
+
+			Assert.assertEquals(records.toString(), 2, records.size());
+
+			Map<String, Object> record1 = records.get(0);
+
+			Object deploymentInstanceId = record1.get("deployment-instance-id");
+
+			Assert.assertTrue(
+				String.valueOf(deploymentInstanceId),
+				Validator.isNotNull(String.valueOf(deploymentInstanceId)));
+
+			Map<String, Object> record2 = records.get(1);
+
+			Assert.assertEquals(
+				deploymentInstanceId, record2.get("deployment-instance-id"));
+
+			Assert.assertTrue(
+				Files.exists(
+					liferayHome.resolve(
+						"data/fips-audit-deployment-instance-id")));
+		}
+		finally {
+			_delete(liferayHome);
+		}
+	}
+
+	@Test
+	public void testWriteFormatsTimestampInUTC() {
+		TimeZone timeZone = TimeZone.getDefault();
+
+		try {
+			TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+
+			FIPSAuditUtil.write(
+				new FIPSAuditEvent(
+					RandomTestUtil.randomString(),
+					FIPSAuditEvent.Severity.INFO));
+
+			Map<String, Object> record = _getRecord(Level.INFO);
+
+			String timestamp = String.valueOf(record.get("timestamp"));
+
+			Instant instant = Instant.parse(timestamp);
+
+			Assert.assertTrue(
+				timestamp,
+				Math.abs(System.currentTimeMillis() - instant.toEpochMilli()) <
+					Time.MINUTE);
+		}
+		finally {
+			TimeZone.setDefault(timeZone);
+		}
+	}
+
+	@Test
+	public void testWriteLogsRecordAtTheSeverityLevel() {
+		_testWriteLogsRecordAtTheSeverityLevel(
+			Level.ERROR, FIPSAuditEvent.Severity.CRITICAL);
+		_testWriteLogsRecordAtTheSeverityLevel(
+			Level.INFO, FIPSAuditEvent.Severity.INFO);
+	}
+
+	@Test
+	public void testWriteNestsFields() {
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
+
+		String spoofedProviderName = RandomTestUtil.randomString();
+
+		fipsAuditEvent.put("provider-name", spoofedProviderName);
+
+		FIPSAuditUtil.write(fipsAuditEvent);
+
+		Map<String, Object> record = _getRecord(Level.INFO);
+
+		Provider provider = _getProvider();
+
+		Assert.assertEquals(provider.getName(), record.get("provider-name"));
+
+		Map<?, ?> fields = (Map<?, ?>)record.get("fields");
+
+		Assert.assertEquals(spoofedProviderName, fields.get("provider-name"));
+	}
+
+	@Test
+	public void testWriteNormalizesFieldTimestamps() {
+		_testWriteNormalizesFieldTimestamp(
+			"2025-05-06T14:19:23.471Z",
+			Date.from(Instant.parse("2025-05-06T14:19:23.471Z")));
+		_testWriteNormalizesFieldTimestamp(
+			"2026-05-06T14:19:23.000Z", Instant.parse("2026-05-06T14:19:23Z"));
+		_testWriteNormalizesFieldTimestamp(
+			"2026-05-06T14:19:23.471Z",
+			Instant.parse("2026-05-06T14:19:23.471999999Z"));
+		_testWriteNormalizesFieldTimestamp(
+			"2026-05-06T14:19:23.471Z",
+			OffsetDateTime.parse("2026-05-06T16:19:23.471+02:00"));
+	}
+
+	@Test
+	public void testWriteNormalizesNestedFieldTimestamps() {
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
+
+		fipsAuditEvent.put(
+			"provider-self-test",
+			Collections.singletonMap(
+				"completed", Instant.parse("2026-05-06T14:19:23.471Z")));
+		fipsAuditEvent.put(
+			"provider-timestamps",
+			Arrays.asList(Instant.parse("2026-05-06T14:19:23Z")));
+
+		FIPSAuditUtil.write(fipsAuditEvent);
+
+		Map<String, Object> record = _getRecord(Level.INFO);
+
+		Map<?, ?> fields = (Map<?, ?>)record.get("fields");
+
+		Map<?, ?> providerSelfTestMap = (Map<?, ?>)fields.get(
+			"provider-self-test");
+
+		Assert.assertEquals(
+			"2026-05-06T14:19:23.471Z", providerSelfTestMap.get("completed"));
+
+		Assert.assertEquals(
+			Arrays.asList("2026-05-06T14:19:23.000Z"),
+			fields.get("provider-timestamps"));
+	}
+
+	@Test
+	public void testWriteRejectsAFieldTimestampWithoutATimeZone() {
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
+
+		fipsAuditEvent.put(
+			"provider-timestamp", LocalDateTime.parse("2026-05-06T14:19:23"));
+
+		Assert.assertThrows(
+			IllegalArgumentException.class,
+			() -> FIPSAuditUtil.write(fipsAuditEvent));
+	}
+
+	@Test
+	public void testWriteSequencesRecordsMonotonically() {
+		FIPSAuditUtil.write(
+			new FIPSAuditEvent(
+				RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO));
+		FIPSAuditUtil.write(
+			new FIPSAuditEvent(
+				RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO));
+
+		List<Map<String, Object>> records = _getRecords(Level.INFO);
+
+		Assert.assertEquals(records.toString(), 2, records.size());
+
+		Map<String, Object> record1 = records.get(0);
+		Map<String, Object> record2 = records.get(1);
+
+		long eventSequence1 = (Long)record1.get("event-sequence");
+		long eventSequence2 = (Long)record2.get("event-sequence");
+
+		Assert.assertEquals(
+			records.toString(), eventSequence1 + 1, eventSequence2);
+	}
+
+	@Test
+	public void testWriteThrowsWhenAppenderIsMissing() {
+		Mockito.when(
+			_logger.isEnabled(Level.INFO)
+		).thenReturn(
+			true
+		);
+
+		_testWriteThrows();
+	}
+
+	@Test
+	public void testWriteThrowsWhenLayoutIsNotTheNDJSONLayout() {
+		Mockito.when(
+			_logger.isEnabled(Level.INFO)
+		).thenReturn(
+			true
+		);
+
+		RollingFileAppender rollingFileAppender = Mockito.mock(
+			RollingFileAppender.class);
+
+		Mockito.doReturn(
+			Mockito.mock(Layout.class)
+		).when(
+			rollingFileAppender
+		).getLayout();
+
+		_mockLogManager(rollingFileAppender);
+
+		_testWriteThrows();
+	}
+
+	@Test
+	public void testWriteThrowsWhenLoggerIsDisabled() {
+		Mockito.when(
+			_logger.isEnabled(Level.INFO)
+		).thenReturn(
+			false
+		);
+
+		_testWriteThrows();
+	}
+
+	private void _delete(Path path) throws IOException {
+		File file = path.toFile();
+
+		File[] childFiles = file.listFiles();
+
+		if (childFiles != null) {
+			for (File childFile : childFiles) {
+				_delete(childFile.toPath());
+			}
+		}
+
+		Files.delete(path);
+	}
+
+	private Provider _getProvider() {
+		Provider[] providers = Security.getProviders();
+
+		return providers[0];
+	}
+
+	private Map<String, Object> _getRecord(Level level) {
+		List<Map<String, Object>> records = _getRecords(level);
+
+		return records.get(records.size() - 1);
+	}
+
+	private List<Map<String, Object>> _getRecords(Level level) {
+		List<Map<String, Object>> records = new ArrayList<>();
+
+		ArgumentCaptor<Message> argumentCaptor = ArgumentCaptor.forClass(
+			Message.class);
+
+		Mockito.verify(
+			_logger, Mockito.atLeastOnce()
+		).log(
+			Mockito.eq(level), argumentCaptor.capture()
+		);
+
+		for (Message message : argumentCaptor.getAllValues()) {
+			ObjectMessage objectMessage = (ObjectMessage)message;
+
+			records.add((Map<String, Object>)objectMessage.getParameter());
+		}
+
+		return records;
+	}
+
+	private void _mockLogManager(RollingFileAppender rollingFileAppender) {
+		Configuration configuration = Mockito.mock(Configuration.class);
+
+		Mockito.when(
+			configuration.getAppender("FIPS_AUDIT_FILE")
+		).thenReturn(
+			rollingFileAppender
+		);
+
+		LoggerContext loggerContext = Mockito.mock(LoggerContext.class);
+
+		Mockito.when(
+			loggerContext.getConfiguration()
+		).thenReturn(
+			configuration
+		);
+
+		_logManagerMockedStatic.when(
+			() -> LogManager.getContext(false)
+		).thenReturn(
+			loggerContext
+		);
+	}
+
+	private void _testWriteLogsRecordAtTheSeverityLevel(
+		Level level, FIPSAuditEvent.Severity severity) {
+
+		FIPSAuditUtil.write(
+			new FIPSAuditEvent(RandomTestUtil.randomString(), severity));
+
+		Map<String, Object> record = _getRecord(level);
+
+		Assert.assertEquals(severity.name(), record.get("severity"));
+	}
+
+	private void _testWriteNormalizesFieldTimestamp(
+		String expectedTimestamp, Object value) {
+
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
+
+		fipsAuditEvent.put("provider-timestamp", value);
+
+		FIPSAuditUtil.write(fipsAuditEvent);
+
+		Map<String, Object> record = _getRecord(Level.INFO);
+
+		Map<?, ?> fields = (Map<?, ?>)record.get("fields");
+
+		Assert.assertEquals(
+			expectedTimestamp, fields.get("provider-timestamp"));
+	}
+
+	private void _testWriteThrows() {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable("FIPS_ENABLED", true);
+			MockedStatic<ServerDetector> serverDetectorMockedStatic =
+				Mockito.mockStatic(
+					ServerDetector.class, Mockito.CALLS_REAL_METHODS)) {
+
+			serverDetectorMockedStatic.when(
+				ServerDetector::getServerId
+			).thenReturn(
+				"tomcat"
+			);
+
+			Assert.assertThrows(
+				IllegalStateException.class,
+				() -> FIPSAuditUtil.write(
+					new FIPSAuditEvent(
+						RandomTestUtil.randomString(),
+						FIPSAuditEvent.Severity.INFO)));
+		}
+	}
+
+	private static Logger _logger;
+
+	private static MockedStatic<LogManager> _logManagerMockedStatic;
+
+	private SafeCloseable _safeCloseable;
+
+}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
@@ -114,9 +114,11 @@ public class FIPSAuditUtilTest {
 				eventType, FIPSAuditEvent.Severity.CRITICAL);
 
 			String fromState = RandomTestUtil.randomString();
-			String toState = RandomTestUtil.randomString();
 
 			fipsAuditEvent.put("from-state", fromState);
+
+			String toState = RandomTestUtil.randomString();
+
 			fipsAuditEvent.put("to-state", toState);
 
 			FIPSAuditUtil.write(fipsAuditEvent);
@@ -499,7 +501,7 @@ public class FIPSAuditUtilTest {
 			serverDetectorMockedStatic.when(
 				ServerDetector::getServerId
 			).thenReturn(
-				"tomcat"
+				RandomTestUtil.randomString()
 			);
 
 			Assert.assertThrows(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99383
https://liferay.atlassian.net/browse/LPD-93284
https://liferay.atlassian.net/browse/LPD-93283

**Supersedes #3220.** Its forward, brianchandotcom#180391, was closed with `rebase error`. The nineteen commits are unchanged and rebased onto current `master`; the two conflicts and their resolution are described under Rebase below. Nothing is stacked: reviewing this PR reviews the whole feature.

## Rebase

`master` gained LPD-93272, which allows an on-demand self test from the operational state. It touches the two lines this branch also rewrites, in `FIPSApplicationStateMachineUtil` and its test, so it is the whole of the conflict. Both resolutions are the union, and both features survive.

`OPERATIONAL` now reaches `KEY_CSP_ENTRY` and `QUIESCENT` from this branch and `SELF_TEST` from LPD-93272:

```java
FIPSApplicationState.OPERATIONAL,
Set.of(
	FIPSApplicationState.ERROR, FIPSApplicationState.KEY_CSP_ENTRY,
	FIPSApplicationState.POWER_OFF, FIPSApplicationState.QUIESCENT,
	FIPSApplicationState.SELF_TEST),
```

`testTransition` keeps the `OPERATIONAL` to `SELF_TEST` row LPD-93272 added, alongside the five rows this branch adds, and `testTransitionWithIllegalState` keeps that row deleted. The model is fully covered: twenty legal transitions, twenty assertions.

Nothing else moved. The net diff against current `master` differs from the net diff of #3220 against its base by exactly those two hunks.

## What Is Being Fixed

A FIPS application state transition left no evidence behind, and there was no audit stream a downstream consumer could read. ISO/IEC 19790 §7.11.4 [AS11.09] requires the finite state model to be documented, and the §7.6.3.2 audit assertions ([AS06.16], [AS06.17], [AS06.27], [AS06.28], [AS06.31], [AS06.32]) require a module to provide its events to an audit mechanism. The target is **Security Level 1** (LPD-93270) and those audit assertions are Level 2, so this trail goes beyond Level 1 deliberately, for Level 2 readiness. The one Level 1 mandate it satisfies is §7.11.6.2 [AS11.29] functional testing, sharpened by SP 800-140 VE11.29.01.

## How It Is Being Fixed

A dedicated logger feeds a rolling `FIPS_AUDIT_FILE` appender that writes one compact JSON object per line. `FIPSAuditNDJSONLayout` is a registered `@Plugin` layout that mirrors `LiferayXmlLayout`, the existing custom layout in the same package, and serializes through `JSONUtil`. It lives in `portal-kernel` because the OSGi system bundle does not export `org.apache.logging.log4j.core.config.plugins`, which is also why the four existing Log4j plugins live there. `additivity="false"` keeps a record out of the portal log, the console and the per-company files, where an interleaved line would break a line-oriented consumer; the file is created `rw-------` rather than at the process umask; and `ignoreExceptions="false"` makes a write failure surface instead of vanishing into Log4j's status logger.

`FIPSAuditUtil.write` is the only way into the log. Every record carries the same envelope — `cmvp-certificate-id`, `deployment-instance-id`, `event-schema-version`, `event-sequence`, `event-type`, `fields`, `provider-name`, `provider-version`, `severity`, `timestamp` — and caller-supplied fields nest under the reserved `fields` key, so an event can neither overwrite an envelope key nor misattribute the module that produced it. `event-sequence` is a per-JVM-run counter that orders two records written in the same millisecond, which a consumer needs because §5.4 delegates chaining to the operational environment. Timestamps are normalized to the canonical UTC form as the record is built, and a temporal value carrying no time zone is refused rather than recorded ambiguously. Log4j stays behind `FIPSLog4jUtil` in the non-exported `internal.log4j` package, following `Log4JUtil` and `Log4jConfigUtil`, so the exported `security.fips` package imports none of it.

`FIPSApplicationStateMachineUtil` records each transition where the transition happens rather than at each caller, so a state the model gains later cannot slip through unrecorded, and it registers its shutdown hook when the class loads so no caller has to install it. The finite state model is specified separately, as [AS11.09] requires: [FIPS Application Finite State Model](https://liferay.atlassian.net/wiki/spaces/ENGAPPSECURITY/pages/5217026051).

## Only A FIPS Audit Record Enters The FIPS Audit Log

The appender's exclusivity was a convention rather than a boundary. Log4j routes by category name, not by caller, so any code that obtained the category `FIPSLog4jUtil` writes into would land in the log, a dot-suffixed child of it inherits the appender, and a `portal-log4j-ext.xml` merged at startup can attach `FIPS_AUDIT_FILE` to further loggers. The layout rendered such an event as a message key instead of refusing it, so the file stayed well formed while the log was polluted, and a stray logger could put material into it that [AS06.28] keeps out of an audit record.

Each record now carries a dedicated marker. `FIPSAuditFilter` accepts an event only when it carries that marker and its message is the record map the kernel facade builds; everything else is refused. The layout refuses the same shape a second time, which covers the case the filter cannot: an ext file that replaces the appender drops the filter with it, and a replacement still renders through the layout. A refused event is logged at the level of the class that refused it rather than dropped, under that class's own category, which the audit appender is not attached to, so the report cannot re-enter the log it was refused from.

## One Trade-Off Worth A Second Look

The `JSONUtil` switch costs canonical key ordering, and that is worth stating rather than burying. Measured against `lib/portal/json-java.jar`: `JSONObjectImpl` wraps `org.json.JSONObject`, which is `HashMap`-backed, so key order is arbitrary at every level and can shift with the key set or the JDK. A record stays byte-reproducible as a **line**, but no longer as a re-serialized object. A nested object can come out looking sorted purely by hash accident, so a spot check proves nothing. `event-sequence` still gives a consumer a deterministic order, and §5.4 delegates the chaining itself to the operational environment.

The same measurement turned up two things that had to be closed before the switch was safe. `org.json` **drops** a null value, and `JSONObjectImpl.put` **swallows** the `JSONException` for a non-finite number into a warning on the portal log — the one log this trail is configured to stay out of. Either would leave a record that omits a field it was told to carry. `FIPSAuditEvent.put` rejects null and non-finite values alongside sensitive security parameters, walking nested maps and iterables. That walk also closes an existing gap: key material nested inside a map or a list previously passed the [AS06.28] check.

## Testing

39 unit tests: `FIPSApplicationStateMachineUtilTest` 12, `FIPSAuditUtilTest` 12, `FIPSAuditNDJSONLayoutTest` 8, `FIPSAuditEventTest` 4, `FIPSAuditFilterTest` 3.

`FIPSAuditUtilTest` in `portal-security-fips-test` is the functional test, 7 cases. Every unit test stubs the logger, so none of them can tell whether a record ever reaches a file, which is how two defects survived a green suite. It asserts the wiring instead: that the appender resolved its pattern and created the file, that the file is owner-only, that every line parses as one JSON object, that each record carries the ten envelope keys, that every timestamp is canonical and every sequence monotonic, and that the boot transitions are on disk. It is skipped unless FIPS is enabled and needs the FIPS CI environment of LPD-80674 to run for real.

## Known Limitations

- **File permissions are chosen, not verified.** [AS06.22] and [AS06.23] put the operating system's configuration in the administrator guidance, so the writer enforces what it owns, which is delivery, and leaves protection to the operational environment. The owner-only mode is asserted by the functional test against the reference platform.
- **A hard kill records nothing.** An orderly stop is recorded from the framework stop path, before the servlet context shuts Log4J down, and a JVM shutdown hook covers an interrupt during boot. `SIGKILL` runs neither.
- **A failed write leaves the state changed.** The record is written after the swap, because writing first would trade a lost record for a phantom one: the swap can still be refused after a record claiming it has landed, and [AS06.29] asks the module to provide its events to an audit mechanism without obliging it to undo one it could not record.
- **`KEY_CSP_ENTRY` and `QUIESCENT` have no caller yet.** Raised by @caio-farias on a superseded PR and answered there: [AS11.11] makes the Key/CSP entry state conditional on CSP entry being implemented, which `CryptoManager` already satisfies, and the KMS work under LPD-88411 supplies the callers. LPD-97889 is the right place to confirm the level scoping.

## PR Check

**pr-check: PASS** — tested on `70f3508f9e61dab1e691656baca1d48a3ad5eb18`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

39 unit tests, no failures: `FIPSApplicationStateMachineUtilTest` 12, `FIPSAuditUtilTest` 12, `FIPSAuditNDJSONLayoutTest` 8, `FIPSAuditEventTest` 4, `FIPSAuditFilterTest` 3. The state machine class is the one the rebase conflict touched, so the union resolution is confirmed by the suite rather than by reading alone. `ModulesStructureTest` 8/8 is the scanner that validates the `portal-log4j.xml` change.

Cross-Module Compile covers `portal-security-fips-rest-impl`, the module LPD-93272 added to `master`. It calls `FIPSApplicationStateMachineUtil.selfTest`, and this branch adds a three argument overload while keeping the one argument one, so its main and test sources both still compile.

Baseline was forced with `--rerun-tasks --no-build-cache` and did compare rather than returning a cached pass — `Comparing portal-kernel.jar against com.liferay.portal.kernel-188.1.0.jar` — producing no report. `security/fips` at `1.2.0` and `kernel/util` at `100.1.0` are the right versions, and `portal-kernel` `Bundle-Version` is already `189.0.0` on `master`.

One pre-existing finding is deliberately left out of this pull. Baseline reports `com.liferay.exportimport.test.util` as `VERSION INCREASE REQUIRED`, `2.0.0` to `2.1.0`. It is not this branch's: `f805ac868e295 LPD-100541 Consolidate the duplicated export and import test helpers` added 135 lines of public API to that package and bumped neither its `packageinfo` nor its `bnd.bnd`. Fixing it here would put an unrelated module's version bump in a FIPS pull, so it is recorded rather than carried.
