### PR TITLE
LPD-103042 Apply a configured AntiSamy policy only to its own class name

### DIFF
--- a/modules/apps/portal-security/portal-security-antisamy-test/build.gradle
+++ b/modules/apps/portal-security/portal-security-antisamy-test/build.gradle
@@ -1,3 +1,4 @@
 dependencies {
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/portal-security/portal-security-antisamy-test/src/testIntegration/java/com/liferay/portal/security/antisamy/internal/test/AntiSamySanitizerImplTest.java
+++ b/modules/apps/portal-security/portal-security-antisamy-test/src/testIntegration/java/com/liferay/portal/security/antisamy/internal/test/AntiSamySanitizerImplTest.java
@@ -7,10 +7,14 @@ package com.liferay.portal.security.antisamy.internal.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.test.TestInfo;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -48,6 +52,41 @@ public class AntiSamySanitizerImplTest {
 				"right here.",
 			"This little text should not have a space removed but it happens " +
 				"right here.");
+	}
+
+	@Test
+	@TestInfo("LPD-103042")
+	public void testSanitizeWithConfiguredClassName() throws Exception {
+		String className = RandomTestUtil.randomString();
+		String factoryPid =
+			"com.liferay.portal.security.antisamy.configuration." +
+				"AntiSamyClassNameConfiguration";
+
+		String pid = ConfigurationTestUtil.createFactoryConfiguration(
+			factoryPid,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"className", className
+			).put(
+				"configurationFileURL",
+				"/META-INF/resources/fragment-sanitizer-configuration.xml"
+			).build());
+
+		String svg = "<svg><circle cx=\"1\"></circle></svg>";
+
+		try {
+			Assert.assertEquals(svg, _sanitize(className, svg));
+			Assert.assertEquals(
+				StringPool.BLANK, _sanitize(className + "Rel", svg));
+		}
+		finally {
+			ConfigurationTestUtil.deleteFactoryConfiguration(pid, factoryPid);
+		}
+	}
+
+	private String _sanitize(String className, String value) throws Exception {
+		return _sanitizer.sanitize(
+			TestPropsValues.getCompanyId(), 0, 0, className, 0,
+			ContentTypes.TEXT_HTML, new String[0], value, new HashMap<>());
 	}
 
 	private void _testSanitize(String expectedValue, String value)

