### PR TITLE
LPD-103084 Address post-merge review feedback for the AWS key manager

### DIFF
--- a/modules/apps/portal-security/portal-security-key-provider-aws/bnd.bnd
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/bnd.bnd
@@ -5,4 +5,3 @@ Import-Package:\
 	!javax.xml.bind,\
 	\
 	*
-Liferay-Releng-Module-Group-Title: Portal Security Key

--- a/modules/apps/portal-security/portal-security-key-provider-aws/build.gradle
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	compileOnly project(":apps:portal-security:portal-security-key-spi")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:petra:petra-string")
+	testImplementation group: "com.amazonaws", name: "aws-java-sdk-core", version: "1.12.719"
 	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.test", version: "default"
 	testImplementation group: "junit", name: "junit", version: "4.13.1"
 	testImplementation group: "org.mockito", name: "mockito-core", version: "4.4.0"

--- a/modules/apps/portal-security/portal-security-key-provider-aws/build.gradle
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/build.gradle
@@ -1,9 +1,9 @@
 dependencies {
 	compileInclude group: "com.amazonaws", name: "aws-java-sdk-core", version: "1.12.719"
 	compileInclude group: "com.amazonaws", name: "aws-java-sdk-kms", version: "1.12.719"
-	compileInclude group: "com.amazonaws", name: "aws-java-sdk-secretsmanager", version: "1.12.778"
-	compileInclude group: "com.amazonaws", name: "aws-java-sdk-sts", version: "1.12.778"
-	compileInclude group: "com.amazonaws", name: "jmespath-java", version: "1.12.778"
+	compileInclude group: "com.amazonaws", name: "aws-java-sdk-secretsmanager", version: "1.12.719"
+	compileInclude group: "com.amazonaws", name: "aws-java-sdk-sts", version: "1.12.719"
+	compileInclude group: "com.amazonaws", name: "jmespath-java", version: "1.12.719"
 	compileInclude group: "software.amazon.ion", name: "ion-java", version: "1.0.2"
 	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bndlib", version: "6.4.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSClientManager.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSClientManager.java
@@ -18,6 +18,7 @@ import com.liferay.portal.kernel.util.Validator;
 import java.util.Objects;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Supplier;
 
 /**
  * @author Christopher Kian
@@ -28,19 +29,9 @@ public class AWSClientManager<T> {
 		ClientFactory<T> clientFactory, String fipsEndpointTemplate,
 		String region, boolean useFIPSEndpoint) {
 
-		_clientFactory = clientFactory;
-		_fipsEndpointTemplate = fipsEndpointTemplate;
-		_region = _resolveRegion(region);
-		_useFIPSEndpoint = useFIPSEndpoint;
-
-		_awsCredentialsProvider =
-			DefaultAWSCredentialsProviderChain.getInstance();
-
-		ReentrantReadWriteLock reentrantReadWriteLock =
-			new ReentrantReadWriteLock();
-
-		_readLock = reentrantReadWriteLock.readLock();
-		_writeLock = reentrantReadWriteLock.writeLock();
+		this(
+			clientFactory, fipsEndpointTemplate, region,
+			AWSRegionUtil::getRegion, useFIPSEndpoint);
 	}
 
 	public void close() {
@@ -99,7 +90,7 @@ public class AWSClientManager<T> {
 	}
 
 	public void updateConfiguration(String region, boolean useFIPSEndpoint) {
-		region = _resolveRegion(region);
+		region = _resolveRegion(region, _regionSupplier);
 
 		_writeLock.lock();
 
@@ -134,6 +125,27 @@ public class AWSClientManager<T> {
 				String region)
 			throws Exception;
 
+	}
+
+	protected AWSClientManager(
+		ClientFactory<T> clientFactory, String fipsEndpointTemplate,
+		String region, Supplier<String> regionSupplier,
+		boolean useFIPSEndpoint) {
+
+		_clientFactory = clientFactory;
+		_fipsEndpointTemplate = fipsEndpointTemplate;
+		_region = _resolveRegion(region, regionSupplier);
+		_regionSupplier = regionSupplier;
+		_useFIPSEndpoint = useFIPSEndpoint;
+
+		_awsCredentialsProvider =
+			DefaultAWSCredentialsProviderChain.getInstance();
+
+		ReentrantReadWriteLock reentrantReadWriteLock =
+			new ReentrantReadWriteLock();
+
+		_readLock = reentrantReadWriteLock.readLock();
+		_writeLock = reentrantReadWriteLock.writeLock();
 	}
 
 	private void _closeClient() {
@@ -171,9 +183,11 @@ public class AWSClientManager<T> {
 		return new AwsClientBuilder.EndpointConfiguration(endpoint, _region);
 	}
 
-	private String _resolveRegion(String region) {
+	private String _resolveRegion(
+		String region, Supplier<String> regionSupplier) {
+
 		if (Validator.isNull(region)) {
-			return AWSRegionUtil.getRegion();
+			return regionSupplier.get();
 		}
 
 		return region;
@@ -189,6 +203,7 @@ public class AWSClientManager<T> {
 	private final String _fipsEndpointTemplate;
 	private final Lock _readLock;
 	private volatile String _region;
+	private final Supplier<String> _regionSupplier;
 	private volatile boolean _useFIPSEndpoint;
 	private final Lock _writeLock;
 

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSClientManager.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/main/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSClientManager.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.Objects;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -100,15 +101,10 @@ public class AWSClientManager<T> {
 	public void updateConfiguration(String region, boolean useFIPSEndpoint) {
 		region = _resolveRegion(region);
 
-		if (Validator.isNull(region)) {
-			throw new IllegalArgumentException(
-				"AWS region could not be resolved");
-		}
-
 		_writeLock.lock();
 
 		try {
-			if (!region.equals(_region) ||
+			if (!Objects.equals(region, _region) ||
 				(useFIPSEndpoint != _useFIPSEndpoint)) {
 
 				_region = region;

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSByteBufferUtilTest.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSByteBufferUtilTest.java
@@ -31,12 +31,12 @@ public class AWSByteBufferUtilTest {
 
 		byte[] backingArray = bytes.clone();
 
-		byte[] result = AWSByteBufferUtil.getBytes(
-			ByteBuffer.wrap(backingArray));
+		ByteBuffer byteBuffer = ByteBuffer.wrap(backingArray);
 
-		Assert.assertArrayEquals(bytes, result);
+		byte[] result = AWSByteBufferUtil.getBytes(byteBuffer);
 
 		Assert.assertArrayEquals(new byte[bytes.length], backingArray);
+		Assert.assertArrayEquals(bytes, result);
 	}
 
 	@Test

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSByteBufferUtilTest.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSByteBufferUtilTest.java
@@ -1,0 +1,62 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.util;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSByteBufferUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testGetBytes() {
+		byte[] bytes = RandomTestUtil.randomBytes();
+
+		byte[] backingArray = bytes.clone();
+
+		byte[] result = AWSByteBufferUtil.getBytes(
+			ByteBuffer.wrap(backingArray));
+
+		Assert.assertArrayEquals(bytes, result);
+
+		Assert.assertArrayEquals(new byte[bytes.length], backingArray);
+	}
+
+	@Test
+	public void testGetBytesLeavesReadOnlyBuffer() {
+		byte[] bytes = RandomTestUtil.randomBytes();
+
+		byte[] backingArray = bytes.clone();
+
+		ByteBuffer byteBuffer = ByteBuffer.wrap(backingArray);
+
+		byte[] result = AWSByteBufferUtil.getBytes(
+			byteBuffer.asReadOnlyBuffer());
+
+		Assert.assertArrayEquals(bytes, backingArray);
+		Assert.assertArrayEquals(bytes, result);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testGetBytesRejectsNull() {
+		AWSByteBufferUtil.getBytes(null);
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSClientManagerTest.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSClientManagerTest.java
@@ -7,6 +7,7 @@ package com.liferay.portal.security.key.provider.aws.internal.util;
 
 import com.amazonaws.AmazonWebServiceClient;
 
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.concurrent.atomic.AtomicInteger;
@@ -37,7 +38,7 @@ public class AWSClientManagerTest {
 			new AWSClientManager<>(
 				(awsCredentialsProvider, endpointConfiguration, region) ->
 					amazonWebServiceClient,
-				"kms-fips.{region}.amazonaws.com", "us-east-1", false);
+				RandomTestUtil.randomString(), "us-east-1", false);
 
 		awsClientManager.execute(client -> client);
 
@@ -53,7 +54,7 @@ public class AWSClientManagerTest {
 		AWSClientManager<Object> awsClientManager = new AWSClientManager<>(
 			(awsCredentialsProvider, endpointConfiguration, region) ->
 				new Object(),
-			"kms-fips.{region}.amazonaws.com", null, () -> "us-west-2", false);
+			RandomTestUtil.randomString(), null, () -> "us-west-2", false);
 
 		Assert.assertEquals("us-west-2", awsClientManager.getRegion());
 	}
@@ -63,7 +64,7 @@ public class AWSClientManagerTest {
 		AWSClientManager<Object> awsClientManager = new AWSClientManager<>(
 			(awsCredentialsProvider, endpointConfiguration, region) ->
 				new Object(),
-			"kms-fips.{region}.amazonaws.com", "us-east-1", false);
+			RandomTestUtil.randomString(), "us-east-1", false);
 
 		awsClientManager.close();
 
@@ -80,7 +81,7 @@ public class AWSClientManagerTest {
 
 				return new Object();
 			},
-			"kms-fips.{region}.amazonaws.com", "us-east-1", false);
+			RandomTestUtil.randomString(), "us-east-1", false);
 
 		awsClientManager.execute(client -> client);
 		awsClientManager.execute(client -> client);
@@ -100,7 +101,7 @@ public class AWSClientManagerTest {
 
 				return new Object();
 			},
-			"kms-fips.{region}.amazonaws.com", "us-east-1", false);
+			RandomTestUtil.randomString(), "us-east-1", false);
 
 		awsClientManager.execute(client -> client);
 
@@ -124,7 +125,7 @@ public class AWSClientManagerTest {
 
 				return new Object();
 			},
-			"kms-fips.{region}.amazonaws.com", "us-east-1", false);
+			RandomTestUtil.randomString(), "us-east-1", false);
 
 		awsClientManager.execute(client -> client);
 
@@ -142,7 +143,7 @@ public class AWSClientManagerTest {
 		AWSClientManager<Object> awsClientManager = new AWSClientManager<>(
 			(awsCredentialsProvider, endpointConfiguration, region) ->
 				new Object(),
-			"kms-fips.{region}.amazonaws.com", "us-east-1", () -> null, false);
+			RandomTestUtil.randomString(), "us-east-1", () -> null, false);
 
 		awsClientManager.updateConfiguration(null, false);
 

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSClientManagerTest.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSClientManagerTest.java
@@ -1,0 +1,128 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.key.provider.aws.internal.util;
+
+import com.amazonaws.AmazonWebServiceClient;
+
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+/**
+ * @author Christopher Kian
+ */
+public class AWSClientManagerTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testCloseShutsDownClient() throws Exception {
+		AmazonWebServiceClient amazonWebServiceClient = Mockito.mock(
+			AmazonWebServiceClient.class);
+
+		AWSClientManager<AmazonWebServiceClient> awsClientManager =
+			new AWSClientManager<>(
+				(awsCredentialsProvider, endpointConfiguration, region) ->
+					amazonWebServiceClient,
+				"kms-fips.{region}.amazonaws.com", "us-east-1", false);
+
+		awsClientManager.execute(client -> client);
+
+		awsClientManager.close();
+
+		Mockito.verify(
+			amazonWebServiceClient
+		).shutdown();
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void testExecuteAfterCloseThrows() throws Exception {
+		AWSClientManager<Object> awsClientManager = new AWSClientManager<>(
+			(awsCredentialsProvider, endpointConfiguration, region) ->
+				new Object(),
+			"kms-fips.{region}.amazonaws.com", "us-east-1", false);
+
+		awsClientManager.close();
+
+		awsClientManager.execute(client -> client);
+	}
+
+	@Test
+	public void testExecuteBuildsClientOnceAndReuses() throws Exception {
+		AtomicInteger builds = new AtomicInteger();
+
+		AWSClientManager<Object> awsClientManager = new AWSClientManager<>(
+			(awsCredentialsProvider, endpointConfiguration, region) -> {
+				builds.incrementAndGet();
+
+				return new Object();
+			},
+			"kms-fips.{region}.amazonaws.com", "us-east-1", false);
+
+		awsClientManager.execute(client -> client);
+		awsClientManager.execute(client -> client);
+
+		Assert.assertEquals(1, builds.get());
+	}
+
+	@Test
+	public void testUpdateConfigurationRebuildsOnRegionChange()
+		throws Exception {
+
+		AtomicInteger builds = new AtomicInteger();
+
+		AWSClientManager<Object> awsClientManager = new AWSClientManager<>(
+			(awsCredentialsProvider, endpointConfiguration, region) -> {
+				builds.incrementAndGet();
+
+				return new Object();
+			},
+			"kms-fips.{region}.amazonaws.com", "us-east-1", false);
+
+		awsClientManager.execute(client -> client);
+
+		awsClientManager.updateConfiguration("us-west-2", false);
+
+		awsClientManager.execute(client -> client);
+
+		Assert.assertEquals(2, builds.get());
+		Assert.assertEquals("us-west-2", awsClientManager.getRegion());
+	}
+
+	@Test
+	public void testUpdateConfigurationReusesClientOnSameRegion()
+		throws Exception {
+
+		AtomicInteger builds = new AtomicInteger();
+
+		AWSClientManager<Object> awsClientManager = new AWSClientManager<>(
+			(awsCredentialsProvider, endpointConfiguration, region) -> {
+				builds.incrementAndGet();
+
+				return new Object();
+			},
+			"kms-fips.{region}.amazonaws.com", "us-east-1", false);
+
+		awsClientManager.execute(client -> client);
+
+		awsClientManager.updateConfiguration("us-east-1", false);
+
+		awsClientManager.execute(client -> client);
+
+		Assert.assertEquals(1, builds.get());
+	}
+
+}

--- a/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSClientManagerTest.java
+++ b/modules/apps/portal-security/portal-security-key-provider-aws/src/test/java/com/liferay/portal/security/key/provider/aws/internal/util/AWSClientManagerTest.java
@@ -48,6 +48,16 @@ public class AWSClientManagerTest {
 		).shutdown();
 	}
 
