### PR TITLE
LPD-99950 Reserve portal schema version 38.7.7 for release-2026.q3

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_4_x/PortalUpgradeProcessRegistryImpl.java
@@ -817,7 +817,10 @@ public class PortalUpgradeProcessRegistryImpl
 			new LayoutStagingExternalReferenceCodeUpgradeProcess());
 
 		upgradeVersionTreeMap.put(
-			new Version(38, 7, 7),
+			new Version(38, 7, 7), new DummyUpgradeProcess());
+
+		upgradeVersionTreeMap.put(
+			new Version(38, 7, 8),
 			UpgradeModulesFactory.create(
 				new String[] {"com.liferay.portal.security.audit.router"},
 				null));


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99950

## What Is Being Fixed

Nothing is broken on master. This pull reserves a schema version so that LPD-99950's upgrade can be backported to release-2026.q3 under BPR-91982 without losing an upgrade on any path.

release-2026.q3 was cut on 2026-08-02 and master took 38.7.7 for the audit router on 2026-08-10 with LPD-98544, a Story with no backport, so that entry will never reach q3. `PortalUpgradeProcess.getPendingSchemaVersions` uses `tailMap(fromSchemaVersion, false)`, which is strictly greater, so q3 has no number left that works: registering the fix above master's 38.7.7 makes a q3 database skip the audit router for good when it moves to master, and registering it at 38.7.7 while the audit router is still there loses one of the two.

## How It Is Being Fixed

38.7.7 becomes a `DummyUpgradeProcess` and the audit router moves up to 38.7.8, so release-2026.q3 can register the fix on the plain 38.7.7. This is what the Upgrade team asked for rather than a qualifier (Mariano Alvaro, 2026-08-19, "what we usually do"), and the pattern is established: master already registers `DummyUpgradeProcess` at 16.0.0, 25.1.2, 29.1.1, 34.1.0, 38.1.0 and 38.2.3, three of them introduced exactly this way in `01419cc7afa64` (LPD-87577), `17f16f2e3c38e` (LPD-81218) and `74dac584ec5ea` (LPD-101498). The alternative, a `38.7.7.step-1` qualifier on the backport branch, was ruled out because `9531a060c603f` (LPD-44331) says in its own message that qualifiers will not be allowed for future upgrades.

This is addressed to AppSec because the entry that moves is yours: a database sitting at exactly 38.7.7 will run `com.liferay.portal.security.audit.router` a second time, as 38.7.8.

That re-run is safe, and it was measured rather than argued. Three passes of the bundle's db-upgrade client against this build, on a customer database restored at 31.3.0:

| | pass 1 | pass 2, `Release_` rewound to 38.7.7 | pass 3, no rewind |
| --- | --- | --- | --- |
| portal schema | 31.3.0 -> 38.8.2 | 38.7.7 -> 38.8.2 | 38.8.2 -> 38.8.2 |
| portal steps run | every step from 31.3.0 | 38.7.8, 38.8.0, 38.8.1, 38.8.2 | none |
| `AuditConfigurationUpgradeProcess` executions | 1 | 0 | 0 |
| audit router `Release_` | created, 0.0.1 -> 1.0.0 | untouched at 1.0.0 | untouched at 1.0.0 |
| layout rows | 22 -> 22 | 22 -> 22 | 22 -> 22 |

Pass 2 is the case this pull creates, and the audit configuration process did not execute at all. The 38.7.8 slot is `UpgradeModulesFactory.create({"com.liferay.portal.security.audit.router"}, null)`, whose `doUpgrade` is only `Release_` bookkeeping: `updateExtractedModules` calls `ReleaseDAO.addRelease`, which returns immediately when the row already exists with a non-null `schemaVersion`, and the two legacy-module methods are no-ops because the arrays are null. So the second run only re-seeds a row that is already at 1.0.0, and `AuditRouterUpgradeStepRegistrator` keeps its step gated `"0.0.1"` to `"1.0.0"` against that row. Even a forced re-run would be harmless, since `AuditConfigurationUpgradeProcess.doUpgrade` returns early with no system-scoped `AuditConfiguration`, returns early when `enabled` already equals the default, and skips any company that already has its own configuration.

## Notes For The Reviewer

- The 38.7.7 dummy is never executed on the path that matters: pass 2 started at 38.7.8 because the `tailMap` is strictly greater.
- This pull has to merge before the q3 backport, otherwise there is a window in which a q3 customer lands at 38.7.7 and the audit router is censored for good.
- The commit carries LPD-99950 rather than a new ticket, which matches all three precedent gap commits.
- Nothing above 38.7.8 is touched: `UpgradeDB2` at 38.8.0, this bug's fix at 38.8.1 and `UpgradeCompanyInfo` at 38.8.2 keep their numbers, so any database at 38.8.0 or later is unaffected.

## Why Are There No Tests?

The change renumbers two registry entries and has no behavior of its own to assert; the fix it makes room for already carries `LayoutDuplicateExternalReferenceCodeUpgradeProcessTest` on master. What this pull does create, a second execution of the audit router for a database at exactly 38.7.7, is not expressible as a unit test, so it was verified with the three upgrade passes above instead.

## PR Check

**pr-check: PASS** — tested on `17c4f06c191f736b3fabbc8f75f7d7a6a9e47afd`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Java Unit Tests | PASS |

<!-- pr-check {"result": "success", "sha": "17c4f06c191f736b3fabbc8f75f7d7a6a9e47afd"} -->
