### PR TITLE
LPD-102802 Escape the OAuth 2 application thumbnail URL

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/client/test/SecurityTest.java
@@ -6,21 +6,30 @@
 package com.liferay.oauth2.provider.client.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.document.library.url.provider.DLFileVersionURLProvider;
 import com.liferay.oauth2.provider.constants.GrantType;
 import com.liferay.oauth2.provider.model.OAuth2Application;
+import com.liferay.oauth2.provider.model.OAuth2Authorization;
+import com.liferay.oauth2.provider.service.OAuth2ApplicationLocalService;
 import com.liferay.oauth2.provider.service.OAuth2ScopeGrantLocalService;
+import com.liferay.petra.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.portal.image.ImageToolUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.service.CompanyLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -28,9 +37,13 @@ import jakarta.ws.rs.client.Invocation;
 import jakarta.ws.rs.client.WebTarget;
 import jakarta.ws.rs.core.Response;
 
+import java.awt.image.BufferedImage;
+
 import java.net.URI;
 
 import java.util.Collections;
+import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
@@ -42,6 +55,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.osgi.framework.BundleActivator;
+import org.osgi.framework.ServiceRegistration;
 
 /**
  * @author Stian Sigvartsen
@@ -62,6 +76,29 @@ public class SecurityTest extends BaseClientTestCase {
 			).queryParam(
 				"response_type", "code"
 			));
+	}
+
+	@Test
+	public void testEscapeOAuth2ApplicationThumbnailURL() {
+		String bodyString = _getAuthorizationPageBodyString(
+			webTarget -> webTarget.queryParam(
+				"client_id", _CLIENT_ID_THUMBNAIL_URL
+			).queryParam(
+				"response_type", "code"
+			));
+
+		Assert.assertTrue(
+			bodyString.contains("src=\"" + _THUMBNAIL_URL_ESCAPED + "\""));
+	}
+
+	@Test
+	public void testEscapeOAuth2ApplicationThumbnailURLInImageTag()
+		throws Exception {
+
+		String bodyString = _getConnectedApplicationPageBodyString();
+
+		Assert.assertTrue(
+			bodyString.contains("src=\"" + _THUMBNAIL_URL_ESCAPED + "\""));
 	}
 
 	@Test
@@ -268,6 +305,17 @@ public class SecurityTest extends BaseClientTestCase {
 	private void _assertAuthorizationPageEscapesInjectedScript(
 		Function<WebTarget, WebTarget> authorizeRequestFunction) {
 
+		String bodyString = _getAuthorizationPageBodyString(
+			authorizeRequestFunction);
+
+		Assert.assertFalse(bodyString.contains(_INJECTED_SCRIPT));
+		Assert.assertTrue(
+			bodyString.contains(HtmlUtil.escape(_INJECTED_SCRIPT)));
+	}
+
+	private String _getAuthorizationPageBodyString(
+		Function<WebTarget, WebTarget> authorizeRequestFunction) {
+
 		Function<WebTarget, Invocation.Builder> invocationBuilderFunction =
 			getAuthenticatedInvocationBuilderFunction(
 				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
@@ -302,11 +350,51 @@ public class SecurityTest extends BaseClientTestCase {
 		Invocation.Builder invocationBuilder = invocationBuilderFunction.apply(
 			webTarget);
 
-		String bodyString = getBodyAsString(invocationBuilder.get());
+		return getBodyAsString(invocationBuilder.get());
+	}
 
-		Assert.assertFalse(bodyString.contains(_INJECTED_SCRIPT));
-		Assert.assertTrue(
-			bodyString.contains(HtmlUtil.escape(_INJECTED_SCRIPT)));
+	private String _getConnectedApplicationPageBodyString() throws Exception {
+		URI uri = new URI(
+			PortalUtil.getControlPanelFullURL(
+				TestPropsValues.getGroupId(),
+				_PORTLET_ID_CONNECTED_APPLICATIONS,
+				HashMapBuilder.put(
+					"_" + _PORTLET_ID_CONNECTED_APPLICATIONS +
+						"_mvcRenderCommandName",
+					new String[] {
+						"/oauth2_provider/view_connected_applications"
+					}
+				).put(
+					"_" + _PORTLET_ID_CONNECTED_APPLICATIONS +
+						"_oAuth2ApplicationId",
+					new String[] {String.valueOf(_oAuth2ApplicationId)}
+				).put(
+					"_" + _PORTLET_ID_CONNECTED_APPLICATIONS +
+						"_oAuth2AuthorizationId",
+					new String[] {String.valueOf(_oAuth2AuthorizationId)}
+				).build()));
+
+		WebTarget webTarget = getWebTarget();
+
+		webTarget = webTarget.path(uri.getPath());
+
+		Map<String, String[]> parameterMap = HttpComponentsUtil.getParameterMap(
+			uri.getRawQuery());
+
+		for (Map.Entry<String, String[]> entry : parameterMap.entrySet()) {
+			webTarget = webTarget.queryParam(
+				entry.getKey(), (Object[])entry.getValue());
+		}
+
+		Invocation.Builder invocationBuilder =
+			getAuthenticatedInvocationBuilderFunction(
+				_user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD,
+				null
+			).apply(
+				webTarget
+			);
+
+		return getBodyAsString(invocationBuilder.get());
 	}
 
 	private static final String _CLIENT_ID_CODE = RandomTestUtil.randomString();
@@ -317,6 +405,9 @@ public class SecurityTest extends BaseClientTestCase {
 	private static final String _CLIENT_ID_DEFAULT_USER =
 		RandomTestUtil.randomString();
 
+	private static final String _CLIENT_ID_THUMBNAIL_URL =
+		RandomTestUtil.randomString();
+
 	private static final String _CLIENT_ID_UNESCAPED_NAME =
 		RandomTestUtil.randomString();
 
@@ -325,11 +416,30 @@ public class SecurityTest extends BaseClientTestCase {
 
 	private static final String _INJECTED_SCRIPT = "<script>alert(1)</script>";
 
+	private static final String _PORTLET_ID_CONNECTED_APPLICATIONS =
+		"com_liferay_oauth2_provider_web_internal_portlet_" +
+			"OAuth2ConnectedApplicationsPortlet";
+
 	private static final String _SCOPE_ALIAS =
 		"Liferay.Captcha.REST.everything.read";
 
 	private static final String _SCOPE_APPLICATION_NAME =
 		"Liferay.Captcha.REST";
+
+	private static final String _THUMBNAIL_URL =
+		"http://localhost/documents/1/2/icon.png?version=1.0&t=1&" +
+			"imageThumbnail=1'";
+
+	private static final String _THUMBNAIL_URL_ESCAPED =
+		"http://localhost/documents/1/2/icon.png?version=1.0&amp;t=1&amp;" +
+			"imageThumbnail=1&#39;";
+
+	private long _oAuth2ApplicationId;
+
+	@Inject
+	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
+
+	private long _oAuth2AuthorizationId;
 
 	@Inject
 	private OAuth2ScopeGrantLocalService _oAuth2ScopeGrantLocalService;
@@ -363,6 +473,8 @@ public class SecurityTest extends BaseClientTestCase {
 			createOAuth2Application(
 				companyId, company.getGuestUser(), _CLIENT_ID_DEFAULT_USER);
 
+			_createThumbnailURLOAuth2Application(companyId);
+
 			createOAuth2Application(
 				companyId, _user, _CLIENT_ID_UNESCAPED_NAME,
 				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
@@ -386,6 +498,56 @@ public class SecurityTest extends BaseClientTestCase {
 				).put(
 					"service.ranking", Integer.MAX_VALUE
 				).build());
+		}
+
+		private void _createThumbnailURLOAuth2Application(long companyId)
+			throws Exception {
+
+			OAuth2Application oAuth2Application = createOAuth2Application(
+				companyId, _user, _CLIENT_ID_THUMBNAIL_URL,
+				Collections.singletonList(GrantType.AUTHORIZATION_CODE),
+				Collections.singletonList("everything"));
+
+			_oAuth2ApplicationLocalService.updateIcon(
+				oAuth2Application.getOAuth2ApplicationId(),
+				new UnsyncByteArrayInputStream(
+					ImageToolUtil.getBytes(
+						new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB),
+						"png")));
+
+			ServiceRegistration<DLFileVersionURLProvider> serviceRegistration =
+				bundleContext.registerService(
+					DLFileVersionURLProvider.class,
+					new DLFileVersionURLProvider() {
+
+						@Override
+						public List<Type> getTypes() {
+							return Collections.singletonList(Type.THUMBNAIL);
+						}
+
+						@Override
+						public String getURL(
+							FileVersion fileVersion,
+							ThemeDisplay themeDisplay) {
+
+							return _THUMBNAIL_URL;
+						}
+
+					},
+					HashMapDictionaryBuilder.<String, Object>put(
+						"service.ranking", Integer.MAX_VALUE
+					).build());
+
+			autoCloseables.add(serviceRegistration::unregister);
+
+			OAuth2Authorization oAuth2Authorization = addOAuth2Authorization(
+				companyId, _user, oAuth2Application,
+				RandomTestUtil.randomString(), new Date(),
+				new Date(System.currentTimeMillis() + Time.HOUR));
+
+			_oAuth2ApplicationId = oAuth2Application.getOAuth2ApplicationId();
+			_oAuth2AuthorizationId =
+				oAuth2Authorization.getOAuth2AuthorizationId();
 		}
 
 	}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/authorize/authorize.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/authorize/authorize.jsp
@@ -21,12 +21,6 @@ if (Validator.isNotNull(replyTo) && !replyTo.startsWith(PortalUtil.getPortalURL(
 }
 %>
 
-<aui:style type="text/css">
-	.bg-img-app {
-		background-image: url('<%= HtmlUtil.escapeAttribute(oAuth2AuthorizePortletDisplayContext.getThumbnailURL()) %>');
-	}
-</aui:style>
-
 <clay:container-fluid
 	cssClass="closed consent"
 >
@@ -34,7 +28,11 @@ if (Validator.isNotNull(replyTo) && !replyTo.startsWith(PortalUtil.getPortalURL(
 		<div class="sheet">
 			<div class="panel-group panel-group-flush">
 				<div class="panel-body">
-					<div class="app-icon aspect-ratio-bg-cover bg-img-app"></div>
+					<clay:sticker
+						cssClass="app-icon"
+						imageAlt=""
+						imageSrc="<%= HtmlUtil.escapeAttribute(oAuth2AuthorizePortletDisplayContext.getThumbnailURL()) %>"
+					/>
 
 					<liferay-user:user-portrait
 						user="<%= user %>"

--- a/portal-web/docroot/html/taglib/ui/icon/link_content.jspf
+++ b/portal-web/docroot/html/taglib/ui/icon/link_content.jspf
@@ -17,10 +17,10 @@
 			<c:when test="<%= Validator.isNotNull(src) %>">
 				<c:choose>
 					<c:when test="<%= Validator.isNotNull(id) %>">
-						<img id="<%= id %>" src="<%= src %>" <%= details %> />
+						<img id="<%= id %>" src="<%= HtmlUtil.escapeAttribute(src) %>" <%= details %> />
 					</c:when>
 					<c:otherwise>
-						<img src="<%= src %>" <%= details %> />
+						<img src="<%= HtmlUtil.escapeAttribute(src) %>" <%= details %> />
 					</c:otherwise>
 				</c:choose>
 			</c:when>

--- a/portal-web/docroot/html/taglib/ui/icon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon/page.jsp
@@ -82,18 +82,16 @@ if (!linkCssClass.contains("keep-aria-attributes") && (useDialog || (urlIsNotNul
 	<aui:script type="module">
 		import {registerIcon} from '<%= FrontendESMUtil.buildURL(themeDisplay, "frontend-js-web", "legacy") %>';
 
-		registerIcon(
-			{
-				forcePost: <%= forcePost %>,
-				id: '<portlet:namespace /><%= id %>',
+		registerIcon({
+			forcePost: <%= forcePost %>,
+			id: '<portlet:namespace /><%= id %>',
 
-				<c:if test="<%= Validator.isNotNull(srcHover) %>">
-					src: '<%= src %>',
-					srcHover: '<%= srcHover %>',
-				</c:if>
+			<c:if test="<%= Validator.isNotNull(srcHover) %>">
+				src: '<%= HtmlUtil.escapeJS(src) %>',
+				srcHover: '<%= HtmlUtil.escapeJS(srcHover) %>',
+			</c:if>
 
-				useDialog: <%= useDialog %>
-			}
-		);
+			useDialog: <%= useDialog %>,
+		});
 	</aui:script>
 </c:if>


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102802

Rewritten after @jgarcialr's review. All three findings were correct, and two of them were mistakes in the first version of this pull request.

## What Is Being Fixed

The application thumbnail URL reached three sinks, and the ticket's own description needs one correction: `authorize/authorize.jsp:26` was never an `liferay-ui:icon` call, it was a CSS one.

- **The authorization page, a CSS sink.** The URL went into `background-image: url('...')` inside an `aui:style` block, escaped with `HtmlUtil.escapeAttribute`. A `style` element is raw text, so the entities are never decoded: every ampersand of the query string reached the browser as `&amp;`, which renamed the parameters to `amp;t` and `amp;imageThumbnail` and dropped the thumbnail flag.

  ```
  background-image: url('http://localhost/documents/1/2/icon.png?version=1.0&amp;t=1&amp;imageThumbnail=1&#39;');
  ```

- **`taglib/ui/icon/link_content.jspf`, an HTML attribute sink.** It writes `src` into the `src` of an `img` element with no escaping, and `icon/page.jsp` includes that file in six places. This is the live sink: `connected_applications/view_application.jsp` passes a thumbnail URL and no `icon`, which is exactly the branch that renders the image. The first version of this pull request claimed the opposite, that `src` never rendered and the widget showed no icon. That was wrong: only `page.jsp` was grepped and the `<%@ include %>` was not followed.

- **`taglib/ui/icon/page.jsp`, a JavaScript sink.** The tag also writes `src` and `srcHover` into a JavaScript object literal between single quotes. No caller passes `srcHover` today, which is what gates that block, so this one is hardening rather than an observable defect.

None of the three is exploitable today: `DLURLHelperImpl` runs the file name and the UUID through `URLCodec.encodeURL`, so a quote in an uploaded icon's name arrives as `%27`.

## How It Is Being Fixed

`escapeJS` for the JavaScript sink and `escapeAttribute` for the `img` sink, both in the tag so every caller is covered.

For the authorization page the URL stops going into CSS at all. `escapeCSS` cannot fix it: it emits the delimiting space only before a digit (`HtmlUtil.java:261-269`), so an escape followed by a hex letter is absorbed into it and `/documents` collapses into `\2fd` plus `ocuments` — the first version of this pull request had exactly that defect, and `HtmlUtilTest:58` pins the behaviour. Moving the declaration into a `style` attribute, as `search_container/image.jsp` does, is rejected by `CSPTagIllegalAttributesCheck` unless it is wrapped in `liferay-ui:csp`, and `JSPLiferayUICSPTagCheck` rejects that tag in new code (LPD-73599, "use a React component instead"). So the thumbnail is now rendered by a `clay:sticker`, whose `imageSrc` becomes the `src` of an `img`, escaped at the call site the way `look_and_feel_theme_details.jsp` does it. The user portrait next to it already renders as a sticker, and the `app-icon` class carries over, so the 80x80 box is unchanged. The `bg-img-app` class existed only as the hook for the removed rule and no stylesheet defines it.

## Tests

Two tests in `SecurityTest`, one per rendered page. Each asserts the literal `src` the browser receives instead of recomputing it with the escaper the JSP uses — the previous assertion called `HtmlUtil.escapeCSS` itself, which is why CI passed while the URL was being corrupted.

| | master | first version (`escapeCSS`) | this version |
| --- | --- | --- | --- |
| `testEscapeOAuth2ApplicationThumbnailURL` (authorization page) | FAILED | FAILED | PASSED |
| `testEscapeOAuth2ApplicationThumbnailURLInImageTag` (connected applications) | FAILED | n/a | PASSED |
| the other eight tests in the class | PASSED | PASSED | PASSED |

The URL is pinned with a `DLFileVersionURLProvider`: an application with no icon falls back to the default icon path, which has nothing to escape, and a real icon only yields a thumbnail URL once the image processor has run. `getThumbnailSrc` consults that provider first, so the value is deterministic. Reaching `view_application.jsp` also needs an authorization owned by the authenticated user and the `oAuth2ApplicationId` parameter, without which the page throws a `NullPointerException` on `renderResponse.setTitle`.

Also applied from the review: `ImageToolUtil.getBytes` replaces the hand-rolled `ImageIO` call, and `_prepareThumbnailURL` is renamed `_createThumbnailURLOAuth2Application` to match its siblings.

## PR Check

**pr-check: FAIL** — tested on `5c8e59a8015add70624e73e4cd1773d4a488901a`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Baseline | FAIL |
| JSP Compile | PASS |
| Java Unit Tests | PASS |

**Baseline fails on a module this branch does not touch.** `:apps:headless:headless-cms:headless-cms-api:baseline` reports `Semantic versioning is incorrect` and asks to *lower* `com/liferay/headless/cms/resource/v1_0/packageinfo` from `3.1.0` to `3.0.0`. That is an `EXCESSIVE VERSION INCREASE`, which the pr-check procedure says to report rather than commit. The debt comes from master with `aed5313800a5c` (LPD-97871), which raised the version further than the API change required, so the same failure reproduces on master and does not depend on this pull request. It clears itself once master carries the correction and this branch is rebased. Everything else passes.

<!-- pr-check {"result": "failure", "sha": "5c8e59a8015add70624e73e4cd1773d4a488901a"} -->