+	@Test
+	public void testConstructorResolvesRegionFromSupplier() throws Exception {
+		AWSClientManager<Object> awsClientManager = new AWSClientManager<>(
+			(awsCredentialsProvider, endpointConfiguration, region) ->
+				new Object(),
+			"kms-fips.{region}.amazonaws.com", null, () -> "us-west-2", false);
+
+		Assert.assertEquals("us-west-2", awsClientManager.getRegion());
+	}
+
 	@Test(expected = IllegalStateException.class)
 	public void testExecuteAfterCloseThrows() throws Exception {
 		AWSClientManager<Object> awsClientManager = new AWSClientManager<>(
@@ -123,6 +133,20 @@ public class AWSClientManagerTest {
 		awsClientManager.execute(client -> client);
 
 		Assert.assertEquals(1, builds.get());
+	}
+
+	@Test
+	public void testUpdateConfigurationToleratesUnresolvableRegion()
+		throws Exception {
+
+		AWSClientManager<Object> awsClientManager = new AWSClientManager<>(
+			(awsCredentialsProvider, endpointConfiguration, region) ->
+				new Object(),
+			"kms-fips.{region}.amazonaws.com", "us-east-1", () -> null, false);
+
+		awsClientManager.updateConfiguration(null, false);
+
+		Assert.assertNull(awsClientManager.getRegion());
 	}
 
 }


### PR DESCRIPTION
Post-merge cleanup from rafaprax's review of the AWS key manager PRs (#3217 / #3218), addressing the findings that landed on already-merged L1/L2 code:

- Drop the unprecedented `Liferay-Releng-Module-Group-Title` header from `bnd.bnd`.
- Align the AWS SDK dependency versions on the managed `1.12.719`.
- Reconcile `AWSClientManager.updateConfiguration` with first activation: an unresolvable region no longer throws (provider stays DEGRADED) rather than failing the `@Modified` update.
- Add unit tests for `AWSClientManager` (lazy build/reuse, close, updateConfiguration) and `AWSByteBufferUtil` (including the zeroization path).
