### PR TITLE
LPD-93284 Log every FIPS state transition as NDJSON

### DIFF
--- a/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
+++ b/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
@@ -6,6 +6,7 @@
 package com.liferay.portal.security.fips.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -89,7 +90,14 @@ public class FIPSAuditUtilTest {
 
 		JSONObject jsonObject = _getJSONObject(eventType, jsonObjects);
 
-		for (String envelopeKey : _ENVELOPE_KEYS) {
+		for (String envelopeKey :
+				new String[] {
+					"cmvp-certificate-id", "deployment-instance-id",
+					"event-schema-version", "event-sequence", "event-type",
+					"fields", "provider-name", "provider-version", "severity",
+					"timestamp"
+				}) {
+
 			Assert.assertTrue(jsonObject.has(envelopeKey));
 		}
 
@@ -128,7 +136,7 @@ public class FIPSAuditUtilTest {
 
 		_assertBootStateTransitions(jsonObjects);
 		_assertCanonicalTimestamps(jsonObjects);
-		_assertContiguousEventSequences(jsonObjects);
+		_assertIncrementingEventSequences(jsonObjects);
 		_assertOneDeploymentInstanceId(jsonObjects);
 	}
 
@@ -295,22 +303,22 @@ public class FIPSAuditUtilTest {
 	}
 
 	private void _assertBootStateTransitions(List<JSONObject> jsonObjects) {
-		List<String> transitions = new ArrayList<>();
+		List<String> transitions = TransformUtil.transform(
+			jsonObjects,
+			jsonObject -> {
+				String eventType = jsonObject.getString("event-type");
 
-		for (JSONObject jsonObject : jsonObjects) {
-			String eventType = jsonObject.getString("event-type");
+				if (!eventType.equals("fips-state-transition")) {
+					return null;
+				}
 
-			if (!eventType.equals("fips-state-transition")) {
-				continue;
-			}
+				JSONObject fieldsJSONObject = jsonObject.getJSONObject(
+					"fields");
 
-			JSONObject fieldsJSONObject = jsonObject.getJSONObject("fields");
-
-			transitions.add(
-				StringBundler.concat(
+				return StringBundler.concat(
 					fieldsJSONObject.getString("from-state"), " to ",
-					fieldsJSONObject.getString("to-state")));
-		}
+					fieldsJSONObject.getString("to-state"));
+			});
 
 		Assert.assertTrue(transitions.contains("INITIALIZING to SELF_TEST"));
 		Assert.assertTrue(transitions.contains("SELF_TEST to OPERATIONAL"));
@@ -326,7 +334,9 @@ public class FIPSAuditUtilTest {
 		}
 	}
 
-	private void _assertContiguousEventSequences(List<JSONObject> jsonObjects) {
+	private void _assertIncrementingEventSequences(
+		List<JSONObject> jsonObjects) {
+
 		long previousEventSequence = 0;
 
 		for (JSONObject jsonObject : jsonObjects) {
@@ -398,11 +408,5 @@ public class FIPSAuditUtilTest {
 
 		return jsonObject.getLong("event-sequence");
 	}
-
-	private static final String[] _ENVELOPE_KEYS = {
-		"cmvp-certificate-id", "deployment-instance-id", "event-schema-version",
-		"event-sequence", "event-type", "fields", "provider-name",
-		"provider-version", "severity", "timestamp"
-	};
 
 }

--- a/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
+++ b/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
@@ -55,8 +55,7 @@ public class FIPSAuditUtilTest {
 	public void testAuditLogFileExists() {
 		Path path = _getAuditLogPath();
 
-		Assert.assertTrue(
-			"Unable to find the FIPS audit log " + path, Files.exists(path));
+		Assert.assertTrue(Files.exists(path));
 	}
 
 	@Test
@@ -78,8 +77,7 @@ public class FIPSAuditUtilTest {
 	@Test
 	public void testAuditLogRecordsAreParseable() throws Exception {
 		for (String line : Files.readAllLines(_getAuditLogPath())) {
-			Assert.assertTrue(
-				"Blank line in the FIPS audit log", Validator.isNotNull(line));
+			Assert.assertTrue(Validator.isNotNull(line));
 
 			JSONFactoryUtil.createJSONObject(line);
 		}
@@ -91,9 +89,6 @@ public class FIPSAuditUtilTest {
 			String timestamp = jsonObject.getString("timestamp");
 
 			Assert.assertTrue(
-				StringBundler.concat(
-					"Noncanonical timestamp \"", timestamp,
-					"\" in the FIPS audit record ", jsonObject),
 				timestamp.matches(
 					"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"));
 		}
@@ -107,9 +102,7 @@ public class FIPSAuditUtilTest {
 			long eventSequence = jsonObject.getLong("event-sequence");
 
 			if (eventSequence > previousEventSequence) {
-				Assert.assertEquals(
-					String.valueOf(jsonObject), previousEventSequence + 1,
-					eventSequence);
+				Assert.assertEquals(previousEventSequence + 1, eventSequence);
 			}
 
 			previousEventSequence = eventSequence;
@@ -120,11 +113,7 @@ public class FIPSAuditUtilTest {
 	public void testAuditLogRecordsCarryTheCommonEnvelope() throws Exception {
 		for (JSONObject jsonObject : _getRecordJSONObjects()) {
 			for (String envelopeKey : _ENVELOPE_KEYS) {
-				Assert.assertTrue(
-					StringBundler.concat(
-						"Unable to find \"", envelopeKey,
-						"\" in the FIPS audit record ", jsonObject),
-					jsonObject.has(envelopeKey));
+				Assert.assertTrue(jsonObject.has(envelopeKey));
 			}
 		}
 	}
@@ -148,12 +137,8 @@ public class FIPSAuditUtilTest {
 					fieldsJSONObject.getString("to-state")));
 		}
 
-		Assert.assertTrue(
-			transitions.toString(),
-			transitions.contains("INITIALIZING to SELF_TEST"));
-		Assert.assertTrue(
-			transitions.toString(),
-			transitions.contains("SELF_TEST to OPERATIONAL"));
+		Assert.assertTrue(transitions.contains("INITIALIZING to SELF_TEST"));
+		Assert.assertTrue(transitions.contains("SELF_TEST to OPERATIONAL"));
 	}
 
 	private Path _getAuditLogPath() {

--- a/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
+++ b/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
@@ -1,0 +1,183 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.security.fips.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jorge García Jiménez
+ */
+@RunWith(Arquillian.class)
+public class FIPSAuditUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() {
+		Assume.assumeTrue(PropsValues.FIPS_ENABLED);
+	}
+
+	@Test
+	public void testAuditLogFileExists() {
+		Path path = _getAuditLogPath();
+
+		Assert.assertTrue(
+			"Unable to find the FIPS audit log " + path, Files.exists(path));
+	}
+
+	@Test
+	public void testAuditLogFileIsReadableByTheOwnerOnly() throws Exception {
+		Path path = _getAuditLogPath();
+
+		FileSystem fileSystem = path.getFileSystem();
+
+		Set<String> supportedFileAttributeViews =
+			fileSystem.supportedFileAttributeViews();
+
+		Assume.assumeTrue(supportedFileAttributeViews.contains("posix"));
+
+		Assert.assertEquals(
+			PosixFilePermissions.fromString("rw-------"),
+			Files.getPosixFilePermissions(path));
+	}
+
+	@Test
+	public void testAuditLogRecordsAreParseable() throws Exception {
+		for (String line : Files.readAllLines(_getAuditLogPath())) {
+			Assert.assertTrue(
+				"Blank line in the FIPS audit log", Validator.isNotNull(line));
+
+			JSONFactoryUtil.createJSONObject(line);
+		}
+	}
+
+	@Test
+	public void testAuditLogRecordsCarryACanonicalTimestamp() throws Exception {
+		for (JSONObject jsonObject : _getRecordJSONObjects()) {
+			String timestamp = jsonObject.getString("timestamp");
+
+			Assert.assertTrue(
+				StringBundler.concat(
+					"Noncanonical timestamp \"", timestamp,
+					"\" in the FIPS audit record ", jsonObject),
+				timestamp.matches(
+					"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"));
+		}
+	}
+
+	@Test
+	public void testAuditLogRecordsCarryAMonotonicSequence() throws Exception {
+		long previousEventSequence = 0;
+
+		for (JSONObject jsonObject : _getRecordJSONObjects()) {
+			long eventSequence = jsonObject.getLong("event-sequence");
+
+			if (eventSequence > previousEventSequence) {
+				Assert.assertEquals(
+					String.valueOf(jsonObject), previousEventSequence + 1,
+					eventSequence);
+			}
+
+			previousEventSequence = eventSequence;
+		}
+	}
+
+	@Test
+	public void testAuditLogRecordsCarryTheCommonEnvelope() throws Exception {
+		for (JSONObject jsonObject : _getRecordJSONObjects()) {
+			for (String envelopeKey : _ENVELOPE_KEYS) {
+				Assert.assertTrue(
+					StringBundler.concat(
+						"Unable to find \"", envelopeKey,
+						"\" in the FIPS audit record ", jsonObject),
+					jsonObject.has(envelopeKey));
+			}
+		}
+	}
+
+	@Test
+	public void testAuditLogRecordsTheBootStateTransitions() throws Exception {
+		List<String> transitions = new ArrayList<>();
+
+		for (JSONObject jsonObject : _getRecordJSONObjects()) {
+			String eventType = jsonObject.getString("event-type");
+
+			if (!eventType.equals("fips-state-transition")) {
+				continue;
+			}
+
+			JSONObject fieldsJSONObject = jsonObject.getJSONObject("fields");
+
+			transitions.add(
+				StringBundler.concat(
+					fieldsJSONObject.getString("from-state"), " to ",
+					fieldsJSONObject.getString("to-state")));
+		}
+
+		Assert.assertTrue(
+			transitions.toString(),
+			transitions.contains("INITIALIZING to SELF_TEST"));
+		Assert.assertTrue(
+			transitions.toString(),
+			transitions.contains("SELF_TEST to OPERATIONAL"));
+	}
+
+	private Path _getAuditLogPath() {
+		LocalDate localDate = LocalDate.now(ZoneOffset.UTC);
+
+		return Paths.get(
+			PropsValues.LIFERAY_HOME, "logs",
+			StringBundler.concat("fips-audit.", localDate, ".ndjson"));
+	}
+
+	private List<JSONObject> _getRecordJSONObjects() throws Exception {
+		List<JSONObject> jsonObjects = new ArrayList<>();
+
+		for (String line : Files.readAllLines(_getAuditLogPath())) {
+			jsonObjects.add(JSONFactoryUtil.createJSONObject(line));
+		}
+
+		return jsonObjects;
+	}
+
+	private static final String[] _ENVELOPE_KEYS = {
+		"cmvp-certificate-id", "deployment-instance-id", "event-schema-version",
+		"event-sequence", "event-type", "fields", "provider-name",
+		"provider-version", "severity", "timestamp"
+	};
+
+}

--- a/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
+++ b/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
@@ -90,16 +90,16 @@ public class FIPSAuditUtilTest {
 
 		JSONObject jsonObject = _getJSONObject(eventType, jsonObjects);
 
-		for (String envelopeKey :
-				new String[] {
-					"cmvp-certificate-id", "deployment-instance-id",
-					"event-schema-version", "event-sequence", "event-type",
-					"fields", "provider-name", "provider-version", "severity",
-					"timestamp"
-				}) {
-
-			Assert.assertTrue(jsonObject.has(envelopeKey));
-		}
+		Assert.assertTrue(jsonObject.has("cmvp-certificate-id"));
+		Assert.assertTrue(jsonObject.has("deployment-instance-id"));
+		Assert.assertTrue(jsonObject.has("event-schema-version"));
+		Assert.assertTrue(jsonObject.has("event-sequence"));
+		Assert.assertTrue(jsonObject.has("event-type"));
+		Assert.assertTrue(jsonObject.has("fields"));
+		Assert.assertTrue(jsonObject.has("provider-name"));
+		Assert.assertTrue(jsonObject.has("provider-version"));
+		Assert.assertTrue(jsonObject.has("severity"));
+		Assert.assertTrue(jsonObject.has("timestamp"));
 
 		Assert.assertEquals(
 			GetterUtil.getString(

--- a/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
+++ b/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
@@ -368,14 +368,15 @@ public class FIPSAuditUtilTest {
 	private JSONObject _getJSONObject(
 		String eventType, List<JSONObject> jsonObjects) {
 
-		jsonObjects = ListUtil.filter(
+		List<JSONObject> eventTypeJSONObjects = ListUtil.filter(
 			jsonObjects,
 			jsonObject -> Objects.equals(
 				eventType, jsonObject.getString("event-type")));
 
-		Assert.assertEquals(jsonObjects.toString(), 1, jsonObjects.size());
+		Assert.assertEquals(
+			eventTypeJSONObjects.toString(), 1, eventTypeJSONObjects.size());
 
-		return jsonObjects.get(0);
+		return eventTypeJSONObjects.get(0);
 	}
 
 	private List<JSONObject> _getJSONObjects() throws Exception {

--- a/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
+++ b/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
@@ -60,7 +60,7 @@ public class FIPSAuditUtilTest {
 	}
 
 	@Test
-	public void testAuditLogFileIsReadableByTheOwnerOnly() throws Exception {
+	public void testAuditLogFileIsAccessibleByTheOwnerOnly() throws Exception {
 		Path path = _getAuditLogPath();
 
 		FileSystem fileSystem = path.getFileSystem();
@@ -100,7 +100,7 @@ public class FIPSAuditUtilTest {
 	}
 
 	@Test
-	public void testAuditLogRecordsCarryAMonotonicSequence() throws Exception {
+	public void testAuditLogRecordsCarryAContiguousSequence() throws Exception {
 		long previousEventSequence = 0;
 
 		for (JSONObject jsonObject : _getRecordJSONObjects()) {

--- a/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
+++ b/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
@@ -7,24 +7,42 @@ package com.liferay.portal.security.fips.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.security.fips.FIPSAuditEvent;
+import com.liferay.portal.kernel.security.fips.FIPSAuditUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermissions;
 
+import java.security.Provider;
+import java.security.Security;
+
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import org.junit.Assert;
@@ -37,6 +55,7 @@ import org.junit.runner.RunWith;
 
 /**
  * @author Jorge García Jiménez
+ * @author Rafael Praxedes
  */
 @RunWith(Arquillian.class)
 public class FIPSAuditUtilTest {
@@ -52,8 +71,216 @@ public class FIPSAuditUtilTest {
 	}
 
 	@Test
-	public void testWriteCreatesAnOwnerOnlyAuditLogFile() throws Exception {
-		Path path = _getAuditLogPath();
+	public void testWrite() throws Exception {
+		long lastEventSequence = _getLastEventSequence();
+
+		String eventType = RandomTestUtil.randomString();
+
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			eventType, FIPSAuditEvent.Severity.INFO);
+
+		String reason = RandomTestUtil.randomString();
+
+		fipsAuditEvent.put("reason", reason);
+
+		FIPSAuditUtil.write(fipsAuditEvent);
+
+		List<JSONObject> jsonObjects = _getJSONObjects();
+
+		JSONObject jsonObject = _getJSONObject(eventType, jsonObjects);
+
+		for (String envelopeKey : _ENVELOPE_KEYS) {
+			Assert.assertTrue(jsonObject.has(envelopeKey));
+		}
+
+		Assert.assertEquals(
+			GetterUtil.getString(
+				PropsValues.FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID),
+			jsonObject.getString("cmvp-certificate-id"));
+
+		Assert.assertTrue(
+			Validator.isNotNull(
+				jsonObject.getString("deployment-instance-id")));
+
+		Assert.assertEquals(
+			"1.0", jsonObject.getString("event-schema-version"));
+		Assert.assertEquals(
+			lastEventSequence + 1, jsonObject.getLong("event-sequence"));
+
+		JSONObject fieldsJSONObject = jsonObject.getJSONObject("fields");
+
+		Assert.assertEquals(reason, fieldsJSONObject.getString("reason"));
+
+		Provider provider = Security.getProviders()[0];
+
+		Assert.assertEquals(
+			provider.getName(), jsonObject.getString("provider-name"));
+		Assert.assertEquals(
+			provider.getVersionStr(), jsonObject.getString("provider-version"));
+
+		Assert.assertEquals("INFO", jsonObject.getString("severity"));
+
+		Instant instant = Instant.parse(jsonObject.getString("timestamp"));
+
+		Assert.assertTrue(
+			Math.abs(System.currentTimeMillis() - instant.toEpochMilli()) <
+				Time.MINUTE);
+
+		_assertBootStateTransitions(jsonObjects);
+		_assertCanonicalTimestamps(jsonObjects);
+		_assertContiguousEventSequences(jsonObjects);
+		_assertOneDeploymentInstanceId(jsonObjects);
+	}
+
+	@Test
+	public void testWriteWithAFieldTimestampWithoutATimeZone()
+		throws Exception {
+
+		String eventType = RandomTestUtil.randomString();
+
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			eventType, FIPSAuditEvent.Severity.INFO);
+
+		fipsAuditEvent.put(
+			"provider-timestamp", LocalDateTime.parse("2026-05-06T14:19:23"));
+
+		Assert.assertThrows(
+			IllegalArgumentException.class,
+			() -> FIPSAuditUtil.write(fipsAuditEvent));
+
+		for (JSONObject jsonObject : _getJSONObjects()) {
+			Assert.assertNotEquals(
+				eventType, jsonObject.getString("event-type"));
+		}
+	}
+
+	@Test
+	public void testWriteWithASpoofedProviderName() throws Exception {
+		String eventType = RandomTestUtil.randomString();
+
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			eventType, FIPSAuditEvent.Severity.INFO);
+
+		String spoofedProviderName = RandomTestUtil.randomString();
+
+		fipsAuditEvent.put("provider-name", spoofedProviderName);
+
+		FIPSAuditUtil.write(fipsAuditEvent);
+
+		JSONObject jsonObject = _getJSONObject(eventType);
+
+		Provider provider = Security.getProviders()[0];
+
+		Assert.assertEquals(
+			provider.getName(), jsonObject.getString("provider-name"));
+
+		JSONObject fieldsJSONObject = jsonObject.getJSONObject("fields");
+
+		Assert.assertEquals(
+			spoofedProviderName, fieldsJSONObject.getString("provider-name"));
+	}
+
+	@Test
+	public void testWriteWithCriticalSeverity() throws Exception {
+		String eventType = RandomTestUtil.randomString();
+
+		FIPSAuditUtil.write(
+			new FIPSAuditEvent(eventType, FIPSAuditEvent.Severity.CRITICAL));
+
+		JSONObject jsonObject = _getJSONObject(eventType);
+
+		Assert.assertEquals("CRITICAL", jsonObject.getString("severity"));
+	}
+
+	@Test
+	public void testWriteWithFieldTimestamps() throws Exception {
+		String eventType = RandomTestUtil.randomString();
+
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			eventType, FIPSAuditEvent.Severity.INFO);
+
+		fipsAuditEvent.put(
+			"completed-date",
+			Date.from(Instant.parse("2025-05-06T14:19:23.471Z")));
+		fipsAuditEvent.put(
+			"completed-instant",
+			Instant.parse("2026-05-06T14:19:23.471999999Z"));
+		fipsAuditEvent.put(
+			"completed-offset-date-time",
+			OffsetDateTime.parse("2026-05-06T16:19:23.471+02:00"));
+		fipsAuditEvent.put(
+			"provider-self-test",
+			Collections.singletonMap(
+				"completed", Instant.parse("2026-05-06T14:19:23.471Z")));
+		fipsAuditEvent.put(
+			"provider-timestamps",
+			Arrays.asList(Instant.parse("2026-05-06T14:19:23Z")));
+
+		FIPSAuditUtil.write(fipsAuditEvent);
+
+		JSONObject jsonObject = _getJSONObject(eventType);
+
+		JSONObject fieldsJSONObject = jsonObject.getJSONObject("fields");
+
+		Assert.assertEquals(
+			"2025-05-06T14:19:23.471Z",
+			fieldsJSONObject.getString("completed-date"));
+		Assert.assertEquals(
+			"2026-05-06T14:19:23.471Z",
+			fieldsJSONObject.getString("completed-instant"));
+		Assert.assertEquals(
+			"2026-05-06T14:19:23.471Z",
+			fieldsJSONObject.getString("completed-offset-date-time"));
+
+		JSONObject providerSelfTestJSONObject = fieldsJSONObject.getJSONObject(
+			"provider-self-test");
+
+		Assert.assertEquals(
+			"2026-05-06T14:19:23.471Z",
+			providerSelfTestJSONObject.getString("completed"));
+
+		JSONArray providerTimestampsJSONArray = fieldsJSONObject.getJSONArray(
+			"provider-timestamps");
+
+		Assert.assertEquals(
+			"2026-05-06T14:19:23.000Z",
+			providerTimestampsJSONArray.getString(0));
+	}
+
+	@Test
+	public void testWriteWithoutADeploymentInstanceId() throws Exception {
+		Assume.assumeTrue(
+			Validator.isNull(PropsValues.FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID));
+
+		String eventType = RandomTestUtil.randomString();
+
+		FIPSAuditUtil.write(
+			new FIPSAuditEvent(eventType, FIPSAuditEvent.Severity.INFO));
+
+		JSONObject jsonObject = _getJSONObject(eventType);
+
+		Path path = Paths.get(
+			PropsValues.LIFERAY_HOME, "data",
+			"fips-audit-deployment-instance-id");
+
+		Assert.assertTrue(Files.exists(path));
+
+		String persistedId = new String(
+			Files.readAllBytes(path), StandardCharsets.UTF_8);
+
+		Assert.assertEquals(
+			persistedId.trim(), jsonObject.getString("deployment-instance-id"));
+	}
+
+	@Test
+	public void testWriteWithPosixFileSystem() throws Exception {
+		FIPSAuditUtil.write(
+			new FIPSAuditEvent(
+				RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO));
+
+		Path path = _getFIPSAuditLogPath();
+
+		Assert.assertTrue(Files.exists(path));
 
 		FileSystem fileSystem = path.getFileSystem();
 
@@ -67,47 +294,10 @@ public class FIPSAuditUtilTest {
 			Files.getPosixFilePermissions(path));
 	}
 
-	@Test
-	public void testWriteCreatesTheAuditLogFile() {
-		Path path = _getAuditLogPath();
-
-		Assert.assertTrue(Files.exists(path));
-	}
-
-	@Test
-	public void testWriteProducesACanonicalTimestamp() throws Exception {
-		for (JSONObject jsonObject : _getRecordJSONObjects()) {
-			String timestamp = jsonObject.getString("timestamp");
-
-			Assert.assertTrue(
-				timestamp.matches(
-					"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"));
-		}
-	}
-
-	@Test
-	public void testWriteProducesParseableRecords() throws Exception {
-		for (String line : Files.readAllLines(_getAuditLogPath())) {
-			Assert.assertTrue(Validator.isNotNull(line));
-
-			JSONFactoryUtil.createJSONObject(line);
-		}
-	}
-
-	@Test
-	public void testWriteProducesTheCommonEnvelope() throws Exception {
-		for (JSONObject jsonObject : _getRecordJSONObjects()) {
-			for (String envelopeKey : _ENVELOPE_KEYS) {
-				Assert.assertTrue(jsonObject.has(envelopeKey));
-			}
-		}
-	}
-
-	@Test
-	public void testWriteRecordsTheBootStateTransitions() throws Exception {
+	private void _assertBootStateTransitions(List<JSONObject> jsonObjects) {
 		List<String> transitions = new ArrayList<>();
 
-		for (JSONObject jsonObject : _getRecordJSONObjects()) {
+		for (JSONObject jsonObject : jsonObjects) {
 			String eventType = jsonObject.getString("event-type");
 
 			if (!eventType.equals("fips-state-transition")) {
@@ -126,11 +316,20 @@ public class FIPSAuditUtilTest {
 		Assert.assertTrue(transitions.contains("SELF_TEST to OPERATIONAL"));
 	}
 
-	@Test
-	public void testWriteSequencesRecordsContiguously() throws Exception {
+	private void _assertCanonicalTimestamps(List<JSONObject> jsonObjects) {
+		for (JSONObject jsonObject : jsonObjects) {
+			String timestamp = jsonObject.getString("timestamp");
+
+			Assert.assertTrue(
+				timestamp.matches(
+					"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"));
+		}
+	}
+
+	private void _assertContiguousEventSequences(List<JSONObject> jsonObjects) {
 		long previousEventSequence = 0;
 
-		for (JSONObject jsonObject : _getRecordJSONObjects()) {
+		for (JSONObject jsonObject : jsonObjects) {
 			long eventSequence = jsonObject.getLong("event-sequence");
 
 			if (eventSequence > previousEventSequence) {
@@ -141,7 +340,20 @@ public class FIPSAuditUtilTest {
 		}
 	}
 
-	private Path _getAuditLogPath() {
+	private void _assertOneDeploymentInstanceId(List<JSONObject> jsonObjects) {
+		JSONObject firstJSONObject = jsonObjects.get(0);
+
+		String deploymentInstanceId = firstJSONObject.getString(
+			"deployment-instance-id");
+
+		for (JSONObject jsonObject : jsonObjects) {
+			Assert.assertEquals(
+				deploymentInstanceId,
+				jsonObject.getString("deployment-instance-id"));
+		}
+	}
+
+	private Path _getFIPSAuditLogPath() {
 		LocalDate localDate = LocalDate.now(ZoneOffset.UTC);
 
 		return Paths.get(
@@ -149,14 +361,41 @@ public class FIPSAuditUtilTest {
 			StringBundler.concat("fips-audit.", localDate, ".ndjson"));
 	}
 
-	private List<JSONObject> _getRecordJSONObjects() throws Exception {
+	private JSONObject _getJSONObject(String eventType) throws Exception {
+		return _getJSONObject(eventType, _getJSONObjects());
+	}
+
+	private JSONObject _getJSONObject(
+		String eventType, List<JSONObject> jsonObjects) {
+
+		jsonObjects = ListUtil.filter(
+			jsonObjects,
+			jsonObject -> Objects.equals(
+				eventType, jsonObject.getString("event-type")));
+
+		Assert.assertEquals(jsonObjects.toString(), 1, jsonObjects.size());
+
+		return jsonObjects.get(0);
+	}
+
+	private List<JSONObject> _getJSONObjects() throws Exception {
 		List<JSONObject> jsonObjects = new ArrayList<>();
 
-		for (String line : Files.readAllLines(_getAuditLogPath())) {
-			jsonObjects.add(JSONFactoryUtil.createJSONObject(line));
+		for (String json : Files.readAllLines(_getFIPSAuditLogPath())) {
+			Assert.assertTrue(Validator.isNotNull(json));
+
+			jsonObjects.add(JSONFactoryUtil.createJSONObject(json));
 		}
 
 		return jsonObjects;
+	}
+
+	private long _getLastEventSequence() throws Exception {
+		List<JSONObject> jsonObjects = _getJSONObjects();
+
+		JSONObject jsonObject = jsonObjects.get(jsonObjects.size() - 1);
+
+		return jsonObject.getLong("event-sequence");
 	}
 
 	private static final String[] _ENVELOPE_KEYS = {

--- a/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
+++ b/modules/apps/portal-security/portal-security-fips-test/src/testIntegration/java/com/liferay/portal/security/fips/test/FIPSAuditUtilTest.java
@@ -52,14 +52,7 @@ public class FIPSAuditUtilTest {
 	}
 
 	@Test
-	public void testAuditLogFileExists() {
-		Path path = _getAuditLogPath();
-
-		Assert.assertTrue(Files.exists(path));
-	}
-
-	@Test
-	public void testAuditLogFileIsAccessibleByTheOwnerOnly() throws Exception {
+	public void testWriteCreatesAnOwnerOnlyAuditLogFile() throws Exception {
 		Path path = _getAuditLogPath();
 
 		FileSystem fileSystem = path.getFileSystem();
@@ -75,16 +68,14 @@ public class FIPSAuditUtilTest {
 	}
 
 	@Test
-	public void testAuditLogRecordsAreParseable() throws Exception {
-		for (String line : Files.readAllLines(_getAuditLogPath())) {
-			Assert.assertTrue(Validator.isNotNull(line));
+	public void testWriteCreatesTheAuditLogFile() {
+		Path path = _getAuditLogPath();
 
-			JSONFactoryUtil.createJSONObject(line);
-		}
+		Assert.assertTrue(Files.exists(path));
 	}
 
 	@Test
-	public void testAuditLogRecordsCarryACanonicalTimestamp() throws Exception {
+	public void testWriteProducesACanonicalTimestamp() throws Exception {
 		for (JSONObject jsonObject : _getRecordJSONObjects()) {
 			String timestamp = jsonObject.getString("timestamp");
 
@@ -95,22 +86,16 @@ public class FIPSAuditUtilTest {
 	}
 
 	@Test
-	public void testAuditLogRecordsCarryAContiguousSequence() throws Exception {
-		long previousEventSequence = 0;
+	public void testWriteProducesParseableRecords() throws Exception {
+		for (String line : Files.readAllLines(_getAuditLogPath())) {
+			Assert.assertTrue(Validator.isNotNull(line));
 
-		for (JSONObject jsonObject : _getRecordJSONObjects()) {
-			long eventSequence = jsonObject.getLong("event-sequence");
-
-			if (eventSequence > previousEventSequence) {
-				Assert.assertEquals(previousEventSequence + 1, eventSequence);
-			}
-
-			previousEventSequence = eventSequence;
+			JSONFactoryUtil.createJSONObject(line);
 		}
 	}
 
 	@Test
-	public void testAuditLogRecordsCarryTheCommonEnvelope() throws Exception {
+	public void testWriteProducesTheCommonEnvelope() throws Exception {
 		for (JSONObject jsonObject : _getRecordJSONObjects()) {
 			for (String envelopeKey : _ENVELOPE_KEYS) {
 				Assert.assertTrue(jsonObject.has(envelopeKey));
@@ -119,7 +104,7 @@ public class FIPSAuditUtilTest {
 	}
 
 	@Test
-	public void testAuditLogRecordsTheBootStateTransitions() throws Exception {
+	public void testWriteRecordsTheBootStateTransitions() throws Exception {
 		List<String> transitions = new ArrayList<>();
 
 		for (JSONObject jsonObject : _getRecordJSONObjects()) {
@@ -139,6 +124,21 @@ public class FIPSAuditUtilTest {
 
 		Assert.assertTrue(transitions.contains("INITIALIZING to SELF_TEST"));
 		Assert.assertTrue(transitions.contains("SELF_TEST to OPERATIONAL"));
+	}
+
+	@Test
+	public void testWriteSequencesRecordsContiguously() throws Exception {
+		long previousEventSequence = 0;
+
+		for (JSONObject jsonObject : _getRecordJSONObjects()) {
+			long eventSequence = jsonObject.getLong("event-sequence");
+
+			if (eventSequence > previousEventSequence) {
+				Assert.assertEquals(previousEventSequence + 1, eventSequence);
+			}
+
+			previousEventSequence = eventSequence;
+		}
 	}
 
 	private Path _getAuditLogPath() {

--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -358,7 +358,7 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 		}
 
 		if (PropsValues.FIPS_ENABLED) {
-			FIPSApplicationStateMachineUtil.powerOff("Server shutdown");
+			FIPSApplicationStateMachineUtil.powerOff("Portal");
 		}
 	}
 

--- a/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
+++ b/modules/core/portal-bootstrap/src/main/java/com/liferay/portal/bootstrap/ModuleFrameworkImpl.java
@@ -356,6 +356,10 @@ public class ModuleFrameworkImpl implements ModuleFramework {
 		if (Boolean.parseBoolean(System.getenv("LIFERAY_CLEAN_OSGI_STATE"))) {
 			_cleanOSGiStateFolder();
 		}
+
+		if (PropsValues.FIPS_ENABLED) {
+			FIPSApplicationStateMachineUtil.powerOff("Server shutdown");
+		}
 	}
 
 	@Override

--- a/portal-impl/src/META-INF/portal-log4j.xml
+++ b/portal-impl/src/META-INF/portal-log4j.xml
@@ -31,6 +31,14 @@
 				<Layout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} %-5p [%t][%c{1}:%L] %m%n" type="PatternLayout" />
 			</FilePattern>
 		</Appender>
+
+		<Appender filePattern="@liferay.home@/logs/fips-audit.%d{yyyy-MM-dd}{UTC}.ndjson" filePermissions="rw-------" ignoreExceptions="false" immediateFlush="true" name="FIPS_AUDIT_FILE" type="RollingFile">
+			<Layout type="FIPSAuditNDJSONLayout" />
+
+			<TimeBasedTriggeringPolicy />
+
+			<DirectWriteRolloverStrategy />
+		</Appender>
 	</Appenders>
 
 	<Loggers>
@@ -83,6 +91,11 @@
 		<Logger level="INFO" name="com.liferay.portal.kernel.dependency.manager.DependencyManagerSyncUtil" />
 		<Logger level="INFO" name="com.liferay.portal.kernel.deploy" />
 		<Logger level="WARN" name="com.liferay.portal.kernel.internal.configuration.ConfigurationImpl" />
+
+		<Logger additivity="false" level="INFO" name="com.liferay.portal.kernel.internal.log4j.Log4jFIPSAuditUtil">
+			<AppenderRef ref="FIPS_AUDIT_FILE" />
+		</Logger>
+
 		<Logger level="ERROR" name="com.liferay.portal.kernel.lar" />
 		<Logger level="INFO" name="com.liferay.portal.kernel.messaging.config.DefaultMessagingConfigurator" />
 		<Logger level="ERROR" name="com.liferay.portal.kernel.model.Image" />

--- a/portal-impl/src/META-INF/portal-log4j.xml
+++ b/portal-impl/src/META-INF/portal-log4j.xml
@@ -33,6 +33,8 @@
 		</Appender>
 
 		<Appender filePattern="@liferay.home@/logs/fips-audit.%d{yyyy-MM-dd}{UTC}.ndjson" filePermissions="rw-------" ignoreExceptions="false" immediateFlush="true" name="FIPS_AUDIT_FILE" type="RollingFile">
+			<Filter type="FIPSAuditFilter" />
+
 			<Layout type="FIPSAuditNDJSONLayout" />
 
 			<TimeBasedTriggeringPolicy />

--- a/portal-impl/src/META-INF/portal-log4j.xml
+++ b/portal-impl/src/META-INF/portal-log4j.xml
@@ -92,7 +92,7 @@
 		<Logger level="INFO" name="com.liferay.portal.kernel.deploy" />
 		<Logger level="WARN" name="com.liferay.portal.kernel.internal.configuration.ConfigurationImpl" />
 
-		<Logger additivity="false" level="INFO" name="com.liferay.portal.kernel.internal.log4j.Log4jFIPSAuditUtil">
+		<Logger additivity="false" level="INFO" name="com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil">
 			<AppenderRef ref="FIPS_AUDIT_FILE" />
 		</Logger>
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7725,6 +7725,26 @@
 ##
 
     #
+    # Set the deployment instance ID recorded in the common envelope of every
+    # FIPS audit event. Leave blank to derive a stable per install identifier.
+    # In a cluster, set a distinct value per node so that downstream SIEM
+    # correlation can attribute each event to the node that emitted it.
+    #
+    # Env: LIFERAY_FIPS_PERIOD_AUDIT_PERIOD_DEPLOYMENT_PERIOD_INSTANCE_PERIOD_ID
+    #
+    fips.audit.deployment.instance.id=
+
+    #
+    # Set the CMVP certificate ID of the validated cryptographic module,
+    # recorded in the common envelope of every FIPS audit event. This is
+    # deployment metadata that the JCE provider does not expose. Leave blank if
+    # it is unset.
+    #
+    # Env: LIFERAY_FIPS_PERIOD_AUDIT_PERIOD_PROVIDER_PERIOD_CMVP_PERIOD_CERTIFICATE_PERIOD_ID
+    #
+    fips.audit.provider.cmvp.certificate.id=
+
+    #
     # Set this to true to operate the portal in FIPS mode. When enabled, the
     # portal validates that the security providers configured in the JVM's
     # java.security file are registered in the order required to route

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7726,9 +7726,9 @@
 
     #
     # Set the deployment instance ID written in the common envelope of every
-    # FIPS audit record. Leave blank to derive a stable identifier for the
+    # FIPS audit event. Leave blank to derive a stable identifier for the
     # installation. In a cluster, set a distinct value per node so that
-    # downstream SIEM correlation can attribute each record to the node that
+    # downstream SIEM correlation can attribute each event to the node that
     # wrote it.
     #
     # Env: LIFERAY_FIPS_PERIOD_AUDIT_PERIOD_DEPLOYMENT_PERIOD_INSTANCE_PERIOD_ID
@@ -7737,7 +7737,7 @@
 
     #
     # Set the CMVP certificate ID of the validated cryptographic module, written
-    # in the common envelope of every FIPS audit record. This is deployment
+    # in the common envelope of every FIPS audit event. This is deployment
     # metadata that the JCE provider does not expose. Leave blank when the
     # certificate ID is not known.
     #

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7726,9 +7726,10 @@
 
     #
     # Set the deployment instance ID written in the common envelope of every
-    # FIPS audit record. Leave blank to derive a stable per install identifier.
-    # In a cluster, set a distinct value per node so that downstream SIEM
-    # correlation can attribute each record to the node that wrote it.
+    # FIPS audit record. Leave blank to derive a stable identifier for the
+    # installation. In a cluster, set a distinct value per node so that
+    # downstream SIEM correlation can attribute each record to the node that
+    # wrote it.
     #
     # Env: LIFERAY_FIPS_PERIOD_AUDIT_PERIOD_DEPLOYMENT_PERIOD_INSTANCE_PERIOD_ID
     #
@@ -7737,8 +7738,8 @@
     #
     # Set the CMVP certificate ID of the validated cryptographic module, written
     # in the common envelope of every FIPS audit record. This is deployment
-    # metadata that the JCE provider does not expose. Leave blank if it is
-    # unset.
+    # metadata that the JCE provider does not expose. Leave blank when the
+    # certificate ID is not known.
     #
     # Env: LIFERAY_FIPS_PERIOD_AUDIT_PERIOD_PROVIDER_PERIOD_CMVP_PERIOD_CERTIFICATE_PERIOD_ID
     #

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7725,20 +7725,20 @@
 ##
 
     #
-    # Set the deployment instance ID recorded in the common envelope of every
-    # FIPS audit event. Leave blank to derive a stable per install identifier.
+    # Set the deployment instance ID written in the common envelope of every
+    # FIPS audit record. Leave blank to derive a stable per install identifier.
     # In a cluster, set a distinct value per node so that downstream SIEM
-    # correlation can attribute each event to the node that emitted it.
+    # correlation can attribute each record to the node that wrote it.
     #
     # Env: LIFERAY_FIPS_PERIOD_AUDIT_PERIOD_DEPLOYMENT_PERIOD_INSTANCE_PERIOD_ID
     #
     fips.audit.deployment.instance.id=
 
     #
-    # Set the CMVP certificate ID of the validated cryptographic module,
-    # recorded in the common envelope of every FIPS audit event. This is
-    # deployment metadata that the JCE provider does not expose. Leave blank if
-    # it is unset.
+    # Set the CMVP certificate ID of the validated cryptographic module, written
+    # in the common envelope of every FIPS audit record. This is deployment
+    # metadata that the JCE provider does not expose. Leave blank if it is
+    # unset.
     #
     # Env: LIFERAY_FIPS_PERIOD_AUDIT_PERIOD_PROVIDER_PERIOD_CMVP_PERIOD_CERTIFICATE_PERIOD_ID
     #

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
@@ -53,9 +53,11 @@ public class FIPSAuditFilterTest {
 	@Test
 	public void testFilterDeniesAnEventWithoutARecord() {
 		_testFilterDenies(
-			FIPSLog4jUtil.getMarker(), new ObjectMessage("not-a-map"));
+			FIPSLog4jUtil.getMarker(),
+			new ObjectMessage(RandomTestUtil.randomString()));
 		_testFilterDenies(
-			FIPSLog4jUtil.getMarker(), new SimpleMessage("Not a record"));
+			FIPSLog4jUtil.getMarker(),
+			new SimpleMessage(RandomTestUtil.randomString()));
 	}
 
 	@Test

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
@@ -59,21 +59,22 @@ public class FIPSAuditFilterTest {
 		Marker marker = MarkerManager.getMarker(FIPSLog4jUtil.MARKER_NAME);
 
 		_testFilterDenies(
-			marker, new ObjectMessage("not-a-map"),
-			"does not carry a FIPS audit record");
+			"does not carry a FIPS audit record", marker,
+			new ObjectMessage("not-a-map"));
 		_testFilterDenies(
-			marker, new SimpleMessage("Not a record"),
-			"does not carry a FIPS audit record");
+			"does not carry a FIPS audit record", marker,
+			new SimpleMessage("Not a record"));
 	}
 
 	@Test
 	public void testFilterDeniesAnEventWithoutTheMarker() {
 		_testFilterDenies(
+			"carries no \"FIPS_AUDIT\" marker",
 			MarkerManager.getMarker(RandomTestUtil.randomString()),
-			new ObjectMessage(_record), "carries no \"FIPS_AUDIT\" marker");
+			new ObjectMessage(_record));
 		_testFilterDenies(
-			null, new ObjectMessage(_record),
-			"carries no \"FIPS_AUDIT\" marker");
+			"carries no \"FIPS_AUDIT\" marker", null,
+			new ObjectMessage(_record));
 	}
 
 	private FIPSAuditFilter _createFIPSAuditFilter() {
@@ -94,7 +95,7 @@ public class FIPSAuditFilterTest {
 	}
 
 	private void _testFilterDenies(
-		Marker marker, Message message, String expectedMessage) {
+		String expectedMessage, Marker marker, Message message) {
 
 		FIPSAuditFilter fipsAuditFilter = _createFIPSAuditFilter();
 
@@ -117,6 +118,6 @@ public class FIPSAuditFilterTest {
 	}
 
 	private final Map<String, Object> _record = Collections.singletonMap(
-		"event-type", "fips-state-transition");
+		RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
 }

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
@@ -8,12 +8,9 @@ package com.liferay.portal.kernel.internal.log4j;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.test.log.LogCapture;
-import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.Level;
@@ -50,31 +47,23 @@ public class FIPSAuditFilterTest {
 			Filter.Result.ACCEPT,
 			fipsAuditFilter.filter(
 				_createLogEvent(
-					MarkerManager.getMarker(FIPSLog4jUtil.MARKER_NAME),
-					new ObjectMessage(_record))));
+					FIPSLog4jUtil.getMarker(), new ObjectMessage(_record))));
 	}
 
 	@Test
 	public void testFilterDeniesAnEventWithoutARecord() {
-		Marker marker = MarkerManager.getMarker(FIPSLog4jUtil.MARKER_NAME);
-
 		_testFilterDenies(
-			"carries no FIPS audit record", marker,
-			new ObjectMessage("not-a-map"));
+			FIPSLog4jUtil.getMarker(), new ObjectMessage("not-a-map"));
 		_testFilterDenies(
-			"carries no FIPS audit record", marker,
-			new SimpleMessage("Not a record"));
+			FIPSLog4jUtil.getMarker(), new SimpleMessage("Not a record"));
 	}
 
 	@Test
 	public void testFilterDeniesAnEventWithoutTheMarker() {
 		_testFilterDenies(
-			"carries no \"FIPS_AUDIT\" marker",
 			MarkerManager.getMarker(RandomTestUtil.randomString()),
 			new ObjectMessage(_record));
-		_testFilterDenies(
-			"carries no \"FIPS_AUDIT\" marker", null,
-			new ObjectMessage(_record));
+		_testFilterDenies(null, new ObjectMessage(_record));
 	}
 
 	private FIPSAuditFilter _createFIPSAuditFilter() {
@@ -94,26 +83,12 @@ public class FIPSAuditFilterTest {
 		return builder.build();
 	}
 
-	private void _testFilterDenies(
-		String expectedMessage, Marker marker, Message message) {
-
+	private void _testFilterDenies(Marker marker, Message message) {
 		FIPSAuditFilter fipsAuditFilter = _createFIPSAuditFilter();
 
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				FIPSAuditFilter.class.getName(), LoggerTestUtil.ERROR)) {
-
-			Assert.assertEquals(
-				Filter.Result.DENY,
-				fipsAuditFilter.filter(_createLogEvent(marker, message)));
-
-			List<String> messages = logCapture.getMessages();
-
-			Assert.assertEquals(messages.toString(), 1, messages.size());
-
-			String errorMessage = messages.get(0);
-
-			Assert.assertTrue(errorMessage.contains(expectedMessage));
-		}
+		Assert.assertEquals(
+			Filter.Result.DENY,
+			fipsAuditFilter.filter(_createLogEvent(marker, message)));
 	}
 
 	private final Map<String, Object> _record = Collections.singletonMap(

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
@@ -1,0 +1,122 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.internal.log4j;
+
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.ObjectMessage;
+import org.apache.logging.log4j.message.SimpleMessage;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSAuditFilterTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			CodeCoverageAssertor.INSTANCE, LiferayUnitTestRule.INSTANCE);
+
+	@Test
+	public void testFilterAcceptsARecord() {
+		FIPSAuditFilter fipsAuditFilter = _createFIPSAuditFilter();
+
+		Assert.assertEquals(
+			Filter.Result.ACCEPT,
+			fipsAuditFilter.filter(
+				_createLogEvent(
+					MarkerManager.getMarker(FIPSLog4jUtil.MARKER_NAME),
+					new ObjectMessage(_record))));
+	}
+
+	@Test
+	public void testFilterDeniesAnEventWithoutARecord() {
+		Marker marker = MarkerManager.getMarker(FIPSLog4jUtil.MARKER_NAME);
+
+		_testFilterDenies(
+			marker, new ObjectMessage("not-a-map"),
+			"does not carry a FIPS audit record");
+		_testFilterDenies(
+			marker, new SimpleMessage("Not a record"),
+			"does not carry a FIPS audit record");
+	}
+
+	@Test
+	public void testFilterDeniesAnEventWithoutTheMarker() {
+		_testFilterDenies(
+			MarkerManager.getMarker(RandomTestUtil.randomString()),
+			new ObjectMessage(_record), "carries no \"FIPS_AUDIT\" marker");
+		_testFilterDenies(
+			null, new ObjectMessage(_record),
+			"carries no \"FIPS_AUDIT\" marker");
+	}
+
+	private FIPSAuditFilter _createFIPSAuditFilter() {
+		FIPSAuditFilter.Builder builder = FIPSAuditFilter.newBuilder();
+
+		return builder.build();
+	}
+
+	private LogEvent _createLogEvent(Marker marker, Message message) {
+		Log4jLogEvent.Builder builder = Log4jLogEvent.newBuilder();
+
+		builder.setLevel(Level.INFO);
+		builder.setLoggerName(RandomTestUtil.randomString());
+		builder.setMarker(marker);
+		builder.setMessage(message);
+
+		return builder.build();
+	}
+
+	private void _testFilterDenies(
+		Marker marker, Message message, String expectedMessage) {
+
+		FIPSAuditFilter fipsAuditFilter = _createFIPSAuditFilter();
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				FIPSAuditFilter.class.getName(), LoggerTestUtil.ERROR)) {
+
+			Assert.assertEquals(
+				Filter.Result.DENY,
+				fipsAuditFilter.filter(_createLogEvent(marker, message)));
+
+			List<String> messages = logCapture.getMessages();
+
+			Assert.assertEquals(messages.toString(), 1, messages.size());
+
+			String errorMessage = messages.get(0);
+
+			Assert.assertTrue(
+				errorMessage, errorMessage.contains(expectedMessage));
+		}
+	}
+
+	private final Map<String, Object> _record = Collections.singletonMap(
+		"event-type", "fips-state-transition");
+
+}

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
@@ -40,18 +40,19 @@ public class FIPSAuditFilterTest {
 			CodeCoverageAssertor.INSTANCE, LiferayUnitTestRule.INSTANCE);
 
 	@Test
-	public void testFilterAcceptsARecord() {
+	public void testFilterAcceptsAFIPSAuditLogEntry() {
 		FIPSAuditFilter fipsAuditFilter = _createFIPSAuditFilter();
 
 		Assert.assertEquals(
 			Filter.Result.ACCEPT,
 			fipsAuditFilter.filter(
 				_createLogEvent(
-					FIPSLog4jUtil.getMarker(), new ObjectMessage(_record))));
+					FIPSLog4jUtil.getMarker(),
+					new ObjectMessage(_fipsAuditLogEntry))));
 	}
 
 	@Test
-	public void testFilterDeniesAnEventWithoutARecord() {
+	public void testFilterDeniesAnEventWithoutAFIPSAuditLogEntry() {
 		_testFilterDenies(
 			FIPSLog4jUtil.getMarker(),
 			new ObjectMessage(RandomTestUtil.randomString()));
@@ -64,8 +65,8 @@ public class FIPSAuditFilterTest {
 	public void testFilterDeniesAnEventWithoutTheMarker() {
 		_testFilterDenies(
 			MarkerManager.getMarker(RandomTestUtil.randomString()),
-			new ObjectMessage(_record));
-		_testFilterDenies(null, new ObjectMessage(_record));
+			new ObjectMessage(_fipsAuditLogEntry));
+		_testFilterDenies(null, new ObjectMessage(_fipsAuditLogEntry));
 	}
 
 	private FIPSAuditFilter _createFIPSAuditFilter() {
@@ -93,7 +94,8 @@ public class FIPSAuditFilterTest {
 			fipsAuditFilter.filter(_createLogEvent(marker, message)));
 	}
 
-	private final Map<String, Object> _record = Collections.singletonMap(
-		RandomTestUtil.randomString(), RandomTestUtil.randomString());
+	private final Map<String, Object> _fipsAuditLogEntry =
+		Collections.singletonMap(
+			RandomTestUtil.randomString(), RandomTestUtil.randomString());
 
 }

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
@@ -59,10 +59,10 @@ public class FIPSAuditFilterTest {
 		Marker marker = MarkerManager.getMarker(FIPSLog4jUtil.MARKER_NAME);
 
 		_testFilterDenies(
-			"does not carry a FIPS audit record", marker,
+			"carries no FIPS audit record", marker,
 			new ObjectMessage("not-a-map"));
 		_testFilterDenies(
-			"does not carry a FIPS audit record", marker,
+			"carries no FIPS audit record", marker,
 			new SimpleMessage("Not a record"));
 	}
 

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilterTest.java
@@ -112,8 +112,7 @@ public class FIPSAuditFilterTest {
 
 			String errorMessage = messages.get(0);
 
-			Assert.assertTrue(
-				errorMessage, errorMessage.contains(expectedMessage));
+			Assert.assertTrue(errorMessage.contains(expectedMessage));
 		}
 	}
 

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
@@ -114,8 +114,10 @@ public class FIPSAuditNDJSONLayoutTest {
 
 	@Test
 	public void testToSerializableRejectsAForeignEvent() {
-		_testToSerializableThrows(new ObjectMessage("not-a-map"));
-		_testToSerializableThrows(new SimpleMessage("Not a record"));
+		_testToSerializableThrows(
+			new ObjectMessage(RandomTestUtil.randomString()));
+		_testToSerializableThrows(
+			new SimpleMessage(RandomTestUtil.randomString()));
 	}
 
 	@Test

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
@@ -93,12 +93,11 @@ public class FIPSAuditNDJSONLayoutTest {
 
 	@Test
 	public void testToSerializableEndsWithASingleNewLine() {
-		String ndjson = _toSerializable(
-			Collections.singletonMap("event-type", "fips-state-transition"));
-
 		Assert.assertEquals(
-			"{\"event-type\":\"fips-state-transition\"}\n", ndjson);
-		Assert.assertEquals(ndjson.length() - 1, ndjson.indexOf('\n'));
+			"{\"event-type\":\"fips-state-transition\"}\n",
+			_toSerializable(
+				Collections.singletonMap(
+					"event-type", "fips-state-transition")));
 	}
 
 	@Test

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
@@ -138,7 +138,7 @@ public class FIPSAuditNDJSONLayoutTest {
 
 			for (String message : messages) {
 				Assert.assertTrue(
-					message, message.contains("carries no FIPS audit record"));
+					message.contains("carries no FIPS audit record"));
 			}
 		}
 	}

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
@@ -126,11 +126,11 @@ public class FIPSAuditNDJSONLayoutTest {
 			Assert.assertEquals(
 				"",
 				fipsAuditNDJSONLayout.toSerializable(
-					_createLogEvent(new SimpleMessage("Not a record"))));
+					_createLogEvent(new ObjectMessage("not-a-map"))));
 			Assert.assertEquals(
 				"",
 				fipsAuditNDJSONLayout.toSerializable(
-					_createLogEvent(new ObjectMessage("not-a-map"))));
+					_createLogEvent(new SimpleMessage("Not a record"))));
 
 			List<String> messages = logCapture.getMessages();
 

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
@@ -1,0 +1,257 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.internal.log4j;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.json.JSONFactoryImpl;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.io.ByteArrayOutputStream;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.core.layout.ByteBufferDestination;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.ObjectMessage;
+import org.apache.logging.log4j.message.SimpleMessage;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Rafael Praxedes
+ */
+public class FIPSAuditNDJSONLayoutTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			CodeCoverageAssertor.INSTANCE, LiferayUnitTestRule.INSTANCE);
+
+	@Before
+	public void setUp() {
+		JSONFactoryUtil jsonFactoryUtil = new JSONFactoryUtil();
+
+		jsonFactoryUtil.setJSONFactory(new JSONFactoryImpl());
+	}
+
+	@Test
+	public void testEncode() {
+		Map<String, Object> record = LinkedHashMapBuilder.<String, Object>put(
+			"event-type", "fips-state-transition"
+		).put(
+			"severity", "CRITICAL"
+		).build();
+
+		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
+			_createFIPSAuditNDJSONLayout();
+
+		TestByteBufferDestination testByteBufferDestination =
+			new TestByteBufferDestination();
+
+		fipsAuditNDJSONLayout.encode(
+			_createLogEvent(new ObjectMessage(record)),
+			testByteBufferDestination);
+
+		Assert.assertEquals(
+			_toSerializable(record), testByteBufferDestination.toString());
+	}
+
+	@Test
+	public void testGetContentType() {
+		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
+			_createFIPSAuditNDJSONLayout();
+
+		Assert.assertEquals(
+			"application/x-ndjson; charset=UTF-8",
+			fipsAuditNDJSONLayout.getContentType());
+	}
+
+	@Test
+	public void testToSerializableEndsWithASingleNewLine() {
+		String ndjson = _toSerializable(
+			Collections.singletonMap("event-type", "fips-state-transition"));
+
+		Assert.assertEquals(
+			"{\"event-type\":\"fips-state-transition\"}\n", ndjson);
+		Assert.assertEquals(ndjson.length() - 1, ndjson.indexOf('\n'));
+	}
+
+	@Test
+	public void testToSerializableEscapesReservedCharacters() {
+		Assert.assertEquals(
+			"{\"provider-error-message\":\"a\\\\b\\\"c\\nd\\re\\tf\\u0001g" +
+				"\\u2028h\\u2029i\"}\n",
+			_toSerializable(
+				Collections.singletonMap(
+					"provider-error-message",
+					new String(
+						new char[] {
+							'a', '\\', 'b', '"', 'c', '\n', 'd', '\r', 'e',
+							'\t', 'f', 0x01, 'g', 0x2028, 'h', 0x2029, 'i'
+						}))));
+	}
+
+	@Test
+	public void testToSerializableWritesEveryEntry() throws Exception {
+		Map<String, Object> record = LinkedHashMapBuilder.<String, Object>put(
+			"event-type", "fips-state-transition"
+		).put(
+			"severity", "INFO"
+		).put(
+			"timestamp", "2026-08-04T12:00:00.000Z"
+		).build();
+
+		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
+			_toSerializable(record));
+
+		Assert.assertEquals(record.size(), jsonObject.length());
+
+		for (Map.Entry<String, Object> entry : record.entrySet()) {
+			Assert.assertEquals(
+				entry.getValue(), jsonObject.getString(entry.getKey()));
+		}
+	}
+
+	@Test
+	public void testToSerializableWritesMessageKeyForUnreadableMessages() {
+		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
+			_createFIPSAuditNDJSONLayout();
+
+		Assert.assertEquals(
+			"{\"message\":\"Unable to \\\"parse\\\" the record\"}\n",
+			fipsAuditNDJSONLayout.toSerializable(
+				_createLogEvent(
+					new SimpleMessage("Unable to \"parse\" the record"))));
+
+		Assert.assertEquals(
+			"{\"message\":\"not-a-map\"}\n",
+			fipsAuditNDJSONLayout.toSerializable(
+				_createLogEvent(new ObjectMessage("not-a-map"))));
+	}
+
+	@Test
+	public void testToSerializableWritesNestedMaps() {
+		Assert.assertEquals(
+			"{\"fields\":{\"from-state\":\"SELF_TEST\"}}\n",
+			_toSerializable(
+				Collections.singletonMap(
+					"fields",
+					Collections.singletonMap("from-state", "SELF_TEST"))));
+	}
+
+	@Test
+	public void testToSerializableWritesValueTypes() {
+		_testToSerializable(
+			"array", new String[] {"first", "second"},
+			"[\"first\",\"second\"]");
+		_testToSerializable("boolean", Boolean.TRUE, "true");
+		_testToSerializable("decimal", 1.5D, "1.5");
+		_testToSerializable("iterable", Arrays.asList("one", 2), "[\"one\",2]");
+		_testToSerializable("number", 42, "42");
+		_testToSerializable("string", "text", "\"text\"");
+	}
+
+	private FIPSAuditNDJSONLayout _createFIPSAuditNDJSONLayout() {
+		FIPSAuditNDJSONLayout.Builder builder =
+			FIPSAuditNDJSONLayout.newBuilder();
+
+		return builder.build();
+	}
+
+	private LogEvent _createLogEvent(Message message) {
+		Log4jLogEvent.Builder builder = Log4jLogEvent.newBuilder();
+
+		builder.setLevel(Level.INFO);
+		builder.setLoggerName(RandomTestUtil.randomString());
+		builder.setMessage(message);
+
+		return builder.build();
+	}
+
+	private void _testToSerializable(
+		String key, Object value, String valueJSON) {
+
+		Assert.assertEquals(
+			StringBundler.concat("{\"", key, "\":", valueJSON, "}\n"),
+			_toSerializable(Collections.singletonMap(key, value)));
+	}
+
+	private String _toSerializable(Map<String, Object> record) {
+		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
+			_createFIPSAuditNDJSONLayout();
+
+		return fipsAuditNDJSONLayout.toSerializable(
+			_createLogEvent(new ObjectMessage(record)));
+	}
+
+	private static class TestByteBufferDestination
+		implements ByteBufferDestination {
+
+		@Override
+		public ByteBuffer drain(ByteBuffer byteBuffer) {
+			byteBuffer.flip();
+
+			writeBytes(byteBuffer);
+
+			byteBuffer.clear();
+
+			return byteBuffer;
+		}
+
+		@Override
+		public ByteBuffer getByteBuffer() {
+			return _byteBuffer;
+		}
+
+		@Override
+		public String toString() {
+			drain(_byteBuffer);
+
+			byte[] bytes = _byteArrayOutputStream.toByteArray();
+
+			return new String(bytes, StandardCharsets.UTF_8);
+		}
+
+		@Override
+		public void writeBytes(byte[] bytes, int offset, int length) {
+			_byteArrayOutputStream.write(bytes, offset, length);
+		}
+
+		@Override
+		public void writeBytes(ByteBuffer byteBuffer) {
+			byte[] bytes = new byte[byteBuffer.remaining()];
+
+			byteBuffer.get(bytes);
+
+			writeBytes(bytes, 0, bytes.length);
+		}
+
+		private final ByteArrayOutputStream _byteArrayOutputStream =
+			new ByteArrayOutputStream();
+		private final ByteBuffer _byteBuffer = ByteBuffer.allocate(4096);
+
+	}
+
+}

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
@@ -138,8 +138,7 @@ public class FIPSAuditNDJSONLayoutTest {
 
 			for (String message : messages) {
 				Assert.assertTrue(
-					message,
-					message.contains("does not carry a FIPS audit record"));
+					message, message.contains("carries no FIPS audit record"));
 			}
 		}
 	}

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
@@ -13,8 +13,6 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
-import com.liferay.portal.test.log.LogCapture;
-import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.io.ByteArrayOutputStream;
@@ -24,7 +22,6 @@ import java.nio.charset.StandardCharsets;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.Level;
@@ -117,30 +114,8 @@ public class FIPSAuditNDJSONLayoutTest {
 
 	@Test
 	public void testToSerializableRejectsAForeignEvent() {
-		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
-			_createFIPSAuditNDJSONLayout();
-
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				FIPSAuditNDJSONLayout.class.getName(), LoggerTestUtil.ERROR)) {
-
-			Assert.assertEquals(
-				"",
-				fipsAuditNDJSONLayout.toSerializable(
-					_createLogEvent(new ObjectMessage("not-a-map"))));
-			Assert.assertEquals(
-				"",
-				fipsAuditNDJSONLayout.toSerializable(
-					_createLogEvent(new SimpleMessage("Not a record"))));
-
-			List<String> messages = logCapture.getMessages();
-
-			Assert.assertEquals(messages.toString(), 2, messages.size());
-
-			for (String message : messages) {
-				Assert.assertTrue(
-					message.contains("carries no FIPS audit record"));
-			}
-		}
+		_testToSerializableThrows(new ObjectMessage("not-a-map"));
+		_testToSerializableThrows(new SimpleMessage("Not a record"));
 	}
 
 	@Test
@@ -209,6 +184,20 @@ public class FIPSAuditNDJSONLayoutTest {
 		Assert.assertEquals(
 			StringBundler.concat("{\"", key, "\":", valueJSON, "}\n"),
 			_toSerializable(Collections.singletonMap(key, value)));
+	}
+
+	private void _testToSerializableThrows(Message message) {
+		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
+			_createFIPSAuditNDJSONLayout();
+
+		IllegalStateException illegalStateException = Assert.assertThrows(
+			IllegalStateException.class,
+			() -> fipsAuditNDJSONLayout.toSerializable(
+				_createLogEvent(message)));
+
+		String errorMessage = illegalStateException.getMessage();
+
+		Assert.assertTrue(errorMessage.contains("carries no FIPS audit event"));
 	}
 
 	private String _toSerializable(Map<String, Object> record) {

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
@@ -13,6 +13,8 @@ import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.CodeCoverageAssertor;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.io.ByteArrayOutputStream;
@@ -22,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.Level;
@@ -114,6 +117,35 @@ public class FIPSAuditNDJSONLayoutTest {
 	}
 
 	@Test
+	public void testToSerializableRejectsAForeignEvent() {
+		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
+			_createFIPSAuditNDJSONLayout();
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				FIPSAuditNDJSONLayout.class.getName(), LoggerTestUtil.ERROR)) {
+
+			Assert.assertEquals(
+				"",
+				fipsAuditNDJSONLayout.toSerializable(
+					_createLogEvent(new SimpleMessage("Not a record"))));
+			Assert.assertEquals(
+				"",
+				fipsAuditNDJSONLayout.toSerializable(
+					_createLogEvent(new ObjectMessage("not-a-map"))));
+
+			List<String> messages = logCapture.getMessages();
+
+			Assert.assertEquals(messages.toString(), 2, messages.size());
+
+			for (String message : messages) {
+				Assert.assertTrue(
+					message,
+					message.contains("does not carry a FIPS audit record"));
+			}
+		}
+	}
+
+	@Test
 	public void testToSerializableWritesEveryEntry() throws Exception {
 		Map<String, Object> record = LinkedHashMapBuilder.<String, Object>put(
 			"event-type", "fips-state-transition"
@@ -132,23 +164,6 @@ public class FIPSAuditNDJSONLayoutTest {
 			Assert.assertEquals(
 				entry.getValue(), jsonObject.getString(entry.getKey()));
 		}
-	}
-
-	@Test
-	public void testToSerializableWritesMessageKeyForUnreadableMessages() {
-		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
-			_createFIPSAuditNDJSONLayout();
-
-		Assert.assertEquals(
-			"{\"message\":\"Unable to \\\"parse\\\" the record\"}\n",
-			fipsAuditNDJSONLayout.toSerializable(
-				_createLogEvent(
-					new SimpleMessage("Unable to \"parse\" the record"))));
-
-		Assert.assertEquals(
-			"{\"message\":\"not-a-map\"}\n",
-			fipsAuditNDJSONLayout.toSerializable(
-				_createLogEvent(new ObjectMessage("not-a-map"))));
 	}
 
 	@Test

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
@@ -58,11 +58,12 @@ public class FIPSAuditNDJSONLayoutTest {
 
 	@Test
 	public void testEncode() {
-		Map<String, Object> record = LinkedHashMapBuilder.<String, Object>put(
-			"event-type", "fips-state-transition"
-		).put(
-			"severity", "CRITICAL"
-		).build();
+		Map<String, Object> fipsAuditLogEntry =
+			LinkedHashMapBuilder.<String, Object>put(
+				"event-type", "fips-state-transition"
+			).put(
+				"severity", "CRITICAL"
+			).build();
 
 		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
 			_createFIPSAuditNDJSONLayout();
@@ -71,11 +72,12 @@ public class FIPSAuditNDJSONLayoutTest {
 			new TestByteBufferDestination();
 
 		fipsAuditNDJSONLayout.encode(
-			_createLogEvent(new ObjectMessage(record)),
+			_createLogEvent(new ObjectMessage(fipsAuditLogEntry)),
 			testByteBufferDestination);
 
 		Assert.assertEquals(
-			_toSerializable(record), testByteBufferDestination.toString());
+			_toSerializable(fipsAuditLogEntry),
+			testByteBufferDestination.toString());
 	}
 
 	@Test
@@ -122,20 +124,21 @@ public class FIPSAuditNDJSONLayoutTest {
 
 	@Test
 	public void testToSerializableWritesEveryEntry() throws Exception {
-		Map<String, Object> record = LinkedHashMapBuilder.<String, Object>put(
-			"event-type", "fips-state-transition"
-		).put(
-			"severity", "INFO"
-		).put(
-			"timestamp", "2026-08-04T12:00:00.000Z"
-		).build();
+		Map<String, Object> fipsAuditLogEntry =
+			LinkedHashMapBuilder.<String, Object>put(
+				"event-type", "fips-state-transition"
+			).put(
+				"severity", "INFO"
+			).put(
+				"timestamp", "2026-08-04T12:00:00.000Z"
+			).build();
 
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
-			_toSerializable(record));
+			_toSerializable(fipsAuditLogEntry));
 
-		Assert.assertEquals(record.size(), jsonObject.length());
+		Assert.assertEquals(fipsAuditLogEntry.size(), jsonObject.length());
 
-		for (Map.Entry<String, Object> entry : record.entrySet()) {
+		for (Map.Entry<String, Object> entry : fipsAuditLogEntry.entrySet()) {
 			Assert.assertEquals(
 				entry.getValue(), jsonObject.getString(entry.getKey()));
 		}
@@ -202,12 +205,12 @@ public class FIPSAuditNDJSONLayoutTest {
 		Assert.assertTrue(errorMessage.contains("carries no FIPS audit event"));
 	}
 
-	private String _toSerializable(Map<String, Object> record) {
+	private String _toSerializable(Map<String, Object> fipsAuditLogEntry) {
 		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
 			_createFIPSAuditNDJSONLayout();
 
 		return fipsAuditNDJSONLayout.toSerializable(
-			_createLogEvent(new ObjectMessage(record)));
+			_createLogEvent(new ObjectMessage(fipsAuditLogEntry)));
 	}
 
 	private static class TestByteBufferDestination

--- a/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
+++ b/portal-impl/test/unit/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayoutTest.java
@@ -60,9 +60,9 @@ public class FIPSAuditNDJSONLayoutTest {
 	public void testEncode() {
 		Map<String, Object> fipsAuditLogEntry =
 			LinkedHashMapBuilder.<String, Object>put(
-				"event-type", "fips-state-transition"
+				RandomTestUtil.randomString(), RandomTestUtil.randomString()
 			).put(
-				"severity", "CRITICAL"
+				RandomTestUtil.randomString(), RandomTestUtil.randomString()
 			).build();
 
 		FIPSAuditNDJSONLayout fipsAuditNDJSONLayout =
@@ -77,7 +77,7 @@ public class FIPSAuditNDJSONLayoutTest {
 
 		Assert.assertEquals(
 			_toSerializable(fipsAuditLogEntry),
-			testByteBufferDestination.toString());
+			testByteBufferDestination.getString());
 	}
 
 	@Test
@@ -126,11 +126,11 @@ public class FIPSAuditNDJSONLayoutTest {
 	public void testToSerializableWritesEveryEntry() throws Exception {
 		Map<String, Object> fipsAuditLogEntry =
 			LinkedHashMapBuilder.<String, Object>put(
-				"event-type", "fips-state-transition"
+				RandomTestUtil.randomString(), RandomTestUtil.randomString()
 			).put(
-				"severity", "INFO"
+				RandomTestUtil.randomString(), RandomTestUtil.randomString()
 			).put(
-				"timestamp", "2026-08-04T12:00:00.000Z"
+				RandomTestUtil.randomString(), RandomTestUtil.randomString()
 			).build();
 
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
@@ -232,8 +232,7 @@ public class FIPSAuditNDJSONLayoutTest {
 			return _byteBuffer;
 		}
 
-		@Override
-		public String toString() {
+		public String getString() {
 			drain(_byteBuffer);
 
 			byte[] bytes = _byteArrayOutputStream.toByteArray();

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilter.java
@@ -1,0 +1,102 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.internal.log4j;
+
+import com.liferay.petra.string.StringBundler;
+
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
+import org.apache.logging.log4j.core.filter.AbstractFilter;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.ObjectMessage;
+
+/**
+ * @author Jorge García Jiménez
+ */
+@Plugin(
+	category = Node.CATEGORY, elementType = Filter.ELEMENT_TYPE,
+	name = FIPSAuditFilter.PLUGIN_NAME, printObject = true
+)
+public final class FIPSAuditFilter extends AbstractFilter {
+
+	public static final String PLUGIN_NAME = "FIPSAuditFilter";
+
+	@PluginBuilderFactory
+	public static Builder newBuilder() {
+		return new Builder();
+	}
+
+	@Override
+	public Result filter(LogEvent logEvent) {
+		Marker marker = logEvent.getMarker();
+
+		if ((marker == null) ||
+			!marker.isInstanceOf(FIPSLog4jUtil.MARKER_NAME)) {
+
+			_logger.error(
+				StringBundler.concat(
+					"Unable to write the event from the logger \"",
+					logEvent.getLoggerName(),
+					"\" to the FIPS audit trail because it carries no \"",
+					FIPSLog4jUtil.MARKER_NAME, "\" marker"));
+
+			return Result.DENY;
+		}
+
+		if (!_hasRecord(logEvent.getMessage())) {
+			_logger.error(
+				StringBundler.concat(
+					"Unable to write the event from the logger \"",
+					logEvent.getLoggerName(),
+					"\" to the FIPS audit trail because its message does not ",
+					"carry a FIPS audit record"));
+
+			return Result.DENY;
+		}
+
+		return Result.ACCEPT;
+	}
+
+	public static class Builder
+		implements org.apache.logging.log4j.core.util.Builder<FIPSAuditFilter> {
+
+		@Override
+		public FIPSAuditFilter build() {
+			return new FIPSAuditFilter();
+		}
+
+	}
+
+	private FIPSAuditFilter() {
+		super(Result.ACCEPT, Result.DENY);
+	}
+
+	private boolean _hasRecord(Message message) {
+		if (!(message instanceof ObjectMessage)) {
+			return false;
+		}
+
+		ObjectMessage objectMessage = (ObjectMessage)message;
+
+		if (objectMessage.getParameter() instanceof Map) {
+			return true;
+		}
+
+		return false;
+	}
+
+	private static final Logger _logger = LogManager.getLogger(
+		FIPSAuditFilter.class);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilter.java
@@ -5,12 +5,8 @@
 
 package com.liferay.portal.kernel.internal.log4j;
 
-import com.liferay.petra.string.StringBundler;
-
 import java.util.Map;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.core.Filter;
 import org.apache.logging.log4j.core.LogEvent;
@@ -42,26 +38,20 @@ public final class FIPSAuditFilter extends AbstractFilter {
 		Marker marker = logEvent.getMarker();
 
 		if ((marker == null) ||
-			!marker.isInstanceOf(FIPSLog4jUtil.MARKER_NAME)) {
-
-			_logger.error(
-				StringBundler.concat(
-					"Unable to write the log event from the logger \"",
-					logEvent.getLoggerName(),
-					"\" to the FIPS audit log because it carries no \"",
-					FIPSLog4jUtil.MARKER_NAME, "\" marker"));
+			!marker.isInstanceOf(FIPSLog4jUtil.getMarker())) {
 
 			return Result.DENY;
 		}
 
-		if (!_hasRecord(logEvent.getMessage())) {
-			_logger.error(
-				StringBundler.concat(
-					"Unable to write the log event from the logger \"",
-					logEvent.getLoggerName(),
-					"\" to the FIPS audit log because its message carries no ",
-					"FIPS audit record"));
+		Message message = logEvent.getMessage();
 
+		if (!(message instanceof ObjectMessage)) {
+			return Result.DENY;
+		}
+
+		ObjectMessage objectMessage = (ObjectMessage)message;
+
+		if (!(objectMessage.getParameter() instanceof Map)) {
 			return Result.DENY;
 		}
 
@@ -81,18 +71,5 @@ public final class FIPSAuditFilter extends AbstractFilter {
 	private FIPSAuditFilter() {
 		super(Result.ACCEPT, Result.DENY);
 	}
-
-	private boolean _hasRecord(Message message) {
-		if (!(message instanceof ObjectMessage)) {
-			return false;
-		}
-
-		ObjectMessage objectMessage = (ObjectMessage)message;
-
-		return objectMessage.getParameter() instanceof Map;
-	}
-
-	private static final Logger _logger = LogManager.getLogger(
-		FIPSAuditFilter.class);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilter.java
@@ -89,11 +89,7 @@ public final class FIPSAuditFilter extends AbstractFilter {
 
 		ObjectMessage objectMessage = (ObjectMessage)message;
 
-		if (objectMessage.getParameter() instanceof Map) {
-			return true;
-		}
-
-		return false;
+		return objectMessage.getParameter() instanceof Map;
 	}
 
 	private static final Logger _logger = LogManager.getLogger(

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditFilter.java
@@ -46,9 +46,9 @@ public final class FIPSAuditFilter extends AbstractFilter {
 
 			_logger.error(
 				StringBundler.concat(
-					"Unable to write the event from the logger \"",
+					"Unable to write the log event from the logger \"",
 					logEvent.getLoggerName(),
-					"\" to the FIPS audit trail because it carries no \"",
+					"\" to the FIPS audit log because it carries no \"",
 					FIPSLog4jUtil.MARKER_NAME, "\" marker"));
 
 			return Result.DENY;
@@ -57,10 +57,10 @@ public final class FIPSAuditFilter extends AbstractFilter {
 		if (!_hasRecord(logEvent.getMessage())) {
 			_logger.error(
 				StringBundler.concat(
-					"Unable to write the event from the logger \"",
+					"Unable to write the log event from the logger \"",
 					logEvent.getLoggerName(),
-					"\" to the FIPS audit trail because its message does not ",
-					"carry a FIPS audit record"));
+					"\" to the FIPS audit log because its message carries no ",
+					"FIPS audit record"));
 
 			return Result.DENY;
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
@@ -1,0 +1,107 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.internal.log4j;
+
+import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+
+import java.nio.charset.StandardCharsets;
+
+import java.util.Map;
+
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.Node;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginBuilderFactory;
+import org.apache.logging.log4j.core.layout.AbstractStringLayout;
+import org.apache.logging.log4j.core.layout.ByteBufferDestination;
+import org.apache.logging.log4j.core.layout.Encoder;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.ObjectMessage;
+
+/**
+ * @author Rafael Praxedes
+ * @see    LiferayXmlLayout
+ */
+@Plugin(
+	category = Node.CATEGORY, elementType = Layout.ELEMENT_TYPE,
+	name = FIPSAuditNDJSONLayout.PLUGIN_NAME, printObject = true
+)
+public final class FIPSAuditNDJSONLayout extends AbstractStringLayout {
+
+	public static final String PLUGIN_NAME = "FIPSAuditNDJSONLayout";
+
+	@PluginBuilderFactory
+	public static Builder newBuilder() {
+		return new Builder();
+	}
+
+	@Override
+	public void encode(
+		LogEvent logEvent, ByteBufferDestination byteBufferDestination) {
+
+		StringBuilder sb = getStringBuilder();
+
+		_generateNDJSON(logEvent, sb);
+
+		Encoder<StringBuilder> encoder = getStringBuilderEncoder();
+
+		encoder.encode(sb, byteBufferDestination);
+	}
+
+	@Override
+	public String getContentType() {
+		return "application/x-ndjson; charset=UTF-8";
+	}
+
+	@Override
+	public String toSerializable(LogEvent logEvent) {
+		StringBuilder sb = getStringBuilder();
+
+		_generateNDJSON(logEvent, sb);
+
+		return sb.toString();
+	}
+
+	public static class Builder
+		implements org.apache.logging.log4j.core.util.Builder
+			<FIPSAuditNDJSONLayout> {
+
+		@Override
+		public FIPSAuditNDJSONLayout build() {
+			return new FIPSAuditNDJSONLayout();
+		}
+
+	}
+
+	private FIPSAuditNDJSONLayout() {
+		super(StandardCharsets.UTF_8);
+	}
+
+	private void _generateNDJSON(LogEvent logEvent, StringBuilder sb) {
+		Message message = logEvent.getMessage();
+
+		Object record = null;
+
+		if (message instanceof ObjectMessage) {
+			ObjectMessage objectMessage = (ObjectMessage)message;
+
+			record = objectMessage.getParameter();
+		}
+
+		if (record instanceof Map) {
+			sb.append(JSONFactoryUtil.createJSONObject((Map<?, ?>)record));
+		}
+		else {
+			sb.append(JSONUtil.put("message", message.getFormattedMessage()));
+		}
+
+		sb.append(CharPool.NEW_LINE);
+	}
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
@@ -49,7 +49,7 @@ public final class FIPSAuditNDJSONLayout extends AbstractStringLayout {
 
 		StringBuilder sb = getStringBuilder();
 
-		_generateNDJSON(logEvent, sb);
+		_generateNDJSONLog(logEvent, sb);
 
 		Encoder<StringBuilder> encoder = getStringBuilderEncoder();
 
@@ -65,7 +65,7 @@ public final class FIPSAuditNDJSONLayout extends AbstractStringLayout {
 	public String toSerializable(LogEvent logEvent) {
 		StringBuilder sb = getStringBuilder();
 
-		_generateNDJSON(logEvent, sb);
+		_generateNDJSONLog(logEvent, sb);
 
 		return sb.toString();
 	}
@@ -85,7 +85,7 @@ public final class FIPSAuditNDJSONLayout extends AbstractStringLayout {
 		super(StandardCharsets.UTF_8);
 	}
 
-	private void _generateNDJSON(LogEvent logEvent, StringBuilder sb) {
+	private void _generateNDJSONLog(LogEvent logEvent, StringBuilder sb) {
 		Message message = logEvent.getMessage();
 
 		Object record = null;

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
@@ -47,7 +47,7 @@ public final class FIPSAuditNDJSONLayout extends AbstractStringLayout {
 
 		Encoder<StringBuilder> encoder = getStringBuilderEncoder();
 
-		encoder.encode(_toNDJSONLog(logEvent), byteBufferDestination);
+		encoder.encode(_toNDJSON(logEvent), byteBufferDestination);
 	}
 
 	@Override
@@ -57,7 +57,7 @@ public final class FIPSAuditNDJSONLayout extends AbstractStringLayout {
 
 	@Override
 	public String toSerializable(LogEvent logEvent) {
-		StringBuilder sb = _toNDJSONLog(logEvent);
+		StringBuilder sb = _toNDJSON(logEvent);
 
 		return sb.toString();
 	}
@@ -77,18 +77,18 @@ public final class FIPSAuditNDJSONLayout extends AbstractStringLayout {
 		super(StandardCharsets.UTF_8);
 	}
 
-	private StringBuilder _toNDJSONLog(LogEvent logEvent) {
+	private StringBuilder _toNDJSON(LogEvent logEvent) {
 		Message message = logEvent.getMessage();
 
-		Object object = null;
+		Object parameter = null;
 
 		if (message instanceof ObjectMessage) {
 			ObjectMessage objectMessage = (ObjectMessage)message;
 
-			object = objectMessage.getParameter();
+			parameter = objectMessage.getParameter();
 		}
 
-		if (!(object instanceof Map)) {
+		if (!(parameter instanceof Map)) {
 			throw new IllegalStateException(
 				StringBundler.concat(
 					"Unable to write the log event from the logger \"",
@@ -99,7 +99,7 @@ public final class FIPSAuditNDJSONLayout extends AbstractStringLayout {
 
 		StringBuilder sb = getStringBuilder();
 
-		sb.append(JSONFactoryUtil.createJSONObject((Map<?, ?>)object));
+		sb.append(JSONFactoryUtil.createJSONObject((Map<?, ?>)parameter));
 
 		sb.append(CharPool.NEW_LINE);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
@@ -99,10 +99,10 @@ public final class FIPSAuditNDJSONLayout extends AbstractStringLayout {
 		if (!(record instanceof Map)) {
 			_logger.error(
 				StringBundler.concat(
-					"Unable to write the event from the logger \"",
+					"Unable to write the log event from the logger \"",
 					logEvent.getLoggerName(),
-					"\" to the FIPS audit trail because its message does not ",
-					"carry a FIPS audit record"));
+					"\" to the FIPS audit log because its message carries no ",
+					"FIPS audit record"));
 
 			return;
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
@@ -13,8 +13,6 @@ import java.nio.charset.StandardCharsets;
 
 import java.util.Map;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Node;
@@ -47,13 +45,9 @@ public final class FIPSAuditNDJSONLayout extends AbstractStringLayout {
 	public void encode(
 		LogEvent logEvent, ByteBufferDestination byteBufferDestination) {
 
-		StringBuilder sb = getStringBuilder();
-
-		_generateNDJSONLog(logEvent, sb);
-
 		Encoder<StringBuilder> encoder = getStringBuilderEncoder();
 
-		encoder.encode(sb, byteBufferDestination);
+		encoder.encode(_toNDJSONLog(logEvent), byteBufferDestination);
 	}
 
 	@Override
@@ -63,9 +57,7 @@ public final class FIPSAuditNDJSONLayout extends AbstractStringLayout {
 
 	@Override
 	public String toSerializable(LogEvent logEvent) {
-		StringBuilder sb = getStringBuilder();
-
-		_generateNDJSONLog(logEvent, sb);
+		StringBuilder sb = _toNDJSONLog(logEvent);
 
 		return sb.toString();
 	}
@@ -85,34 +77,33 @@ public final class FIPSAuditNDJSONLayout extends AbstractStringLayout {
 		super(StandardCharsets.UTF_8);
 	}
 
-	private void _generateNDJSONLog(LogEvent logEvent, StringBuilder sb) {
+	private StringBuilder _toNDJSONLog(LogEvent logEvent) {
 		Message message = logEvent.getMessage();
 
-		Object record = null;
+		Object object = null;
 
 		if (message instanceof ObjectMessage) {
 			ObjectMessage objectMessage = (ObjectMessage)message;
 
-			record = objectMessage.getParameter();
+			object = objectMessage.getParameter();
 		}
 
-		if (!(record instanceof Map)) {
-			_logger.error(
+		if (!(object instanceof Map)) {
+			throw new IllegalStateException(
 				StringBundler.concat(
 					"Unable to write the log event from the logger \"",
 					logEvent.getLoggerName(),
 					"\" to the FIPS audit log because its message carries no ",
-					"FIPS audit record"));
-
-			return;
+					"FIPS audit event"));
 		}
 
-		sb.append(JSONFactoryUtil.createJSONObject((Map<?, ?>)record));
+		StringBuilder sb = getStringBuilder();
+
+		sb.append(JSONFactoryUtil.createJSONObject((Map<?, ?>)object));
 
 		sb.append(CharPool.NEW_LINE);
-	}
 
-	private static final Logger _logger = LogManager.getLogger(
-		FIPSAuditNDJSONLayout.class);
+		return sb;
+	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSAuditNDJSONLayout.java
@@ -6,13 +6,15 @@
 package com.liferay.portal.kernel.internal.log4j;
 
 import com.liferay.petra.string.CharPool;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
-import com.liferay.portal.kernel.json.JSONUtil;
 
 import java.nio.charset.StandardCharsets;
 
 import java.util.Map;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Node;
@@ -94,14 +96,23 @@ public final class FIPSAuditNDJSONLayout extends AbstractStringLayout {
 			record = objectMessage.getParameter();
 		}
 
-		if (record instanceof Map) {
-			sb.append(JSONFactoryUtil.createJSONObject((Map<?, ?>)record));
+		if (!(record instanceof Map)) {
+			_logger.error(
+				StringBundler.concat(
+					"Unable to write the event from the logger \"",
+					logEvent.getLoggerName(),
+					"\" to the FIPS audit trail because its message does not ",
+					"carry a FIPS audit record"));
+
+			return;
 		}
-		else {
-			sb.append(JSONUtil.put("message", message.getFormattedMessage()));
-		}
+
+		sb.append(JSONFactoryUtil.createJSONObject((Map<?, ?>)record));
 
 		sb.append(CharPool.NEW_LINE);
 	}
+
+	private static final Logger _logger = LogManager.getLogger(
+		FIPSAuditNDJSONLayout.class);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.message.ObjectMessage;
  * @author Jorge García Jiménez
  * @author Rafael Praxedes
  */
-public class Log4jFIPSAuditUtil {
+public class FIPSLog4jUtil {
 
 	public static void write(
 		Map<String, Object> fields, FIPSAuditEvent.Severity severity) {
@@ -56,7 +56,7 @@ public class Log4jFIPSAuditUtil {
 			throw new IllegalStateException(
 				StringBundler.concat(
 					"Unable to write a FIPS audit record because the logger \"",
-					Log4jFIPSAuditUtil.class.getName(),
+					FIPSLog4jUtil.class.getName(),
 					"\" is disabled for the level \"", level,
 					"\". Check that the portal property ",
 					"\"log4j.configure.on.startup\" is enabled and that no ",
@@ -97,6 +97,6 @@ public class Log4jFIPSAuditUtil {
 	private static final String _APPENDER_NAME = "FIPS_AUDIT_FILE";
 
 	private static final Logger _logger = LogManager.getLogger(
-		Log4jFIPSAuditUtil.class);
+		FIPSLog4jUtil.class);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
@@ -34,13 +34,14 @@ public class FIPSLog4jUtil {
 	}
 
 	public static void write(
-		Map<String, Object> fields, FIPSAuditEvent.Severity severity) {
+		Map<String, Object> fipsAuditLogEntry,
+		FIPSAuditEvent.Severity severity) {
 
 		Level level = _getLevel(severity);
 
 		_validate(level);
 
-		_logger.log(level, _marker, new ObjectMessage(fields));
+		_logger.log(level, _marker, new ObjectMessage(fipsAuditLogEntry));
 	}
 
 	private static Level _getLevel(FIPSAuditEvent.Severity severity) {

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
@@ -15,6 +15,8 @@ import java.util.Map;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
@@ -27,6 +29,8 @@ import org.apache.logging.log4j.message.ObjectMessage;
  */
 public class FIPSLog4jUtil {
 
+	public static final String MARKER_NAME = "FIPS_AUDIT";
+
 	public static void write(
 		Map<String, Object> fields, FIPSAuditEvent.Severity severity) {
 
@@ -34,7 +38,7 @@ public class FIPSLog4jUtil {
 
 		_validate(level);
 
-		_logger.log(level, new ObjectMessage(fields));
+		_logger.log(level, _marker, new ObjectMessage(fields));
 	}
 
 	private static Level _getLevel(FIPSAuditEvent.Severity severity) {
@@ -98,5 +102,7 @@ public class FIPSLog4jUtil {
 
 	private static final Logger _logger = LogManager.getLogger(
 		FIPSLog4jUtil.class);
+
+	private static final Marker _marker = MarkerManager.getMarker(MARKER_NAME);
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
@@ -29,7 +29,9 @@ import org.apache.logging.log4j.message.ObjectMessage;
  */
 public class FIPSLog4jUtil {
 
-	public static final String MARKER_NAME = "FIPS_AUDIT";
+	public static Marker getMarker() {
+		return _marker;
+	}
 
 	public static void write(
 		Map<String, Object> fields, FIPSAuditEvent.Severity severity) {
@@ -95,6 +97,7 @@ public class FIPSLog4jUtil {
 	private static final Logger _logger = LogManager.getLogger(
 		FIPSLog4jUtil.class);
 
-	private static final Marker _marker = MarkerManager.getMarker(MARKER_NAME);
+	private static final Marker _marker = MarkerManager.getMarker(
+		"FIPS_AUDIT_MARKER");
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
@@ -61,7 +61,7 @@ public class FIPSLog4jUtil {
 		if (!_logger.isEnabled(level)) {
 			throw new IllegalStateException(
 				StringBundler.concat(
-					"Unable to write a FIPS audit record because the logger \"",
+					"Unable to write a FIPS audit event because the logger \"",
 					FIPSLog4jUtil.class.getName(),
 					"\" is disabled for the level \"", level,
 					"\". Check that the portal property ",
@@ -79,14 +79,14 @@ public class FIPSLog4jUtil {
 		if (!(appender instanceof RollingFileAppender)) {
 			throw new IllegalStateException(
 				StringBundler.concat(
-					"Unable to write a FIPS audit record because the appender ",
+					"Unable to write a FIPS audit event because the appender ",
 					"\"", _APPENDER_NAME, "\" is not configured"));
 		}
 
 		if (!(appender.getLayout() instanceof FIPSAuditNDJSONLayout)) {
 			throw new IllegalStateException(
 				StringBundler.concat(
-					"Unable to write a FIPS audit record because the appender ",
+					"Unable to write a FIPS audit event because the appender ",
 					"\"", _APPENDER_NAME, "\" does not render it with \"",
 					FIPSAuditNDJSONLayout.PLUGIN_NAME, "\""));
 		}

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
@@ -67,8 +67,6 @@ public class FIPSLog4jUtil {
 					"configuration lowers the level of that logger"));
 		}
 
-		RollingFileAppender rollingFileAppender = null;
-
 		LoggerContext loggerContext = (LoggerContext)LogManager.getContext(
 			false);
 
@@ -76,20 +74,14 @@ public class FIPSLog4jUtil {
 
 		Appender appender = configuration.getAppender(_APPENDER_NAME);
 
-		if (appender instanceof RollingFileAppender) {
-			rollingFileAppender = (RollingFileAppender)appender;
-		}
-
-		if (rollingFileAppender == null) {
+		if (!(appender instanceof RollingFileAppender)) {
 			throw new IllegalStateException(
 				StringBundler.concat(
 					"Unable to write a FIPS audit record because the appender ",
 					"\"", _APPENDER_NAME, "\" is not configured"));
 		}
 
-		if (!(rollingFileAppender.getLayout() instanceof
-				FIPSAuditNDJSONLayout)) {
-
+		if (!(appender.getLayout() instanceof FIPSAuditNDJSONLayout)) {
 			throw new IllegalStateException(
 				StringBundler.concat(
 					"Unable to write a FIPS audit record because the appender ",

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/Log4jFIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/Log4jFIPSAuditUtil.java
@@ -1,0 +1,106 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.internal.log4j;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.security.fips.FIPSAuditEvent;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.ServerDetector;
+
+import java.util.Map;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.message.ObjectMessage;
+
+/**
+ * @author Jorge García Jiménez
+ * @author Rafael Praxedes
+ */
+public class Log4jFIPSAuditUtil {
+
+	public static void write(
+		Map<String, Object> record, FIPSAuditEvent.Severity severity) {
+
+		Level level = _getLevel(severity);
+
+		_validateDeliverable(level);
+
+		_logger.log(level, new ObjectMessage(record));
+	}
+
+	private static Level _getLevel(FIPSAuditEvent.Severity severity) {
+		if (severity == FIPSAuditEvent.Severity.CRITICAL) {
+			return Level.ERROR;
+		}
+
+		return Level.INFO;
+	}
+
+	private static RollingFileAppender _getRollingFileAppender() {
+		LoggerContext loggerContext = (LoggerContext)LogManager.getContext(
+			false);
+
+		Configuration configuration = loggerContext.getConfiguration();
+
+		Appender appender = configuration.getAppender(_APPENDER_NAME);
+
+		if (appender instanceof RollingFileAppender) {
+			return (RollingFileAppender)appender;
+		}
+
+		return null;
+	}
+
+	private static void _validateDeliverable(Level level) {
+		if (!PropsValues.FIPS_ENABLED ||
+			(ServerDetector.getServerId() == null)) {
+
+			return;
+		}
+
+		if (!_logger.isEnabled(level)) {
+			throw new IllegalStateException(
+				StringBundler.concat(
+					"Unable to write a FIPS audit record because the logger \"",
+					Log4jFIPSAuditUtil.class.getName(),
+					"\" is disabled for the level \"", level,
+					"\". Check that the portal property ",
+					"\"log4j.configure.on.startup\" is enabled and that no ",
+					"configuration lowers the level of that logger"));
+		}
+
+		RollingFileAppender rollingFileAppender = _getRollingFileAppender();
+
+		if (rollingFileAppender == null) {
+			throw new IllegalStateException(
+				StringBundler.concat(
+					"Unable to write a FIPS audit record because the appender ",
+					"\"", _APPENDER_NAME, "\" is not configured"));
+		}
+
+		if (!(rollingFileAppender.getLayout() instanceof
+				FIPSAuditNDJSONLayout)) {
+
+			throw new IllegalStateException(
+				StringBundler.concat(
+					"Unable to write a FIPS audit record because the appender ",
+					"\"", _APPENDER_NAME, "\" does not render it with \"",
+					FIPSAuditNDJSONLayout.PLUGIN_NAME, "\""));
+		}
+	}
+
+	private static final String _APPENDER_NAME = "FIPS_AUDIT_FILE";
+
+	private static final Logger _logger = LogManager.getLogger(
+		Log4jFIPSAuditUtil.class);
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/Log4jFIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/Log4jFIPSAuditUtil.java
@@ -28,13 +28,13 @@ import org.apache.logging.log4j.message.ObjectMessage;
 public class Log4jFIPSAuditUtil {
 
 	public static void write(
-		Map<String, Object> record, FIPSAuditEvent.Severity severity) {
+		Map<String, Object> fields, FIPSAuditEvent.Severity severity) {
 
 		Level level = _getLevel(severity);
 
-		_validateDeliverable(level);
+		_validate(level);
 
-		_logger.log(level, new ObjectMessage(record));
+		_logger.log(level, new ObjectMessage(fields));
 	}
 
 	private static Level _getLevel(FIPSAuditEvent.Severity severity) {
@@ -45,22 +45,7 @@ public class Log4jFIPSAuditUtil {
 		return Level.INFO;
 	}
 
-	private static RollingFileAppender _getRollingFileAppender() {
-		LoggerContext loggerContext = (LoggerContext)LogManager.getContext(
-			false);
-
-		Configuration configuration = loggerContext.getConfiguration();
-
-		Appender appender = configuration.getAppender(_APPENDER_NAME);
-
-		if (appender instanceof RollingFileAppender) {
-			return (RollingFileAppender)appender;
-		}
-
-		return null;
-	}
-
-	private static void _validateDeliverable(Level level) {
+	private static void _validate(Level level) {
 		if (!PropsValues.FIPS_ENABLED ||
 			(ServerDetector.getServerId() == null)) {
 
@@ -78,7 +63,18 @@ public class Log4jFIPSAuditUtil {
 					"configuration lowers the level of that logger"));
 		}
 
-		RollingFileAppender rollingFileAppender = _getRollingFileAppender();
+		RollingFileAppender rollingFileAppender = null;
+
+		LoggerContext loggerContext = (LoggerContext)LogManager.getContext(
+			false);
+
+		Configuration configuration = loggerContext.getConfiguration();
+
+		Appender appender = configuration.getAppender(_APPENDER_NAME);
+
+		if (appender instanceof RollingFileAppender) {
+			rollingFileAppender = (RollingFileAppender)appender;
+		}
 
 		if (rollingFileAppender == null) {
 			throw new IllegalStateException(

--- a/portal-kernel/src/com/liferay/portal/kernel/log4j/Log4JUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/log4j/Log4JUtil.java
@@ -76,7 +76,7 @@ public class Log4JUtil {
 		}
 		else {
 			priorities = Log4jConfigUtil.configureLog4J(
-				urlContent, "TEXT_FILE", "XML_FILE");
+				urlContent, "FIPS_AUDIT_FILE", "TEXT_FILE", "XML_FILE");
 		}
 
 		for (Map.Entry<String, String> entry : priorities.entrySet()) {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationState.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationState.java
@@ -10,6 +10,7 @@ package com.liferay.portal.kernel.security.fips;
  */
 public enum FIPSApplicationState {
 
-	ERROR, INITIALIZING, OPERATIONAL, POWER_OFF, SELF_TEST
+	ERROR, INITIALIZING, KEY_CSP_ENTRY, OPERATIONAL, POWER_OFF, QUIESCENT,
+	SELF_TEST
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
@@ -6,66 +6,228 @@
 package com.liferay.portal.kernel.security.fips;
 
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 /**
  * @author Jorge García Jiménez
  */
 public class FIPSApplicationStateMachineUtil {
 
+	public static void error(String failedStep, Throwable throwable) {
+		_transition(
+			FIPSApplicationState.ERROR,
+			fipsAuditEvent -> {
+				fipsAuditEvent.put("failed-step", failedStep);
+				fipsAuditEvent.put(
+					"provider-error-message", _getMessage(throwable));
+			});
+	}
+
 	public static FIPSApplicationState getFIPSApplicationState() {
 		return _fipsApplicationStateAtomicReference.get();
 	}
 
+	public static void keyCSPEntry(
+		String cryptoOfficerUserId, String operationType, Runnable runnable) {
+
+		_transition(
+			FIPSApplicationState.KEY_CSP_ENTRY,
+			fipsAuditEvent -> {
+				fipsAuditEvent.put(
+					"crypto-officer-user-id", cryptoOfficerUserId);
+				fipsAuditEvent.put("operation-type", operationType);
+			});
+
+		_runAndTransitionToOperational(
+			"Key or CSP entry", "The operation was completed successfully",
+			runnable);
+	}
+
+	public static void operational(String cryptoOfficerUserId, String reason) {
+		_transition(
+			FIPSApplicationState.OPERATIONAL,
+			fipsAuditEvent -> {
+				fipsAuditEvent.put(
+					"crypto-officer-user-id", cryptoOfficerUserId);
+				fipsAuditEvent.put("reason", reason);
+			});
+	}
+
+	public static void powerOff(String initiatingActor) {
+		_transition(
+			FIPSApplicationState.POWER_OFF,
+			fipsAuditEvent -> fipsAuditEvent.put(
+				"initiating-actor", initiatingActor));
+	}
+
+	public static void quiescent(String cryptoOfficerUserId, String reason) {
+		_transition(
+			FIPSApplicationState.QUIESCENT,
+			fipsAuditEvent -> {
+				fipsAuditEvent.put(
+					"crypto-officer-user-id", cryptoOfficerUserId);
+				fipsAuditEvent.put("reason", reason);
+			});
+	}
+
 	public static void selfTest(Runnable runnable) {
-		_transition(FIPSApplicationState.SELF_TEST);
+		_transition(
+			FIPSApplicationState.SELF_TEST,
+			fipsAuditEvent -> fipsAuditEvent.put(
+				"message", "The integrity checks were started"));
+
+		_runSelfTest(runnable);
+	}
+
+	public static void selfTest(
+		String cryptoOfficerUserId, String recoveryAction, Runnable runnable) {
+
+		_transition(
+			FIPSApplicationState.SELF_TEST,
+			fipsAuditEvent -> {
+				fipsAuditEvent.put(
+					"crypto-officer-user-id", cryptoOfficerUserId);
+				fipsAuditEvent.put("recovery-action", recoveryAction);
+			});
+
+		_runSelfTest(runnable);
+	}
+
+	private static String _getMessage(Throwable throwable) {
+		String message = throwable.getMessage();
+
+		if (message == null) {
+			return throwable.toString();
+		}
+
+		return message;
+	}
+
+	private static FIPSAuditEvent.Severity _getSeverity(
+		FIPSApplicationState fipsApplicationState) {
+
+		if (fipsApplicationState == FIPSApplicationState.ERROR) {
+			return FIPSAuditEvent.Severity.CRITICAL;
+		}
+
+		return FIPSAuditEvent.Severity.INFO;
+	}
+
+	private static void _registerShutdownHook() {
+		Runtime runtime = Runtime.getRuntime();
+
+		runtime.addShutdownHook(
+			new Thread(
+				() -> {
+					if (getFIPSApplicationState() ==
+							FIPSApplicationState.POWER_OFF) {
+
+						return;
+					}
+
+					try {
+						powerOff("OS signal");
+					}
+					catch (Throwable throwable) {
+						if (_log.isDebugEnabled()) {
+							_log.debug(throwable);
+						}
+					}
+				}));
+	}
+
+	private static void _runAndTransitionToOperational(
+		String failedStep, String message, Runnable runnable) {
 
 		try {
 			runnable.run();
 		}
 		catch (Throwable throwable) {
-			_transition(FIPSApplicationState.ERROR);
+			error(failedStep, throwable);
 
 			throw throwable;
 		}
 
-		_transition(FIPSApplicationState.OPERATIONAL);
+		_transition(
+			FIPSApplicationState.OPERATIONAL,
+			fipsAuditEvent -> fipsAuditEvent.put("message", message));
 	}
 
-	private static void _transition(FIPSApplicationState fipsApplicationState) {
-		_fipsApplicationStateAtomicReference.updateAndGet(
-			currentFIPSApplicationState -> {
-				Set<FIPSApplicationState> nextFIPSApplicationStates =
-					_allowedTransitions.getOrDefault(
-						currentFIPSApplicationState, Set.of());
-
-				if (!nextFIPSApplicationStates.contains(fipsApplicationState)) {
-					throw new IllegalStateException(
-						StringBundler.concat(
-							"Unable to transition the FIPS application state ",
-							"from \"", currentFIPSApplicationState, "\" to \"",
-							fipsApplicationState, "\""));
-				}
-
-				return fipsApplicationState;
-			});
+	private static void _runSelfTest(Runnable runnable) {
+		_runAndTransitionToOperational(
+			"Self test",
+			"All checks and the validated provider self tests passed",
+			runnable);
 	}
+
+	private static void _transition(
+		FIPSApplicationState fipsApplicationState,
+		Consumer<FIPSAuditEvent> fipsAuditEventConsumer) {
+
+		FIPSApplicationState previousFIPSApplicationState =
+			_fipsApplicationStateAtomicReference.getAndUpdate(
+				currentFIPSApplicationState -> {
+					Set<FIPSApplicationState> nextFIPSApplicationStates =
+						_allowedTransitions.getOrDefault(
+							currentFIPSApplicationState, Set.of());
+
+					if (!nextFIPSApplicationStates.contains(
+							fipsApplicationState)) {
+
+						throw new IllegalStateException(
+							StringBundler.concat(
+								"Unable to transition the FIPS application ",
+								"state from \"", currentFIPSApplicationState,
+								"\" to \"", fipsApplicationState, "\""));
+					}
+
+					return fipsApplicationState;
+				});
+
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			"fips-state-transition", _getSeverity(fipsApplicationState));
+
+		fipsAuditEvent.put("from-state", previousFIPSApplicationState.name());
+		fipsAuditEvent.put("to-state", fipsApplicationState.name());
+
+		fipsAuditEventConsumer.accept(fipsAuditEvent);
+
+		FIPSAuditUtil.write(fipsAuditEvent);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FIPSApplicationStateMachineUtil.class);
 
 	private static final Map<FIPSApplicationState, Set<FIPSApplicationState>>
 		_allowedTransitions = Map.of(
-			FIPSApplicationState.ERROR, Set.of(FIPSApplicationState.POWER_OFF),
+			FIPSApplicationState.ERROR,
+			Set.of(
+				FIPSApplicationState.POWER_OFF, FIPSApplicationState.SELF_TEST),
 			FIPSApplicationState.INITIALIZING,
 			Set.of(
 				FIPSApplicationState.ERROR, FIPSApplicationState.POWER_OFF,
 				FIPSApplicationState.SELF_TEST),
+			FIPSApplicationState.KEY_CSP_ENTRY,
+			Set.of(
+				FIPSApplicationState.ERROR, FIPSApplicationState.OPERATIONAL,
+				FIPSApplicationState.POWER_OFF),
 			FIPSApplicationState.OPERATIONAL,
 			Set.of(
-				FIPSApplicationState.ERROR, FIPSApplicationState.POWER_OFF,
+				FIPSApplicationState.ERROR, FIPSApplicationState.KEY_CSP_ENTRY,
+				FIPSApplicationState.POWER_OFF, FIPSApplicationState.QUIESCENT,
 				FIPSApplicationState.SELF_TEST),
 			FIPSApplicationState.POWER_OFF, Set.of(),
+			FIPSApplicationState.QUIESCENT,
+			Set.of(
+				FIPSApplicationState.ERROR, FIPSApplicationState.KEY_CSP_ENTRY,
+				FIPSApplicationState.OPERATIONAL,
+				FIPSApplicationState.POWER_OFF),
 			FIPSApplicationState.SELF_TEST,
 			Set.of(
 				FIPSApplicationState.ERROR, FIPSApplicationState.OPERATIONAL,
@@ -73,5 +235,9 @@ public class FIPSApplicationStateMachineUtil {
 	private static final AtomicReference<FIPSApplicationState>
 		_fipsApplicationStateAtomicReference = new AtomicReference<>(
 			FIPSApplicationState.INITIALIZING);
+
+	static {
+		_registerShutdownHook();
+	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
@@ -8,6 +8,7 @@ package com.liferay.portal.kernel.security.fips;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.PropsValues;
 
 import java.util.Map;
 import java.util.Set;
@@ -237,7 +238,9 @@ public class FIPSApplicationStateMachineUtil {
 			FIPSApplicationState.INITIALIZING);
 
 	static {
-		_registerShutdownHook();
+		if (PropsValues.FIPS_ENABLED) {
+			_registerShutdownHook();
+		}
 	}
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtil.java
@@ -133,7 +133,7 @@ public class FIPSApplicationStateMachineUtil {
 					}
 
 					try {
-						powerOff("OS signal");
+						powerOff("Operating system");
 					}
 					catch (Throwable throwable) {
 						if (_log.isDebugEnabled()) {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
@@ -36,12 +36,10 @@ public class FIPSAuditEvent {
 		return _severity;
 	}
 
-	public FIPSAuditEvent put(String key, Object value) {
+	public void put(String key, Object value) {
 		_validate(key, value);
 
 		_fields.put(key, value);
-
-		return this;
 	}
 
 	public enum Severity {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
@@ -7,6 +7,8 @@ package com.liferay.portal.kernel.security.fips;
 
 import com.liferay.petra.string.StringBundler;
 
+import java.lang.reflect.Array;
+
 import java.security.Key;
 import java.security.spec.KeySpec;
 
@@ -79,6 +81,14 @@ public class FIPSAuditEvent {
 					"event"));
 		}
 
+		if (_isSensitiveSecurityParameter(value)) {
+			throw new IllegalArgumentException(
+				StringBundler.concat(
+					"Unable to write the FIPS audit field \"", key,
+					"\" because a sensitive security parameter must never ",
+					"reach a FIPS audit event"));
+		}
+
 		if (value instanceof Iterable) {
 			for (Object curValue : (Iterable<?>)value) {
 				_validate(key, curValue);
@@ -97,20 +107,22 @@ public class FIPSAuditEvent {
 			return;
 		}
 
+		Class<?> valueClass = value.getClass();
+
+		if (valueClass.isArray()) {
+			for (int i = 0; i < Array.getLength(value); i++) {
+				_validate(key, Array.get(value, i));
+			}
+
+			return;
+		}
+
 		if (_isNonfiniteNumber(value)) {
 			throw new IllegalArgumentException(
 				StringBundler.concat(
 					"Unable to write the FIPS audit field \"", key,
 					"\" because the number \"", value,
 					"\" is not finite and has no JSON representation"));
-		}
-
-		if (_isSensitiveSecurityParameter(value)) {
-			throw new IllegalArgumentException(
-				StringBundler.concat(
-					"Unable to write the FIPS audit field \"", key,
-					"\" because a sensitive security parameter must never ",
-					"reach a FIPS audit event"));
 		}
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
@@ -76,7 +76,7 @@ public class FIPSAuditEvent {
 				StringBundler.concat(
 					"Unable to write the FIPS audit field \"", key,
 					"\" because a null value is dropped from a FIPS audit ",
-					"record"));
+					"event"));
 		}
 
 		if (value instanceof Iterable) {
@@ -110,7 +110,7 @@ public class FIPSAuditEvent {
 				StringBundler.concat(
 					"Unable to write the FIPS audit field \"", key,
 					"\" because a sensitive security parameter must never ",
-					"reach a FIPS audit record"));
+					"reach a FIPS audit event"));
 		}
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
@@ -1,0 +1,123 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.petra.string.StringBundler;
+
+import java.security.Key;
+import java.security.spec.KeySpec;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSAuditEvent {
+
+	public FIPSAuditEvent(String eventType, Severity severity) {
+		_eventType = eventType;
+		_severity = severity;
+	}
+
+	public String getEventType() {
+		return _eventType;
+	}
+
+	public Map<String, Object> getFields() {
+		return Collections.unmodifiableMap(_fields);
+	}
+
+	public Severity getSeverity() {
+		return _severity;
+	}
+
+	public FIPSAuditEvent put(String key, Object value) {
+		_validate(key, value);
+
+		_fields.put(key, value);
+
+		return this;
+	}
+
+	public enum Severity {
+
+		CRITICAL, INFO
+
+	}
+
+	private boolean _isNonfiniteNumber(Object value) {
+		if (value instanceof Double) {
+			return !Double.isFinite((Double)value);
+		}
+
+		if (value instanceof Float) {
+			return !Float.isFinite((Float)value);
+		}
+
+		return false;
+	}
+
+	private boolean _isSensitiveSecurityParameter(Object value) {
+		if (value instanceof byte[] || value instanceof char[] ||
+			value instanceof Key || value instanceof KeySpec) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private void _validate(String key, Object value) {
+		if (value == null) {
+			throw new IllegalArgumentException(
+				StringBundler.concat(
+					"Unable to record the FIPS audit field \"", key,
+					"\" because a null value is dropped from an audit record ",
+					"instead of being written"));
+		}
+
+		if (value instanceof Iterable) {
+			for (Object curValue : (Iterable<?>)value) {
+				_validate(key, curValue);
+			}
+
+			return;
+		}
+
+		if (value instanceof Map) {
+			Map<?, ?> map = (Map<?, ?>)value;
+
+			for (Map.Entry<?, ?> entry : map.entrySet()) {
+				_validate(key, entry.getValue());
+			}
+
+			return;
+		}
+
+		if (_isNonfiniteNumber(value)) {
+			throw new IllegalArgumentException(
+				StringBundler.concat(
+					"Unable to record the FIPS audit field \"", key,
+					"\" because the number \"", value,
+					"\" is not finite and cannot be written as JSON"));
+		}
+
+		if (_isSensitiveSecurityParameter(value)) {
+			throw new IllegalArgumentException(
+				StringBundler.concat(
+					"Unable to record the FIPS audit field \"", key,
+					"\" because a sensitive security parameter must never ",
+					"reach an audit record"));
+		}
+	}
+
+	private final String _eventType;
+	private final Map<String, Object> _fields = new LinkedHashMap<>();
+	private final Severity _severity;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
@@ -76,9 +76,9 @@ public class FIPSAuditEvent {
 		if (value == null) {
 			throw new IllegalArgumentException(
 				StringBundler.concat(
-					"Unable to record the FIPS audit field \"", key,
-					"\" because a null value is dropped from an audit record ",
-					"instead of being written"));
+					"Unable to write the FIPS audit field \"", key,
+					"\" because a null value is dropped from a FIPS audit ",
+					"record"));
 		}
 
 		if (value instanceof Iterable) {
@@ -102,17 +102,17 @@ public class FIPSAuditEvent {
 		if (_isNonfiniteNumber(value)) {
 			throw new IllegalArgumentException(
 				StringBundler.concat(
-					"Unable to record the FIPS audit field \"", key,
+					"Unable to write the FIPS audit field \"", key,
 					"\" because the number \"", value,
-					"\" is not finite and cannot be written as JSON"));
+					"\" is not finite and has no JSON representation"));
 		}
 
 		if (_isSensitiveSecurityParameter(value)) {
 			throw new IllegalArgumentException(
 				StringBundler.concat(
-					"Unable to record the FIPS audit field \"", key,
+					"Unable to write the FIPS audit field \"", key,
 					"\" because a sensitive security parameter must never ",
-					"reach an audit record"));
+					"reach a FIPS audit record"));
 		}
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.kernel.security.fips;
 
+import com.liferay.petra.concurrent.DCLSingleton;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -44,6 +45,8 @@ import java.util.concurrent.atomic.AtomicLong;
 public class FIPSAuditUtil {
 
 	public static void write(FIPSAuditEvent fipsAuditEvent) {
+		Provider provider = _getProvider();
+
 		FIPSAuditEvent.Severity severity = fipsAuditEvent.getSeverity();
 
 		FIPSLog4jUtil.write(
@@ -61,27 +64,9 @@ public class FIPSAuditUtil {
 			).put(
 				"fields", _normalizeTimestamps(fipsAuditEvent.getFields())
 			).put(
-				"provider-name",
-				() -> {
-					Provider provider = _getProvider();
-
-					if (provider == null) {
-						return "";
-					}
-
-					return provider.getName();
-				}
+				"provider-name", _getProviderName(provider)
 			).put(
-				"provider-version",
-				() -> {
-					Provider provider = _getProvider();
-
-					if (provider == null) {
-						return "";
-					}
-
-					return provider.getVersionStr();
-				}
+				"provider-version", _getProviderVersion(provider)
 			).put(
 				"severity", severity.name()
 			).put(
@@ -90,18 +75,7 @@ public class FIPSAuditUtil {
 			severity);
 	}
 
-	private static String _formatTimestamp(Instant instant) {
-		return _dateTimeFormatter.format(instant.atZone(ZoneOffset.UTC));
-	}
-
-	private static String _getDeploymentInstanceId() {
-		String deploymentInstanceId =
-			PropsValues.FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID;
-
-		if (Validator.isNotNull(deploymentInstanceId)) {
-			return deploymentInstanceId;
-		}
-
+	private static String _deriveDeploymentInstanceId() {
 		Path path = Paths.get(
 			PropsValues.LIFERAY_HOME, "data",
 			"fips-audit-deployment-instance-id");
@@ -124,9 +98,25 @@ public class FIPSAuditUtil {
 		}
 		catch (IOException ioException) {
 			throw new UncheckedIOException(
-				"Unable to resolve the FIPS deployment instance ID",
+				"Unable to resolve the FIPS audit deployment instance ID",
 				ioException);
 		}
+	}
+
+	private static String _formatTimestamp(Instant instant) {
+		return _dateTimeFormatter.format(instant.atZone(ZoneOffset.UTC));
+	}
+
+	private static String _getDeploymentInstanceId() {
+		String deploymentInstanceId =
+			PropsValues.FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID;
+
+		if (Validator.isNotNull(deploymentInstanceId)) {
+			return deploymentInstanceId;
+		}
+
+		return _deploymentInstanceIdDCLSingleton.getSingleton(
+			FIPSAuditUtil::_deriveDeploymentInstanceId);
 	}
 
 	private static Provider _getProvider() {
@@ -137,6 +127,22 @@ public class FIPSAuditUtil {
 		}
 
 		return providers[0];
+	}
+
+	private static String _getProviderName(Provider provider) {
+		if (provider == null) {
+			return "";
+		}
+
+		return provider.getName();
+	}
+
+	private static String _getProviderVersion(Provider provider) {
+		if (provider == null) {
+			return "";
+		}
+
+		return provider.getVersionStr();
 	}
 
 	private static Object _normalizeTimestamp(Object value) {
@@ -192,6 +198,8 @@ public class FIPSAuditUtil {
 
 	private static final DateTimeFormatter _dateTimeFormatter =
 		DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+	private static final DCLSingleton<String>
+		_deploymentInstanceIdDCLSingleton = new DCLSingleton<>();
 	private static final AtomicLong _eventSequence = new AtomicLong();
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
@@ -160,7 +160,9 @@ public class FIPSAuditUtil {
 			return _normalizeTimestamps((Map<?, ?>)value);
 		}
 
-		if (value instanceof TemporalAccessor temporalAccessor) {
+		if (value instanceof TemporalAccessor) {
+			TemporalAccessor temporalAccessor = (TemporalAccessor)value;
+
 			try {
 				return _formatTimestamp(Instant.from(temporalAccessor));
 			}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
@@ -10,12 +10,15 @@ import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.PropsValues;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+
+import java.lang.reflect.Array;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -61,7 +64,8 @@ public class FIPSAuditUtil {
 		FIPSLog4jUtil.write(
 			LinkedHashMapBuilder.<String, Object>put(
 				"cmvp-certificate-id",
-				PropsValues.FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID
+				GetterUtil.getString(
+					PropsValues.FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID)
 			).put(
 				"deployment-instance-id", _getDeploymentInstanceId()
 			).put(
@@ -172,6 +176,18 @@ public class FIPSAuditUtil {
 						temporalAccessor, "\" because it carries no time zone"),
 					dateTimeException);
 			}
+		}
+
+		Class<?> valueClass = value.getClass();
+
+		if (valueClass.isArray()) {
+			List<Object> normalizedValues = new ArrayList<>();
+
+			for (int i = 0; i < Array.getLength(value); i++) {
+				normalizedValues.add(_normalizeTimestamp(Array.get(value, i)));
+			}
+
+			return normalizedValues;
 		}
 
 		return value;

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
@@ -1,0 +1,199 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.internal.log4j.Log4jFIPSAuditUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import java.security.Provider;
+import java.security.Security;
+
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author Jorge García Jiménez
+ * @author Rafael Praxedes
+ */
+public class FIPSAuditUtil {
+
+	public static void write(FIPSAuditEvent fipsAuditEvent) {
+		FIPSAuditEvent.Severity severity = fipsAuditEvent.getSeverity();
+
+		Log4jFIPSAuditUtil.write(
+			LinkedHashMapBuilder.<String, Object>put(
+				"cmvp-certificate-id",
+				PropsValues.FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID
+			).put(
+				"deployment-instance-id", _getDeploymentInstanceId()
+			).put(
+				"event-schema-version", "1.0"
+			).put(
+				"event-sequence", _eventSequence.incrementAndGet()
+			).put(
+				"event-type", fipsAuditEvent.getEventType()
+			).put(
+				"fields", _normalizeTimestamps(fipsAuditEvent.getFields())
+			).put(
+				"provider-name",
+				() -> {
+					Provider provider = _getProvider();
+
+					if (provider == null) {
+						return "";
+					}
+
+					return provider.getName();
+				}
+			).put(
+				"provider-version",
+				() -> {
+					Provider provider = _getProvider();
+
+					if (provider == null) {
+						return "";
+					}
+
+					return provider.getVersionStr();
+				}
+			).put(
+				"severity", severity.name()
+			).put(
+				"timestamp", () -> _formatTimestamp(Instant.now())
+			).build(),
+			severity);
+	}
+
+	private static String _formatTimestamp(Instant instant) {
+		return _dateTimeFormatter.format(instant.atZone(ZoneOffset.UTC));
+	}
+
+	private static String _getDeploymentInstanceId() {
+		String deploymentInstanceId =
+			PropsValues.FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID;
+
+		if (Validator.isNotNull(deploymentInstanceId)) {
+			return deploymentInstanceId;
+		}
+
+		Path path = Paths.get(
+			PropsValues.LIFERAY_HOME, "data",
+			"fips-audit-deployment-instance-id");
+
+		try {
+			if (Files.exists(path)) {
+				String persistedId = new String(
+					Files.readAllBytes(path), StandardCharsets.UTF_8);
+
+				return persistedId.trim();
+			}
+
+			String generatedId = String.valueOf(UUID.randomUUID());
+
+			Files.createDirectories(path.getParent());
+
+			Files.write(path, generatedId.getBytes(StandardCharsets.UTF_8));
+
+			return generatedId;
+		}
+		catch (IOException ioException) {
+			throw new UncheckedIOException(
+				"Unable to resolve the FIPS deployment instance ID",
+				ioException);
+		}
+	}
+
+	private static Provider _getProvider() {
+		Provider[] providers = Security.getProviders();
+
+		if (ArrayUtil.isEmpty(providers)) {
+			return null;
+		}
+
+		return providers[0];
+	}
+
+	private static Object _normalizeTimestamp(Object value) {
+		if (value instanceof Date) {
+			Date date = (Date)value;
+
+			return _formatTimestamp(date.toInstant());
+		}
+
+		if (value instanceof Iterable) {
+			List<Object> normalizedValues = new ArrayList<>();
+
+			for (Object curValue : (Iterable<?>)value) {
+				normalizedValues.add(_normalizeTimestamp(curValue));
+			}
+
+			return normalizedValues;
+		}
+
+		if (value instanceof Map) {
+			return _normalizeTimestamps((Map<?, ?>)value);
+		}
+
+		if (value instanceof TemporalAccessor) {
+			return _formatTimestamp(_toInstant((TemporalAccessor)value));
+		}
+
+		return value;
+	}
+
+	private static Map<String, Object> _normalizeTimestamps(Map<?, ?> map) {
+		Map<String, Object> normalizedMap = new LinkedHashMap<>();
+
+		for (Map.Entry<?, ?> entry : map.entrySet()) {
+			normalizedMap.put(
+				String.valueOf(entry.getKey()),
+				_normalizeTimestamp(entry.getValue()));
+		}
+
+		return normalizedMap;
+	}
+
+	private static Instant _toInstant(TemporalAccessor temporalAccessor) {
+		try {
+			return Instant.from(temporalAccessor);
+		}
+		catch (DateTimeException dateTimeException) {
+			throw new IllegalArgumentException(
+				StringBundler.concat(
+					"Unable to normalize the FIPS audit timestamp \"",
+					temporalAccessor, "\" because it carries no time zone"),
+				dateTimeException);
+		}
+	}
+
+	private static final DateTimeFormatter _dateTimeFormatter =
+		DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+	private static final AtomicLong _eventSequence = new AtomicLong();
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
@@ -6,7 +6,7 @@
 package com.liferay.portal.kernel.security.fips;
 
 import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.internal.log4j.Log4jFIPSAuditUtil;
+import com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -46,7 +46,7 @@ public class FIPSAuditUtil {
 	public static void write(FIPSAuditEvent fipsAuditEvent) {
 		FIPSAuditEvent.Severity severity = fipsAuditEvent.getSeverity();
 
-		Log4jFIPSAuditUtil.write(
+		FIPSLog4jUtil.write(
 			LinkedHashMapBuilder.<String, Object>put(
 				"cmvp-certificate-id",
 				PropsValues.FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
@@ -48,6 +48,14 @@ public class FIPSAuditUtil {
 	public static void write(FIPSAuditEvent fipsAuditEvent) {
 		Provider provider = _getProvider();
 
+		String providerName = StringPool.BLANK;
+		String providerVersion = StringPool.BLANK;
+
+		if (provider != null) {
+			providerName = provider.getName();
+			providerVersion = provider.getVersionStr();
+		}
+
 		FIPSAuditEvent.Severity severity = fipsAuditEvent.getSeverity();
 
 		FIPSLog4jUtil.write(
@@ -65,11 +73,9 @@ public class FIPSAuditUtil {
 			).put(
 				"fields", _normalizeTimestamps(fipsAuditEvent.getFields())
 			).put(
-				"provider-name",
-				(provider == null) ? StringPool.BLANK : provider.getName()
+				"provider-name", providerName
 			).put(
-				"provider-version",
-				(provider == null) ? StringPool.BLANK : provider.getVersionStr()
+				"provider-version", providerVersion
 			).put(
 				"severity", severity.name()
 			).put(

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
@@ -160,8 +160,17 @@ public class FIPSAuditUtil {
 			return _normalizeTimestamps((Map<?, ?>)value);
 		}
 
-		if (value instanceof TemporalAccessor) {
-			return _formatTimestamp(_toInstant((TemporalAccessor)value));
+		if (value instanceof TemporalAccessor temporalAccessor) {
+			try {
+				return _formatTimestamp(Instant.from(temporalAccessor));
+			}
+			catch (DateTimeException dateTimeException) {
+				throw new IllegalArgumentException(
+					StringBundler.concat(
+						"Unable to normalize the FIPS audit timestamp \"",
+						temporalAccessor, "\" because it carries no time zone"),
+					dateTimeException);
+			}
 		}
 
 		return value;
@@ -177,19 +186,6 @@ public class FIPSAuditUtil {
 		}
 
 		return normalizedMap;
-	}
-
-	private static Instant _toInstant(TemporalAccessor temporalAccessor) {
-		try {
-			return Instant.from(temporalAccessor);
-		}
-		catch (DateTimeException dateTimeException) {
-			throw new IllegalArgumentException(
-				StringBundler.concat(
-					"Unable to normalize the FIPS audit timestamp \"",
-					temporalAccessor, "\" because it carries no time zone"),
-				dateTimeException);
-		}
 	}
 
 	private static final DateTimeFormatter _dateTimeFormatter =

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
@@ -9,7 +9,6 @@ import com.liferay.petra.concurrent.DCLSingleton;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.PropsValues;
@@ -26,7 +25,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import java.security.Provider;
-import java.security.Security;
 
 import java.time.DateTimeException;
 import java.time.Instant;
@@ -49,7 +47,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public class FIPSAuditUtil {
 
 	public static void write(FIPSAuditEvent fipsAuditEvent) {
-		Provider provider = _getProvider();
+		Provider provider = FIPSModeValidator.getProvider();
 
 		String providerName = StringPool.BLANK;
 		String providerVersion = StringPool.BLANK;
@@ -83,7 +81,7 @@ public class FIPSAuditUtil {
 			).put(
 				"severity", severity.name()
 			).put(
-				"timestamp", () -> _formatTimestamp(Instant.now())
+				"timestamp", _formatTimestamp(Instant.now())
 			).build(),
 			severity);
 	}
@@ -92,7 +90,19 @@ public class FIPSAuditUtil {
 		return _dateTimeFormatter.format(instant.atZone(ZoneOffset.UTC));
 	}
 
-	private static String _generateDeploymentInstanceId() {
+	private static String _getDeploymentInstanceId() {
+		String deploymentInstanceId =
+			PropsValues.FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID;
+
+		if (Validator.isNotNull(deploymentInstanceId)) {
+			return deploymentInstanceId;
+		}
+
+		return _deploymentInstanceIdDCLSingleton.getSingleton(
+			FIPSAuditUtil::_getPersistedDeploymentInstanceId);
+	}
+
+	private static String _getPersistedDeploymentInstanceId() {
 		Path path = Paths.get(
 			PropsValues.LIFERAY_HOME, "data",
 			"fips-audit-deployment-instance-id");
@@ -118,28 +128,6 @@ public class FIPSAuditUtil {
 				"Unable to resolve the FIPS audit deployment instance ID",
 				ioException);
 		}
-	}
-
-	private static String _getDeploymentInstanceId() {
-		String deploymentInstanceId =
-			PropsValues.FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID;
-
-		if (Validator.isNotNull(deploymentInstanceId)) {
-			return deploymentInstanceId;
-		}
-
-		return _deploymentInstanceIdDCLSingleton.getSingleton(
-			FIPSAuditUtil::_generateDeploymentInstanceId);
-	}
-
-	private static Provider _getProvider() {
-		Provider[] providers = Security.getProviders();
-
-		if (ArrayUtil.isEmpty(providers)) {
-			return null;
-		}
-
-		return providers[0];
 	}
 
 	private static Object _normalizeTimestamp(Object value) {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditUtil.java
@@ -7,6 +7,7 @@ package com.liferay.portal.kernel.security.fips;
 
 import com.liferay.petra.concurrent.DCLSingleton;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
@@ -64,9 +65,11 @@ public class FIPSAuditUtil {
 			).put(
 				"fields", _normalizeTimestamps(fipsAuditEvent.getFields())
 			).put(
-				"provider-name", _getProviderName(provider)
+				"provider-name",
+				(provider == null) ? StringPool.BLANK : provider.getName()
 			).put(
-				"provider-version", _getProviderVersion(provider)
+				"provider-version",
+				(provider == null) ? StringPool.BLANK : provider.getVersionStr()
 			).put(
 				"severity", severity.name()
 			).put(
@@ -75,7 +78,11 @@ public class FIPSAuditUtil {
 			severity);
 	}
 
-	private static String _deriveDeploymentInstanceId() {
+	private static String _formatTimestamp(Instant instant) {
+		return _dateTimeFormatter.format(instant.atZone(ZoneOffset.UTC));
+	}
+
+	private static String _generateDeploymentInstanceId() {
 		Path path = Paths.get(
 			PropsValues.LIFERAY_HOME, "data",
 			"fips-audit-deployment-instance-id");
@@ -103,10 +110,6 @@ public class FIPSAuditUtil {
 		}
 	}
 
-	private static String _formatTimestamp(Instant instant) {
-		return _dateTimeFormatter.format(instant.atZone(ZoneOffset.UTC));
-	}
-
 	private static String _getDeploymentInstanceId() {
 		String deploymentInstanceId =
 			PropsValues.FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID;
@@ -116,7 +119,7 @@ public class FIPSAuditUtil {
 		}
 
 		return _deploymentInstanceIdDCLSingleton.getSingleton(
-			FIPSAuditUtil::_deriveDeploymentInstanceId);
+			FIPSAuditUtil::_generateDeploymentInstanceId);
 	}
 
 	private static Provider _getProvider() {
@@ -127,22 +130,6 @@ public class FIPSAuditUtil {
 		}
 
 		return providers[0];
-	}
-
-	private static String _getProviderName(Provider provider) {
-		if (provider == null) {
-			return "";
-		}
-
-		return provider.getName();
-	}
-
-	private static String _getProviderVersion(Provider provider) {
-		if (provider == null) {
-			return "";
-		}
-
-		return provider.getVersionStr();
 	}
 
 	private static Object _normalizeTimestamp(Object value) {

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeValidator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeValidator.java
@@ -62,6 +62,16 @@ public class FIPSModeValidator {
 				_allowedTLSProtocols, SetUtil.fromArray(tlsProtocols)));
 	}
 
+	public static Provider getProvider() {
+		Provider[] providers = Security.getProviders();
+
+		if (ArrayUtil.isEmpty(providers)) {
+			return null;
+		}
+
+		return providers[0];
+	}
+
 	public static boolean isNotAllowedAlgorithm(String algorithm) {
 		if (!PropsValues.FIPS_ENABLED) {
 			return false;

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -1079,6 +1079,12 @@ public interface PropsKeys {
 		FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS =
 			"field.enable.com.liferay.portal.kernel.model.Organization.status";
 
+	public static final String FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID =
+		"fips.audit.deployment.instance.id";
+
+	public static final String FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID =
+		"fips.audit.provider.cmvp.certificate.id";
+
 	public static final String FIPS_ENABLED = "fips.enabled";
 
 	public static final String FULL_PAGE_DISPLAYABLE = "full.page.displayable";

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsValues.java
@@ -888,6 +888,12 @@ public class PropsValues {
 					PropsKeys.
 						FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS));
 
+	public static final String FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID =
+		PropsUtil.get(PropsKeys.FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID);
+
+	public static final String FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID =
+		PropsUtil.get(PropsKeys.FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID);
+
 	public static final boolean FIPS_ENABLED = GetterUtil.getBoolean(
 		PropsUtil.get(PropsKeys.FIPS_ENABLED));
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -6,7 +6,7 @@
 package com.liferay.portal.kernel.security.fips;
 
 import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.portal.kernel.internal.log4j.Log4jFIPSAuditUtil;
+import com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -51,7 +51,7 @@ public class FIPSApplicationStateMachineUtilTest {
 			LogManager.class, Mockito.CALLS_REAL_METHODS);
 
 		_logManagerMockedStatic.when(
-			() -> LogManager.getLogger(Log4jFIPSAuditUtil.class)
+			() -> LogManager.getLogger(FIPSLog4jUtil.class)
 		).thenReturn(
 			_logger
 		);

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -71,7 +71,8 @@ public class FIPSApplicationStateMachineUtilTest {
 			invocation -> {
 				ObjectMessage objectMessage = invocation.getArgument(2);
 
-				_records.add((Map<String, Object>)objectMessage.getParameter());
+				_fipsAuditLogEntries.add(
+					(Map<String, Object>)objectMessage.getParameter());
 
 				return null;
 			}
@@ -103,15 +104,17 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.ERROR,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Map<String, Object> record = _getLastRecord();
+		Map<String, Object> fipsAuditLogEntry = _getLastFIPSAuditLogEntry();
 
-		_assertEnvelope("event-type", record, "fips-state-transition");
-		_assertEnvelope("severity", record, "CRITICAL");
-		_assertField("failed-step", record, failedStep);
-		_assertField("from-state", record, "OPERATIONAL");
+		_assertEnvelope(
+			"event-type", fipsAuditLogEntry, "fips-state-transition");
+		_assertEnvelope("severity", fipsAuditLogEntry, "CRITICAL");
+		_assertField("failed-step", fipsAuditLogEntry, failedStep);
+		_assertField("from-state", fipsAuditLogEntry, "OPERATIONAL");
 		_assertField(
-			"provider-error-message", record, "The provider is unhappy");
-		_assertField("to-state", record, "ERROR");
+			"provider-error-message", fipsAuditLogEntry,
+			"The provider is unhappy");
+		_assertField("to-state", fipsAuditLogEntry, "ERROR");
 	}
 
 	@Test
@@ -130,18 +133,22 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.OPERATIONAL,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Assert.assertEquals(_records.toString(), 2, _records.size());
+		Assert.assertEquals(
+			_fipsAuditLogEntries.toString(), 2, _fipsAuditLogEntries.size());
 
-		_assertEnvelope("severity", _records.get(0), "INFO");
+		_assertEnvelope("severity", _fipsAuditLogEntries.get(0), "INFO");
 		_assertField(
-			"crypto-officer-user-id", _records.get(0), cryptoOfficerUserId);
-		_assertField("operation-type", _records.get(0), operationType);
-		_assertField("to-state", _records.get(0), "KEY_CSP_ENTRY");
-		_assertField("from-state", _records.get(1), "KEY_CSP_ENTRY");
+			"crypto-officer-user-id", _fipsAuditLogEntries.get(0),
+			cryptoOfficerUserId);
 		_assertField(
-			"message", _records.get(1),
+			"operation-type", _fipsAuditLogEntries.get(0), operationType);
+		_assertField("to-state", _fipsAuditLogEntries.get(0), "KEY_CSP_ENTRY");
+		_assertField(
+			"from-state", _fipsAuditLogEntries.get(1), "KEY_CSP_ENTRY");
+		_assertField(
+			"message", _fipsAuditLogEntries.get(1),
 			"The operation was completed successfully");
-		_assertField("to-state", _records.get(1), "OPERATIONAL");
+		_assertField("to-state", _fipsAuditLogEntries.get(1), "OPERATIONAL");
 	}
 
 	@Test
@@ -160,13 +167,16 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.ERROR,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Assert.assertEquals(_records.toString(), 2, _records.size());
+		Assert.assertEquals(
+			_fipsAuditLogEntries.toString(), 2, _fipsAuditLogEntries.size());
 
-		_assertEnvelope("severity", _records.get(1), "CRITICAL");
-		_assertField("failed-step", _records.get(1), "Key or CSP entry");
+		_assertEnvelope("severity", _fipsAuditLogEntries.get(1), "CRITICAL");
 		_assertField(
-			"provider-error-message", _records.get(1), "The key is unusable");
-		_assertField("to-state", _records.get(1), "ERROR");
+			"failed-step", _fipsAuditLogEntries.get(1), "Key or CSP entry");
+		_assertField(
+			"provider-error-message", _fipsAuditLogEntries.get(1),
+			"The key is unusable");
+		_assertField("to-state", _fipsAuditLogEntries.get(1), "ERROR");
 	}
 
 	@Test
@@ -183,13 +193,14 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.OPERATIONAL,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Map<String, Object> record = _getLastRecord();
+		Map<String, Object> fipsAuditLogEntry = _getLastFIPSAuditLogEntry();
 
-		_assertEnvelope("severity", record, "INFO");
-		_assertField("crypto-officer-user-id", record, cryptoOfficerUserId);
-		_assertField("from-state", record, "QUIESCENT");
-		_assertField("reason", record, reason);
-		_assertField("to-state", record, "OPERATIONAL");
+		_assertEnvelope("severity", fipsAuditLogEntry, "INFO");
+		_assertField(
+			"crypto-officer-user-id", fipsAuditLogEntry, cryptoOfficerUserId);
+		_assertField("from-state", fipsAuditLogEntry, "QUIESCENT");
+		_assertField("reason", fipsAuditLogEntry, reason);
+		_assertField("to-state", fipsAuditLogEntry, "OPERATIONAL");
 	}
 
 	@Test
@@ -204,12 +215,12 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.POWER_OFF,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Map<String, Object> record = _getLastRecord();
+		Map<String, Object> fipsAuditLogEntry = _getLastFIPSAuditLogEntry();
 
-		_assertEnvelope("severity", record, "INFO");
-		_assertField("from-state", record, "OPERATIONAL");
-		_assertField("initiating-actor", record, initiatingActor);
-		_assertField("to-state", record, "POWER_OFF");
+		_assertEnvelope("severity", fipsAuditLogEntry, "INFO");
+		_assertField("from-state", fipsAuditLogEntry, "OPERATIONAL");
+		_assertField("initiating-actor", fipsAuditLogEntry, initiatingActor);
+		_assertField("to-state", fipsAuditLogEntry, "POWER_OFF");
 	}
 
 	@Test
@@ -225,13 +236,14 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.QUIESCENT,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Map<String, Object> record = _getLastRecord();
+		Map<String, Object> fipsAuditLogEntry = _getLastFIPSAuditLogEntry();
 
-		_assertEnvelope("severity", record, "INFO");
-		_assertField("crypto-officer-user-id", record, cryptoOfficerUserId);
-		_assertField("from-state", record, "OPERATIONAL");
-		_assertField("reason", record, reason);
-		_assertField("to-state", record, "QUIESCENT");
+		_assertEnvelope("severity", fipsAuditLogEntry, "INFO");
+		_assertField(
+			"crypto-officer-user-id", fipsAuditLogEntry, cryptoOfficerUserId);
+		_assertField("from-state", fipsAuditLogEntry, "OPERATIONAL");
+		_assertField("reason", fipsAuditLogEntry, reason);
+		_assertField("to-state", fipsAuditLogEntry, "QUIESCENT");
 	}
 
 	@Test
@@ -246,12 +258,12 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.POWER_OFF,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Map<String, Object> record = _getLastRecord();
+		Map<String, Object> fipsAuditLogEntry = _getLastFIPSAuditLogEntry();
 
-		_assertEnvelope("severity", record, "INFO");
-		_assertField("from-state", record, "OPERATIONAL");
-		_assertField("initiating-actor", record, "Operating system");
-		_assertField("to-state", record, "POWER_OFF");
+		_assertEnvelope("severity", fipsAuditLogEntry, "INFO");
+		_assertField("from-state", fipsAuditLogEntry, "OPERATIONAL");
+		_assertField("initiating-actor", fipsAuditLogEntry, "Operating system");
+		_assertField("to-state", fipsAuditLogEntry, "POWER_OFF");
 	}
 
 	@Test
@@ -266,7 +278,7 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.POWER_OFF,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Assert.assertTrue(_records.isEmpty());
+		Assert.assertTrue(_fipsAuditLogEntries.isEmpty());
 	}
 
 	@Test
@@ -279,16 +291,18 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.OPERATIONAL,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Assert.assertEquals(_records.toString(), 2, _records.size());
+		Assert.assertEquals(
+			_fipsAuditLogEntries.toString(), 2, _fipsAuditLogEntries.size());
 
-		_assertField("from-state", _records.get(0), "INITIALIZING");
+		_assertField("from-state", _fipsAuditLogEntries.get(0), "INITIALIZING");
 		_assertField(
-			"message", _records.get(0), "The integrity checks were started");
-		_assertField("to-state", _records.get(0), "SELF_TEST");
+			"message", _fipsAuditLogEntries.get(0),
+			"The integrity checks were started");
+		_assertField("to-state", _fipsAuditLogEntries.get(0), "SELF_TEST");
 		_assertField(
-			"message", _records.get(1),
+			"message", _fipsAuditLogEntries.get(1),
 			"All checks and the validated provider self tests passed");
-		_assertField("to-state", _records.get(1), "OPERATIONAL");
+		_assertField("to-state", _fipsAuditLogEntries.get(1), "OPERATIONAL");
 	}
 
 	@Test
@@ -313,14 +327,17 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.OPERATIONAL,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Assert.assertEquals(_records.toString(), 2, _records.size());
+		Assert.assertEquals(
+			_fipsAuditLogEntries.toString(), 2, _fipsAuditLogEntries.size());
 
 		_assertField(
-			"crypto-officer-user-id", _records.get(0), cryptoOfficerUserId);
-		_assertField("from-state", _records.get(0), "ERROR");
-		_assertField("recovery-action", _records.get(0), recoveryAction);
-		_assertField("to-state", _records.get(0), "SELF_TEST");
-		_assertField("to-state", _records.get(1), "OPERATIONAL");
+			"crypto-officer-user-id", _fipsAuditLogEntries.get(0),
+			cryptoOfficerUserId);
+		_assertField("from-state", _fipsAuditLogEntries.get(0), "ERROR");
+		_assertField(
+			"recovery-action", _fipsAuditLogEntries.get(0), recoveryAction);
+		_assertField("to-state", _fipsAuditLogEntries.get(0), "SELF_TEST");
+		_assertField("to-state", _fipsAuditLogEntries.get(1), "OPERATIONAL");
 	}
 
 	@Test
@@ -438,21 +455,21 @@ public class FIPSApplicationStateMachineUtilTest {
 	}
 
 	private void _assertEnvelope(
-		String key, Map<String, Object> record, String value) {
+		String key, Map<String, Object> fipsAuditLogEntry, String value) {
 
-		Assert.assertEquals(value, record.get(key));
+		Assert.assertEquals(value, fipsAuditLogEntry.get(key));
 	}
 
 	private void _assertField(
-		String key, Map<String, Object> record, String value) {
+		String key, Map<String, Object> fipsAuditLogEntry, String value) {
 
-		Map<?, ?> fields = (Map<?, ?>)record.get("fields");
+		Map<?, ?> fields = (Map<?, ?>)fipsAuditLogEntry.get("fields");
 
 		Assert.assertEquals(value, fields.get(key));
 	}
 
-	private Map<String, Object> _getLastRecord() {
-		return _records.get(_records.size() - 1);
+	private Map<String, Object> _getLastFIPSAuditLogEntry() {
+		return _fipsAuditLogEntries.get(_fipsAuditLogEntries.size() - 1);
 	}
 
 	private Thread _registerShutdownHook() {
@@ -497,7 +514,7 @@ public class FIPSApplicationStateMachineUtilTest {
 	}
 
 	private void _testSelfTest(RuntimeException runtimeException) {
-		_records.clear();
+		_fipsAuditLogEntries.clear();
 
 		_setFIPSApplicationState(FIPSApplicationState.INITIALIZING);
 
@@ -512,19 +529,20 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.ERROR,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Assert.assertEquals(_records.toString(), 2, _records.size());
+		Assert.assertEquals(
+			_fipsAuditLogEntries.toString(), 2, _fipsAuditLogEntries.size());
 
-		_assertEnvelope("severity", _records.get(1), "CRITICAL");
-		_assertField("failed-step", _records.get(1), "Self test");
-		_assertField("from-state", _records.get(1), "SELF_TEST");
-		_assertField("to-state", _records.get(1), "ERROR");
+		_assertEnvelope("severity", _fipsAuditLogEntries.get(1), "CRITICAL");
+		_assertField("failed-step", _fipsAuditLogEntries.get(1), "Self test");
+		_assertField("from-state", _fipsAuditLogEntries.get(1), "SELF_TEST");
+		_assertField("to-state", _fipsAuditLogEntries.get(1), "ERROR");
 	}
 
 	private void _testTransition(
 		FIPSApplicationState fromFIPSApplicationState,
 		FIPSApplicationState toFIPSApplicationState) {
 
-		_records.clear();
+		_fipsAuditLogEntries.clear();
 
 		_setFIPSApplicationState(fromFIPSApplicationState);
 
@@ -534,20 +552,24 @@ public class FIPSApplicationStateMachineUtilTest {
 			toFIPSApplicationState,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Assert.assertEquals(_records.toString(), 1, _records.size());
+		Assert.assertEquals(
+			_fipsAuditLogEntries.toString(), 1, _fipsAuditLogEntries.size());
 
-		_assertEnvelope("event-type", _records.get(0), "fips-state-transition");
+		_assertEnvelope(
+			"event-type", _fipsAuditLogEntries.get(0), "fips-state-transition");
 		_assertField(
-			"from-state", _records.get(0), fromFIPSApplicationState.name());
+			"from-state", _fipsAuditLogEntries.get(0),
+			fromFIPSApplicationState.name());
 		_assertField(
-			"to-state", _records.get(0), toFIPSApplicationState.name());
+			"to-state", _fipsAuditLogEntries.get(0),
+			toFIPSApplicationState.name());
 	}
 
 	private void _testTransitionWithIllegalState(
 		FIPSApplicationState fromFIPSApplicationState,
 		FIPSApplicationState toFIPSApplicationState) {
 
-		_records.clear();
+		_fipsAuditLogEntries.clear();
 
 		_setFIPSApplicationState(fromFIPSApplicationState);
 
@@ -559,7 +581,7 @@ public class FIPSApplicationStateMachineUtilTest {
 			fromFIPSApplicationState,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Assert.assertTrue(_records.isEmpty());
+		Assert.assertTrue(_fipsAuditLogEntries.isEmpty());
 	}
 
 	private void _transition(FIPSApplicationState fipsApplicationState) {
@@ -575,7 +597,8 @@ public class FIPSApplicationStateMachineUtilTest {
 
 	private static MockedStatic<LogManager> _logManagerMockedStatic;
 
-	private final List<Map<String, Object>> _records = new ArrayList<>();
+	private final List<Map<String, Object>> _fipsAuditLogEntries =
+		new ArrayList<>();
 	private SafeCloseable _safeCloseable;
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -10,7 +10,6 @@ import com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.util.PropsUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,8 +43,6 @@ public class FIPSApplicationStateMachineUtilTest {
 
 	@BeforeClass
 	public static void setUpClass() {
-		PropsUtil.get("fips.enabled");
-
 		_logger = Mockito.mock(Logger.class);
 
 		_logManagerMockedStatic = Mockito.mockStatic(
@@ -106,7 +103,7 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.ERROR,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Map<String, Object> record = _getRecord();
+		Map<String, Object> record = _getLastRecord();
 
 		_assertEnvelope("event-type", record, "fips-state-transition");
 		_assertEnvelope("severity", record, "CRITICAL");
@@ -186,7 +183,7 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.OPERATIONAL,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Map<String, Object> record = _getRecord();
+		Map<String, Object> record = _getLastRecord();
 
 		_assertEnvelope("severity", record, "INFO");
 		_assertField("crypto-officer-user-id", record, cryptoOfficerUserId);
@@ -207,7 +204,7 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.POWER_OFF,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Map<String, Object> record = _getRecord();
+		Map<String, Object> record = _getLastRecord();
 
 		_assertEnvelope("severity", record, "INFO");
 		_assertField("from-state", record, "OPERATIONAL");
@@ -228,7 +225,7 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.QUIESCENT,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Map<String, Object> record = _getRecord();
+		Map<String, Object> record = _getLastRecord();
 
 		_assertEnvelope("severity", record, "INFO");
 		_assertField("crypto-officer-user-id", record, cryptoOfficerUserId);
@@ -249,7 +246,7 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.POWER_OFF,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Map<String, Object> record = _getRecord();
+		Map<String, Object> record = _getLastRecord();
 
 		_assertEnvelope("severity", record, "INFO");
 		_assertField("from-state", record, "OPERATIONAL");
@@ -292,7 +289,10 @@ public class FIPSApplicationStateMachineUtilTest {
 			"message", _records.get(1),
 			"All checks and the validated provider self tests passed");
 		_assertField("to-state", _records.get(1), "OPERATIONAL");
+	}
 
+	@Test
+	public void testSelfTestWithFailure() {
 		_testSelfTest(new RuntimeException());
 		_testSelfTest(new SecurityException());
 	}
@@ -451,7 +451,7 @@ public class FIPSApplicationStateMachineUtilTest {
 		Assert.assertEquals(value, fields.get(key));
 	}
 
-	private Map<String, Object> _getRecord() {
+	private Map<String, Object> _getLastRecord() {
 		return _records.get(_records.size() - 1);
 	}
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -269,7 +269,7 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.POWER_OFF,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Assert.assertTrue(_records.toString(), _records.isEmpty());
+		Assert.assertTrue(_records.isEmpty());
 	}
 
 	@Test
@@ -440,7 +440,7 @@ public class FIPSApplicationStateMachineUtilTest {
 	private void _assertEnvelope(
 		String key, Map<String, Object> record, String value) {
 
-		Assert.assertEquals(String.valueOf(record), value, record.get(key));
+		Assert.assertEquals(value, record.get(key));
 	}
 
 	private void _assertField(
@@ -448,7 +448,7 @@ public class FIPSApplicationStateMachineUtilTest {
 
 		Map<?, ?> fields = (Map<?, ?>)record.get("fields");
 
-		Assert.assertEquals(String.valueOf(record), value, fields.get(key));
+		Assert.assertEquals(value, fields.get(key));
 	}
 
 	private Map<String, Object> _getRecord() {
@@ -559,7 +559,7 @@ public class FIPSApplicationStateMachineUtilTest {
 			fromFIPSApplicationState,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
-		Assert.assertTrue(_records.toString(), _records.isEmpty());
+		Assert.assertTrue(_records.isEmpty());
 	}
 
 	private void _transition(FIPSApplicationState fipsApplicationState) {

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.message.Message;
 import org.apache.logging.log4j.message.ObjectMessage;
 
@@ -71,7 +72,7 @@ public class FIPSApplicationStateMachineUtilTest {
 
 		Mockito.doAnswer(
 			invocation -> {
-				ObjectMessage objectMessage = invocation.getArgument(1);
+				ObjectMessage objectMessage = invocation.getArgument(2);
 
 				_records.add((Map<String, Object>)objectMessage.getParameter());
 
@@ -80,7 +81,8 @@ public class FIPSApplicationStateMachineUtilTest {
 		).when(
 			_logger
 		).log(
-			Mockito.any(Level.class), Mockito.any(Message.class)
+			Mockito.any(Level.class), Mockito.any(Marker.class),
+			Mockito.any(Message.class)
 		);
 
 		_setFIPSApplicationState(FIPSApplicationState.INITIALIZING);

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -107,14 +107,14 @@ public class FIPSApplicationStateMachineUtilTest {
 		Map<String, Object> fipsAuditLogEntry = _getLastFIPSAuditLogEntry();
 
 		_assertEnvelope(
-			"event-type", fipsAuditLogEntry, "fips-state-transition");
-		_assertEnvelope("severity", fipsAuditLogEntry, "CRITICAL");
-		_assertField("failed-step", fipsAuditLogEntry, failedStep);
-		_assertField("from-state", fipsAuditLogEntry, "OPERATIONAL");
+			fipsAuditLogEntry, "event-type", "fips-state-transition");
+		_assertEnvelope(fipsAuditLogEntry, "severity", "CRITICAL");
+		_assertField(fipsAuditLogEntry, "failed-step", failedStep);
+		_assertField(fipsAuditLogEntry, "from-state", "OPERATIONAL");
 		_assertField(
-			"provider-error-message", fipsAuditLogEntry,
+			fipsAuditLogEntry, "provider-error-message",
 			"The provider is unhappy");
-		_assertField("to-state", fipsAuditLogEntry, "ERROR");
+		_assertField(fipsAuditLogEntry, "to-state", "ERROR");
 	}
 
 	@Test
@@ -136,19 +136,19 @@ public class FIPSApplicationStateMachineUtilTest {
 		Assert.assertEquals(
 			_fipsAuditLogEntries.toString(), 2, _fipsAuditLogEntries.size());
 
-		_assertEnvelope("severity", _fipsAuditLogEntries.get(0), "INFO");
+		_assertEnvelope(_fipsAuditLogEntries.get(0), "severity", "INFO");
 		_assertField(
-			"crypto-officer-user-id", _fipsAuditLogEntries.get(0),
+			_fipsAuditLogEntries.get(0), "crypto-officer-user-id",
 			cryptoOfficerUserId);
 		_assertField(
-			"operation-type", _fipsAuditLogEntries.get(0), operationType);
-		_assertField("to-state", _fipsAuditLogEntries.get(0), "KEY_CSP_ENTRY");
+			_fipsAuditLogEntries.get(0), "operation-type", operationType);
+		_assertField(_fipsAuditLogEntries.get(0), "to-state", "KEY_CSP_ENTRY");
 		_assertField(
-			"from-state", _fipsAuditLogEntries.get(1), "KEY_CSP_ENTRY");
+			_fipsAuditLogEntries.get(1), "from-state", "KEY_CSP_ENTRY");
 		_assertField(
-			"message", _fipsAuditLogEntries.get(1),
+			_fipsAuditLogEntries.get(1), "message",
 			"The operation was completed successfully");
-		_assertField("to-state", _fipsAuditLogEntries.get(1), "OPERATIONAL");
+		_assertField(_fipsAuditLogEntries.get(1), "to-state", "OPERATIONAL");
 	}
 
 	@Test
@@ -170,13 +170,13 @@ public class FIPSApplicationStateMachineUtilTest {
 		Assert.assertEquals(
 			_fipsAuditLogEntries.toString(), 2, _fipsAuditLogEntries.size());
 
-		_assertEnvelope("severity", _fipsAuditLogEntries.get(1), "CRITICAL");
+		_assertEnvelope(_fipsAuditLogEntries.get(1), "severity", "CRITICAL");
 		_assertField(
-			"failed-step", _fipsAuditLogEntries.get(1), "Key or CSP entry");
+			_fipsAuditLogEntries.get(1), "failed-step", "Key or CSP entry");
 		_assertField(
-			"provider-error-message", _fipsAuditLogEntries.get(1),
+			_fipsAuditLogEntries.get(1), "provider-error-message",
 			"The key is unusable");
-		_assertField("to-state", _fipsAuditLogEntries.get(1), "ERROR");
+		_assertField(_fipsAuditLogEntries.get(1), "to-state", "ERROR");
 	}
 
 	@Test
@@ -195,12 +195,12 @@ public class FIPSApplicationStateMachineUtilTest {
 
 		Map<String, Object> fipsAuditLogEntry = _getLastFIPSAuditLogEntry();
 
-		_assertEnvelope("severity", fipsAuditLogEntry, "INFO");
+		_assertEnvelope(fipsAuditLogEntry, "severity", "INFO");
 		_assertField(
-			"crypto-officer-user-id", fipsAuditLogEntry, cryptoOfficerUserId);
-		_assertField("from-state", fipsAuditLogEntry, "QUIESCENT");
-		_assertField("reason", fipsAuditLogEntry, reason);
-		_assertField("to-state", fipsAuditLogEntry, "OPERATIONAL");
+			fipsAuditLogEntry, "crypto-officer-user-id", cryptoOfficerUserId);
+		_assertField(fipsAuditLogEntry, "from-state", "QUIESCENT");
+		_assertField(fipsAuditLogEntry, "reason", reason);
+		_assertField(fipsAuditLogEntry, "to-state", "OPERATIONAL");
 	}
 
 	@Test
@@ -217,10 +217,10 @@ public class FIPSApplicationStateMachineUtilTest {
 
 		Map<String, Object> fipsAuditLogEntry = _getLastFIPSAuditLogEntry();
 
-		_assertEnvelope("severity", fipsAuditLogEntry, "INFO");
-		_assertField("from-state", fipsAuditLogEntry, "OPERATIONAL");
-		_assertField("initiating-actor", fipsAuditLogEntry, initiatingActor);
-		_assertField("to-state", fipsAuditLogEntry, "POWER_OFF");
+		_assertEnvelope(fipsAuditLogEntry, "severity", "INFO");
+		_assertField(fipsAuditLogEntry, "from-state", "OPERATIONAL");
+		_assertField(fipsAuditLogEntry, "initiating-actor", initiatingActor);
+		_assertField(fipsAuditLogEntry, "to-state", "POWER_OFF");
 	}
 
 	@Test
@@ -238,19 +238,19 @@ public class FIPSApplicationStateMachineUtilTest {
 
 		Map<String, Object> fipsAuditLogEntry = _getLastFIPSAuditLogEntry();
 
-		_assertEnvelope("severity", fipsAuditLogEntry, "INFO");
+		_assertEnvelope(fipsAuditLogEntry, "severity", "INFO");
 		_assertField(
-			"crypto-officer-user-id", fipsAuditLogEntry, cryptoOfficerUserId);
-		_assertField("from-state", fipsAuditLogEntry, "OPERATIONAL");
-		_assertField("reason", fipsAuditLogEntry, reason);
-		_assertField("to-state", fipsAuditLogEntry, "QUIESCENT");
+			fipsAuditLogEntry, "crypto-officer-user-id", cryptoOfficerUserId);
+		_assertField(fipsAuditLogEntry, "from-state", "OPERATIONAL");
+		_assertField(fipsAuditLogEntry, "reason", reason);
+		_assertField(fipsAuditLogEntry, "to-state", "QUIESCENT");
 	}
 
 	@Test
 	public void testRegisterShutdownHook() {
 		_setFIPSApplicationState(FIPSApplicationState.OPERATIONAL);
 
-		Thread thread = _registerShutdownHook();
+		Thread thread = _getShutdownHook();
 
 		thread.run();
 
@@ -260,17 +260,17 @@ public class FIPSApplicationStateMachineUtilTest {
 
 		Map<String, Object> fipsAuditLogEntry = _getLastFIPSAuditLogEntry();
 
-		_assertEnvelope("severity", fipsAuditLogEntry, "INFO");
-		_assertField("from-state", fipsAuditLogEntry, "OPERATIONAL");
-		_assertField("initiating-actor", fipsAuditLogEntry, "Operating system");
-		_assertField("to-state", fipsAuditLogEntry, "POWER_OFF");
+		_assertEnvelope(fipsAuditLogEntry, "severity", "INFO");
+		_assertField(fipsAuditLogEntry, "from-state", "OPERATIONAL");
+		_assertField(fipsAuditLogEntry, "initiating-actor", "Operating system");
+		_assertField(fipsAuditLogEntry, "to-state", "POWER_OFF");
 	}
 
 	@Test
 	public void testRegisterShutdownHookWithPowerOffState() {
 		_setFIPSApplicationState(FIPSApplicationState.POWER_OFF);
 
-		Thread thread = _registerShutdownHook();
+		Thread thread = _getShutdownHook();
 
 		thread.run();
 
@@ -294,21 +294,21 @@ public class FIPSApplicationStateMachineUtilTest {
 		Assert.assertEquals(
 			_fipsAuditLogEntries.toString(), 2, _fipsAuditLogEntries.size());
 
-		_assertField("from-state", _fipsAuditLogEntries.get(0), "INITIALIZING");
+		_assertField(_fipsAuditLogEntries.get(0), "from-state", "INITIALIZING");
 		_assertField(
-			"message", _fipsAuditLogEntries.get(0),
+			_fipsAuditLogEntries.get(0), "message",
 			"The integrity checks were started");
-		_assertField("to-state", _fipsAuditLogEntries.get(0), "SELF_TEST");
+		_assertField(_fipsAuditLogEntries.get(0), "to-state", "SELF_TEST");
 		_assertField(
-			"message", _fipsAuditLogEntries.get(1),
+			_fipsAuditLogEntries.get(1), "message",
 			"All checks and the validated provider self tests passed");
-		_assertField("to-state", _fipsAuditLogEntries.get(1), "OPERATIONAL");
+		_assertField(_fipsAuditLogEntries.get(1), "to-state", "OPERATIONAL");
 	}
 
 	@Test
 	public void testSelfTestWithFailure() {
-		_testSelfTest(new RuntimeException());
-		_testSelfTest(new SecurityException());
+		_testSelfTestWithFailure(new RuntimeException());
+		_testSelfTestWithFailure(new SecurityException());
 	}
 
 	@Test
@@ -331,27 +331,36 @@ public class FIPSApplicationStateMachineUtilTest {
 			_fipsAuditLogEntries.toString(), 2, _fipsAuditLogEntries.size());
 
 		_assertField(
-			"crypto-officer-user-id", _fipsAuditLogEntries.get(0),
+			_fipsAuditLogEntries.get(0), "crypto-officer-user-id",
 			cryptoOfficerUserId);
-		_assertField("from-state", _fipsAuditLogEntries.get(0), "ERROR");
+		_assertField(_fipsAuditLogEntries.get(0), "from-state", "ERROR");
 		_assertField(
-			"recovery-action", _fipsAuditLogEntries.get(0), recoveryAction);
-		_assertField("to-state", _fipsAuditLogEntries.get(0), "SELF_TEST");
-		_assertField("to-state", _fipsAuditLogEntries.get(1), "OPERATIONAL");
+			_fipsAuditLogEntries.get(0), "recovery-action", recoveryAction);
+		_assertField(_fipsAuditLogEntries.get(0), "to-state", "SELF_TEST");
+		_assertField(_fipsAuditLogEntries.get(1), "to-state", "OPERATIONAL");
 	}
 
 	@Test
 	public void testTransition() {
+
+		// ERROR
+
 		_testTransition(
 			FIPSApplicationState.ERROR, FIPSApplicationState.POWER_OFF);
 		_testTransition(
 			FIPSApplicationState.ERROR, FIPSApplicationState.SELF_TEST);
+
+		// INITIALIZING
+
 		_testTransition(
 			FIPSApplicationState.INITIALIZING, FIPSApplicationState.ERROR);
 		_testTransition(
 			FIPSApplicationState.INITIALIZING, FIPSApplicationState.POWER_OFF);
 		_testTransition(
 			FIPSApplicationState.INITIALIZING, FIPSApplicationState.SELF_TEST);
+
+		// KEY_CSP_ENTRY
+
 		_testTransition(
 			FIPSApplicationState.KEY_CSP_ENTRY, FIPSApplicationState.ERROR);
 		_testTransition(
@@ -359,6 +368,9 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.OPERATIONAL);
 		_testTransition(
 			FIPSApplicationState.KEY_CSP_ENTRY, FIPSApplicationState.POWER_OFF);
+
+		// OPERATIONAL
+
 		_testTransition(
 			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.ERROR);
 		_testTransition(
@@ -370,6 +382,9 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.QUIESCENT);
 		_testTransition(
 			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.SELF_TEST);
+
+		// QUIESCENT
+
 		_testTransition(
 			FIPSApplicationState.QUIESCENT, FIPSApplicationState.ERROR);
 		_testTransition(
@@ -378,6 +393,9 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.QUIESCENT, FIPSApplicationState.OPERATIONAL);
 		_testTransition(
 			FIPSApplicationState.QUIESCENT, FIPSApplicationState.POWER_OFF);
+
+		// SELF_TEST
+
 		_testTransition(
 			FIPSApplicationState.SELF_TEST, FIPSApplicationState.ERROR);
 		_testTransition(
@@ -388,6 +406,9 @@ public class FIPSApplicationStateMachineUtilTest {
 
 	@Test
 	public void testTransitionWithIllegalState() {
+
+		// ERROR
+
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.ERROR, FIPSApplicationState.ERROR);
 		_testTransitionWithIllegalState(
@@ -398,6 +419,9 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.ERROR, FIPSApplicationState.OPERATIONAL);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.ERROR, FIPSApplicationState.QUIESCENT);
+
+		// INITIALIZING
+
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.INITIALIZING,
 			FIPSApplicationState.INITIALIZING);
@@ -409,6 +433,9 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.OPERATIONAL);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.INITIALIZING, FIPSApplicationState.QUIESCENT);
+
+		// KEY_CSP_ENTRY
+
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.KEY_CSP_ENTRY,
 			FIPSApplicationState.INITIALIZING);
@@ -419,11 +446,17 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.KEY_CSP_ENTRY, FIPSApplicationState.QUIESCENT);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.KEY_CSP_ENTRY, FIPSApplicationState.SELF_TEST);
+
+		// OPERATIONAL
+
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.OPERATIONAL,
 			FIPSApplicationState.INITIALIZING);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.OPERATIONAL);
+
+		// POWER_OFF
+
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.POWER_OFF, FIPSApplicationState.ERROR);
 		_testTransitionWithIllegalState(
@@ -438,12 +471,18 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.POWER_OFF, FIPSApplicationState.QUIESCENT);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.POWER_OFF, FIPSApplicationState.SELF_TEST);
+
+		// QUIESCENT
+
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.QUIESCENT, FIPSApplicationState.INITIALIZING);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.QUIESCENT, FIPSApplicationState.QUIESCENT);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.QUIESCENT, FIPSApplicationState.SELF_TEST);
+
+		// SELF_TEST
+
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.SELF_TEST, FIPSApplicationState.INITIALIZING);
 		_testTransitionWithIllegalState(
@@ -455,13 +494,13 @@ public class FIPSApplicationStateMachineUtilTest {
 	}
 
 	private void _assertEnvelope(
-		String key, Map<String, Object> fipsAuditLogEntry, String value) {
+		Map<String, Object> fipsAuditLogEntry, String key, String value) {
 
 		Assert.assertEquals(value, fipsAuditLogEntry.get(key));
 	}
 
 	private void _assertField(
-		String key, Map<String, Object> fipsAuditLogEntry, String value) {
+		Map<String, Object> fipsAuditLogEntry, String key, String value) {
 
 		Map<?, ?> fields = (Map<?, ?>)fipsAuditLogEntry.get("fields");
 
@@ -472,7 +511,7 @@ public class FIPSApplicationStateMachineUtilTest {
 		return _fipsAuditLogEntries.get(_fipsAuditLogEntries.size() - 1);
 	}
 
-	private Thread _registerShutdownHook() {
+	private Thread _getShutdownHook() {
 		try (MockedStatic<Runtime> runtimeMockedStatic = Mockito.mockStatic(
 				Runtime.class)) {
 
@@ -513,7 +552,7 @@ public class FIPSApplicationStateMachineUtilTest {
 		fipsApplicationStateAtomicReference.set(fipsApplicationState);
 	}
 
-	private void _testSelfTest(RuntimeException runtimeException) {
+	private void _testSelfTestWithFailure(RuntimeException runtimeException) {
 		_fipsAuditLogEntries.clear();
 
 		_setFIPSApplicationState(FIPSApplicationState.INITIALIZING);
@@ -532,10 +571,10 @@ public class FIPSApplicationStateMachineUtilTest {
 		Assert.assertEquals(
 			_fipsAuditLogEntries.toString(), 2, _fipsAuditLogEntries.size());
 
-		_assertEnvelope("severity", _fipsAuditLogEntries.get(1), "CRITICAL");
-		_assertField("failed-step", _fipsAuditLogEntries.get(1), "Self test");
-		_assertField("from-state", _fipsAuditLogEntries.get(1), "SELF_TEST");
-		_assertField("to-state", _fipsAuditLogEntries.get(1), "ERROR");
+		_assertEnvelope(_fipsAuditLogEntries.get(1), "severity", "CRITICAL");
+		_assertField(_fipsAuditLogEntries.get(1), "failed-step", "Self test");
+		_assertField(_fipsAuditLogEntries.get(1), "from-state", "SELF_TEST");
+		_assertField(_fipsAuditLogEntries.get(1), "to-state", "ERROR");
 	}
 
 	private void _testTransition(
@@ -556,12 +595,12 @@ public class FIPSApplicationStateMachineUtilTest {
 			_fipsAuditLogEntries.toString(), 1, _fipsAuditLogEntries.size());
 
 		_assertEnvelope(
-			"event-type", _fipsAuditLogEntries.get(0), "fips-state-transition");
+			_fipsAuditLogEntries.get(0), "event-type", "fips-state-transition");
 		_assertField(
-			"from-state", _fipsAuditLogEntries.get(0),
+			_fipsAuditLogEntries.get(0), "from-state",
 			fromFIPSApplicationState.name());
 		_assertField(
-			"to-state", _fipsAuditLogEntries.get(0),
+			_fipsAuditLogEntries.get(0), "to-state",
 			toFIPSApplicationState.name());
 	}
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -5,22 +5,269 @@
 
 package com.liferay.portal.kernel.security.fips;
 
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.internal.log4j.Log4jFIPSAuditUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.ObjectMessage;
+
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * @author Jorge García Jiménez
+ * @author Rafael Praxedes
  */
 public class FIPSApplicationStateMachineUtilTest {
 
+	@BeforeClass
+	public static void setUpClass() {
+		PropsUtil.get("fips.enabled");
+
+		_logger = Mockito.mock(Logger.class);
+
+		_logManagerMockedStatic = Mockito.mockStatic(
+			LogManager.class, Mockito.CALLS_REAL_METHODS);
+
+		_logManagerMockedStatic.when(
+			() -> LogManager.getLogger(Log4jFIPSAuditUtil.class)
+		).thenReturn(
+			_logger
+		);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_logManagerMockedStatic.close();
+	}
+
 	@Before
 	public void setUp() {
+		Mockito.reset(_logger);
+
+		_safeCloseable = PropsValuesTestUtil.swapWithSafeCloseable(
+			"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", RandomTestUtil.randomString());
+
+		Mockito.doAnswer(
+			invocation -> {
+				ObjectMessage objectMessage = invocation.getArgument(1);
+
+				_records.add((Map<String, Object>)objectMessage.getParameter());
+
+				return null;
+			}
+		).when(
+			_logger
+		).log(
+			Mockito.any(Level.class), Mockito.any(Message.class)
+		);
+
 		_setFIPSApplicationState(FIPSApplicationState.INITIALIZING);
+	}
+
+	@After
+	public void tearDown() {
+		_safeCloseable.close();
+	}
+
+	@Test
+	public void testError() {
+		_setFIPSApplicationState(FIPSApplicationState.OPERATIONAL);
+
+		String failedStep = RandomTestUtil.randomString();
+
+		FIPSApplicationStateMachineUtil.error(
+			failedStep, new SecurityException("The provider is unhappy"));
+
+		Assert.assertEquals(
+			FIPSApplicationState.ERROR,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Map<String, Object> record = _getRecord();
+
+		_assertEnvelope("event-type", record, "fips-state-transition");
+		_assertEnvelope("severity", record, "CRITICAL");
+		_assertField("failed-step", record, failedStep);
+		_assertField("from-state", record, "OPERATIONAL");
+		_assertField(
+			"provider-error-message", record, "The provider is unhappy");
+		_assertField("to-state", record, "ERROR");
+	}
+
+	@Test
+	public void testKeyCSPEntry() {
+		_setFIPSApplicationState(FIPSApplicationState.OPERATIONAL);
+
+		String cryptoOfficerUserId = RandomTestUtil.randomString();
+		String operationType = RandomTestUtil.randomString();
+
+		FIPSApplicationStateMachineUtil.keyCSPEntry(
+			cryptoOfficerUserId, operationType,
+			() -> {
+			});
+
+		Assert.assertEquals(
+			FIPSApplicationState.OPERATIONAL,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Assert.assertEquals(_records.toString(), 2, _records.size());
+
+		_assertEnvelope("severity", _records.get(0), "INFO");
+		_assertField(
+			"crypto-officer-user-id", _records.get(0), cryptoOfficerUserId);
+		_assertField("operation-type", _records.get(0), operationType);
+		_assertField("to-state", _records.get(0), "KEY_CSP_ENTRY");
+		_assertField("from-state", _records.get(1), "KEY_CSP_ENTRY");
+		_assertField(
+			"message", _records.get(1),
+			"The operation was completed successfully");
+		_assertField("to-state", _records.get(1), "OPERATIONAL");
+	}
+
+	@Test
+	public void testKeyCSPEntryWithFailedOperation() {
+		_setFIPSApplicationState(FIPSApplicationState.OPERATIONAL);
+
+		Assert.assertThrows(
+			SecurityException.class,
+			() -> FIPSApplicationStateMachineUtil.keyCSPEntry(
+				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
+				() -> {
+					throw new SecurityException("The key is unusable");
+				}));
+
+		Assert.assertEquals(
+			FIPSApplicationState.ERROR,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Assert.assertEquals(_records.toString(), 2, _records.size());
+
+		_assertEnvelope("severity", _records.get(1), "CRITICAL");
+		_assertField("failed-step", _records.get(1), "Key or CSP entry");
+		_assertField(
+			"provider-error-message", _records.get(1), "The key is unusable");
+		_assertField("to-state", _records.get(1), "ERROR");
+	}
+
+	@Test
+	public void testOperational() {
+		_setFIPSApplicationState(FIPSApplicationState.QUIESCENT);
+
+		String cryptoOfficerUserId = RandomTestUtil.randomString();
+		String reason = RandomTestUtil.randomString();
+
+		FIPSApplicationStateMachineUtil.operational(
+			cryptoOfficerUserId, reason);
+
+		Assert.assertEquals(
+			FIPSApplicationState.OPERATIONAL,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Map<String, Object> record = _getRecord();
+
+		_assertEnvelope("severity", record, "INFO");
+		_assertField("crypto-officer-user-id", record, cryptoOfficerUserId);
+		_assertField("from-state", record, "QUIESCENT");
+		_assertField("reason", record, reason);
+		_assertField("to-state", record, "OPERATIONAL");
+	}
+
+	@Test
+	public void testPowerOff() {
+		_setFIPSApplicationState(FIPSApplicationState.OPERATIONAL);
+
+		String initiatingActor = RandomTestUtil.randomString();
+
+		FIPSApplicationStateMachineUtil.powerOff(initiatingActor);
+
+		Assert.assertEquals(
+			FIPSApplicationState.POWER_OFF,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Map<String, Object> record = _getRecord();
+
+		_assertEnvelope("severity", record, "INFO");
+		_assertField("from-state", record, "OPERATIONAL");
+		_assertField("initiating-actor", record, initiatingActor);
+		_assertField("to-state", record, "POWER_OFF");
+	}
+
+	@Test
+	public void testQuiescent() {
+		_setFIPSApplicationState(FIPSApplicationState.OPERATIONAL);
+
+		String cryptoOfficerUserId = RandomTestUtil.randomString();
+		String reason = RandomTestUtil.randomString();
+
+		FIPSApplicationStateMachineUtil.quiescent(cryptoOfficerUserId, reason);
+
+		Assert.assertEquals(
+			FIPSApplicationState.QUIESCENT,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Map<String, Object> record = _getRecord();
+
+		_assertEnvelope("severity", record, "INFO");
+		_assertField("crypto-officer-user-id", record, cryptoOfficerUserId);
+		_assertField("from-state", record, "OPERATIONAL");
+		_assertField("reason", record, reason);
+		_assertField("to-state", record, "QUIESCENT");
+	}
+
+	@Test
+	public void testRegisterShutdownHook() {
+		_setFIPSApplicationState(FIPSApplicationState.OPERATIONAL);
+
+		Thread thread = _registerShutdownHook();
+
+		thread.run();
+
+		Assert.assertEquals(
+			FIPSApplicationState.POWER_OFF,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Map<String, Object> record = _getRecord();
+
+		_assertEnvelope("severity", record, "INFO");
+		_assertField("from-state", record, "OPERATIONAL");
+		_assertField("initiating-actor", record, "OS signal");
+		_assertField("to-state", record, "POWER_OFF");
+	}
+
+	@Test
+	public void testRegisterShutdownHookWithPowerOffState() {
+		_setFIPSApplicationState(FIPSApplicationState.POWER_OFF);
+
+		Thread thread = _registerShutdownHook();
+
+		thread.run();
+
+		Assert.assertEquals(
+			FIPSApplicationState.POWER_OFF,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Assert.assertTrue(_records.toString(), _records.isEmpty());
 	}
 
 	@Test
@@ -33,8 +280,45 @@ public class FIPSApplicationStateMachineUtilTest {
 			FIPSApplicationState.OPERATIONAL,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
 
+		Assert.assertEquals(_records.toString(), 2, _records.size());
+
+		_assertField("from-state", _records.get(0), "INITIALIZING");
+		_assertField(
+			"message", _records.get(0), "The integrity checks were started");
+		_assertField("to-state", _records.get(0), "SELF_TEST");
+		_assertField(
+			"message", _records.get(1),
+			"All checks and the validated provider self tests passed");
+		_assertField("to-state", _records.get(1), "OPERATIONAL");
+
 		_testSelfTest(new RuntimeException());
 		_testSelfTest(new SecurityException());
+	}
+
+	@Test
+	public void testSelfTestWithRecovery() {
+		_setFIPSApplicationState(FIPSApplicationState.ERROR);
+
+		String cryptoOfficerUserId = RandomTestUtil.randomString();
+		String recoveryAction = RandomTestUtil.randomString();
+
+		FIPSApplicationStateMachineUtil.selfTest(
+			cryptoOfficerUserId, recoveryAction,
+			() -> {
+			});
+
+		Assert.assertEquals(
+			FIPSApplicationState.OPERATIONAL,
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Assert.assertEquals(_records.toString(), 2, _records.size());
+
+		_assertField(
+			"crypto-officer-user-id", _records.get(0), cryptoOfficerUserId);
+		_assertField("from-state", _records.get(0), "ERROR");
+		_assertField("recovery-action", _records.get(0), recoveryAction);
+		_assertField("to-state", _records.get(0), "SELF_TEST");
+		_assertField("to-state", _records.get(1), "OPERATIONAL");
 	}
 
 	@Test
@@ -42,17 +326,39 @@ public class FIPSApplicationStateMachineUtilTest {
 		_testTransition(
 			FIPSApplicationState.ERROR, FIPSApplicationState.POWER_OFF);
 		_testTransition(
+			FIPSApplicationState.ERROR, FIPSApplicationState.SELF_TEST);
+		_testTransition(
 			FIPSApplicationState.INITIALIZING, FIPSApplicationState.ERROR);
 		_testTransition(
 			FIPSApplicationState.INITIALIZING, FIPSApplicationState.POWER_OFF);
 		_testTransition(
 			FIPSApplicationState.INITIALIZING, FIPSApplicationState.SELF_TEST);
 		_testTransition(
+			FIPSApplicationState.KEY_CSP_ENTRY, FIPSApplicationState.ERROR);
+		_testTransition(
+			FIPSApplicationState.KEY_CSP_ENTRY,
+			FIPSApplicationState.OPERATIONAL);
+		_testTransition(
+			FIPSApplicationState.KEY_CSP_ENTRY, FIPSApplicationState.POWER_OFF);
+		_testTransition(
 			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.ERROR);
+		_testTransition(
+			FIPSApplicationState.OPERATIONAL,
+			FIPSApplicationState.KEY_CSP_ENTRY);
 		_testTransition(
 			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.POWER_OFF);
 		_testTransition(
+			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.QUIESCENT);
+		_testTransition(
 			FIPSApplicationState.OPERATIONAL, FIPSApplicationState.SELF_TEST);
+		_testTransition(
+			FIPSApplicationState.QUIESCENT, FIPSApplicationState.ERROR);
+		_testTransition(
+			FIPSApplicationState.QUIESCENT, FIPSApplicationState.KEY_CSP_ENTRY);
+		_testTransition(
+			FIPSApplicationState.QUIESCENT, FIPSApplicationState.OPERATIONAL);
+		_testTransition(
+			FIPSApplicationState.QUIESCENT, FIPSApplicationState.POWER_OFF);
 		_testTransition(
 			FIPSApplicationState.SELF_TEST, FIPSApplicationState.ERROR);
 		_testTransition(
@@ -68,15 +374,32 @@ public class FIPSApplicationStateMachineUtilTest {
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.ERROR, FIPSApplicationState.INITIALIZING);
 		_testTransitionWithIllegalState(
+			FIPSApplicationState.ERROR, FIPSApplicationState.KEY_CSP_ENTRY);
+		_testTransitionWithIllegalState(
 			FIPSApplicationState.ERROR, FIPSApplicationState.OPERATIONAL);
 		_testTransitionWithIllegalState(
-			FIPSApplicationState.ERROR, FIPSApplicationState.SELF_TEST);
+			FIPSApplicationState.ERROR, FIPSApplicationState.QUIESCENT);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.INITIALIZING,
 			FIPSApplicationState.INITIALIZING);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.INITIALIZING,
+			FIPSApplicationState.KEY_CSP_ENTRY);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.INITIALIZING,
 			FIPSApplicationState.OPERATIONAL);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.INITIALIZING, FIPSApplicationState.QUIESCENT);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.KEY_CSP_ENTRY,
+			FIPSApplicationState.INITIALIZING);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.KEY_CSP_ENTRY,
+			FIPSApplicationState.KEY_CSP_ENTRY);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.KEY_CSP_ENTRY, FIPSApplicationState.QUIESCENT);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.KEY_CSP_ENTRY, FIPSApplicationState.SELF_TEST);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.OPERATIONAL,
 			FIPSApplicationState.INITIALIZING);
@@ -87,15 +410,76 @@ public class FIPSApplicationStateMachineUtilTest {
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.POWER_OFF, FIPSApplicationState.INITIALIZING);
 		_testTransitionWithIllegalState(
+			FIPSApplicationState.POWER_OFF, FIPSApplicationState.KEY_CSP_ENTRY);
+		_testTransitionWithIllegalState(
 			FIPSApplicationState.POWER_OFF, FIPSApplicationState.OPERATIONAL);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.POWER_OFF, FIPSApplicationState.POWER_OFF);
 		_testTransitionWithIllegalState(
+			FIPSApplicationState.POWER_OFF, FIPSApplicationState.QUIESCENT);
+		_testTransitionWithIllegalState(
 			FIPSApplicationState.POWER_OFF, FIPSApplicationState.SELF_TEST);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.QUIESCENT, FIPSApplicationState.INITIALIZING);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.QUIESCENT, FIPSApplicationState.QUIESCENT);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.QUIESCENT, FIPSApplicationState.SELF_TEST);
 		_testTransitionWithIllegalState(
 			FIPSApplicationState.SELF_TEST, FIPSApplicationState.INITIALIZING);
 		_testTransitionWithIllegalState(
+			FIPSApplicationState.SELF_TEST, FIPSApplicationState.KEY_CSP_ENTRY);
+		_testTransitionWithIllegalState(
+			FIPSApplicationState.SELF_TEST, FIPSApplicationState.QUIESCENT);
+		_testTransitionWithIllegalState(
 			FIPSApplicationState.SELF_TEST, FIPSApplicationState.SELF_TEST);
+	}
+
+	private void _assertEnvelope(
+		String key, Map<String, Object> record, String value) {
+
+		Assert.assertEquals(String.valueOf(record), value, record.get(key));
+	}
+
+	private void _assertField(
+		String key, Map<String, Object> record, String value) {
+
+		Map<?, ?> fields = (Map<?, ?>)record.get("fields");
+
+		Assert.assertEquals(String.valueOf(record), value, fields.get(key));
+	}
+
+	private Map<String, Object> _getRecord() {
+		return _records.get(_records.size() - 1);
+	}
+
+	private Thread _registerShutdownHook() {
+		try (MockedStatic<Runtime> runtimeMockedStatic = Mockito.mockStatic(
+				Runtime.class)) {
+
+			Runtime runtime = Mockito.mock(Runtime.class);
+
+			runtimeMockedStatic.when(
+				Runtime::getRuntime
+			).thenReturn(
+				runtime
+			);
+
+			ReflectionTestUtil.invoke(
+				FIPSApplicationStateMachineUtil.class, "_registerShutdownHook",
+				new Class<?>[0]);
+
+			ArgumentCaptor<Thread> argumentCaptor = ArgumentCaptor.forClass(
+				Thread.class);
+
+			Mockito.verify(
+				runtime
+			).addShutdownHook(
+				argumentCaptor.capture()
+			);
+
+			return argumentCaptor.getValue();
+		}
 	}
 
 	private void _setFIPSApplicationState(
@@ -111,6 +495,8 @@ public class FIPSApplicationStateMachineUtilTest {
 	}
 
 	private void _testSelfTest(RuntimeException runtimeException) {
+		_records.clear();
+
 		_setFIPSApplicationState(FIPSApplicationState.INITIALIZING);
 
 		Assert.assertThrows(
@@ -123,11 +509,20 @@ public class FIPSApplicationStateMachineUtilTest {
 		Assert.assertEquals(
 			FIPSApplicationState.ERROR,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Assert.assertEquals(_records.toString(), 2, _records.size());
+
+		_assertEnvelope("severity", _records.get(1), "CRITICAL");
+		_assertField("failed-step", _records.get(1), "Self test");
+		_assertField("from-state", _records.get(1), "SELF_TEST");
+		_assertField("to-state", _records.get(1), "ERROR");
 	}
 
 	private void _testTransition(
 		FIPSApplicationState fromFIPSApplicationState,
 		FIPSApplicationState toFIPSApplicationState) {
+
+		_records.clear();
 
 		_setFIPSApplicationState(fromFIPSApplicationState);
 
@@ -136,11 +531,21 @@ public class FIPSApplicationStateMachineUtilTest {
 		Assert.assertEquals(
 			toFIPSApplicationState,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Assert.assertEquals(_records.toString(), 1, _records.size());
+
+		_assertEnvelope("event-type", _records.get(0), "fips-state-transition");
+		_assertField(
+			"from-state", _records.get(0), fromFIPSApplicationState.name());
+		_assertField(
+			"to-state", _records.get(0), toFIPSApplicationState.name());
 	}
 
 	private void _testTransitionWithIllegalState(
 		FIPSApplicationState fromFIPSApplicationState,
 		FIPSApplicationState toFIPSApplicationState) {
+
+		_records.clear();
 
 		_setFIPSApplicationState(fromFIPSApplicationState);
 
@@ -151,12 +556,24 @@ public class FIPSApplicationStateMachineUtilTest {
 		Assert.assertEquals(
 			fromFIPSApplicationState,
 			FIPSApplicationStateMachineUtil.getFIPSApplicationState());
+
+		Assert.assertTrue(_records.toString(), _records.isEmpty());
 	}
 
 	private void _transition(FIPSApplicationState fipsApplicationState) {
 		ReflectionTestUtil.invoke(
 			FIPSApplicationStateMachineUtil.class, "_transition",
-			new Class<?>[] {FIPSApplicationState.class}, fipsApplicationState);
+			new Class<?>[] {FIPSApplicationState.class, Consumer.class},
+			fipsApplicationState,
+			(Consumer<FIPSAuditEvent>)fipsAuditEvent -> {
+			});
 	}
+
+	private static Logger _logger;
+
+	private static MockedStatic<LogManager> _logManagerMockedStatic;
+
+	private final List<Map<String, Object>> _records = new ArrayList<>();
+	private SafeCloseable _safeCloseable;
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineUtilTest.java
@@ -253,7 +253,7 @@ public class FIPSApplicationStateMachineUtilTest {
 
 		_assertEnvelope("severity", record, "INFO");
 		_assertField("from-state", record, "OPERATIONAL");
-		_assertField("initiating-actor", record, "OS signal");
+		_assertField("initiating-actor", record, "Operating system");
 		_assertField("to-state", record, "POWER_OFF");
 	}
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventTest.java
@@ -1,0 +1,90 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+
+import javax.crypto.spec.PBEKeySpec;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSAuditEventTest {
+
+	@Test
+	public void testPut() {
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
+
+		String reason = RandomTestUtil.randomString();
+
+		fipsAuditEvent.put("reason", reason);
+
+		Map<String, Object> fields = fipsAuditEvent.getFields();
+
+		Assert.assertEquals(reason, fields.get("reason"));
+	}
+
+	@Test
+	public void testPutRejectsANonfiniteNumber() {
+		_testPutRejects(Double.NaN);
+		_testPutRejects(Double.POSITIVE_INFINITY);
+		_testPutRejects(Float.NEGATIVE_INFINITY);
+		_testPutRejects(Float.NaN);
+	}
+
+	@Test
+	public void testPutRejectsANullValue() {
+		_testPutRejects(null);
+	}
+
+	@Test
+	public void testPutRejectsASensitiveSecurityParameter() throws Exception {
+		KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+
+		KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+		_testPutRejects(keyPair.getPrivate());
+		_testPutRejects(keyPair.getPublic());
+
+		char[] chars = RandomTestUtil.randomString(
+		).toCharArray();
+
+		_testPutRejects(RandomTestUtil.randomBytes());
+		_testPutRejects(chars);
+		_testPutRejects(new PBEKeySpec(chars));
+	}
+
+	private void _testPutRejects(Object value) {
+		_testPutRejectsValue(value);
+		_testPutRejectsValue(Arrays.asList(value));
+		_testPutRejectsValue(Collections.singletonMap("nested", value));
+	}
+
+	private void _testPutRejectsValue(Object value) {
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
+
+		Assert.assertThrows(
+			IllegalArgumentException.class,
+			() -> fipsAuditEvent.put(RandomTestUtil.randomString(), value));
+
+		Map<String, Object> fields = fipsAuditEvent.getFields();
+
+		Assert.assertTrue(String.valueOf(fields), fields.isEmpty());
+	}
+
+}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventTest.java
@@ -84,7 +84,7 @@ public class FIPSAuditEventTest {
 
 		Map<String, Object> fields = fipsAuditEvent.getFields();
 
-		Assert.assertTrue(String.valueOf(fields), fields.isEmpty());
+		Assert.assertTrue(fields.isEmpty());
 	}
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventTest.java
@@ -68,7 +68,7 @@ public class FIPSAuditEventTest {
 		_testPutRejects(new PBEKeySpec(chars));
 	}
 
-	private void _assertPutRejects(Object value) {
+	private void _assertPutThrows(Object value) {
 		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
 			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
 
@@ -82,10 +82,10 @@ public class FIPSAuditEventTest {
 	}
 
 	private void _testPutRejects(Object value) {
-		_assertPutRejects(Arrays.asList(value));
-		_assertPutRejects(Collections.singletonMap("nested", value));
-		_assertPutRejects(new Object[] {value});
-		_assertPutRejects(value);
+		_assertPutThrows(Arrays.asList(value));
+		_assertPutThrows(Collections.singletonMap("nested", value));
+		_assertPutThrows(new Object[] {value});
+		_assertPutThrows(value);
 	}
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventTest.java
@@ -84,6 +84,7 @@ public class FIPSAuditEventTest {
 	private void _testPutRejects(Object value) {
 		_assertPutRejects(Arrays.asList(value));
 		_assertPutRejects(Collections.singletonMap("nested", value));
+		_assertPutRejects(new Object[] {value});
 		_assertPutRejects(value);
 	}
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditEventTest.java
@@ -57,24 +57,18 @@ public class FIPSAuditEventTest {
 
 		KeyPair keyPair = keyPairGenerator.generateKeyPair();
 
-		_testPutRejects(keyPair.getPrivate());
-		_testPutRejects(keyPair.getPublic());
+		String randomString = RandomTestUtil.randomString();
 
-		char[] chars = RandomTestUtil.randomString(
-		).toCharArray();
+		char[] chars = randomString.toCharArray();
 
 		_testPutRejects(RandomTestUtil.randomBytes());
 		_testPutRejects(chars);
+		_testPutRejects(keyPair.getPrivate());
+		_testPutRejects(keyPair.getPublic());
 		_testPutRejects(new PBEKeySpec(chars));
 	}
 
-	private void _testPutRejects(Object value) {
-		_testPutRejectsValue(value);
-		_testPutRejectsValue(Arrays.asList(value));
-		_testPutRejectsValue(Collections.singletonMap("nested", value));
-	}
-
-	private void _testPutRejectsValue(Object value) {
+	private void _assertPutRejects(Object value) {
 		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
 			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
 
@@ -85,6 +79,12 @@ public class FIPSAuditEventTest {
 		Map<String, Object> fields = fipsAuditEvent.getFields();
 
 		Assert.assertTrue(fields.isEmpty());
+	}
+
+	private void _testPutRejects(Object value) {
+		_assertPutRejects(Arrays.asList(value));
+		_assertPutRejects(Collections.singletonMap("nested", value));
+		_assertPutRejects(value);
 	}
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
@@ -5,8 +5,10 @@
 
 package com.liferay.portal.kernel.security.fips;
 
+import com.liferay.petra.concurrent.DCLSingleton;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -87,6 +89,11 @@ public class FIPSAuditUtilTest {
 	@Before
 	public void setUp() {
 		Mockito.reset(_logger);
+
+		DCLSingleton<String> dclSingleton = ReflectionTestUtil.getFieldValue(
+			FIPSAuditUtil.class, "_deploymentInstanceIdDCLSingleton");
+
+		dclSingleton.destroy(null);
 
 		_safeCloseable = PropsValuesTestUtil.swapWithSafeCloseable(
 			"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", RandomTestUtil.randomString());

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
@@ -6,7 +6,7 @@
 package com.liferay.portal.kernel.security.fips;
 
 import com.liferay.petra.lang.SafeCloseable;
-import com.liferay.portal.kernel.internal.log4j.Log4jFIPSAuditUtil;
+import com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -72,7 +72,7 @@ public class FIPSAuditUtilTest {
 			LogManager.class, Mockito.CALLS_REAL_METHODS);
 
 		_logManagerMockedStatic.when(
-			() -> LogManager.getLogger(Log4jFIPSAuditUtil.class)
+			() -> LogManager.getLogger(FIPSLog4jUtil.class)
 		).thenReturn(
 			_logger
 		);

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
@@ -11,16 +11,17 @@ import com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.ServerDetector;
 import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.Validator;
 
-import java.io.File;
 import java.io.IOException;
 
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 
 import java.security.Provider;
 import java.security.Security;
@@ -67,8 +68,6 @@ public class FIPSAuditUtilTest {
 
 	@BeforeClass
 	public static void setUpClass() {
-		PropsUtil.get("fips.enabled");
-
 		_logger = Mockito.mock(Logger.class);
 
 		_logManagerMockedStatic = Mockito.mockStatic(
@@ -90,6 +89,8 @@ public class FIPSAuditUtilTest {
 	public void setUp() {
 		Mockito.reset(_logger);
 
+		Security.insertProviderAt(_testProvider, 1);
+
 		DCLSingleton<String> dclSingleton = ReflectionTestUtil.getFieldValue(
 			FIPSAuditUtil.class, "_deploymentInstanceIdDCLSingleton");
 
@@ -103,6 +104,8 @@ public class FIPSAuditUtilTest {
 
 	@After
 	public void tearDown() {
+		Security.removeProvider(_TEST_PROVIDER_NAME);
+
 		_safeCloseable.close();
 	}
 
@@ -130,7 +133,7 @@ public class FIPSAuditUtilTest {
 
 			FIPSAuditUtil.write(fipsAuditEvent);
 
-			Map<String, Object> record = _getRecord(Level.ERROR);
+			Map<String, Object> record = _getLastRecord(Level.ERROR);
 
 			Assert.assertEquals("4743", record.get("cmvp-certificate-id"));
 			Assert.assertEquals(
@@ -143,12 +146,10 @@ public class FIPSAuditUtilTest {
 			Assert.assertEquals(fromState, fields.get("from-state"));
 			Assert.assertEquals(toState, fields.get("to-state"));
 
-			Provider provider = _getProvider();
-
 			Assert.assertEquals(
-				provider.getName(), record.get("provider-name"));
+				_TEST_PROVIDER_NAME, record.get("provider-name"));
 			Assert.assertEquals(
-				provider.getVersionStr(), record.get("provider-version"));
+				_TEST_PROVIDER_VERSION, record.get("provider-version"));
 
 			Assert.assertEquals("CRITICAL", record.get("severity"));
 
@@ -164,7 +165,8 @@ public class FIPSAuditUtilTest {
 	public void testWriteDerivesStableDeploymentInstanceIdWhenUnset()
 		throws Exception {
 
-		Path liferayHome = Files.createTempDirectory("fips-audit-test");
+		Path liferayHome = Files.createTempDirectory(
+			FIPSAuditUtilTest.class.getName());
 
 		try (SafeCloseable safeCloseable1 =
 				PropsValuesTestUtil.swapWithSafeCloseable(
@@ -223,7 +225,7 @@ public class FIPSAuditUtilTest {
 					RandomTestUtil.randomString(),
 					FIPSAuditEvent.Severity.INFO));
 
-			Map<String, Object> record = _getRecord(Level.INFO);
+			Map<String, Object> record = _getLastRecord(Level.INFO);
 
 			String timestamp = String.valueOf(record.get("timestamp"));
 
@@ -257,11 +259,9 @@ public class FIPSAuditUtilTest {
 
 		FIPSAuditUtil.write(fipsAuditEvent);
 
-		Map<String, Object> record = _getRecord(Level.INFO);
+		Map<String, Object> record = _getLastRecord(Level.INFO);
 
-		Provider provider = _getProvider();
-
-		Assert.assertEquals(provider.getName(), record.get("provider-name"));
+		Assert.assertEquals(_TEST_PROVIDER_NAME, record.get("provider-name"));
 
 		Map<?, ?> fields = (Map<?, ?>)record.get("fields");
 
@@ -298,7 +298,7 @@ public class FIPSAuditUtilTest {
 
 		FIPSAuditUtil.write(fipsAuditEvent);
 
-		Map<String, Object> record = _getRecord(Level.INFO);
+		Map<String, Object> record = _getLastRecord(Level.INFO);
 
 		Map<?, ?> fields = (Map<?, ?>)record.get("fields");
 
@@ -393,26 +393,34 @@ public class FIPSAuditUtilTest {
 	}
 
 	private void _delete(Path path) throws IOException {
-		File file = path.toFile();
+		Files.walkFileTree(
+			path,
+			new SimpleFileVisitor<Path>() {
 
-		File[] childFiles = file.listFiles();
+				@Override
+				public FileVisitResult postVisitDirectory(
+						Path path, IOException ioException)
+					throws IOException {
 
-		if (childFiles != null) {
-			for (File childFile : childFiles) {
-				_delete(childFile.toPath());
-			}
-		}
+					Files.delete(path);
 
-		Files.delete(path);
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult visitFile(
+						Path path, BasicFileAttributes basicFileAttributes)
+					throws IOException {
+
+					Files.delete(path);
+
+					return FileVisitResult.CONTINUE;
+				}
+
+			});
 	}
 
-	private Provider _getProvider() {
-		Provider[] providers = Security.getProviders();
-
-		return providers[0];
-	}
-
-	private Map<String, Object> _getRecord(Level level) {
+	private Map<String, Object> _getLastRecord(Level level) {
 		List<Map<String, Object>> records = _getRecords(level);
 
 		return records.get(records.size() - 1);
@@ -471,7 +479,7 @@ public class FIPSAuditUtilTest {
 		FIPSAuditUtil.write(
 			new FIPSAuditEvent(RandomTestUtil.randomString(), severity));
 
-		Map<String, Object> record = _getRecord(level);
+		Map<String, Object> record = _getLastRecord(level);
 
 		Assert.assertEquals(severity.name(), record.get("severity"));
 	}
@@ -486,7 +494,7 @@ public class FIPSAuditUtilTest {
 
 		FIPSAuditUtil.write(fipsAuditEvent);
 
-		Map<String, Object> record = _getRecord(Level.INFO);
+		Map<String, Object> record = _getLastRecord(Level.INFO);
 
 		Map<?, ?> fields = (Map<?, ?>)record.get("fields");
 
@@ -516,10 +524,25 @@ public class FIPSAuditUtilTest {
 		}
 	}
 
+	private static final String _TEST_PROVIDER_NAME = "TestProvider";
+
+	private static final String _TEST_PROVIDER_VERSION = "9.9";
+
 	private static Logger _logger;
 
 	private static MockedStatic<LogManager> _logManagerMockedStatic;
+	private static final Provider _testProvider = new TestProvider();
 
 	private SafeCloseable _safeCloseable;
+
+	private static class TestProvider extends Provider {
+
+		private TestProvider() {
+			super(
+				_TEST_PROVIDER_NAME, _TEST_PROVIDER_VERSION,
+				"Test provider for the FIPS audit envelope");
+		}
+
+	}
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
@@ -41,7 +41,6 @@ import java.util.TimeZone;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.MarkerManager;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
@@ -435,8 +434,7 @@ public class FIPSAuditUtilTest {
 		Mockito.verify(
 			_logger, Mockito.atLeastOnce()
 		).log(
-			Mockito.eq(level),
-			Mockito.eq(MarkerManager.getMarker(FIPSLog4jUtil.MARKER_NAME)),
+			Mockito.eq(level), Mockito.eq(FIPSLog4jUtil.getMarker()),
 			argumentCaptor.capture()
 		);
 

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
@@ -148,7 +148,6 @@ public class FIPSAuditUtilTest {
 			String timestamp = String.valueOf(record.get("timestamp"));
 
 			Assert.assertTrue(
-				timestamp,
 				timestamp.matches(
 					"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"));
 		}
@@ -188,7 +187,6 @@ public class FIPSAuditUtilTest {
 			Object deploymentInstanceId = record1.get("deployment-instance-id");
 
 			Assert.assertTrue(
-				String.valueOf(deploymentInstanceId),
 				Validator.isNotNull(String.valueOf(deploymentInstanceId)));
 
 			Map<String, Object> record2 = records.get(1);
@@ -225,7 +223,6 @@ public class FIPSAuditUtilTest {
 			Instant instant = Instant.parse(timestamp);
 
 			Assert.assertTrue(
-				timestamp,
 				Math.abs(System.currentTimeMillis() - instant.toEpochMilli()) <
 					Time.MINUTE);
 		}
@@ -341,8 +338,7 @@ public class FIPSAuditUtilTest {
 		long eventSequence1 = (Long)record1.get("event-sequence");
 		long eventSequence2 = (Long)record2.get("event-sequence");
 
-		Assert.assertEquals(
-			records.toString(), eventSequence1 + 1, eventSequence2);
+		Assert.assertEquals(eventSequence1 + 1, eventSequence2);
 	}
 
 	@Test

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
@@ -14,9 +14,7 @@ import com.liferay.portal.kernel.util.Time;
 
 import java.time.Instant;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
@@ -69,6 +67,12 @@ public class FIPSAuditUtilTest {
 	@Before
 	public void setUp() {
 		Mockito.reset(_logger);
+
+		Mockito.when(
+			_logger.isEnabled(Level.INFO)
+		).thenReturn(
+			true
+		);
 
 		_safeCloseable = PropsValuesTestUtil.swapWithSafeCloseable(
 			"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", RandomTestUtil.randomString());
@@ -129,23 +133,11 @@ public class FIPSAuditUtilTest {
 
 	@Test
 	public void testWriteThrowsWhenAppenderIsMissing() {
-		Mockito.when(
-			_logger.isEnabled(Level.INFO)
-		).thenReturn(
-			true
-		);
-
 		_testWriteThrows();
 	}
 
 	@Test
 	public void testWriteThrowsWhenLayoutIsNotTheNDJSONLayout() {
-		Mockito.when(
-			_logger.isEnabled(Level.INFO)
-		).thenReturn(
-			true
-		);
-
 		RollingFileAppender rollingFileAppender = Mockito.mock(
 			RollingFileAppender.class);
 
@@ -172,8 +164,6 @@ public class FIPSAuditUtilTest {
 	}
 
 	private Map<String, Object> _getLastFIPSAuditLogEntry() {
-		List<Map<String, Object>> fipsAuditLogEntries = new ArrayList<>();
-
 		ArgumentCaptor<Message> argumentCaptor = ArgumentCaptor.forClass(
 			Message.class);
 
@@ -184,14 +174,9 @@ public class FIPSAuditUtilTest {
 			argumentCaptor.capture()
 		);
 
-		for (Message message : argumentCaptor.getAllValues()) {
-			ObjectMessage objectMessage = (ObjectMessage)message;
+		ObjectMessage objectMessage = (ObjectMessage)argumentCaptor.getValue();
 
-			fipsAuditLogEntries.add(
-				(Map<String, Object>)objectMessage.getParameter());
-		}
-
-		return fipsAuditLogEntries.get(fipsAuditLogEntries.size() - 1);
+		return (Map<String, Object>)objectMessage.getParameter();
 	}
 
 	private void _mockLogManager(RollingFileAppender rollingFileAppender) {

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
@@ -38,6 +38,7 @@ import java.util.TimeZone;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.MarkerManager;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
@@ -421,7 +422,9 @@ public class FIPSAuditUtilTest {
 		Mockito.verify(
 			_logger, Mockito.atLeastOnce()
 		).log(
-			Mockito.eq(level), argumentCaptor.capture()
+			Mockito.eq(level),
+			Mockito.eq(MarkerManager.getMarker(FIPSLog4jUtil.MARKER_NAME)),
+			argumentCaptor.capture()
 		);
 
 		for (Message message : argumentCaptor.getAllValues()) {

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.util.Time;
 import java.time.Instant;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
@@ -104,6 +105,26 @@ public class FIPSAuditUtilTest {
 		finally {
 			TimeZone.setDefault(timeZone);
 		}
+	}
+
+	@Test
+	public void testWriteNormalizesAFieldTimestampInAnArray() {
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
+
+		fipsAuditEvent.put(
+			"provider-timestamps",
+			new Instant[] {Instant.parse("2026-05-06T14:19:23.471Z")});
+
+		FIPSAuditUtil.write(fipsAuditEvent);
+
+		Map<String, Object> fipsAuditLogEntry = _getLastFIPSAuditLogEntry();
+
+		Map<?, ?> fields = (Map<?, ?>)fipsAuditLogEntry.get("fields");
+
+		Assert.assertEquals(
+			Collections.singletonList("2026-05-06T14:19:23.471Z"),
+			fields.get("provider-timestamps"));
 	}
 
 	@Test

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
@@ -1,0 +1,517 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.internal.log4j.Log4jFIPSAuditUtil;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.ServerDetector;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.io.File;
+import java.io.IOException;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import java.security.Provider;
+import java.security.Security;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.RollingFileAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.ObjectMessage;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+/**
+ * @author Jorge García Jiménez
+ * @author Rafael Praxedes
+ */
+public class FIPSAuditUtilTest {
+
+	@BeforeClass
+	public static void setUpClass() {
+		PropsUtil.get("fips.enabled");
+
+		_logger = Mockito.mock(Logger.class);
+
+		_logManagerMockedStatic = Mockito.mockStatic(
+			LogManager.class, Mockito.CALLS_REAL_METHODS);
+
+		_logManagerMockedStatic.when(
+			() -> LogManager.getLogger(Log4jFIPSAuditUtil.class)
+		).thenReturn(
+			_logger
+		);
+	}
+
+	@AfterClass
+	public static void tearDownClass() {
+		_logManagerMockedStatic.close();
+	}
+
+	@Before
+	public void setUp() {
+		Mockito.reset(_logger);
+
+		_safeCloseable = PropsValuesTestUtil.swapWithSafeCloseable(
+			"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", RandomTestUtil.randomString());
+
+		_mockLogManager(null);
+	}
+
+	@After
+	public void tearDown() {
+		_safeCloseable.close();
+	}
+
+	@Test
+	public void testWrite() {
+		try (SafeCloseable safeCloseable1 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", "instance-1");
+			SafeCloseable safeCloseable2 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID", "4743")) {
+
+			String eventType = RandomTestUtil.randomString();
+
+			FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+				eventType, FIPSAuditEvent.Severity.CRITICAL);
+
+			String fromState = RandomTestUtil.randomString();
+			String toState = RandomTestUtil.randomString();
+
+			fipsAuditEvent.put("from-state", fromState);
+			fipsAuditEvent.put("to-state", toState);
+
+			FIPSAuditUtil.write(fipsAuditEvent);
+
+			Map<String, Object> record = _getRecord(Level.ERROR);
+
+			Assert.assertEquals("4743", record.get("cmvp-certificate-id"));
+			Assert.assertEquals(
+				"instance-1", record.get("deployment-instance-id"));
+			Assert.assertEquals("1.0", record.get("event-schema-version"));
+			Assert.assertEquals(eventType, record.get("event-type"));
+
+			Map<?, ?> fields = (Map<?, ?>)record.get("fields");
+
+			Assert.assertEquals(fromState, fields.get("from-state"));
+			Assert.assertEquals(toState, fields.get("to-state"));
+
+			Provider provider = _getProvider();
+
+			Assert.assertEquals(
+				provider.getName(), record.get("provider-name"));
+			Assert.assertEquals(
+				provider.getVersionStr(), record.get("provider-version"));
+
+			Assert.assertEquals("CRITICAL", record.get("severity"));
+
+			String timestamp = String.valueOf(record.get("timestamp"));
+
+			Assert.assertTrue(
+				timestamp,
+				timestamp.matches(
+					"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"));
+		}
+	}
+
+	@Test
+	public void testWriteDerivesStableDeploymentInstanceIdWhenUnset()
+		throws Exception {
+
+		Path liferayHome = Files.createTempDirectory("fips-audit-test");
+
+		try (SafeCloseable safeCloseable1 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"LIFERAY_HOME", liferayHome.toString());
+			SafeCloseable safeCloseable2 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", "");
+			SafeCloseable safeCloseable3 =
+				PropsValuesTestUtil.swapWithSafeCloseable(
+					"FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID", "")) {
+
+			FIPSAuditUtil.write(
+				new FIPSAuditEvent(
+					RandomTestUtil.randomString(),
+					FIPSAuditEvent.Severity.INFO));
+			FIPSAuditUtil.write(
+				new FIPSAuditEvent(
+					RandomTestUtil.randomString(),
+					FIPSAuditEvent.Severity.INFO));
+
+			List<Map<String, Object>> records = _getRecords(Level.INFO);
+
+			Assert.assertEquals(records.toString(), 2, records.size());
+
+			Map<String, Object> record1 = records.get(0);
+
+			Object deploymentInstanceId = record1.get("deployment-instance-id");
+
+			Assert.assertTrue(
+				String.valueOf(deploymentInstanceId),
+				Validator.isNotNull(String.valueOf(deploymentInstanceId)));
+
+			Map<String, Object> record2 = records.get(1);
+
+			Assert.assertEquals(
+				deploymentInstanceId, record2.get("deployment-instance-id"));
+
+			Assert.assertTrue(
+				Files.exists(
+					liferayHome.resolve(
+						"data/fips-audit-deployment-instance-id")));
+		}
+		finally {
+			_delete(liferayHome);
+		}
+	}
+
+	@Test
+	public void testWriteFormatsTimestampInUTC() {
+		TimeZone timeZone = TimeZone.getDefault();
+
+		try {
+			TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+
+			FIPSAuditUtil.write(
+				new FIPSAuditEvent(
+					RandomTestUtil.randomString(),
+					FIPSAuditEvent.Severity.INFO));
+
+			Map<String, Object> record = _getRecord(Level.INFO);
+
+			String timestamp = String.valueOf(record.get("timestamp"));
+
+			Instant instant = Instant.parse(timestamp);
+
+			Assert.assertTrue(
+				timestamp,
+				Math.abs(System.currentTimeMillis() - instant.toEpochMilli()) <
+					Time.MINUTE);
+		}
+		finally {
+			TimeZone.setDefault(timeZone);
+		}
+	}
+
+	@Test
+	public void testWriteLogsRecordAtTheSeverityLevel() {
+		_testWriteLogsRecordAtTheSeverityLevel(
+			Level.ERROR, FIPSAuditEvent.Severity.CRITICAL);
+		_testWriteLogsRecordAtTheSeverityLevel(
+			Level.INFO, FIPSAuditEvent.Severity.INFO);
+	}
+
+	@Test
+	public void testWriteNestsFields() {
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
+
+		String spoofedProviderName = RandomTestUtil.randomString();
+
+		fipsAuditEvent.put("provider-name", spoofedProviderName);
+
+		FIPSAuditUtil.write(fipsAuditEvent);
+
+		Map<String, Object> record = _getRecord(Level.INFO);
+
+		Provider provider = _getProvider();
+
+		Assert.assertEquals(provider.getName(), record.get("provider-name"));
+
+		Map<?, ?> fields = (Map<?, ?>)record.get("fields");
+
+		Assert.assertEquals(spoofedProviderName, fields.get("provider-name"));
+	}
+
+	@Test
+	public void testWriteNormalizesFieldTimestamps() {
+		_testWriteNormalizesFieldTimestamp(
+			"2025-05-06T14:19:23.471Z",
+			Date.from(Instant.parse("2025-05-06T14:19:23.471Z")));
+		_testWriteNormalizesFieldTimestamp(
+			"2026-05-06T14:19:23.000Z", Instant.parse("2026-05-06T14:19:23Z"));
+		_testWriteNormalizesFieldTimestamp(
+			"2026-05-06T14:19:23.471Z",
+			Instant.parse("2026-05-06T14:19:23.471999999Z"));
+		_testWriteNormalizesFieldTimestamp(
+			"2026-05-06T14:19:23.471Z",
+			OffsetDateTime.parse("2026-05-06T16:19:23.471+02:00"));
+	}
+
+	@Test
+	public void testWriteNormalizesNestedFieldTimestamps() {
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
+
+		fipsAuditEvent.put(
+			"provider-self-test",
+			Collections.singletonMap(
+				"completed", Instant.parse("2026-05-06T14:19:23.471Z")));
+		fipsAuditEvent.put(
+			"provider-timestamps",
+			Arrays.asList(Instant.parse("2026-05-06T14:19:23Z")));
+
+		FIPSAuditUtil.write(fipsAuditEvent);
+
+		Map<String, Object> record = _getRecord(Level.INFO);
+
+		Map<?, ?> fields = (Map<?, ?>)record.get("fields");
+
+		Map<?, ?> providerSelfTestMap = (Map<?, ?>)fields.get(
+			"provider-self-test");
+
+		Assert.assertEquals(
+			"2026-05-06T14:19:23.471Z", providerSelfTestMap.get("completed"));
+
+		Assert.assertEquals(
+			Arrays.asList("2026-05-06T14:19:23.000Z"),
+			fields.get("provider-timestamps"));
+	}
+
+	@Test
+	public void testWriteRejectsAFieldTimestampWithoutATimeZone() {
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
+
+		fipsAuditEvent.put(
+			"provider-timestamp", LocalDateTime.parse("2026-05-06T14:19:23"));
+
+		Assert.assertThrows(
+			IllegalArgumentException.class,
+			() -> FIPSAuditUtil.write(fipsAuditEvent));
+	}
+
+	@Test
+	public void testWriteSequencesRecordsMonotonically() {
+		FIPSAuditUtil.write(
+			new FIPSAuditEvent(
+				RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO));
+		FIPSAuditUtil.write(
+			new FIPSAuditEvent(
+				RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO));
+
+		List<Map<String, Object>> records = _getRecords(Level.INFO);
+
+		Assert.assertEquals(records.toString(), 2, records.size());
+
+		Map<String, Object> record1 = records.get(0);
+		Map<String, Object> record2 = records.get(1);
+
+		long eventSequence1 = (Long)record1.get("event-sequence");
+		long eventSequence2 = (Long)record2.get("event-sequence");
+
+		Assert.assertEquals(
+			records.toString(), eventSequence1 + 1, eventSequence2);
+	}
+
+	@Test
+	public void testWriteThrowsWhenAppenderIsMissing() {
+		Mockito.when(
+			_logger.isEnabled(Level.INFO)
+		).thenReturn(
+			true
+		);
+
+		_testWriteThrows();
+	}
+
+	@Test
+	public void testWriteThrowsWhenLayoutIsNotTheNDJSONLayout() {
+		Mockito.when(
+			_logger.isEnabled(Level.INFO)
+		).thenReturn(
+			true
+		);
+
+		RollingFileAppender rollingFileAppender = Mockito.mock(
+			RollingFileAppender.class);
+
+		Mockito.doReturn(
+			Mockito.mock(Layout.class)
+		).when(
+			rollingFileAppender
+		).getLayout();
+
+		_mockLogManager(rollingFileAppender);
+
+		_testWriteThrows();
+	}
+
+	@Test
+	public void testWriteThrowsWhenLoggerIsDisabled() {
+		Mockito.when(
+			_logger.isEnabled(Level.INFO)
+		).thenReturn(
+			false
+		);
+
+		_testWriteThrows();
+	}
+
+	private void _delete(Path path) throws IOException {
+		File file = path.toFile();
+
+		File[] childFiles = file.listFiles();
+
+		if (childFiles != null) {
+			for (File childFile : childFiles) {
+				_delete(childFile.toPath());
+			}
+		}
+
+		Files.delete(path);
+	}
+
+	private Provider _getProvider() {
+		Provider[] providers = Security.getProviders();
+
+		return providers[0];
+	}
+
+	private Map<String, Object> _getRecord(Level level) {
+		List<Map<String, Object>> records = _getRecords(level);
+
+		return records.get(records.size() - 1);
+	}
+
+	private List<Map<String, Object>> _getRecords(Level level) {
+		List<Map<String, Object>> records = new ArrayList<>();
+
+		ArgumentCaptor<Message> argumentCaptor = ArgumentCaptor.forClass(
+			Message.class);
+
+		Mockito.verify(
+			_logger, Mockito.atLeastOnce()
+		).log(
+			Mockito.eq(level), argumentCaptor.capture()
+		);
+
+		for (Message message : argumentCaptor.getAllValues()) {
+			ObjectMessage objectMessage = (ObjectMessage)message;
+
+			records.add((Map<String, Object>)objectMessage.getParameter());
+		}
+
+		return records;
+	}
+
+	private void _mockLogManager(RollingFileAppender rollingFileAppender) {
+		Configuration configuration = Mockito.mock(Configuration.class);
+
+		Mockito.when(
+			configuration.getAppender("FIPS_AUDIT_FILE")
+		).thenReturn(
+			rollingFileAppender
+		);
+
+		LoggerContext loggerContext = Mockito.mock(LoggerContext.class);
+
+		Mockito.when(
+			loggerContext.getConfiguration()
+		).thenReturn(
+			configuration
+		);
+
+		_logManagerMockedStatic.when(
+			() -> LogManager.getContext(false)
+		).thenReturn(
+			loggerContext
+		);
+	}
+
+	private void _testWriteLogsRecordAtTheSeverityLevel(
+		Level level, FIPSAuditEvent.Severity severity) {
+
+		FIPSAuditUtil.write(
+			new FIPSAuditEvent(RandomTestUtil.randomString(), severity));
+
+		Map<String, Object> record = _getRecord(level);
+
+		Assert.assertEquals(severity.name(), record.get("severity"));
+	}
+
+	private void _testWriteNormalizesFieldTimestamp(
+		String expectedTimestamp, Object value) {
+
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
+
+		fipsAuditEvent.put("provider-timestamp", value);
+
+		FIPSAuditUtil.write(fipsAuditEvent);
+
+		Map<String, Object> record = _getRecord(Level.INFO);
+
+		Map<?, ?> fields = (Map<?, ?>)record.get("fields");
+
+		Assert.assertEquals(
+			expectedTimestamp, fields.get("provider-timestamp"));
+	}
+
+	private void _testWriteThrows() {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable("FIPS_ENABLED", true);
+			MockedStatic<ServerDetector> serverDetectorMockedStatic =
+				Mockito.mockStatic(
+					ServerDetector.class, Mockito.CALLS_REAL_METHODS)) {
+
+			serverDetectorMockedStatic.when(
+				ServerDetector::getServerId
+			).thenReturn(
+				"tomcat"
+			);
+
+			Assert.assertThrows(
+				IllegalStateException.class,
+				() -> FIPSAuditUtil.write(
+					new FIPSAuditEvent(
+						RandomTestUtil.randomString(),
+						FIPSAuditEvent.Severity.INFO)));
+		}
+	}
+
+	private static Logger _logger;
+
+	private static MockedStatic<LogManager> _logManagerMockedStatic;
+
+	private SafeCloseable _safeCloseable;
+
+}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
@@ -5,35 +5,16 @@
 
 package com.liferay.portal.kernel.security.fips;
 
-import com.liferay.petra.concurrent.DCLSingleton;
 import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ServerDetector;
 import com.liferay.portal.kernel.util.Time;
-import com.liferay.portal.kernel.util.Validator;
-
-import java.io.IOException;
-
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
-
-import java.security.Provider;
-import java.security.Security;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
@@ -88,13 +69,6 @@ public class FIPSAuditUtilTest {
 	public void setUp() {
 		Mockito.reset(_logger);
 
-		Security.insertProviderAt(_testProvider, 1);
-
-		DCLSingleton<String> dclSingleton = ReflectionTestUtil.getFieldValue(
-			FIPSAuditUtil.class, "_deploymentInstanceIdDCLSingleton");
-
-		dclSingleton.destroy(null);
-
 		_safeCloseable = PropsValuesTestUtil.swapWithSafeCloseable(
 			"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", RandomTestUtil.randomString());
 
@@ -103,113 +77,7 @@ public class FIPSAuditUtilTest {
 
 	@After
 	public void tearDown() {
-		Security.removeProvider(_TEST_PROVIDER_NAME);
-
 		_safeCloseable.close();
-	}
-
-	@Test
-	public void testWrite() {
-		try (SafeCloseable safeCloseable1 =
-				PropsValuesTestUtil.swapWithSafeCloseable(
-					"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", "instance-1");
-			SafeCloseable safeCloseable2 =
-				PropsValuesTestUtil.swapWithSafeCloseable(
-					"FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID", "4743")) {
-
-			String eventType = RandomTestUtil.randomString();
-
-			FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
-				eventType, FIPSAuditEvent.Severity.CRITICAL);
-
-			String fromState = RandomTestUtil.randomString();
-
-			fipsAuditEvent.put("from-state", fromState);
-
-			String toState = RandomTestUtil.randomString();
-
-			fipsAuditEvent.put("to-state", toState);
-
-			FIPSAuditUtil.write(fipsAuditEvent);
-
-			Map<String, Object> record = _getLastRecord(Level.ERROR);
-
-			Assert.assertEquals("4743", record.get("cmvp-certificate-id"));
-			Assert.assertEquals(
-				"instance-1", record.get("deployment-instance-id"));
-			Assert.assertEquals("1.0", record.get("event-schema-version"));
-			Assert.assertEquals(eventType, record.get("event-type"));
-
-			Map<?, ?> fields = (Map<?, ?>)record.get("fields");
-
-			Assert.assertEquals(fromState, fields.get("from-state"));
-			Assert.assertEquals(toState, fields.get("to-state"));
-
-			Assert.assertEquals(
-				_TEST_PROVIDER_NAME, record.get("provider-name"));
-			Assert.assertEquals(
-				_TEST_PROVIDER_VERSION, record.get("provider-version"));
-
-			Assert.assertEquals("CRITICAL", record.get("severity"));
-
-			String timestamp = String.valueOf(record.get("timestamp"));
-
-			Assert.assertTrue(
-				timestamp.matches(
-					"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"));
-		}
-	}
-
-	@Test
-	public void testWriteDerivesStableDeploymentInstanceIdWhenUnset()
-		throws Exception {
-
-		Path liferayHome = Files.createTempDirectory(
-			FIPSAuditUtilTest.class.getName());
-
-		try (SafeCloseable safeCloseable1 =
-				PropsValuesTestUtil.swapWithSafeCloseable(
-					"LIFERAY_HOME", liferayHome.toString());
-			SafeCloseable safeCloseable2 =
-				PropsValuesTestUtil.swapWithSafeCloseable(
-					"FIPS_AUDIT_DEPLOYMENT_INSTANCE_ID", "");
-			SafeCloseable safeCloseable3 =
-				PropsValuesTestUtil.swapWithSafeCloseable(
-					"FIPS_AUDIT_PROVIDER_CMVP_CERTIFICATE_ID", "")) {
-
-			FIPSAuditUtil.write(
-				new FIPSAuditEvent(
-					RandomTestUtil.randomString(),
-					FIPSAuditEvent.Severity.INFO));
-			FIPSAuditUtil.write(
-				new FIPSAuditEvent(
-					RandomTestUtil.randomString(),
-					FIPSAuditEvent.Severity.INFO));
-
-			List<Map<String, Object>> records = _getRecords(Level.INFO);
-
-			Assert.assertEquals(records.toString(), 2, records.size());
-
-			Map<String, Object> record1 = records.get(0);
-
-			Object deploymentInstanceId = record1.get("deployment-instance-id");
-
-			Assert.assertTrue(
-				Validator.isNotNull(String.valueOf(deploymentInstanceId)));
-
-			Map<String, Object> record2 = records.get(1);
-
-			Assert.assertEquals(
-				deploymentInstanceId, record2.get("deployment-instance-id"));
-
-			Assert.assertTrue(
-				Files.exists(
-					liferayHome.resolve(
-						"data/fips-audit-deployment-instance-id")));
-		}
-		finally {
-			_delete(liferayHome);
-		}
 	}
 
 	@Test
@@ -224,11 +92,10 @@ public class FIPSAuditUtilTest {
 					RandomTestUtil.randomString(),
 					FIPSAuditEvent.Severity.INFO));
 
-			Map<String, Object> record = _getLastRecord(Level.INFO);
+			Map<String, Object> fipsAuditLogEntry = _getLastFIPSAuditLogEntry();
 
-			String timestamp = String.valueOf(record.get("timestamp"));
-
-			Instant instant = Instant.parse(timestamp);
+			Instant instant = Instant.parse(
+				String.valueOf(fipsAuditLogEntry.get("timestamp")));
 
 			Assert.assertTrue(
 				Math.abs(System.currentTimeMillis() - instant.toEpochMilli()) <
@@ -237,114 +104,6 @@ public class FIPSAuditUtilTest {
 		finally {
 			TimeZone.setDefault(timeZone);
 		}
-	}
-
-	@Test
-	public void testWriteLogsRecordAtTheSeverityLevel() {
-		_testWriteLogsRecordAtTheSeverityLevel(
-			Level.ERROR, FIPSAuditEvent.Severity.CRITICAL);
-		_testWriteLogsRecordAtTheSeverityLevel(
-			Level.INFO, FIPSAuditEvent.Severity.INFO);
-	}
-
-	@Test
-	public void testWriteNestsFields() {
-		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
-			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
-
-		String spoofedProviderName = RandomTestUtil.randomString();
-
-		fipsAuditEvent.put("provider-name", spoofedProviderName);
-
-		FIPSAuditUtil.write(fipsAuditEvent);
-
-		Map<String, Object> record = _getLastRecord(Level.INFO);
-
-		Assert.assertEquals(_TEST_PROVIDER_NAME, record.get("provider-name"));
-
-		Map<?, ?> fields = (Map<?, ?>)record.get("fields");
-
-		Assert.assertEquals(spoofedProviderName, fields.get("provider-name"));
-	}
-
-	@Test
-	public void testWriteNormalizesFieldTimestamps() {
-		_testWriteNormalizesFieldTimestamp(
-			"2025-05-06T14:19:23.471Z",
-			Date.from(Instant.parse("2025-05-06T14:19:23.471Z")));
-		_testWriteNormalizesFieldTimestamp(
-			"2026-05-06T14:19:23.000Z", Instant.parse("2026-05-06T14:19:23Z"));
-		_testWriteNormalizesFieldTimestamp(
-			"2026-05-06T14:19:23.471Z",
-			Instant.parse("2026-05-06T14:19:23.471999999Z"));
-		_testWriteNormalizesFieldTimestamp(
-			"2026-05-06T14:19:23.471Z",
-			OffsetDateTime.parse("2026-05-06T16:19:23.471+02:00"));
-	}
-
-	@Test
-	public void testWriteNormalizesNestedFieldTimestamps() {
-		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
-			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
-
-		fipsAuditEvent.put(
-			"provider-self-test",
-			Collections.singletonMap(
-				"completed", Instant.parse("2026-05-06T14:19:23.471Z")));
-		fipsAuditEvent.put(
-			"provider-timestamps",
-			Arrays.asList(Instant.parse("2026-05-06T14:19:23Z")));
-
-		FIPSAuditUtil.write(fipsAuditEvent);
-
-		Map<String, Object> record = _getLastRecord(Level.INFO);
-
-		Map<?, ?> fields = (Map<?, ?>)record.get("fields");
-
-		Map<?, ?> providerSelfTestMap = (Map<?, ?>)fields.get(
-			"provider-self-test");
-
-		Assert.assertEquals(
-			"2026-05-06T14:19:23.471Z", providerSelfTestMap.get("completed"));
-
-		Assert.assertEquals(
-			Arrays.asList("2026-05-06T14:19:23.000Z"),
-			fields.get("provider-timestamps"));
-	}
-
-	@Test
-	public void testWriteRejectsAFieldTimestampWithoutATimeZone() {
-		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
-			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
-
-		fipsAuditEvent.put(
-			"provider-timestamp", LocalDateTime.parse("2026-05-06T14:19:23"));
-
-		Assert.assertThrows(
-			IllegalArgumentException.class,
-			() -> FIPSAuditUtil.write(fipsAuditEvent));
-	}
-
-	@Test
-	public void testWriteSequencesRecordsMonotonically() {
-		FIPSAuditUtil.write(
-			new FIPSAuditEvent(
-				RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO));
-		FIPSAuditUtil.write(
-			new FIPSAuditEvent(
-				RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO));
-
-		List<Map<String, Object>> records = _getRecords(Level.INFO);
-
-		Assert.assertEquals(records.toString(), 2, records.size());
-
-		Map<String, Object> record1 = records.get(0);
-		Map<String, Object> record2 = records.get(1);
-
-		long eventSequence1 = (Long)record1.get("event-sequence");
-		long eventSequence2 = (Long)record2.get("event-sequence");
-
-		Assert.assertEquals(eventSequence1 + 1, eventSequence2);
 	}
 
 	@Test
@@ -391,42 +150,8 @@ public class FIPSAuditUtilTest {
 		_testWriteThrows();
 	}
 
-	private void _delete(Path path) throws IOException {
-		Files.walkFileTree(
-			path,
-			new SimpleFileVisitor<Path>() {
-
-				@Override
-				public FileVisitResult postVisitDirectory(
-						Path path, IOException ioException)
-					throws IOException {
-
-					Files.delete(path);
-
-					return FileVisitResult.CONTINUE;
-				}
-
-				@Override
-				public FileVisitResult visitFile(
-						Path path, BasicFileAttributes basicFileAttributes)
-					throws IOException {
-
-					Files.delete(path);
-
-					return FileVisitResult.CONTINUE;
-				}
-
-			});
-	}
-
-	private Map<String, Object> _getLastRecord(Level level) {
-		List<Map<String, Object>> records = _getRecords(level);
-
-		return records.get(records.size() - 1);
-	}
-
-	private List<Map<String, Object>> _getRecords(Level level) {
-		List<Map<String, Object>> records = new ArrayList<>();
+	private Map<String, Object> _getLastFIPSAuditLogEntry() {
+		List<Map<String, Object>> fipsAuditLogEntries = new ArrayList<>();
 
 		ArgumentCaptor<Message> argumentCaptor = ArgumentCaptor.forClass(
 			Message.class);
@@ -434,17 +159,18 @@ public class FIPSAuditUtilTest {
 		Mockito.verify(
 			_logger, Mockito.atLeastOnce()
 		).log(
-			Mockito.eq(level), Mockito.eq(FIPSLog4jUtil.getMarker()),
+			Mockito.eq(Level.INFO), Mockito.eq(FIPSLog4jUtil.getMarker()),
 			argumentCaptor.capture()
 		);
 
 		for (Message message : argumentCaptor.getAllValues()) {
 			ObjectMessage objectMessage = (ObjectMessage)message;
 
-			records.add((Map<String, Object>)objectMessage.getParameter());
+			fipsAuditLogEntries.add(
+				(Map<String, Object>)objectMessage.getParameter());
 		}
 
-		return records;
+		return fipsAuditLogEntries.get(fipsAuditLogEntries.size() - 1);
 	}
 
 	private void _mockLogManager(RollingFileAppender rollingFileAppender) {
@@ -471,35 +197,6 @@ public class FIPSAuditUtilTest {
 		);
 	}
 
-	private void _testWriteLogsRecordAtTheSeverityLevel(
-		Level level, FIPSAuditEvent.Severity severity) {
-
-		FIPSAuditUtil.write(
-			new FIPSAuditEvent(RandomTestUtil.randomString(), severity));
-
-		Map<String, Object> record = _getLastRecord(level);
-
-		Assert.assertEquals(severity.name(), record.get("severity"));
-	}
-
-	private void _testWriteNormalizesFieldTimestamp(
-		String expectedTimestamp, Object value) {
-
-		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
-			RandomTestUtil.randomString(), FIPSAuditEvent.Severity.INFO);
-
-		fipsAuditEvent.put("provider-timestamp", value);
-
-		FIPSAuditUtil.write(fipsAuditEvent);
-
-		Map<String, Object> record = _getLastRecord(Level.INFO);
-
-		Map<?, ?> fields = (Map<?, ?>)record.get("fields");
-
-		Assert.assertEquals(
-			expectedTimestamp, fields.get("provider-timestamp"));
-	}
-
 	private void _testWriteThrows() {
 		try (SafeCloseable safeCloseable =
 				PropsValuesTestUtil.swapWithSafeCloseable("FIPS_ENABLED", true);
@@ -522,25 +219,10 @@ public class FIPSAuditUtilTest {
 		}
 	}
 
-	private static final String _TEST_PROVIDER_NAME = "TestProvider";
-
-	private static final String _TEST_PROVIDER_VERSION = "9.9";
-
 	private static Logger _logger;
 
 	private static MockedStatic<LogManager> _logManagerMockedStatic;
-	private static final Provider _testProvider = new TestProvider();
 
 	private SafeCloseable _safeCloseable;
-
-	private static class TestProvider extends Provider {
-
-		private TestProvider() {
-			super(
-				_TEST_PROVIDER_NAME, _TEST_PROVIDER_VERSION,
-				"Test provider for the FIPS audit envelope");
-		}
-
-	}
 
 }

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSAuditUtilTest.java
@@ -114,9 +114,11 @@ public class FIPSAuditUtilTest {
 				eventType, FIPSAuditEvent.Severity.CRITICAL);
 
 			String fromState = RandomTestUtil.randomString();
-			String toState = RandomTestUtil.randomString();
 
 			fipsAuditEvent.put("from-state", fromState);
+
+			String toState = RandomTestUtil.randomString();
+
 			fipsAuditEvent.put("to-state", toState);
 
 			FIPSAuditUtil.write(fipsAuditEvent);
@@ -499,7 +501,7 @@ public class FIPSAuditUtilTest {
 			serverDetectorMockedStatic.when(
 				ServerDetector::getServerId
 			).thenReturn(
-				"tomcat"
+				RandomTestUtil.randomString()
 			);
 
 			Assert.assertThrows(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-99383
https://liferay.atlassian.net/browse/LPD-93284
https://liferay.atlassian.net/browse/LPD-93283

**Supersedes #3245.** Its forward, brianchandotcom#180553, was closed with one note, and that note is the only code change here. Nothing is stacked: reviewing this PR reviews the whole feature.

## Review Round

Brian asked for one thing:

> don't create temp arrays like this ... `jsonObject.has("xxx")` list this out many times

The integration test's `testWrite` drove its ten envelope assertions from a `new String[] {...}` literal. The ten `Assert.assertTrue(jsonObject.has("..."))` calls are now written out, in the case sensitive order the keys already had. The loop bought nothing and cost three things: a failure no longer named the missing key, the key names stopped being greppable, and a four line array literal plus a loop header replaced the one line per key a reader wants.

Sweeping the branch for the same shape found no second instance. Twenty five other constructed collections appear in the diff, and each is real data rather than a fabricated loop source: the state machine's `_allowedTransitions`, `FIPSModeValidator`'s allowed algorithm and cipher suite sets, `StringUtil.replace` argument pairs, and the helper arguments that exist to exercise the nested container recursion.

A pass over the branch against `pr-reviewer/rules` found nothing else to change. One candidate was tried and reverted: renaming the three `testWriteThrowsWhen*` unit cases to name the `IllegalStateException` they assert. `ThrowsIllegalStateException` appears nowhere in `master`, the combined `Throws<Type>When<Scenario>` form appears once in a name that misspells its own verb, and no `portal-kernel` or `portal-impl` unit test names a concrete exception type, while `ThrowsWhen<Scenario>` has four precedents. Rule 001 governs, so the existing names stand.

## No Rebase This Round

The branch still sits on `10a3e9d2`, which is where this fork's `master` is, so the diff stays at 34 commits and 20 files. `liferay/liferay-portal` `master` has moved 22 commits on since, and rebasing onto that tip instead would put those 22 commits into this PR's diff against a fork `master` that does not have them — the mistake that made #3242 read 46 commits. `ci:test:sf` replays the branch onto `liferay/liferay-portal` `master` itself, so it checks the real base regardless. The `packageinfo` conflict that failed `ci:test:sf` last round was resolved by dropping the obsolete `LPD-99383 Baseline` commit, so nothing is left to conflict.

## What Is Being Fixed

A FIPS application state transition left no evidence behind, and there was no audit stream a downstream consumer could read. ISO/IEC 19790 §7.11.4 [AS11.09] requires the finite state model to be documented, and the §7.6.3.2 audit assertions ([AS06.16], [AS06.17], [AS06.27], [AS06.28], [AS06.31], [AS06.32]) require a module to provide its events to an audit mechanism. The target is **Security Level 1** (LPD-93270) and those audit assertions are Level 2, so this trail goes beyond Level 1 deliberately, for Level 2 readiness. The one Level 1 mandate it satisfies is §7.11.6.2 [AS11.29] functional testing, sharpened by SP 800-140 VE11.29.01.

## How It Is Being Fixed

A dedicated logger feeds a rolling `FIPS_AUDIT_FILE` appender that writes one compact JSON object per line. `FIPSAuditNDJSONLayout` is a registered `@Plugin` layout that mirrors `LiferayXmlLayout`, the existing custom layout in the same package, and serializes through `JSONFactoryUtil`. It lives in `portal-kernel` because the OSGi system bundle does not export `org.apache.logging.log4j.core.config.plugins`, which is also why the four existing Log4j plugins live there. `additivity="false"` keeps a record out of the portal log, the console and the per-company files, where an interleaved line would break a line-oriented consumer; the file is created `rw-------` rather than at the process umask; and `ignoreExceptions="false"` makes a write failure surface instead of vanishing into Log4j's status logger.

`FIPSAuditUtil.write` is the only way into the log. Every record carries the same envelope — `cmvp-certificate-id`, `deployment-instance-id`, `event-schema-version`, `event-sequence`, `event-type`, `fields`, `provider-name`, `provider-version`, `severity`, `timestamp` — and caller-supplied fields nest under the reserved `fields` key, so an event can neither overwrite an envelope key nor misattribute the module that produced it. `event-sequence` is a per-JVM-run counter that orders two records written in the same millisecond, which a consumer needs because the module does not chain its records: §7.6.3.2 [AS06.32] places the protection of stored audit data on the operational environment's configuration rather than on the module. Timestamps are normalized to the canonical UTC form as the record is built, and a temporal value carrying no time zone is refused rather than recorded ambiguously. Log4j stays behind `FIPSLog4jUtil` in the non-exported `internal.log4j` package, following `Log4JUtil` and `Log4jConfigUtil`, so the exported `security.fips` package imports none of it.

`FIPSApplicationStateMachineUtil` records each transition where the transition happens rather than at each caller, so a state the model gains later cannot slip through unrecorded, and it registers its shutdown hook when the class loads, when FIPS is enabled, so no caller has to install it. The finite state model is specified separately, as [AS11.09] requires: [FIPS Application Finite State Model](https://liferay.atlassian.net/wiki/spaces/ENGAPPSECURITY/pages/5217026051).

## Only A FIPS Audit Record Enters The FIPS Audit Log

The appender's exclusivity was a convention rather than a boundary. Log4j routes by category name, not by caller, so any code that obtained the category `FIPSLog4jUtil` writes into would land in the log, a dot-suffixed child of it inherits the appender, and a `portal-log4j-ext.xml` merged at startup can attach `FIPS_AUDIT_FILE` to further loggers. The layout rendered such an event as a message key instead of refusing it, so the file stayed well formed while the log was polluted, and a stray logger could put material into it that [AS06.28] keeps out of an audit record.

Each record now carries a dedicated marker, and the filter matches the marker instance through a typed accessor rather than a name. `FIPSAuditFilter` accepts an event only when it carries that marker and its message is the record map the kernel facade builds; everything else is denied silently, because a foreign event reaches the appender only through a misconfiguration and the refusal needs no second logging path of its own. The layout covers the case the filter cannot: an ext file that replaces the appender drops the filter with it, and a replacement still renders through the layout — which refuses a foreign event by throwing. Since the appender disables `ignoreExceptions`, the throw surfaces at the call site of the misrouted logger, so the misconfiguration is discovered at its source instead of polluting the audit trail.

## One Trade-Off Worth A Second Look

The `JSONFactoryUtil` switch costs canonical key ordering, and that is worth stating rather than burying. Measured against `lib/portal/json-java.jar`: `JSONObjectImpl` wraps `org.json.JSONObject`, which is `HashMap`-backed, so key order is arbitrary at every level and can shift with the key set or the JDK. A record stays byte-reproducible as a **line**, but no longer as a re-serialized object. A nested object can come out looking sorted purely by hash accident, so a spot check proves nothing. `event-sequence` still gives a consumer a deterministic order, and record integrity stays with the operational environment, which §7.6.3.2 [AS06.32] configures to protect stored audit data.

The same measurement turned up two things that had to be closed before the switch was safe. `org.json` **drops** a null value, and `JSONObjectImpl.put` **swallows** the `JSONException` for a non-finite number into a warning on the portal log — the one log this trail is configured to stay out of. Either would leave a record that omits a field it was told to carry. `FIPSAuditEvent.put` rejects null and non-finite values alongside sensitive security parameters, walking nested maps and iterables. That walk also closes an existing gap: key material nested inside a map or a list previously passed the [AS06.28] check.

## Testing

33 unit tests: `FIPSApplicationStateMachineUtilTest` 13, `FIPSAuditNDJSONLayoutTest` 8, `FIPSAuditUtilTest` 5, `FIPSAuditEventTest` 4, `FIPSAuditFilterTest` 3. All pass locally.

`FIPSAuditUtilTest` in `portal-security-fips-test` is the functional test, 7 cases. Every unit test stubs the logger, so none of them can tell whether a record ever reaches a file, which is how two defects survived a green suite. Each case therefore calls `FIPSAuditUtil.write` and reads the result back from disk. `testWrite` proves the written record lands end to end — the ten envelope keys, the nested fields, the incremented sequence, a recent canonical timestamp — and then sweeps the whole file: every line parses as one JSON object, every timestamp is canonical, sequences are contiguous, one deployment instance ID spans the file, and the boot transitions are on disk. The scenario cases prove a spoofed envelope key nests under `fields`, a CRITICAL event passes the INFO-level logger, field timestamps come back normalized, a zone-less timestamp leaves nothing behind, a blank property derives the instance ID persisted under `data`, and the file is created owner-only. It is skipped unless FIPS is enabled and needs the FIPS CI environment of LPD-80674 to run for real.

## Known Limitations

- **File permissions are chosen, not verified.** [AS06.22] and [AS06.23] put the operating system's configuration in the administrator guidance, so the writer enforces what it owns, which is delivery, and leaves protection to the operational environment. The owner-only mode is asserted by the functional test against the reference platform.
- **A hard kill records nothing.** An orderly stop is recorded from the framework stop path, before the servlet context shuts Log4J down, and a JVM shutdown hook covers an interrupt during boot. `SIGKILL` runs neither.
- **A failed write leaves the state changed.** The record is written after the swap, because writing first would trade a lost record for a phantom one: the swap can still be refused after a record claiming it has landed, and [AS06.29] asks the module to provide its events to an audit mechanism without obliging it to undo one it could not record.
- **`KEY_CSP_ENTRY` and `QUIESCENT` have no caller yet.** Raised by @caio-farias on a superseded PR and answered there: [AS11.11] makes the Key/CSP entry state conditional on CSP entry being implemented, which `CryptoManager` already satisfies, and the KMS work under LPD-88411 supplies the callers. LPD-97889 is the right place to confirm the level scoping.

## PR Check

**pr-check: PASS** — tested on `3abba5d56767c696ac091e4ba2b7426a17986281`

| Validation | Result |
| --- | --- |
| Source Format | PASS |
| Transaction Usage | PASS |
| Full Portal Build | PASS |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | PASS |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

Two notes on how two of those were read, since neither validation's exit code tells the truth on its own.

**Source Format.** The branch scoped formatter resolves its file set against the remote tip with a two dot diff, so it scanned 509 files rather than the 20 in this diff. It auto fixed two of them — `DeleteObsoleteBackgroundTasksSchedulerJobConfigurationTest` and `IndexOnStartupExecutor` — both from the 22 commit gap between this base and `liferay/liferay-portal` `master`, and neither in this diff. Those two are reverted rather than swept into a `SF` commit under this ticket. All 20 files here were left untouched, and `validate.commit.messages` passed over the whole range.

**Baseline.** `ant baseline-all` exits 1 on one warning row, and it belongs to a package this branch never touches: `com.liferay.headless.cms.resource.v1_0`, `UNCHANGED`, `CUR_VER 3.1.0`, `BASE_VER 3.0.0`, `EXCESSIVE VERSION INCREASE`. `aed5313800a5c LPD-97871 Semantic versioning` raised it, which is already in this base, the upstream tip still carries 3.1.0, and the 22 commit gap adds no API to that package — so it reproduces on `master` without this branch, and the lowering it wrote is reverted rather than carried here. That failure aborts the sweep early, so this branch's own modules were checked separately: `portal-bootstrap` declares no `Export-Package`, `portal-security-fips-test` is a test module, and `portal-kernel` and `portal-impl` were baselined by `ant all` itself with no report file written, which is the gate that matters since baseline exits 0 even when it finds something. `com.liferay.portal.kernel.security.fips` stays at `1.2.0` and `com.liferay.portal.kernel.util` at `master`'s `101.0.0`.

<!-- pr-check {"result": "success", "sha": "3abba5d56767c696ac091e4ba2b7426a17986281"} -->
