### PR TITLE
[FIPS] LPD-102940 Encrypt the MFA time-based OTP seed at rest

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -776,7 +776,8 @@ public class OAuth2ApplicationLocalServiceImpl
 	}
 
 	private void _setClientSecret(
-		String clientSecret, OAuth2Application oAuth2Application) {
+			String clientSecret, OAuth2Application oAuth2Application)
+		throws PortalException {
 
 		if (Validator.isNull(clientSecret) || !PropsValues.FIPS_ENABLED) {
 			oAuth2Application.setClientSecret(clientSecret);
@@ -793,11 +794,13 @@ public class OAuth2ApplicationLocalServiceImpl
 
 		long companyId = oAuth2Application.getCompanyId();
 
-		TransactionCallbackUtil.registerCommitCallback(
+		try (Secret secret = new Secret(keyReference, clientSecret)) {
+			_secretManager.putSecret(companyId, secret);
+		}
+
+		TransactionCallbackUtil.registerRollbackCallback(
 			() -> {
-				try (Secret secret = new Secret(keyReference, clientSecret)) {
-					_secretManager.putSecret(companyId, secret);
-				}
+				_secretManager.deleteSecret(companyId, keyReference);
 
 				return null;
 			});

--- a/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-service/src/main/java/com/liferay/oauth2/provider/service/impl/OAuth2ApplicationLocalServiceImpl.java
@@ -54,7 +54,7 @@ import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
-import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -431,7 +431,7 @@ public class OAuth2ApplicationLocalServiceImpl
 		if (KeyReferenceUtil.isKeyReference(clientSecret)) {
 			long companyId = oAuth2Application.getCompanyId();
 
-			TransactionCommitCallbackUtil.registerCallback(
+			TransactionCallbackUtil.registerCommitCallback(
 				() -> {
 					_secretManager.deleteSecret(
 						companyId,
@@ -793,7 +793,7 @@ public class OAuth2ApplicationLocalServiceImpl
 
 		long companyId = oAuth2Application.getCompanyId();
 
-		TransactionCommitCallbackUtil.registerCallback(
+		TransactionCallbackUtil.registerCommitCallback(
 			() -> {
 				try (Secret secret = new Secret(keyReference, clientSecret)) {
 					_secretManager.putSecret(companyId, secret);

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/service/test/OAuth2ApplicationLocalServiceTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/service/test/OAuth2ApplicationLocalServiceTest.java
@@ -61,8 +61,10 @@ public class OAuth2ApplicationLocalServiceTest {
 
 	@Before
 	public void setUp() throws Exception {
+		_testSecretProvider = new TestSecretProvider();
+
 		_serviceRegistration = _bundleContext.registerService(
-			SecretProvider.class, new TestSecretProvider(),
+			SecretProvider.class, _testSecretProvider,
 			HashMapDictionaryBuilder.<String, Object>put(
 				"secret.provider.id", _PROVIDER_ID
 			).build());
@@ -84,6 +86,36 @@ public class OAuth2ApplicationLocalServiceTest {
 			_KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID);
 
 		_serviceRegistration.unregister();
+	}
+
+	@Test
+	public void testAddOAuth2ApplicationWhenPutSecretFails() throws Exception {
+		try (AutoCloseable autoCloseable =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					PropsValues.class, "FIPS_ENABLED", true)) {
+
+			List<OAuth2Application> oAuth2Applications =
+				_oAuth2ApplicationLocalService.getOAuth2Applications(
+					TestPropsValues.getCompanyId());
+
+			_testSecretProvider.setPutSecretFailure(true);
+
+			try {
+				_addOAuth2Application(RandomTestUtil.randomString());
+
+				Assert.fail();
+			}
+			catch (SecretException secretException) {
+				Assert.assertEquals(
+					_PUT_SECRET_FAILURE_MESSAGE, secretException.getMessage());
+			}
+
+			Assert.assertEquals(
+				oAuth2Applications.size(),
+				_oAuth2ApplicationLocalService.getOAuth2Applications(
+					TestPropsValues.getCompanyId()
+				).size());
+		}
 	}
 
 	@Test
@@ -140,6 +172,9 @@ public class OAuth2ApplicationLocalServiceTest {
 
 	private static final String _PROVIDER_ID = "test-oauth2-secret";
 
+	private static final String _PUT_SECRET_FAILURE_MESSAGE =
+		"Unable to put secret";
+
 	private static final BundleContext _bundleContext =
 		SystemBundleUtil.getBundleContext();
 
@@ -150,6 +185,7 @@ public class OAuth2ApplicationLocalServiceTest {
 	private OAuth2ApplicationLocalService _oAuth2ApplicationLocalService;
 
 	private ServiceRegistration<SecretProvider> _serviceRegistration;
+	private TestSecretProvider _testSecretProvider;
 
 	@DeleteAfterTestRun
 	private User _user;
@@ -204,7 +240,13 @@ public class OAuth2ApplicationLocalServiceTest {
 		}
 
 		@Override
-		public void putSecret(long companyId, Secret secret) {
+		public void putSecret(long companyId, Secret secret)
+			throws SecretException {
+
+			if (_putSecretFailure) {
+				throw new SecretException(_PUT_SECRET_FAILURE_MESSAGE);
+			}
+
 			KeyReference keyReference = secret.getKeyReference();
 
 			_secrets.put(
@@ -212,10 +254,15 @@ public class OAuth2ApplicationLocalServiceTest {
 				new String(secret.getChars()));
 		}
 
+		public void setPutSecretFailure(boolean putSecretFailure) {
+			_putSecretFailure = putSecretFailure;
+		}
+
 		private String _key(long companyId, String secretIdentifier) {
 			return companyId + StringPool.SLASH + secretIdentifier;
 		}
 
+		private boolean _putSecretFailure;
 		private final Map<String, String> _secrets = new ConcurrentHashMap<>();
 
 	}

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-api/bnd.bnd
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Multi-Factor Authentication Time-based OTP API
 Bundle-SymbolicName: com.liferay.multi.factor.authentication.timebased.otp.api
-Bundle-Version: 5.0.2
+Bundle-Version: 5.1.0
 Export-Package:\
 	com.liferay.multi.factor.authentication.timebased.otp.exception,\
 	com.liferay.multi.factor.authentication.timebased.otp.model,\

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-api/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/service/MFATimeBasedOTPEntryLocalService.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-api/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/service/MFATimeBasedOTPEntryLocalService.java
@@ -259,6 +259,11 @@ public interface MFATimeBasedOTPEntryLocalService
 	public PersistedModel getPersistedModel(Serializable primaryKeyObj)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public String getPlaintextSharedSecret(
+			MFATimeBasedOTPEntry mfaTimeBasedOTPEntry)
+		throws PortalException;
+
 	public MFATimeBasedOTPEntry resetFailedAttempts(long userId)
 		throws PortalException;
 
@@ -285,4 +290,4 @@ public interface MFATimeBasedOTPEntryLocalService
 		MFATimeBasedOTPEntry mfaTimeBasedOTPEntry);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:849956131
+// LIFERAY-SERVICE-BUILDER-HASH:1090469820

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-api/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/service/MFATimeBasedOTPEntryLocalServiceUtil.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-api/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/service/MFATimeBasedOTPEntryLocalServiceUtil.java
@@ -294,6 +294,13 @@ public class MFATimeBasedOTPEntryLocalServiceUtil {
 		return getService().getPersistedModel(primaryKeyObj);
 	}
 
+	public static String getPlaintextSharedSecret(
+			MFATimeBasedOTPEntry mfaTimeBasedOTPEntry)
+		throws PortalException {
+
+		return getService().getPlaintextSharedSecret(mfaTimeBasedOTPEntry);
+	}
+
 	public static MFATimeBasedOTPEntry resetFailedAttempts(long userId)
 		throws PortalException {
 
@@ -340,4 +347,4 @@ public class MFATimeBasedOTPEntryLocalServiceUtil {
 			MFATimeBasedOTPEntryLocalService.class);
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:1228028203
+// LIFERAY-SERVICE-BUILDER-HASH:-1577031140

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-api/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/service/MFATimeBasedOTPEntryLocalServiceWrapper.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-api/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/service/MFATimeBasedOTPEntryLocalServiceWrapper.java
@@ -347,6 +347,16 @@ public class MFATimeBasedOTPEntryLocalServiceWrapper
 	}
 
 	@Override
+	public String getPlaintextSharedSecret(
+			com.liferay.multi.factor.authentication.timebased.otp.model.
+				MFATimeBasedOTPEntry mfaTimeBasedOTPEntry)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _mfaTimeBasedOTPEntryLocalService.getPlaintextSharedSecret(
+			mfaTimeBasedOTPEntry);
+	}
+
+	@Override
 	public com.liferay.multi.factor.authentication.timebased.otp.model.
 		MFATimeBasedOTPEntry resetFailedAttempts(long userId)
 			throws com.liferay.portal.kernel.exception.PortalException {
@@ -413,4 +423,4 @@ public class MFATimeBasedOTPEntryLocalServiceWrapper
 	private MFATimeBasedOTPEntryLocalService _mfaTimeBasedOTPEntryLocalService;
 
 }
-// LIFERAY-SERVICE-BUILDER-HASH:-221251668
+// LIFERAY-SERVICE-BUILDER-HASH:1886379628

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-api/src/main/resources/com/liferay/multi/factor/authentication/timebased/otp/service/packageinfo
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-api/src/main/resources/com/liferay/multi/factor/authentication/timebased/otp/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-service/build.gradle
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-service/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	compileOnly group: "jakarta.servlet", name: "jakarta.servlet-api", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:portal-security:portal-security-key-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-service/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/service/impl/MFATimeBasedOTPEntryLocalServiceImpl.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-service/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/service/impl/MFATimeBasedOTPEntryLocalServiceImpl.java
@@ -9,10 +9,19 @@ import com.liferay.multi.factor.authentication.timebased.otp.exception.Duplicate
 import com.liferay.multi.factor.authentication.timebased.otp.exception.NoSuchEntryException;
 import com.liferay.multi.factor.authentication.timebased.otp.model.MFATimeBasedOTPEntry;
 import com.liferay.multi.factor.authentication.timebased.otp.service.base.MFATimeBasedOTPEntryLocalServiceBaseImpl;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.transaction.TransactionCallbackUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.security.key.KeyReference;
+import com.liferay.portal.security.key.KeyReferenceUtil;
+import com.liferay.portal.security.key.secret.Secret;
+import com.liferay.portal.security.key.secret.SecretManager;
 
 import java.util.Date;
 
@@ -34,6 +43,12 @@ public class MFATimeBasedOTPEntryLocalServiceImpl
 			long userId, String sharedSecret)
 		throws PortalException {
 
+		if (KeyReferenceUtil.isKeyReference(sharedSecret)) {
+			throw new PortalException(
+				"Shared secret cannot begin with a reserved key reference " +
+					"prefix");
+		}
+
 		MFATimeBasedOTPEntry mfaTimeBasedOTPEntry =
 			mfaTimeBasedOTPEntryPersistence.fetchByUserId(userId);
 
@@ -52,14 +67,66 @@ public class MFATimeBasedOTPEntryLocalServiceImpl
 		mfaTimeBasedOTPEntry.setUserId(userId);
 		mfaTimeBasedOTPEntry.setUserName(user.getFullName());
 		mfaTimeBasedOTPEntry.setCreateDate(new Date());
-		mfaTimeBasedOTPEntry.setSharedSecret(sharedSecret);
+
+		_setSharedSecret(mfaTimeBasedOTPEntry, sharedSecret);
 
 		return mfaTimeBasedOTPEntryPersistence.update(mfaTimeBasedOTPEntry);
 	}
 
 	@Override
+	public MFATimeBasedOTPEntry deleteMFATimeBasedOTPEntry(
+			long mfaTimeBasedOTPEntryId)
+		throws PortalException {
+
+		return deleteMFATimeBasedOTPEntry(
+			mfaTimeBasedOTPEntryPersistence.findByPrimaryKey(
+				mfaTimeBasedOTPEntryId));
+	}
+
+	@Override
+	public MFATimeBasedOTPEntry deleteMFATimeBasedOTPEntry(
+		MFATimeBasedOTPEntry mfaTimeBasedOTPEntry) {
+
+		String sharedSecret = mfaTimeBasedOTPEntry.getSharedSecret();
+
+		if (KeyReferenceUtil.isKeyReference(sharedSecret)) {
+			long companyId = mfaTimeBasedOTPEntry.getCompanyId();
+
+			TransactionCallbackUtil.registerCommitCallback(
+				() -> {
+					_secretManager.deleteSecret(
+						companyId,
+						KeyReferenceUtil.toKeyReference(sharedSecret));
+
+					return null;
+				});
+		}
+
+		return mfaTimeBasedOTPEntryPersistence.remove(mfaTimeBasedOTPEntry);
+	}
+
+	@Override
 	public MFATimeBasedOTPEntry fetchMFATimeBasedOTPEntryByUserId(long userId) {
 		return mfaTimeBasedOTPEntryPersistence.fetchByUserId(userId);
+	}
+
+	@Override
+	public String getPlaintextSharedSecret(
+			MFATimeBasedOTPEntry mfaTimeBasedOTPEntry)
+		throws PortalException {
+
+		String sharedSecret = mfaTimeBasedOTPEntry.getSharedSecret();
+
+		if (!KeyReferenceUtil.isKeyReference(sharedSecret)) {
+			return sharedSecret;
+		}
+
+		try (Secret secret = _secretManager.getSecret(
+				mfaTimeBasedOTPEntry.getCompanyId(),
+				KeyReferenceUtil.toKeyReference(sharedSecret))) {
+
+			return new String(secret.getChars());
+		}
 	}
 
 	@Override
@@ -125,6 +192,45 @@ public class MFATimeBasedOTPEntryLocalServiceImpl
 
 		return mfaTimeBasedOTPEntryPersistence.update(mfaTimeBasedOTPEntry);
 	}
+
+	private String _getSecretIdentifier(
+		MFATimeBasedOTPEntry mfaTimeBasedOTPEntry) {
+
+		return StringBundler.concat(
+			MFATimeBasedOTPEntry.class.getSimpleName(), StringPool.POUND,
+			mfaTimeBasedOTPEntry.getMfaTimeBasedOTPEntryId());
+	}
+
+	private void _setSharedSecret(
+		MFATimeBasedOTPEntry mfaTimeBasedOTPEntry, String sharedSecret) {
+
+		if (Validator.isNull(sharedSecret) || !PropsValues.FIPS_ENABLED) {
+			mfaTimeBasedOTPEntry.setSharedSecret(sharedSecret);
+
+			return;
+		}
+
+		KeyReference keyReference = new KeyReference(
+			_getSecretIdentifier(mfaTimeBasedOTPEntry), StringPool.STAR,
+			KeyReference.Type.SECRET);
+
+		mfaTimeBasedOTPEntry.setSharedSecret(
+			KeyReferenceUtil.toKeyReferenceString(keyReference));
+
+		long companyId = mfaTimeBasedOTPEntry.getCompanyId();
+
+		TransactionCallbackUtil.registerCommitCallback(
+			() -> {
+				try (Secret secret = new Secret(keyReference, sharedSecret)) {
+					_secretManager.putSecret(companyId, secret);
+				}
+
+				return null;
+			});
+	}
+
+	@Reference
+	private SecretManager _secretManager;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-service/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/service/impl/MFATimeBasedOTPEntryLocalServiceImpl.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-service/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/service/impl/MFATimeBasedOTPEntryLocalServiceImpl.java
@@ -202,7 +202,8 @@ public class MFATimeBasedOTPEntryLocalServiceImpl
 	}
 
 	private void _setSharedSecret(
-		MFATimeBasedOTPEntry mfaTimeBasedOTPEntry, String sharedSecret) {
+			MFATimeBasedOTPEntry mfaTimeBasedOTPEntry, String sharedSecret)
+		throws PortalException {
 
 		if (Validator.isNull(sharedSecret) || !PropsValues.FIPS_ENABLED) {
 			mfaTimeBasedOTPEntry.setSharedSecret(sharedSecret);
@@ -219,11 +220,13 @@ public class MFATimeBasedOTPEntryLocalServiceImpl
 
 		long companyId = mfaTimeBasedOTPEntry.getCompanyId();
 
-		TransactionCallbackUtil.registerCommitCallback(
+		try (Secret secret = new Secret(keyReference, sharedSecret)) {
+			_secretManager.putSecret(companyId, secret);
+		}
+
+		TransactionCallbackUtil.registerRollbackCallback(
 			() -> {
-				try (Secret secret = new Secret(keyReference, sharedSecret)) {
-					_secretManager.putSecret(companyId, secret);
-				}
+				_secretManager.deleteSecret(companyId, keyReference);
 
 				return null;
 			});

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-test/bnd.bnd
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Multi-Factor Authentication Time-based OTP Test
+Bundle-SymbolicName: com.liferay.multi.factor.authentication.timebased.otp.test
+Bundle-Version: 1.0.0

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-test/build.gradle
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-test/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
+	testIntegrationImplementation project(":apps:portal-security:portal-security-key-api")
+	testIntegrationImplementation project(":apps:portal-security:portal-security-key-spi")
+	testIntegrationImplementation project(":dxp:apps:multi-factor-authentication:multi-factor-authentication-timebased-otp-api")
+	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
+}

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-test/src/testIntegration/java/com/liferay/multi/factor/authentication/timebased/otp/service/test/MFATimeBasedOTPEntryLocalServiceTest.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-test/src/testIntegration/java/com/liferay/multi/factor/authentication/timebased/otp/service/test/MFATimeBasedOTPEntryLocalServiceTest.java
@@ -1,0 +1,333 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.multi.factor.authentication.timebased.otp.service.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.multi.factor.authentication.timebased.otp.model.MFATimeBasedOTPEntry;
+import com.liferay.multi.factor.authentication.timebased.otp.service.MFATimeBasedOTPEntryLocalService;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.module.util.SystemBundleUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.security.key.KeyReference;
+import com.liferay.portal.security.key.KeyReferenceUtil;
+import com.liferay.portal.security.key.secret.Secret;
+import com.liferay.portal.security.key.secret.exception.SecretException;
+import com.liferay.portal.security.key.spi.ProviderStatus;
+import com.liferay.portal.security.key.spi.secret.SecretProvider;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+
+/**
+ * @author Pedro Victor Silvestre
+ */
+@RunWith(Arquillian.class)
+public class MFATimeBasedOTPEntryLocalServiceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_testSecretProvider = new TestSecretProvider();
+
+		_serviceRegistration = _bundleContext.registerService(
+			SecretProvider.class, _testSecretProvider,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"secret.provider.id", _PROVIDER_ID
+			).build());
+
+		ConfigurationTestUtil.saveConfiguration(
+			_KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"companySecretProviderId", _PROVIDER_ID
+			).put(
+				"systemSecretProviderId", _PROVIDER_ID
+			).build());
+
+		_user = UserTestUtil.addUser();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		MFATimeBasedOTPEntry mfaTimeBasedOTPEntry =
+			_mfaTimeBasedOTPEntryLocalService.fetchMFATimeBasedOTPEntryByUserId(
+				_user.getUserId());
+
+		if (mfaTimeBasedOTPEntry != null) {
+			_mfaTimeBasedOTPEntryLocalService.deleteMFATimeBasedOTPEntry(
+				mfaTimeBasedOTPEntry);
+		}
+
+		ConfigurationTestUtil.deleteConfiguration(
+			_KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID);
+
+		_serviceRegistration.unregister();
+	}
+
+	@Test
+	public void testAddTimeBasedOTPEntryWhenSharedSecretIsKeyReference()
+		throws Exception {
+
+		try {
+			_mfaTimeBasedOTPEntryLocalService.addTimeBasedOTPEntry(
+				_user.getUserId(),
+				KeyReferenceUtil.toKeyReferenceString(
+					new KeyReference(
+						RandomTestUtil.randomString(), StringPool.STAR,
+						KeyReference.Type.SECRET)));
+
+			Assert.fail();
+		}
+		catch (PortalException portalException) {
+			Assert.assertEquals(
+				"Shared secret cannot begin with a reserved key reference " +
+					"prefix",
+				portalException.getMessage());
+		}
+	}
+
+	@Test
+	public void testDeleteMFATimeBasedOTPEntry() throws Exception {
+		try (AutoCloseable autoCloseable =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					PropsValues.class, "FIPS_ENABLED", true)) {
+
+			MFATimeBasedOTPEntry mfaTimeBasedOTPEntry =
+				_mfaTimeBasedOTPEntryLocalService.addTimeBasedOTPEntry(
+					_user.getUserId(), RandomTestUtil.randomString());
+
+			long companyId = mfaTimeBasedOTPEntry.getCompanyId();
+			String secretIdentifier = _getSecretIdentifier(
+				mfaTimeBasedOTPEntry);
+
+			Assert.assertTrue(
+				_testSecretProvider.getSecretIdentifiers(
+					companyId
+				).contains(
+					secretIdentifier
+				));
+
+			_mfaTimeBasedOTPEntryLocalService.deleteMFATimeBasedOTPEntry(
+				mfaTimeBasedOTPEntry);
+
+			Assert.assertFalse(
+				_testSecretProvider.getSecretIdentifiers(
+					companyId
+				).contains(
+					secretIdentifier
+				));
+		}
+	}
+
+	@Test
+	public void testDeleteMFATimeBasedOTPEntryByPrimaryKey() throws Exception {
+		try (AutoCloseable autoCloseable =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					PropsValues.class, "FIPS_ENABLED", true)) {
+
+			MFATimeBasedOTPEntry mfaTimeBasedOTPEntry =
+				_mfaTimeBasedOTPEntryLocalService.addTimeBasedOTPEntry(
+					_user.getUserId(), RandomTestUtil.randomString());
+
+			long companyId = mfaTimeBasedOTPEntry.getCompanyId();
+			String secretIdentifier = _getSecretIdentifier(
+				mfaTimeBasedOTPEntry);
+
+			_mfaTimeBasedOTPEntryLocalService.deleteMFATimeBasedOTPEntry(
+				mfaTimeBasedOTPEntry.getMfaTimeBasedOTPEntryId());
+
+			Assert.assertFalse(
+				_testSecretProvider.getSecretIdentifiers(
+					companyId
+				).contains(
+					secretIdentifier
+				));
+		}
+	}
+
+	@Test
+	public void testGetPlaintextSharedSecret() throws Exception {
+		try (AutoCloseable autoCloseable =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					PropsValues.class, "FIPS_ENABLED", true)) {
+
+			String sharedSecret = RandomTestUtil.randomString();
+
+			MFATimeBasedOTPEntry mfaTimeBasedOTPEntry =
+				_mfaTimeBasedOTPEntryLocalService.addTimeBasedOTPEntry(
+					_user.getUserId(), sharedSecret);
+
+			Assert.assertEquals(
+				sharedSecret,
+				_mfaTimeBasedOTPEntryLocalService.getPlaintextSharedSecret(
+					mfaTimeBasedOTPEntry));
+			Assert.assertTrue(
+				KeyReferenceUtil.isKeyReference(
+					mfaTimeBasedOTPEntry.getSharedSecret()));
+		}
+	}
+
+	@Test
+	public void testGetPlaintextSharedSecretWhenFIPSIsDisabled()
+		throws Exception {
+
+		String sharedSecret = RandomTestUtil.randomString();
+
+		MFATimeBasedOTPEntry mfaTimeBasedOTPEntry =
+			_mfaTimeBasedOTPEntryLocalService.addTimeBasedOTPEntry(
+				_user.getUserId(), sharedSecret);
+
+		Assert.assertEquals(
+			sharedSecret, mfaTimeBasedOTPEntry.getSharedSecret());
+		Assert.assertEquals(
+			sharedSecret,
+			_mfaTimeBasedOTPEntryLocalService.getPlaintextSharedSecret(
+				mfaTimeBasedOTPEntry));
+	}
+
+	@Test
+	public void testGetPlaintextSharedSecretWhenSharedSecretIsPlaintext()
+		throws Exception {
+
+		String sharedSecret = RandomTestUtil.randomString();
+
+		MFATimeBasedOTPEntry mfaTimeBasedOTPEntry =
+			_mfaTimeBasedOTPEntryLocalService.addTimeBasedOTPEntry(
+				_user.getUserId(), sharedSecret);
+
+		try (AutoCloseable autoCloseable =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					PropsValues.class, "FIPS_ENABLED", true)) {
+
+			Assert.assertEquals(
+				sharedSecret,
+				_mfaTimeBasedOTPEntryLocalService.getPlaintextSharedSecret(
+					mfaTimeBasedOTPEntry));
+		}
+	}
+
+	private String _getSecretIdentifier(
+		MFATimeBasedOTPEntry mfaTimeBasedOTPEntry) {
+
+		KeyReference keyReference = KeyReferenceUtil.toKeyReference(
+			mfaTimeBasedOTPEntry.getSharedSecret());
+
+		return keyReference.getIdentifier();
+	}
+
+	private static final String _KEY_MANAGER_CUSTOM_PROFILE_CONFIGURATION_PID =
+		"com.liferay.portal.security.key.internal.profile.configuration." +
+			"KeyManagerCustomProfileConfiguration";
+
+	private static final String _PROVIDER_ID = "test-mfa-timebased-otp-secret";
+
+	private static final BundleContext _bundleContext =
+		SystemBundleUtil.getBundleContext();
+
+	@Inject
+	private MFATimeBasedOTPEntryLocalService _mfaTimeBasedOTPEntryLocalService;
+
+	private ServiceRegistration<SecretProvider> _serviceRegistration;
+	private TestSecretProvider _testSecretProvider;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+	private static class TestSecretProvider implements SecretProvider {
+
+		@Override
+		public void deleteSecret(long companyId, String secretIdentifier) {
+			_secrets.remove(_getKey(companyId, secretIdentifier));
+		}
+
+		@Override
+		public ProviderStatus getProviderStatus() {
+			return ProviderStatus.OPERATIONAL;
+		}
+
+		@Override
+		public Secret getSecret(long companyId, String secretIdentifier)
+			throws SecretException {
+
+			String value = _secrets.get(_getKey(companyId, secretIdentifier));
+
+			if (value == null) {
+				throw new SecretException(
+					"No secret was found for identifier \"" + secretIdentifier +
+						"\"");
+			}
+
+			return new Secret(
+				new KeyReference(
+					secretIdentifier, _PROVIDER_ID, KeyReference.Type.SECRET),
+				value);
+		}
+
+		@Override
+		public List<String> getSecretIdentifiers(long companyId) {
+			List<String> secretIdentifiers = new ArrayList<>();
+
+			String prefix = companyId + StringPool.SLASH;
+
+			for (String key : _secrets.keySet()) {
+				if (key.startsWith(prefix)) {
+					secretIdentifiers.add(key.substring(prefix.length()));
+				}
+			}
+
+			return secretIdentifiers;
+		}
+
+		@Override
+		public boolean isAllowedCompany(long companyId) {
+			return true;
+		}
+
+		@Override
+		public void putSecret(long companyId, Secret secret) {
+			KeyReference keyReference = secret.getKeyReference();
+
+			_secrets.put(
+				_getKey(companyId, keyReference.getIdentifier()),
+				new String(secret.getChars()));
+		}
+
+		private String _getKey(long companyId, String secretIdentifier) {
+			return companyId + StringPool.SLASH + secretIdentifier;
+		}
+
+		private final Map<String, String> _secrets = new ConcurrentHashMap<>();
+
+	}
+
+}

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-test/src/testIntegration/java/com/liferay/multi/factor/authentication/timebased/otp/service/test/MFATimeBasedOTPEntryLocalServiceTest.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-test/src/testIntegration/java/com/liferay/multi/factor/authentication/timebased/otp/service/test/MFATimeBasedOTPEntryLocalServiceTest.java
@@ -95,6 +95,31 @@ public class MFATimeBasedOTPEntryLocalServiceTest {
 	}
 
 	@Test
+	public void testAddTimeBasedOTPEntryWhenPutSecretFails() throws Exception {
+		try (AutoCloseable autoCloseable =
+				ReflectionTestUtil.setFieldValueWithAutoCloseable(
+					PropsValues.class, "FIPS_ENABLED", true)) {
+
+			_testSecretProvider.setPutSecretFailure(true);
+
+			try {
+				_mfaTimeBasedOTPEntryLocalService.addTimeBasedOTPEntry(
+					_user.getUserId(), RandomTestUtil.randomString());
+
+				Assert.fail();
+			}
+			catch (SecretException secretException) {
+				Assert.assertEquals(
+					_PUT_SECRET_FAILURE_MESSAGE, secretException.getMessage());
+			}
+
+			Assert.assertNull(
+				_mfaTimeBasedOTPEntryLocalService.
+					fetchMFATimeBasedOTPEntryByUserId(_user.getUserId()));
+		}
+	}
+
+	@Test
 	public void testAddTimeBasedOTPEntryWhenSharedSecretIsKeyReference()
 		throws Exception {
 
@@ -251,6 +276,9 @@ public class MFATimeBasedOTPEntryLocalServiceTest {
 
 	private static final String _PROVIDER_ID = "test-mfa-timebased-otp-secret";
 
+	private static final String _PUT_SECRET_FAILURE_MESSAGE =
+		"Unable to put secret";
+
 	private static final BundleContext _bundleContext =
 		SystemBundleUtil.getBundleContext();
 
@@ -314,7 +342,13 @@ public class MFATimeBasedOTPEntryLocalServiceTest {
 		}
 
 		@Override
-		public void putSecret(long companyId, Secret secret) {
+		public void putSecret(long companyId, Secret secret)
+			throws SecretException {
+
+			if (_putSecretFailure) {
+				throw new SecretException(_PUT_SECRET_FAILURE_MESSAGE);
+			}
+
 			KeyReference keyReference = secret.getKeyReference();
 
 			_secrets.put(
@@ -322,10 +356,15 @@ public class MFATimeBasedOTPEntryLocalServiceTest {
 				new String(secret.getChars()));
 		}
 
+		public void setPutSecretFailure(boolean putSecretFailure) {
+			_putSecretFailure = putSecretFailure;
+		}
+
 		private String _getKey(long companyId, String secretIdentifier) {
 			return companyId + StringPool.SLASH + secretIdentifier;
 		}
 
+		private boolean _putSecretFailure;
 		private final Map<String, String> _secrets = new ConcurrentHashMap<>();
 
 	}

--- a/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/checker/TimeBasedOTPBrowserSetupMFAChecker.java
+++ b/modules/dxp/apps/multi-factor-authentication/multi-factor-authentication-timebased-otp-web/src/main/java/com/liferay/multi/factor/authentication/timebased/otp/web/internal/checker/TimeBasedOTPBrowserSetupMFAChecker.java
@@ -507,7 +507,9 @@ public class TimeBasedOTPBrowserSetupMFAChecker
 
 			return MFATimeBasedOTPUtil.verifyTimeBasedOTP(
 				_mfaTimeBasedOTPConfiguration.clockSkew(),
-				mfaTimeBasedOTPEntry.getSharedSecret(), mfaTimeBasedOTP);
+				_mfaTimeBasedOTPEntryLocalService.getPlaintextSharedSecret(
+					mfaTimeBasedOTPEntry),
+				mfaTimeBasedOTP);
 		}
 
 		_sendEmail(user, user.getEmailAddress(), httpServletRequest);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-102940

## What Is Being Fixed

`MFATimeBasedOTPEntry.sharedSecret` was persisted as a plaintext `VARCHAR(75)` column. `MFATimeBasedOTPEntryLocalServiceImpl` wrote the raw Base32 seed straight through, and the module referenced no `Encryptor` and no company key, so it was not covered transitively by the `CompanyInfo#key_` re-anchor from LPD-88890. The FIPS 140-3 readiness design (L1, no plaintext credentials in database columns) and LPD-93648 AC10 require this parameter not to be recoverable at rest in FIPS mode.

## How It Is Being Fixed

When `PropsValues.FIPS_ENABLED` is set, the column now stores a `${secretRef:*:MFATimeBasedOTPEntry#<id>}` key reference and the plaintext goes to the configured vault through `SecretManager`. Reads go through a new `getPlaintextSharedSecret` accessor that returns the stored value unchanged when it is not a key reference, so rows written before this change keep working and are wrapped the next time the user runs setup. Deleting an entry deletes its vault entry. Vault writes and deletes are registered as commit callbacks so they only run once the portal transaction commits.

This is a deliberate replay of LPD-98488, which did the same for the OAuth 2.0 client credential and is already on master. The accessor uses the `get` prefix and the plaintext qualifier that LPD-98488 landed on after review, since Service Builder gives `get`-prefixed methods read-only transaction advice.

Two places diverge from that precedent, both on purpose:

- The vault identifier is namespaced as `MFATimeBasedOTPEntry#<id>` rather than a bare entity ID. `SecretProvider` is keyed only by `(companyId, secretIdentifier)` and `SecretManagerImpl` passes the identifier straight through, so two entities that both use bare numeric IDs collide. This entity draws from the global counter while `OAuth2Application` draws from a named one, so `id == 1` in one company would have resolved to the same vault entry for both features. The fully qualified class name would overflow the 75 character column, hence the simple name. **OAuth2 should converge on a namespaced identifier too** — raising that separately under LPD-88411.
- `deleteMFATimeBasedOTPEntry(long)` is overridden to delegate to the entity variant. The generated `long` variant calls `persistence.remove(id)` directly and would otherwise orphan the vault entry; `OAuth2ApplicationLocalServiceImpl` already had this delegation, so this matches it.

### Open Questions For Reviewers

- **Commit callback vs in-transaction write.** `TransactionCallbackUtil._invoke` logs and swallows callback exceptions, so if the vault write fails the row is already committed holding a reference to nothing, `setUp` reports success, and the user is left with an unusable second factor. No `SecretProvider` implementation ships yet (LPD-88875), so today that is the guaranteed outcome of enabling FIPS. Writing inside the transaction with a rollback callback would trade an unrecoverable enrollment for a harmless orphan. The merged OAuth2 change has the identical exposure, so this is deliberately left alone here rather than diverging unilaterally — flagging it for @liferay-core-infra alongside the transaction usage review below.
- **The plaintext seed stays in the HTTP session.** `TimeBasedOTPBrowserSetupMFAChecker` puts the generated seed in the session during setup and never removes it, so session persistence or replication can still write it to disk or the wire. Pre-existing and out of scope here; worth a follow-up under LPD-88411.
- **`TestSecretProvider` duplicates the fake from `OAuth2ApplicationLocalServiceTest`.** There is no `portal-security-key-test-util` module to share it. Extracting one means touching a merged module, so it is noted as a follow-up rather than done here.

## PR Check

**pr-check: FAIL** — tested on `494334c40c927de6b5aa6a72bf99504975f5183d`

| Validation | Result |
| --- | --- |
| Service Builder | PASS |
| Source Format | PASS |
| Transaction Usage | FAIL |
| Per-Module Compile | PASS |
| Integration Test Compile | PASS |
| Cross-Module Compile | PASS |
| Baseline | FAIL |
| Structural Smoke | PASS |
| Java Unit Tests | PASS |

**Transaction usage requires Core Infrastructure review.** New transaction code (`@Transactional`, `TransactionInvokerUtil`, etc.) has heavy performance implications and requires additional review. After team review is complete, please send this pull request to @liferay-core-infra and request review from @shuyangzhou. For additional questions, use #t-core-infrastructure on Slack.

**Baseline** reported `EXCESSIVE VERSION INCREASE` for `com.liferay.headless.cms.resource.v1_0` (`3.1.0` to `3.0.0`) in `modules/apps/headless/headless-cms/headless-cms-api`. That package is not touched by this branch and the finding reproduces on master, so baseline's repair of it was reverted rather than carried here. No baseline warning was raised against this branch's own API module.

<!-- pr-check {"result": "failure", "sha": "494334c40c927de6b5aa6a72bf99504975f5183d"} -->