--- a/modules/apps/portal-security/portal-security-antisamy-test/src/testIntegration/java/com/liferay/portal/security/antisamy/internal/test/AntiSamySanitizerImplTest.java
+++ b/modules/apps/portal-security/portal-security-antisamy-test/src/testIntegration/java/com/liferay/portal/security/antisamy/internal/test/AntiSamySanitizerImplTest.java
@@ -43,11 +43,13 @@ public class AntiSamySanitizerImplTest {
 	@Test
 	public void testSanitize() throws Exception {
 		_testSanitize(
+			StringPool.BLANK,
 			"<p><a href=\"test\" rel=\"noopener noreferrer\" " +
 				"target=\"_blank\"></a></p>",
 			"<p><a href=\"test\" rel=\"noopener noreferrer\" " +
 				"target=\"_blank\"></a></p>");
 		_testSanitize(
+			StringPool.BLANK,
 			"This little text should not have a space removed but it happens " +
 				"right here.",
 			"This little text should not have a space removed but it happens " +
@@ -81,6 +83,16 @@ public class AntiSamySanitizerImplTest {
 		finally {
 			ConfigurationTestUtil.deleteFactoryConfiguration(pid, factoryPid);
 		}
+
+		Assert.assertEquals(StringPool.BLANK, _sanitize(className, svg));
+	}
+
+	@Test
+	@TestInfo("LPD-103042")
+	public void testSanitizeWithNullClassName() throws Exception {
+		String value = RandomTestUtil.randomString();
+
+		_testSanitize(null, value, value);
 	}
 
 	private String _sanitize(String className, String value) throws Exception {
@@ -89,7 +101,8 @@ public class AntiSamySanitizerImplTest {
 			ContentTypes.TEXT_HTML, new String[0], value, new HashMap<>());
 	}
 
-	private void _testSanitize(String expectedValue, String value)
+	private void _testSanitize(
+			String className, String expectedValue, String value)
 		throws Exception {
 
 		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
@@ -97,12 +110,7 @@ public class AntiSamySanitizerImplTest {
 					"AntiSamySanitizerImpl",
 				LoggerTestUtil.WARN)) {
 
-			Assert.assertEquals(
-				expectedValue,
-				_sanitizer.sanitize(
-					TestPropsValues.getCompanyId(), 0, 0, StringPool.BLANK, 0,
-					ContentTypes.TEXT_HTML, new String[0], value,
-					new HashMap<>()));
+			Assert.assertEquals(expectedValue, _sanitize(className, value));
 
 			Assert.assertTrue(ListUtil.isEmpty(logCapture.getLogEntries()));
 		}

--- a/modules/apps/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/internal/AntiSamySanitizerImpl.java
+++ b/modules/apps/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/internal/AntiSamySanitizerImpl.java
@@ -109,9 +109,9 @@ public class AntiSamySanitizerImpl implements Sanitizer {
 
 			AntiSamy antiSamy = new AntiSamy();
 
-			if (_isConfigured(className, classPK)) {
-				Policy policy = _policies.get(className);
+			Policy policy = _policies.get(className);
 
+			if (policy != null) {
 				cleanResults = antiSamy.scan(content, policy, AntiSamy.SAX);
 			}
 			else {
@@ -143,18 +143,6 @@ public class AntiSamySanitizerImpl implements Sanitizer {
 			throw new IllegalStateException(
 				"Unable to initialize policy", exception);
 		}
-	}
-
-	private boolean _isConfigured(String className, long classPK) {
-		String classNameAndClassPK = className + StringPool.POUND + classPK;
-
-		for (String policyClassName : _policies.keySet()) {
-			if (classNameAndClassPK.startsWith(policyClassName)) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	private boolean _isWhitelisted(String className, long classPK) {

--- a/modules/apps/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/internal/AntiSamySanitizerImpl.java
+++ b/modules/apps/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/internal/AntiSamySanitizerImpl.java
@@ -23,9 +23,9 @@ import java.io.InputStream;
 import java.net.URL;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.owasp.validator.html.AntiSamy;
 import org.owasp.validator.html.CleanResults;
@@ -109,7 +109,11 @@ public class AntiSamySanitizerImpl implements Sanitizer {
 
 			AntiSamy antiSamy = new AntiSamy();
 
-			Policy policy = _policies.get(className);
+			Policy policy = null;
+
+			if (Validator.isNotNull(className)) {
+				policy = _policies.get(className);
+			}
 
 			if (policy != null) {
 				cleanResults = antiSamy.scan(content, policy, AntiSamy.SAX);
@@ -185,7 +189,7 @@ public class AntiSamySanitizerImpl implements Sanitizer {
 		AntiSamySanitizerImpl.class);
 
 	private final List<String> _blacklist = new ArrayList<>();
-	private final Map<String, Policy> _policies = new HashMap<>();
+	private final Map<String, Policy> _policies = new ConcurrentHashMap<>();
 	private final DCLSingleton<Policy> _policyDCLSingleton =
 		new DCLSingleton<>();
 	private final URL _url;

--- a/modules/apps/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/internal/configuration/admin/service/AntiSamySanitizerPublisherManagedServiceFactory.java
+++ b/modules/apps/portal-security/portal-security-antisamy/src/main/java/com/liferay/portal/security/antisamy/internal/configuration/admin/service/AntiSamySanitizerPublisherManagedServiceFactory.java
@@ -47,9 +47,11 @@ public class AntiSamySanitizerPublisherManagedServiceFactory
 			return;
 		}
 
-		String className = _classNames.get(pid);
+		String className = _classNames.remove(pid);
 
-		_antiSamySanitizerImpl.removePolicy(className);
+		if (className != null) {
+			_antiSamySanitizerImpl.removePolicy(className);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-103042

Supersedes #3241, which could not be updated in place. The first two commits are @georgel-pop-lr's, unchanged.

## What Is Being Fixed

### The Configured Policy Was Selected By Prefix And Looked Up Exactly

`AntiSamySanitizerImpl._isConfigured` walked `_policies.keySet()` and returned true when `className + "#" + classPK` started with a registered class name, but `sanitize` then did `_policies.get(className)`, an exact lookup. When the two disagreed the policy was null, `antiSamy.scan(content, null, AntiSamy.SAX)` threw `PolicyException: No policy loaded`, and every write of that entity failed.

`_isConfigured` is deleted and the branch is taken on the exact lookup itself, so a class name with no policy of its own falls through to the default policy instead of selecting a null one.

The shipped `configurator/configurations.json` registers `BlogsEntry`, `FragmentEntryLink` and `KBArticle`. None of the three is a prefix of another sanitized class name, so a stock instance is not affected. Of the 129 distinct class names passed to `SanitizerUtil.sanitize`, 20 pairs are prefix pairs, so any further registration can break another entity: `ClientExtensionEntry`/`ClientExtensionEntryRel`, `CommerceOrder`/`CommerceOrderItem`, `DLFileEntry`/`DLFileEntryType`, `FragmentEntry`/`FragmentEntryVersion`, `ObjectEntry`/`ObjectEntryFolder`, `User`/`UserGroup` and `StyleBookEntry`/`StyleBookEntryVersion` among them. Only same package pairs collide, since the match is on the fully qualified name.

A blank class name is the more reachable trigger. `AntiSamyClassNameConfiguration.className` defaults to `""`, `AntiSamyClassNameConfigurationModelListener.onBeforeSave` validates only `configurationFileURL`, and the field is not required in the System Settings form, so an administrator can add an entry and save it without one. `addPolicy("", url)` then registered a policy under `""`, and `"anything#0".startsWith("")` is always true, so every class name selected a null policy and every sanitized write in the portal failed. A `.config` file, `configurator/configurations.json` or Configuration Admin reaches the same state with no metatype validation at all.

### The Policy Map Was Read While It Was Being Rewritten

Policies are registered and removed on the Configuration Admin thread while `sanitize` reads them on request threads, so a plain `HashMap` could be read mid-rewrite. `_policies` is now a `ConcurrentHashMap`.

That map rejects a null key, and `RSSFeedEntry` passes a null class name, so the lookup skips a null or blank one. This matters beyond the exception: `RSSFeedEntry` catches `SanitizerException` at debug level and keeps the **unsanitized** value, so an unguarded lookup would have silently disabled sanitization for feed entries.

`AntiSamySanitizerPublisherManagedServiceFactory.deleted` read `_classNames.get(pid)`, which is null for a pid it never tracked, and `ConcurrentHashMap.remove(null)` throws where `HashMap.remove(null)` was a harmless no-op. It now reads `_classNames.remove(pid)` and skips an untracked pid, which also stops deleted pids from accumulating in that map.

`Collections.synchronizedMap` would have permitted the null key and avoided both changes, but it appears in 7 files repo wide against 511 for `ConcurrentHashMap` under `modules/apps`, and it would put one global monitor on a path every external reference code write goes through.

## How It Is Being Tested

`AntiSamySanitizerImplTest`:

- `testSanitizeWithConfiguredClassName` registers a policy for a random class name, then sanitizes that name and the same name with `Rel` appended. It fails without the lookup fix with `PolicyException: No policy loaded`. It now also asserts the class name falls back to the default policy once its configuration is deleted, covering `removePolicy` and `deleted`.
- `testSanitizeWithNullClassName` guards the null key path.
- `_testSanitize` takes a class name and routes through `_sanitize`, so the file has one form for the call.

Verified by running `testIntegration --tests AntiSamySanitizerImplTest` against a deployed bundle: 3/3 pass. Separately confirmed against AntiSamy 1.7.5 and the two real policy files that the fragment policy returns the SVG verbatim under SAX and the default policy returns blank under DOM, and that compiling the class without the null guard throws on the null class name.

## Where It Came From

Found while working https://liferay.atlassian.net/browse/LPD-102184, which registers a fourth class name policy, for `LayoutPageTemplateStructureRelElementVariation`. That registration broke every external reference code write of `LayoutPageTemplateStructureRelElementVariationAudienceEntryRel`: 14 integration test failures. That pull was discarded, so the fix and its test are extracted here to be reviewed and land on their own.

## PR Check

**pr-check: PASS** — tested on `c7f11da03d1d47163648f46421a9c83ad77efa09`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS (no unit test counterpart) |

Source Format was confirmed with a planted violation, since a silent pass proves nothing: deliberately unsorted imports in `AntiSamySanitizerImpl` were re-sorted by the run. Baseline surfaced `com.liferay.exportimport.test.util` needing a version increase; that module is byte identical between this branch and master, so the finding is pre-existing (from `f805ac868e295`) and was discarded. Neither module here exports a package, so nothing in this diff carries a `packageinfo` for Baseline to version.

<!-- pr-check {"result": "success", "sha": "c7f11da03d1d47163648f46421a9c83ad77efa09"} -->
